### PR TITLE
Removes ability to withdraw supply yield directly

### DIFF
--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -96,7 +96,6 @@ pub trait MarketExternalInterface {
     // YIELD FUNCTIONS
     // =================
     fn get_static_yield(&self, account_id: AccountId) -> Option<StaticYieldRecord>;
-    fn withdraw_supply_yield(&mut self, amount: Option<BorrowAssetAmount>) -> Promise;
     fn withdraw_static_yield(
         &mut self,
         borrow_asset_amount: Option<BorrowAssetAmount>,

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -246,32 +246,6 @@ impl MarketExternalInterface for Contract {
         self.static_yield.get(&account_id)
     }
 
-    fn withdraw_supply_yield(&mut self, amount: Option<BorrowAssetAmount>) -> Promise {
-        let predecessor = env::predecessor_account_id();
-        let Some(mut supply_position) = self.get_linked_supply_position_mut(predecessor.clone())
-        else {
-            env::panic_str("Supply position does not exist");
-        };
-
-        let amount =
-            amount.unwrap_or_else(|| supply_position.inner().borrow_asset_yield.get_total());
-
-        let withdrawn = supply_position
-            .record_yield_withdrawal(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Attempt to withdraw more yield than has accumulated")
-            });
-        if withdrawn.is_zero() {
-            env::panic_str("No rewards can be withdrawn");
-        }
-        drop(supply_position);
-
-        // TODO: Check for transfer success.
-        self.configuration
-            .borrow_asset
-            .transfer(predecessor, withdrawn)
-    }
-
     fn withdraw_static_yield(
         &mut self,
         borrow_asset_amount: Option<BorrowAssetAmount>,

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -134,10 +134,13 @@ async fn test_happy() {
                     u128::from(supply_position.borrow_asset_yield.get_total()),
                     80,
                 );
+                // Move the yield to the principal so that it can be withdrawn
+                c.harvest_yield(&supply_user, true).await;
 
                 let balance_before = c.borrow_asset_balance_of(supply_user.id()).await;
                 // Withdraw all
-                c.withdraw_supply_yield(&supply_user, None).await;
+                c.create_supply_withdrawal_request(&supply_user, 80).await;
+                c.execute_next_supply_withdrawal_request(&supply_user).await;
                 let balance_after = c.borrow_asset_balance_of(supply_user.id()).await;
 
                 assert_eq!(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -388,23 +388,6 @@ impl TestController {
             .unwrap();
     }
 
-    pub async fn withdraw_supply_yield(
-        &self,
-        supply_user: &Account,
-        amount: Option<u128>,
-    ) -> ExecutionSuccess {
-        eprintln!("{} withdrawing supply yield...", supply_user.id());
-        supply_user
-            .call(self.contract.id(), "withdraw_supply_yield")
-            .args_json(json!({
-                "amount": amount.map(U128),
-            }))
-            .transact()
-            .await
-            .unwrap()
-            .unwrap()
-    }
-
     pub async fn get_static_yield(&self, account_id: &AccountId) -> Option<StaticYieldRecord> {
         self.contract
             .view("get_static_yield")


### PR DESCRIPTION
We want to remove this for a few reasons:
1. The behavior can be closely approximated with a sequence of calls:
    - `harvest_yield(compounding = true)`
    - `create_supply_withdrawal_request(amount = <yield_amount>)`
    - `execute_next_supply_withdrawal_request()`
2. Allowing this behavior allows for a (small) bypass of the supply withdrawal fees & queue.
3. Reduces code & complexity.