### PR TITLE
Gas calculations

### DIFF
--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, marker::PhantomData};
 
 use near_contract_standards::fungible_token::core::ext_ft_core;
-use near_sdk::{env, json_types::U128, near, AccountId, NearToken, Promise};
+use near_sdk::{env, json_types::U128, near, AccountId, Gas, NearToken, Promise};
 
 use crate::number::Decimal;
 
@@ -22,9 +22,14 @@ enum FungibleAssetKind {
 }
 
 impl<T: AssetClass> FungibleAsset<T> {
+    /// Really depends on the implementation, but this should suffice, since
+    /// normal implementations use < 3TGas.
+    pub const GAS_FT_TRANSFER: Gas = Gas::from_tgas(6);
+
     pub fn transfer(&self, receiver_id: AccountId, amount: FungibleAssetAmount<T>) -> Promise {
         match self.kind {
             FungibleAssetKind::Nep141(ref contract_id) => ext_ft_core::ext(contract_id.clone())
+                .with_static_gas(Self::GAS_FT_TRANSFER)
                 .with_attached_deposit(NearToken::from_yoctonear(1))
                 .ft_transfer(receiver_id, u128::from(amount).into(), None),
         }

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -15,6 +15,7 @@ use crate::{
 /// This struct can only be constructed after accumulating interest on a
 /// borrow position. This serves as proof that the interest has accrued, so it
 /// is safe to perform certain other operations.
+#[derive(Clone, Copy)]
 pub struct InterestAccumulationProof(());
 
 #[cfg(test)]
@@ -351,9 +352,11 @@ impl<'a> LinkedBorrowPositionMut<'a> {
         Self(LinkedBorrowPosition::new(market, account_id, position))
     }
 
-    pub fn record_collateral_asset_deposit(&mut self, amount: CollateralAssetAmount) {
-        self.accumulate_interest();
-
+    pub fn record_collateral_asset_deposit(
+        &mut self,
+        _proof: InterestAccumulationProof,
+        amount: CollateralAssetAmount,
+    ) {
         self.position
             .increase_collateral_asset_deposit(amount)
             .unwrap_or_else(|| env::panic_str("Borrow position collateral asset overflow"));
@@ -365,9 +368,11 @@ impl<'a> LinkedBorrowPositionMut<'a> {
         .emit();
     }
 
-    pub fn record_collateral_asset_withdrawal(&mut self, amount: CollateralAssetAmount) {
-        self.accumulate_interest();
-
+    pub fn record_collateral_asset_withdrawal(
+        &mut self,
+        _proof: InterestAccumulationProof,
+        amount: CollateralAssetAmount,
+    ) {
         self.position
             .decrease_collateral_asset_deposit(amount)
             .unwrap_or_else(|| env::panic_str("Borrow position collateral asset underflow"));
@@ -381,11 +386,10 @@ impl<'a> LinkedBorrowPositionMut<'a> {
 
     pub fn record_borrow_asset_in_flight_start(
         &mut self,
+        _proof: InterestAccumulationProof,
         amount: BorrowAssetAmount,
         fees: BorrowAssetAmount,
     ) {
-        self.accumulate_interest();
-
         self.market
             .borrow_asset_in_flight
             .join(amount)
@@ -399,11 +403,10 @@ impl<'a> LinkedBorrowPositionMut<'a> {
 
     pub fn record_borrow_asset_in_flight_end(
         &mut self,
+        _proof: InterestAccumulationProof,
         amount: BorrowAssetAmount,
         fees: BorrowAssetAmount,
     ) {
-        self.accumulate_interest();
-
         // This should never panic, because a given amount of in-flight borrow
         // asset should always be added before it is removed.
         self.market

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -15,10 +15,3 @@ pub mod time_chunk;
 pub mod withdrawal_queue;
 
 pub const MS_IN_A_YEAR: u128 = 31_556_952_000; // 1000 * 60 * 60 * 24 * 365.2425
-
-#[macro_export]
-macro_rules! self_ext {
-    () => {
-        Self::ext(::near_sdk::env::current_account_id())
-    };
-}

--- a/common/src/market/balance_oracle_configuration.rs
+++ b/common/src/market/balance_oracle_configuration.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use near_sdk::{near, AccountId, Promise};
+use near_sdk::{near, AccountId, Gas, Promise};
 
 use crate::{
     asset::{AssetClass, BorrowAsset, CollateralAsset, FungibleAssetAmount},
@@ -20,11 +20,16 @@ pub struct BalanceOracleConfiguration {
 }
 
 impl BalanceOracleConfiguration {
+    // Usually seems to take 1.64 TGas.
+    pub const GAS_RETRIEVE_PRICE_PAIR: Gas = Gas::from_tgas(3);
+
     pub fn retrieve_price_pair(&self) -> Promise {
-        ext_pyth::ext(self.account_id.clone()).list_ema_prices_no_older_than(
-            vec![self.borrow_asset_price_id, self.collateral_asset_price_id],
-            u64::from(self.price_maximum_age_s),
-        )
+        ext_pyth::ext(self.account_id.clone())
+            .with_static_gas(Self::GAS_RETRIEVE_PRICE_PAIR)
+            .list_ema_prices_no_older_than(
+                vec![self.borrow_asset_price_id, self.collateral_asset_price_id],
+                u64::from(self.price_maximum_age_s),
+            )
     }
 
     /// # Errors

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -46,3 +46,6 @@ workspace = true
 
 [[example]]
 name = "gas_report"
+
+[[example]]
+name = "receipt_gas"

--- a/contract/market/examples/receipt_gas.rs
+++ b/contract/market/examples/receipt_gas.rs
@@ -1,0 +1,34 @@
+use templar_common::fee::Fee;
+use test_utils::{setup_everything, SetupEverything};
+
+#[tokio::main]
+async fn main() {
+    let SetupEverything {
+        c,
+        supply_user,
+        borrow_user,
+        liquidator_user,
+        insurance_yield_user,
+        ..
+    } = setup_everything(|c| {
+        c.borrow_origination_fee = Fee::zero();
+    })
+    .await;
+
+    c.supply(&supply_user, 20_000).await;
+    c.collateralize(&borrow_user, 13_000).await;
+    c.borrow(&borrow_user, 10_000).await;
+
+    c.set_collateral_asset_price(0.85).await;
+
+    c.liquidate(&liquidator_user, borrow_user.id(), 11_000)
+        .await;
+
+    let r = c
+        .withdraw_static_yield(&insurance_yield_user, None, None)
+        .await;
+
+    for receipt in r.receipt_outcomes() {
+        eprintln!("{}: {}", receipt.executor_id, receipt.gas_burnt);
+    }
+}

--- a/contract/market/src/impl_ft_receiver.rs
+++ b/contract/market/src/impl_ft_receiver.rs
@@ -3,7 +3,6 @@ use near_sdk::{env, json_types::U128, near, AccountId, PromiseOrValue};
 use templar_common::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
     market::{LiquidateMsg, Nep141MarketDepositMessage},
-    self_ext,
 };
 
 use crate::{Contract, ContractExt};
@@ -67,7 +66,10 @@ impl FungibleTokenReceiver for Contract {
                         .balance_oracle
                         .retrieve_price_pair()
                         .then(
-                            self_ext!().liquidate_ft_transfer_call_01_consume_oracle_response(
+                            self_ext!(
+                                Self::GAS_LIQUIDATE_FT_TRANSFER_CALL_01_CONSUME_ORACLE_RESPONSE
+                            )
+                            .liquidate_ft_transfer_call_01_consume_oracle_response(
                                 sender_id, account_id, amount,
                             ),
                         ),

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -238,7 +238,8 @@ impl Contract {
         }
     }
 
-    pub const GAS_AFTER_EXECUTE_NEXT_WITHDRAWAL: Gas = Gas::from_tgas(5);
+    // ~2.4 Tgas
+    pub const GAS_AFTER_EXECUTE_NEXT_WITHDRAWAL: Gas = Gas::from_tgas(4);
 
     #[private]
     pub fn after_execute_next_withdrawal(&mut self, withdrawal_resolution: WithdrawalResolution) {

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -1,11 +1,12 @@
 use near_sdk::{
-    env, json_types::U128, near, require, AccountId, Promise, PromiseError, PromiseResult,
+    env, json_types::U128, near, require, AccountId, Gas, Promise, PromiseError, PromiseResult,
 };
 use templar_common::{
-    asset::{BorrowAssetAmount, CollateralAssetAmount},
+    asset::{
+        BorrowAsset, BorrowAssetAmount, CollateralAsset, CollateralAssetAmount, FungibleAsset,
+    },
     market::{PricePair, WithdrawalResolution},
     oracle::pyth::OracleResponse,
-    self_ext,
 };
 
 use crate::{Contract, ContractExt};
@@ -34,7 +35,8 @@ impl Contract {
         // that sort, which is just an additional pre condition check.
         // -- https://github.com/Templar-Protocol/contract-mvp/pull/6#discussion_r1923871982
         let mut borrow_position = self.get_or_create_linked_borrow_position_mut(account_id);
-        borrow_position.record_collateral_asset_deposit(amount);
+        let proof = borrow_position.accumulate_interest();
+        borrow_position.record_collateral_asset_deposit(proof, amount);
     }
 
     /// Returns the amount that should be returned to the account.
@@ -123,6 +125,10 @@ impl Contract {
 /// External helpers.
 #[near]
 impl Contract {
+    pub const GAS_BORROW_01_CONSUME_PRICE: Gas = Gas::from_tgas(9)
+        .saturating_add(FungibleAsset::<BorrowAsset>::GAS_FT_TRANSFER)
+        .saturating_add(Self::GAS_BORROW_02_FINALIZE);
+
     #[private]
     pub fn borrow_01_consume_price(
         &mut self,
@@ -156,7 +162,8 @@ impl Contract {
             env::panic_str("No borrower record. Please deposit collateral first.");
         };
 
-        borrow_position.record_borrow_asset_in_flight_start(amount, fees);
+        let proof = borrow_position.accumulate_interest();
+        borrow_position.record_borrow_asset_in_flight_start(proof, amount, fees);
 
         require!(
             borrow_position.is_within_minimum_initial_collateral_ratio(&price_pair),
@@ -173,8 +180,13 @@ impl Contract {
         self.configuration
             .borrow_asset
             .transfer(account_id.clone(), amount)
-            .then(self_ext!().borrow_02_finalize(account_id, amount, fees))
+            .then(
+                self_ext!(Self::GAS_BORROW_02_FINALIZE)
+                    .borrow_02_finalize(account_id, amount, fees),
+            )
     }
+
+    pub const GAS_BORROW_02_FINALIZE: Gas = Gas::from_tgas(9);
 
     #[private]
     pub fn borrow_02_finalize(
@@ -189,7 +201,8 @@ impl Contract {
             env::panic_str("Invariant violation: borrow position does not exist after transfer.");
         };
 
-        borrow_position.record_borrow_asset_in_flight_end(amount, fees);
+        let proof = borrow_position.accumulate_interest();
+        borrow_position.record_borrow_asset_in_flight_end(proof, amount, fees);
 
         match env::promise_result(0) {
             PromiseResult::Successful(_) => {
@@ -197,7 +210,6 @@ impl Contract {
                 //
                 // Borrow position has already been created: finalize
                 // withdrawal record.
-                let proof = borrow_position.accumulate_interest();
                 borrow_position.record_borrow_asset_withdrawal(proof, amount, fees);
             }
             PromiseResult::Failed => {
@@ -225,6 +237,8 @@ impl Contract {
             }
         }
     }
+
+    pub const GAS_AFTER_EXECUTE_NEXT_WITHDRAWAL: Gas = Gas::from_tgas(5);
 
     #[private]
     pub fn after_execute_next_withdrawal(&mut self, withdrawal_resolution: WithdrawalResolution) {
@@ -265,6 +279,8 @@ impl Contract {
                 if let Some(mut supply_position) =
                     self.get_linked_supply_position_mut(withdrawal_resolution.account_id.clone())
                 {
+                    // This should not do very much since we also accumulate
+                    // yield in the initial function call of execute_next_supply_withdrawal_request()
                     let proof = supply_position.accumulate_yield();
                     let mut amount = withdrawal_resolution.amount_to_account;
                     amount.join(withdrawal_resolution.amount_to_fees);
@@ -273,6 +289,11 @@ impl Contract {
             }
         }
     }
+
+    // ~3.3 Tgas
+    pub const GAS_LIQUIDATE_FT_TRANSFER_CALL_01_CONSUME_ORACLE_RESPONSE: Gas = Gas::from_tgas(4)
+        .saturating_add(FungibleAsset::<CollateralAsset>::GAS_FT_TRANSFER)
+        .saturating_add(Self::GAS_LIQUIDATE_FT_TRANSFER_CALL_02_FINALIZE);
 
     #[private]
     pub fn liquidate_ft_transfer_call_01_consume_oracle_response(
@@ -294,12 +315,14 @@ impl Contract {
         self.configuration
             .collateral_asset
             .transfer(liquidator_id.clone(), liquidated_collateral)
-            .then(self_ext!().liquidate_ft_transfer_call_02_finalize(
-                liquidator_id,
-                account_id,
-                amount,
-            ))
+            .then(
+                self_ext!(Self::GAS_LIQUIDATE_FT_TRANSFER_CALL_02_FINALIZE)
+                    .liquidate_ft_transfer_call_02_finalize(liquidator_id, account_id, amount),
+            )
     }
+
+    // ~3.2 Tgas
+    pub const GAS_LIQUIDATE_FT_TRANSFER_CALL_02_FINALIZE: Gas = Gas::from_tgas(4);
 
     /// Called during liquidation process; checks whether the transfer of
     /// collateral to the liquidator was successful.
@@ -320,6 +343,11 @@ impl Contract {
         refund_to_liquidator.into()
     }
 
+    // ~7.25 Tgas
+    pub const GAS_WITHDRAW_COLLATERAL_01_CONSUME_PRICE: Gas = Gas::from_tgas(9)
+        .saturating_add(FungibleAsset::<CollateralAsset>::GAS_FT_TRANSFER)
+        .saturating_add(Self::GAS_WITHDRAW_COLLATERAL_02_FINALIZE);
+
     #[private]
     pub fn withdraw_collateral_01_consume_price(
         &mut self,
@@ -338,7 +366,8 @@ impl Contract {
             env::panic_str("No borrower record. Please deposit collateral first.");
         };
 
-        borrow_position.record_collateral_asset_withdrawal(amount);
+        let proof = borrow_position.accumulate_interest();
+        borrow_position.record_collateral_asset_withdrawal(proof, amount);
 
         require!(
             borrow_position.is_within_minimum_collateral_ratio(&price_pair),
@@ -350,8 +379,14 @@ impl Contract {
         self.configuration
             .collateral_asset
             .transfer(account_id.clone(), amount)
-            .then(self_ext!().withdraw_collateral_02_finalize(account_id, amount))
+            .then(
+                self_ext!(Self::GAS_WITHDRAW_COLLATERAL_02_FINALIZE)
+                    .withdraw_collateral_02_finalize(account_id, amount),
+            )
     }
+
+    // ~1.96 Tgas
+    pub const GAS_WITHDRAW_COLLATERAL_02_FINALIZE: Gas = Gas::from_tgas(3);
 
     #[private]
     pub fn withdraw_collateral_02_finalize(
@@ -370,9 +405,13 @@ impl Contract {
                 env::panic_str("Invariant violation: Borrow position must exist after collateral withdrawal failure.");
             };
 
-            borrow_position.record_collateral_asset_deposit(amount);
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(proof, amount);
         }
     }
+
+    // ~2.0 Tgas
+    pub const GAS_WITHDRAW_STATIC_YIELD_01_FINALIZE: Gas = Gas::from_tgas(3);
 
     #[private]
     pub fn withdraw_static_yield_01_finalize(

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -5,7 +5,6 @@ use templar_common::{
     market::{BorrowAssetMetrics, MarketConfiguration, MarketExternalInterface},
     number::Decimal,
     oracle::pyth::OracleResponse,
-    self_ext,
     snapshot::Snapshot,
     static_yield::StaticYieldRecord,
     supply::SupplyPosition,
@@ -98,7 +97,10 @@ impl MarketExternalInterface for Contract {
         self.configuration
             .balance_oracle
             .retrieve_price_pair()
-            .then(self_ext!().borrow_01_consume_price(account_id, amount))
+            .then(
+                self_ext!(Self::GAS_BORROW_01_CONSUME_PRICE)
+                    .borrow_01_consume_price(account_id, amount),
+            )
     }
 
     fn withdraw_collateral(&mut self, amount: CollateralAssetAmount) -> Promise {
@@ -115,20 +117,27 @@ impl MarketExternalInterface for Contract {
             .is_zero()
         {
             // No need to retrieve prices, since there is zero liability.
-            borrow_position.record_collateral_asset_withdrawal(amount);
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_withdrawal(proof, amount);
             drop(borrow_position);
 
             self.configuration
                 .collateral_asset
                 .transfer(account_id.clone(), amount)
-                .then(self_ext!().withdraw_collateral_02_finalize(account_id, amount))
+                .then(
+                    self_ext!(Self::GAS_WITHDRAW_COLLATERAL_02_FINALIZE)
+                        .withdraw_collateral_02_finalize(account_id, amount),
+                )
         } else {
             drop(borrow_position);
             // They still have liability, so we need to check prices.
             self.configuration
                 .balance_oracle
                 .retrieve_price_pair()
-                .then(self_ext!().withdraw_collateral_01_consume_price(account_id, amount))
+                .then(
+                    self_ext!(Self::GAS_WITHDRAW_COLLATERAL_01_CONSUME_PRICE)
+                        .withdraw_collateral_01_consume_price(account_id, amount),
+                )
         }
     }
 
@@ -192,7 +201,10 @@ impl MarketExternalInterface for Contract {
                     withdrawal_resolution.account_id.clone(),
                     withdrawal_resolution.amount_to_account,
                 )
-                .then(self_ext!().after_execute_next_withdrawal(withdrawal_resolution)),
+                .then(
+                    self_ext!(Self::GAS_AFTER_EXECUTE_NEXT_WITHDRAWAL)
+                        .after_execute_next_withdrawal(withdrawal_resolution),
+                ),
         )
     }
 
@@ -299,11 +311,12 @@ impl MarketExternalInterface for Contract {
             _ => env::panic_str("No yield to withdraw"),
         }
         .then(
-            Self::ext(env::current_account_id()).withdraw_static_yield_01_finalize(
-                predecessor,
-                borrow_asset_amount,
-                collateral_asset_amount,
-            ),
+            self_ext!(Self::GAS_WITHDRAW_STATIC_YIELD_01_FINALIZE)
+                .withdraw_static_yield_01_finalize(
+                    predecessor,
+                    borrow_asset_amount,
+                    collateral_asset_amount,
+                ),
         )
     }
 }

--- a/contract/market/src/lib.rs
+++ b/contract/market/src/lib.rs
@@ -5,6 +5,12 @@ use std::ops::{Deref, DerefMut};
 use near_sdk::{near, BorshStorageKey, PanicOnDefault};
 use templar_common::market::{Market, MarketConfiguration};
 
+macro_rules! self_ext {
+    ($gas:expr) => {
+        Self::ext(::near_sdk::env::current_account_id()).with_static_gas($gas)
+    };
+}
+
 #[derive(BorshStorageKey)]
 #[near(serializers = [borsh])]
 enum StorageKey {

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -382,7 +382,7 @@ impl TestController {
                 "borrow_asset_amount": borrow_asset_amount,
                 "collateral_asset_amount": collateral_asset_amount,
             }))
-            .gas(Gas::from_tgas(30))
+            .gas(Gas::from_tgas(20))
             .transact()
             .await
             .unwrap()
@@ -412,6 +412,7 @@ impl TestController {
             .args_json(json!({
                 "amount": U128(amount),
             }))
+            .gas(Gas::from_tgas(20))
             .transact()
             .await
             .unwrap()
@@ -459,7 +460,10 @@ impl TestController {
             .unwrap()
     }
 
-    pub async fn execute_next_supply_withdrawal_request(&self, account: &Account) {
+    pub async fn execute_next_supply_withdrawal_request(
+        &self,
+        account: &Account,
+    ) -> ExecutionSuccess {
         eprintln!(
             "{} executing next supply withdrawal request...",
             account.id(),
@@ -467,10 +471,11 @@ impl TestController {
         account
             .call(self.contract.id(), "execute_next_supply_withdrawal_request")
             .args_json(json!({}))
+            .gas(Gas::from_tgas(15))
             .transact()
             .await
             .unwrap()
-            .unwrap();
+            .unwrap()
     }
 
     pub async fn liquidate(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -3,7 +3,7 @@ use std::{path::Path, str::FromStr};
 use near_sdk::{
     json_types::{I64, U128, U64},
     serde_json::{self, json},
-    AccountId, NearToken,
+    AccountId, Gas, NearToken,
 };
 use near_workspaces::{
     network::Sandbox, prelude::*, result::ExecutionSuccess, Account, Contract, DevNetwork, Worker,
@@ -374,7 +374,7 @@ impl TestController {
         account: &Account,
         borrow_asset_amount: Option<BorrowAssetAmount>,
         collateral_asset_amount: Option<CollateralAssetAmount>,
-    ) {
+    ) -> ExecutionSuccess {
         eprintln!("{} withdrawing static yield...", account.id());
         account
             .call(self.contract.id(), "withdraw_static_yield")
@@ -382,10 +382,11 @@ impl TestController {
                 "borrow_asset_amount": borrow_asset_amount,
                 "collateral_asset_amount": collateral_asset_amount,
             }))
+            .gas(Gas::from_tgas(30))
             .transact()
             .await
             .unwrap()
-            .unwrap();
+            .unwrap()
     }
 
     pub async fn get_static_yield(&self, account_id: &AccountId) -> Option<StaticYieldRecord> {
@@ -477,7 +478,7 @@ impl TestController {
         liquidator_user: &Account,
         account_id: &AccountId,
         borrow_asset_amount: u128,
-    ) {
+    ) -> ExecutionSuccess {
         eprintln!(
             "{} executing liquidation against {} for {}...",
             liquidator_user.id(),
@@ -493,7 +494,7 @@ impl TestController {
             }))
             .unwrap(),
         )
-        .await;
+        .await
     }
 
     pub async fn mint_asset(&self, ft_id: &AccountId, receiver: &Account, amount: u128) {


### PR DESCRIPTION
Also slightly changes the semantics of the `InterestAccumulationProof` type - it now implements `Copy` so it can be reused during a single receipt. This is okay because `accumulate_interest` will not be affected by changes occurring in the current snapshot.