### PR TITLE
Implement minimum initial collateral ratio

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Install cargo-nextest
         # https://nexte.st/docs/installation/pre-built-binaries/#linux-x86_64
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
-      - name: Run cargo nextest
-        run: cargo nextest run --retries 1
+      - name: Run tests
+        run: ./test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,7 @@ jobs:
       - name: Install cargo-nextest
         # https://nexte.st/docs/installation/pre-built-binaries/#linux-x86_64
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
+      - name: Install cargo-near CLI
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.13.3/cargo-near-installer.sh | sh
       - name: Run tests
         run: ./test.sh

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -136,7 +136,7 @@ impl MarketConfiguration {
         }
     }
 
-    pub fn is_within_initial_minimum_collateral_ratio(
+    pub fn is_within_minimum_initial_collateral_ratio(
         &self,
         borrow_position: &BorrowPosition,
         oracle_price_proof: &OraclePriceProof,

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -17,6 +17,7 @@ pub struct MarketConfiguration {
     pub borrow_asset: FungibleAsset<BorrowAsset>,
     pub collateral_asset: FungibleAsset<CollateralAsset>,
     pub balance_oracle_account_id: AccountId,
+    pub minimum_initial_collateral_ratio: Decimal,
     pub minimum_collateral_ratio_per_borrow: Decimal,
     /// How much of the deposited principal may be lent out (up to 100%)?
     /// This is a matter of protection for supply providers.
@@ -42,11 +43,71 @@ pub struct MarketConfiguration {
     pub maximum_liquidator_spread: Decimal,
 }
 
+pub mod error {
+    use std::fmt::Display;
+
+    use thiserror::Error;
+
+    #[derive(Debug, Clone, Error)]
+    #[error("Invalid configuration field `{field}`: {reason}")]
+    pub struct ConfigurationValidationError {
+        field: &'static str,
+        reason: InvalidFieldReason,
+    }
+
+    #[derive(Debug, Clone)]
+    pub enum InvalidFieldReason {
+        OutOfBounds,
+    }
+
+    impl Display for InvalidFieldReason {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "out of bounds")
+        }
+    }
+
+    pub(super) fn out_of_bounds(field: &'static str) -> ConfigurationValidationError {
+        ConfigurationValidationError {
+            field,
+            reason: InvalidFieldReason::OutOfBounds,
+        }
+    }
+}
+
 impl MarketConfiguration {
+    /// # Errors
+    ///
+    /// If the configuration is invalid.
+    pub fn validate(&self) -> Result<(), error::ConfigurationValidationError> {
+        if self.minimum_initial_collateral_ratio < 1u32 {
+            return Err(error::out_of_bounds("minimum_initial_collateral_ratio"));
+        }
+
+        if self.minimum_collateral_ratio_per_borrow < 1u32 {
+            return Err(error::out_of_bounds("minimum_collateral_ratio_per_borrow"));
+        }
+
+        if self.maximum_borrow_asset_usage_ratio.is_zero()
+            || self.maximum_borrow_asset_usage_ratio > 1u32
+        {
+            return Err(error::out_of_bounds("maximum_borrow_asset_usage_ratio"));
+        }
+
+        if self.maximum_borrow_amount < self.minimum_borrow_amount {
+            return Err(error::out_of_bounds("maximum_borrow_amount"));
+        }
+
+        if self.maximum_liquidator_spread >= 1u32 {
+            return Err(error::out_of_bounds("maximum_liquidator_spread"));
+        }
+
+        Ok(())
+    }
+
     pub fn borrow_status(
         &self,
         borrow_position: &BorrowPosition,
-        oracle_price_proof: OraclePriceProof,
+        oracle_price_proof: &OraclePriceProof,
         block_timestamp_ms: u64,
     ) -> BorrowStatus {
         if !self.is_within_minimum_collateral_ratio(borrow_position, oracle_price_proof) {
@@ -75,35 +136,58 @@ impl MarketConfiguration {
         }
     }
 
+    pub fn is_within_initial_minimum_collateral_ratio(
+        &self,
+        borrow_position: &BorrowPosition,
+        oracle_price_proof: &OraclePriceProof,
+    ) -> bool {
+        is_within_mcr(
+            &self.minimum_initial_collateral_ratio,
+            borrow_position,
+            oracle_price_proof,
+        )
+    }
+
     pub fn is_within_minimum_collateral_ratio(
         &self,
         borrow_position: &BorrowPosition,
-        OraclePriceProof {
-            collateral_asset_price,
-            borrow_asset_price,
-        }: OraclePriceProof,
+        oracle_price_proof: &OraclePriceProof,
     ) -> bool {
-        let scaled_collateral_value =
-            borrow_position.collateral_asset_deposit.as_u128() * collateral_asset_price;
-        let scaled_borrow_value = borrow_position.get_total_borrow_asset_liability().as_u128()
-            * borrow_asset_price
-            * &self.minimum_collateral_ratio_per_borrow;
-
-        scaled_collateral_value >= scaled_borrow_value
+        is_within_mcr(
+            &self.minimum_collateral_ratio_per_borrow,
+            borrow_position,
+            oracle_price_proof,
+        )
     }
 
     pub fn minimum_acceptable_liquidation_amount(
         &self,
         amount: CollateralAssetAmount,
-        oracle_price_proof: OraclePriceProof,
+        oracle_price_proof: &OraclePriceProof,
     ) -> BorrowAssetAmount {
         // minimum_acceptable_amount = collateral_amount * (1 - maximum_liquidator_spread) * collateral_price / borrow_price
         BorrowAssetAmount::new(
-            ((1u32 - &self.maximum_liquidator_spread) * oracle_price_proof.collateral_asset_price
-                / oracle_price_proof.borrow_asset_price
+            ((1u32 - &self.maximum_liquidator_spread) * &oracle_price_proof.collateral_asset_price
+                / &oracle_price_proof.borrow_asset_price
                 * amount.as_u128())
             .to_u128_ceil()
             .unwrap(),
         )
     }
+}
+
+fn is_within_mcr(
+    mcr: &Decimal,
+    borrow_position: &BorrowPosition,
+    OraclePriceProof {
+        collateral_asset_price,
+        borrow_asset_price,
+    }: &OraclePriceProof,
+) -> bool {
+    let scaled_collateral_value =
+        borrow_position.collateral_asset_deposit.as_u128() * collateral_asset_price;
+    let scaled_borrow_value =
+        borrow_position.get_total_borrow_asset_liability().as_u128() * borrow_asset_price * mcr;
+
+    scaled_collateral_value >= scaled_borrow_value
 }

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -42,6 +42,10 @@ pub struct Market {
 
 impl Market {
     pub fn new(prefix: impl IntoStorageKey, configuration: MarketConfiguration) -> Self {
+        if let Err(e) = configuration.validate() {
+            env::panic_str(&e.to_string());
+        }
+
         let prefix = prefix.into_storage_key();
         macro_rules! key {
             ($key: ident) => {
@@ -392,7 +396,7 @@ impl Market {
     pub fn can_borrow_position_be_liquidated(
         &self,
         account_id: &AccountId,
-        oracle_price_proof: OraclePriceProof,
+        oracle_price_proof: &OraclePriceProof,
     ) -> bool {
         let Some(borrow_position) = self.borrow_positions.get(account_id) else {
             return false;

--- a/common/src/number.rs
+++ b/common/src/number.rs
@@ -17,7 +17,7 @@ const MAX_DECIMAL_PRECISION: usize = 38; // = floor(FRACTIONAL_BITS / log2(10))
 #[macro_export]
 macro_rules! dec {
     ($s:literal) => {
-        Decimal::from_str($s).unwrap()
+        <$crate::number::Decimal as std::str::FromStr>::from_str($s).unwrap()
     };
 }
 

--- a/common/src/number.rs
+++ b/common/src/number.rs
@@ -125,6 +125,10 @@ impl Decimal {
         &self.repr.0
     }
 
+    pub fn is_zero(&self) -> bool {
+        self.repr.is_zero()
+    }
+
     pub fn near_equal(&self, other: &Decimal) -> bool {
         self.abs_diff(other).repr <= Self::REPR_EPSILON
     }
@@ -168,7 +172,7 @@ impl Decimal {
     pub fn to_f64_lossy(&self) -> f64 {
         let frac = self.repr.low_u128() as f64 / 2f64.powi(FRACTIONAL_BITS as i32);
         let low = (self.repr >> FRACTIONAL_BITS).low_u128() as f64;
-        let high = (self.repr >> (FRACTIONAL_BITS * 2)).low_u128() as f64;
+        let high = (self.repr >> (FRACTIONAL_BITS * 2)).low_u128() as f64 * 2f64.powi(128);
 
         high + low + frac
     }
@@ -273,16 +277,7 @@ impl Display for Decimal {
 
 impl Debug for Decimal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.fractional_part().is_zero() {
-            write!(f, "{}", self.repr >> FRACTIONAL_BITS)
-        } else {
-            write!(
-                f,
-                "{}.{}",
-                self.repr >> FRACTIONAL_BITS,
-                self.fractional_part_to_dec_string(MAX_DECIMAL_PRECISION),
-            )
-        }
+        write!(f, "{}", self.to_fixed(MAX_DECIMAL_PRECISION))
     }
 }
 
@@ -556,8 +551,8 @@ mod tests {
     #[case(1, 10)]
     #[case(3, 10_000)]
     #[test]
-    #[allow(clippy::cast_precision_loss)]
     fn division(#[case] a: u128, #[case] b: u128) {
+        #[allow(clippy::cast_precision_loss)]
         let quotient = a as f64 / b as f64;
         let abs_difference_lte = |d: Decimal, f: f64| (d.to_f64_lossy() - f).abs() <= 1e-200;
         assert!(abs_difference_lte(

--- a/contract/market/examples/generate_testnet_configuration.rs
+++ b/contract/market/examples/generate_testnet_configuration.rs
@@ -18,6 +18,7 @@ pub fn main() {
             borrow_asset: FungibleAsset::nep141("usdt.fakes.testnet".parse().unwrap()),
             collateral_asset: FungibleAsset::nep141("wrap.testnet".parse().unwrap()),
             balance_oracle_account_id: "balance_oracle".parse().unwrap(),
+            minimum_initial_collateral_ratio: Decimal::from_str("1.25").unwrap(),
             minimum_collateral_ratio_per_borrow: Decimal::from_str("1.2").unwrap(),
             maximum_borrow_asset_usage_ratio: Decimal::from_str("0.99").unwrap(),
             borrow_origination_fee: Fee::zero(),

--- a/contract/market/src/impl_ft_receiver.rs
+++ b/contract/market/src/impl_ft_receiver.rs
@@ -65,7 +65,7 @@ impl FungibleTokenReceiver for Contract {
                 let amount = use_borrow_asset();
 
                 let liquidated_collateral =
-                    self.execute_liquidate_initial(&account_id, amount, oracle_price_proof);
+                    self.execute_liquidate_initial(&account_id, amount, &oracle_price_proof);
 
                 PromiseOrValue::Promise(
                     self.configuration

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -198,7 +198,7 @@ impl Contract {
 
         require!(
             self.configuration
-                .is_within_initial_minimum_collateral_ratio(&borrow_position, &oracle_price_proof),
+                .is_within_minimum_initial_collateral_ratio(&borrow_position, &oracle_price_proof),
             "New position must exceed initial minimum collateral ratio",
         );
 

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -72,7 +72,7 @@ impl Contract {
         &mut self,
         account_id: &AccountId,
         amount: BorrowAssetAmount,
-        oracle_price_proof: OraclePriceProof,
+        oracle_price_proof: &OraclePriceProof,
     ) -> CollateralAssetAmount {
         let mut borrow_position = self
             .borrow_positions
@@ -83,7 +83,7 @@ impl Contract {
             self.configuration
                 .borrow_status(
                     &borrow_position,
-                    oracle_price_proof.clone(),
+                    oracle_price_proof,
                     env::block_timestamp_ms(),
                 )
                 .is_liquidation(),
@@ -198,9 +198,15 @@ impl Contract {
 
         require!(
             self.configuration
+                .is_within_initial_minimum_collateral_ratio(&borrow_position, &oracle_price_proof),
+            "New position must exceed initial minimum collateral ratio",
+        );
+
+        require!(
+            self.configuration
                 .borrow_status(
                     &borrow_position,
-                    oracle_price_proof,
+                    &oracle_price_proof,
                     env::block_timestamp_ms(),
                 )
                 .is_healthy(),

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -61,7 +61,7 @@ impl MarketExternalInterface for Contract {
 
         Some(self.configuration.borrow_status(
             &borrow_position,
-            oracle_price_proof,
+            &oracle_price_proof,
             env::block_timestamp_ms(),
         ))
     }
@@ -118,7 +118,7 @@ impl MarketExternalInterface for Contract {
             require!(
                 self.configuration.is_within_minimum_collateral_ratio(
                     &borrow_position,
-                    oracle_price_proof.unwrap_or_else(|| env::panic_str("Must provide price")),
+                    &oracle_price_proof.unwrap_or_else(|| env::panic_str("Must provide price")),
                 ),
                 "Borrow must still be above MCR after collateral withdrawal.",
             );
@@ -368,7 +368,7 @@ impl MarketExternalInterface for Contract {
         require!(!amount.is_zero(), "Deposit must be nonzero");
 
         let liquidated_collateral =
-            self.execute_liquidate_initial(&account_id, amount, oracle_price_proof);
+            self.execute_liquidate_initial(&account_id, amount, &oracle_price_proof);
 
         let liquidator_id = env::predecessor_account_id();
 

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -1,9 +1,7 @@
-use std::str::FromStr;
-
 use rstest::rstest;
 use tokio::join;
 
-use templar_common::{asset::FungibleAsset, borrow::BorrowStatus, dec, number::Decimal};
+use templar_common::{asset::FungibleAsset, borrow::BorrowStatus, dec};
 use test_utils::*;
 
 #[allow(dead_code)]

--- a/contract/market/tests/minimum_initial_collateral_ratio.rs
+++ b/contract/market/tests/minimum_initial_collateral_ratio.rs
@@ -1,0 +1,106 @@
+use rstest::rstest;
+use templar_common::{dec, fee::Fee, number::Decimal};
+use test_utils::*;
+
+#[rstest]
+#[case(dec!("1.2"), dec!("1.4"))]
+#[case(dec!("1"), dec!("1"))]
+#[case(dec!("1"), dec!("1.1"))]
+#[case(dec!("1"), dec!("2"))]
+#[case(dec!("1"), dec!("5"))]
+#[tokio::test]
+async fn success_above_minimum_initial_collateral_ratio(
+    #[case] minimum: Decimal,
+    #[case] initial: Decimal,
+) {
+    let SetupEverything {
+        c,
+        supply_user,
+        borrow_user,
+        ..
+    } = setup_everything(|c| {
+        c.borrow_origination_fee = Fee::zero();
+        c.minimum_collateral_ratio_per_borrow = minimum;
+        c.minimum_initial_collateral_ratio = initial.clone();
+    })
+    .await;
+
+    c.supply(&supply_user, 10_000).await;
+    c.collateralize(&borrow_user, (1000u32 * initial).to_u128_ceil().unwrap())
+        .await;
+    c.borrow(&borrow_user, 1000, EQUAL_PRICE).await;
+}
+
+#[rstest]
+#[case(dec!("1.2"), dec!("1.4"))]
+#[case(dec!("1"), dec!("1"))]
+#[case(dec!("1"), dec!("1.1"))]
+#[case(dec!("1"), dec!("2"))]
+#[case(dec!("1"), dec!("5"))]
+#[tokio::test]
+#[should_panic = "Smart contract panicked: New position must exceed initial minimum collateral ratio"]
+async fn fail_below_minimum_initial_collateral_ratio(
+    #[case] minimum: Decimal,
+    #[case] initial: Decimal,
+) {
+    let SetupEverything {
+        c,
+        supply_user,
+        borrow_user,
+        ..
+    } = setup_everything(|c| {
+        c.borrow_origination_fee = Fee::zero();
+        c.minimum_collateral_ratio_per_borrow = minimum;
+        c.minimum_initial_collateral_ratio = initial.clone();
+    })
+    .await;
+
+    c.supply(&supply_user, 10_000).await;
+    c.collateralize(
+        &borrow_user,
+        (1000u32 * initial).to_u128_ceil().unwrap() - 1,
+    )
+    .await;
+    c.borrow(&borrow_user, 1000, EQUAL_PRICE).await;
+}
+
+#[rstest]
+#[case(dec!("1.2"), dec!("1.4"))]
+#[case(dec!("1"), dec!("1.1"))]
+#[case(dec!("1.5"), dec!("2"))]
+#[case(dec!("1.5"), dec!("5"))]
+#[tokio::test]
+async fn not_in_liquidation_if_below_minimum_initial_collateral_ratio(
+    #[case] minimum: Decimal,
+    #[case] initial: Decimal,
+) {
+    let SetupEverything {
+        c,
+        supply_user,
+        borrow_user,
+        ..
+    } = setup_everything(|c| {
+        c.borrow_origination_fee = Fee::zero();
+        c.minimum_collateral_ratio_per_borrow = minimum.clone();
+        c.minimum_initial_collateral_ratio = initial.clone();
+    })
+    .await;
+
+    c.supply(&supply_user, 10_000).await;
+    c.collateralize(&borrow_user, (1000u32 * &initial).to_u128_ceil().unwrap())
+        .await;
+    c.borrow(&borrow_user, 1000, EQUAL_PRICE).await;
+
+    let borrow_status = c
+        .get_borrow_status(
+            borrow_user.id(),
+            templar_common::market::OraclePriceProof {
+                collateral_asset_price: dec!("0.99"),
+                borrow_asset_price: Decimal::one(),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert!(!borrow_status.is_liquidation(), "Borrow should not be in liquidation when collateralization ratio is below minimum INITIAL if it is still above the minimum for liquidation.");
+}

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -659,6 +659,7 @@ pub fn market_configuration(
         borrow_asset: FungibleAsset::nep141(borrow_asset_id),
         collateral_asset: FungibleAsset::nep141(collateral_asset_id),
         balance_oracle_account_id: "balance_oracle".parse().unwrap(),
+        minimum_initial_collateral_ratio: Decimal::from_str("1.25").unwrap(),
         minimum_collateral_ratio_per_borrow: Decimal::from_str("1.2").unwrap(),
         maximum_borrow_asset_usage_ratio: Decimal::from_str("0.99").unwrap(),
         borrow_origination_fee: Fee::Proportional(Decimal::from_str("0.1").unwrap()),
@@ -679,6 +680,23 @@ async fn compile_contract(p: &str) -> Vec<u8> {
         .unwrap()
 }
 
+async fn read_contract(name: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_WORKSPACE_DIR"))
+        .join("target/near/")
+        .join(name)
+        .join(name.to_owned() + ".wasm");
+
+    std::fs::read(path).unwrap()
+}
+
+async fn get_contract(name: &str, path: &str) -> Vec<u8> {
+    if std::env::var("TEST_CONTRACTS_PREBUILT").is_ok() {
+        read_contract(name).await
+    } else {
+        compile_contract(path).await
+    }
+}
+
 pub static WASM_MARKET: OnceCell<Vec<u8>> = OnceCell::const_new();
 pub static WASM_MOCK_FT: OnceCell<Vec<u8>> = OnceCell::const_new();
 
@@ -687,7 +705,7 @@ pub async fn setup_market(
     configuration: &MarketConfiguration,
 ) -> Contract {
     let wasm = WASM_MARKET
-        .get_or_init(|| compile_contract("contract/market"))
+        .get_or_init(|| get_contract("templar_market_contract", "contract/market"))
         .await;
 
     let contract = worker.dev_deploy(wasm).await.unwrap();
@@ -712,7 +730,7 @@ pub async fn deploy_ft(
     supply: u128,
 ) -> Contract {
     let wasm = WASM_MOCK_FT
-        .get_or_init(|| compile_contract("mock/ft"))
+        .get_or_init(|| get_contract("mock_ft", "mock/ft"))
         .await;
 
     let contract = account.deploy(wasm).await.unwrap().unwrap();

--- a/test.sh
+++ b/test.sh
@@ -11,4 +11,4 @@ cargo near build non-reproducible-wasm
 
 cd "$ROOT_DIR"
 export TEST_CONTRACTS_PREBUILT=1
-cargo nextest run --retries 1
+cargo nextest run --retries 1 "$@"

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-ROOT_DIR=$(realpath)
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cd "$ROOT_DIR/mock/ft"
 cargo near build non-reproducible-wasm

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -e
+
+ROOT_DIR=$(realpath)
+
+cd "$ROOT_DIR/mock/ft"
+cargo near build non-reproducible-wasm
+
+cd "$ROOT_DIR/contract/market"
+cargo near build non-reproducible-wasm
+
+cd "$ROOT_DIR"
+export TEST_CONTRACTS_PREBUILT=1
+cargo nextest run --retries 1


### PR DESCRIPTION
Adds the field `minimum_initial_collateral_ratio` to the configuration. This field works just like regular MCR, but it is only applied when attempting to borrow *more* tokens.

For example, with a `minimum_initial_collateral_ratio` of 125% and MCR of 120%,

1. Alice collateralizes with 125 NEAR at $1/NEAR.
2. Alice borrows $100 worth of stables.
3. The price of NEAR drops such that 125 NEAR is now only worth $122.
4. Even though Alice's position is below the minimum *initial* collateral ratio, it still is not in liquidation, because it is above 120% collateralized, so the borrow is healthy and nothing happens.