### PR TITLE
Introduce the `self_ext!()` macro to reduce duplication

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,3 +15,10 @@ pub mod time_chunk;
 pub mod withdrawal_queue;
 
 pub const MS_IN_A_YEAR: u128 = 31_556_952_000; // 1000 * 60 * 60 * 24 * 365.2425
+
+#[macro_export]
+macro_rules! self_ext {
+    () => {
+        Self::ext(::near_sdk::env::current_account_id())
+    };
+}

--- a/contract/market/src/impl_ft_receiver.rs
+++ b/contract/market/src/impl_ft_receiver.rs
@@ -3,6 +3,7 @@ use near_sdk::{env, json_types::U128, near, AccountId, PromiseOrValue};
 use templar_common::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
     market::{LiquidateMsg, Nep141MarketDepositMessage},
+    self_ext,
 };
 
 use crate::{Contract, ContractExt};
@@ -66,10 +67,9 @@ impl FungibleTokenReceiver for Contract {
                         .balance_oracle
                         .retrieve_price_pair()
                         .then(
-                            Self::ext(env::current_account_id())
-                                .liquidate_ft_transfer_call_01_consume_oracle_response(
-                                    sender_id, account_id, amount,
-                                ),
+                            self_ext!().liquidate_ft_transfer_call_01_consume_oracle_response(
+                                sender_id, account_id, amount,
+                            ),
                         ),
                 )
             }

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -3,9 +3,9 @@ use near_sdk::{
 };
 use templar_common::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
-    market::PricePair,
-    market::WithdrawalResolution,
+    market::{PricePair, WithdrawalResolution},
     oracle::pyth::OracleResponse,
+    self_ext,
 };
 
 use crate::{Contract, ContractExt};
@@ -173,7 +173,7 @@ impl Contract {
         self.configuration
             .borrow_asset
             .transfer(account_id.clone(), amount)
-            .then(Self::ext(env::current_account_id()).borrow_02_finalize(account_id, amount, fees))
+            .then(self_ext!().borrow_02_finalize(account_id, amount, fees))
     }
 
     #[private]
@@ -294,13 +294,11 @@ impl Contract {
         self.configuration
             .collateral_asset
             .transfer(liquidator_id.clone(), liquidated_collateral)
-            .then(
-                Self::ext(env::current_account_id()).liquidate_ft_transfer_call_02_finalize(
-                    liquidator_id,
-                    account_id,
-                    amount,
-                ),
-            )
+            .then(self_ext!().liquidate_ft_transfer_call_02_finalize(
+                liquidator_id,
+                account_id,
+                amount,
+            ))
     }
 
     /// Called during liquidation process; checks whether the transfer of
@@ -352,10 +350,7 @@ impl Contract {
         self.configuration
             .collateral_asset
             .transfer(account_id.clone(), amount)
-            .then(
-                Self::ext(env::current_account_id())
-                    .withdraw_collateral_02_finalize(account_id, amount),
-            )
+            .then(self_ext!().withdraw_collateral_02_finalize(account_id, amount))
     }
 
     #[private]

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -5,6 +5,7 @@ use templar_common::{
     market::{BorrowAssetMetrics, MarketConfiguration, MarketExternalInterface},
     number::Decimal,
     oracle::pyth::OracleResponse,
+    self_ext,
     snapshot::Snapshot,
     static_yield::StaticYieldRecord,
     supply::SupplyPosition,
@@ -97,7 +98,7 @@ impl MarketExternalInterface for Contract {
         self.configuration
             .balance_oracle
             .retrieve_price_pair()
-            .then(Self::ext(env::current_account_id()).borrow_01_consume_price(account_id, amount))
+            .then(self_ext!().borrow_01_consume_price(account_id, amount))
     }
 
     fn withdraw_collateral(&mut self, amount: CollateralAssetAmount) -> Promise {
@@ -120,20 +121,14 @@ impl MarketExternalInterface for Contract {
             self.configuration
                 .collateral_asset
                 .transfer(account_id.clone(), amount)
-                .then(
-                    Self::ext(env::current_account_id())
-                        .withdraw_collateral_02_finalize(account_id, amount),
-                )
+                .then(self_ext!().withdraw_collateral_02_finalize(account_id, amount))
         } else {
             drop(borrow_position);
             // They still have liability, so we need to check prices.
             self.configuration
                 .balance_oracle
                 .retrieve_price_pair()
-                .then(
-                    Self::ext(env::current_account_id())
-                        .withdraw_collateral_01_consume_price(account_id, amount),
-                )
+                .then(self_ext!().withdraw_collateral_01_consume_price(account_id, amount))
         }
     }
 
@@ -197,10 +192,7 @@ impl MarketExternalInterface for Contract {
                     withdrawal_resolution.account_id.clone(),
                     withdrawal_resolution.amount_to_account,
                 )
-                .then(
-                    Self::ext(env::current_account_id())
-                        .after_execute_next_withdrawal(withdrawal_resolution),
-                ),
+                .then(self_ext!().after_execute_next_withdrawal(withdrawal_resolution)),
         )
     }
 


### PR DESCRIPTION
Because `Self::ext(env::current_account_id())` is long and difficult to read.