### PR TITLE
Adds `snapshot_limit` optional parameter to `harvest_yield` function

### DIFF
--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -226,7 +226,10 @@ impl<M: Deref<Target = Market>> LinkedBorrowPosition<M> {
         interest.to_u128_ceil().unwrap().into()
     }
 
-    pub(crate) fn calculate_interest(&self, limit: u32) -> AccumulationRecord<BorrowAsset> {
+    pub(crate) fn calculate_interest(
+        &self,
+        snapshot_limit: u32,
+    ) -> AccumulationRecord<BorrowAsset> {
         let principal: Decimal = self.position.get_borrow_asset_principal().into();
         let mut next_snapshot_index = self.position.borrow_asset_fees.get_next_snapshot_index();
 
@@ -242,7 +245,7 @@ impl<M: Deref<Target = Market>> LinkedBorrowPosition<M> {
             .iter()
             .enumerate()
             .skip(next_snapshot_index as usize)
-            .take(limit as usize)
+            .take(snapshot_limit as usize)
             .map(|(i, s): (usize, &Snapshot)| (i as u32, s))
             .peekable();
 
@@ -474,10 +477,10 @@ impl<'a> LinkedBorrowPositionMut<'a> {
         liability_reduction.amount_remaining
     }
 
-    pub fn accumulate_interest(&mut self) -> InterestAccumulationProof {
+    pub fn accumulate_interest_partial(&mut self, snapshot_limit: u32) {
         self.market.snapshot();
 
-        let accumulation_record = self.calculate_interest(u32::MAX);
+        let accumulation_record = self.calculate_interest(snapshot_limit);
 
         if !accumulation_record.amount.is_zero() {
             MarketEvent::InterestAccumulated {
@@ -490,7 +493,10 @@ impl<'a> LinkedBorrowPositionMut<'a> {
         self.position
             .borrow_asset_fees
             .accumulate(accumulation_record);
+    }
 
+    pub fn accumulate_interest(&mut self) -> InterestAccumulationProof {
+        self.accumulate_interest_partial(u32::MAX);
         InterestAccumulationProof(())
     }
 

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -21,7 +21,7 @@ pub trait MarketExternalInterface {
 
     fn get_configuration(&self) -> MarketConfiguration;
     fn get_snapshots_len(&self) -> u32;
-    fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot>;
+    fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot>;
     fn get_borrow_asset_metrics(&self) -> BorrowAssetMetrics;
 
     fn list_borrows(&self, offset: Option<u32>, count: Option<u32>) -> Vec<AccountId>;

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -20,6 +20,7 @@ pub trait MarketExternalInterface {
     // ========================
 
     fn get_configuration(&self) -> MarketConfiguration;
+    fn get_snapshots_len(&self) -> u32;
     fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot>;
     fn get_borrow_asset_metrics(&self) -> BorrowAssetMetrics;
 

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -79,7 +79,7 @@ pub trait MarketExternalInterface {
     /// harvested in previous, non-compounding `harvest_yield` calls) is
     /// deposited to the supply record, so it will contribute to future yield
     /// calculations.
-    fn harvest_yield(&mut self, compounding: Option<bool>);
+    fn harvest_yield(&mut self, compounding: Option<bool>, snapshot_limit: Option<u32>);
 
     /// This value is an *expected average over time*.
     /// Supply positions actually earn all of their yield the instant it is

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -51,7 +51,7 @@ pub trait MarketExternalInterface {
     /// Applies interest to the predecessor's borrow record.
     /// Not likely to be used in real life, since there it does not affect the
     /// final interest calculation, and rounds fractional interest UP.
-    fn apply_interest(&mut self);
+    fn apply_interest(&mut self, snapshot_limit: Option<u32>);
 
     fn get_last_interest_rate(&self) -> Decimal;
 

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -1,6 +1,6 @@
 use std::ops::{Deref, DerefMut};
 
-use near_sdk::{env, json_types::U64, near, AccountId};
+use near_sdk::{env, json_types::U64, near, require, AccountId};
 
 use crate::{
     accumulator::{AccumulationRecord, Accumulator},
@@ -98,7 +98,8 @@ impl<M> LinkedSupplyPosition<M> {
 
 impl<M: Deref<Target = Market>> LinkedSupplyPosition<M> {
     pub fn with_pending_yield_estimate(&mut self) {
-        self.position.borrow_asset_yield.pending_estimate = self.calculate_yield().get_amount();
+        self.position.borrow_asset_yield.pending_estimate =
+            self.calculate_yield(u32::MAX).get_amount();
         self.position
             .borrow_asset_yield
             .pending_estimate
@@ -136,7 +137,7 @@ impl<M: Deref<Target = Market>> LinkedSupplyPosition<M> {
         estimate_current_snapshot.to_u128_floor().unwrap().into()
     }
 
-    pub fn calculate_yield(&self) -> AccumulationRecord<BorrowAsset> {
+    pub fn calculate_yield(&self, snapshot_limit: u32) -> AccumulationRecord<BorrowAsset> {
         let mut next_snapshot_index = self.position.borrow_asset_yield.get_next_snapshot_index();
 
         let amount: Decimal = self.position.get_borrow_asset_deposit().into();
@@ -151,7 +152,11 @@ impl<M: Deref<Target = Market>> LinkedSupplyPosition<M> {
             clippy::cast_possible_truncation,
             reason = "Assume # of snapshots is never >u32::MAX"
         )]
-        for (i, snapshot) in it.enumerate().skip(next_snapshot_index as usize) {
+        for (i, snapshot) in it
+            .enumerate()
+            .skip(next_snapshot_index as usize)
+            .take(snapshot_limit as usize)
+        {
             accumulated += amount * Decimal::from(snapshot.yield_distribution)
                 / Decimal::from(snapshot.deposited);
 
@@ -198,10 +203,11 @@ impl<'a> LinkedSupplyPositionMut<'a> {
         Self(LinkedSupplyPosition::new(market, account_id, position))
     }
 
-    pub fn accumulate_yield(&mut self) -> YieldAccumulationProof {
+    pub fn accumulate_yield_partial(&mut self, snapshot_limit: u32) {
+        require!(snapshot_limit > 0, "snapshot_limit must be nonzero");
         self.market.snapshot();
 
-        let accumulation_record = self.calculate_yield();
+        let accumulation_record = self.calculate_yield(snapshot_limit);
 
         if !accumulation_record.amount.is_zero() {
             MarketEvent::YieldAccumulated {
@@ -214,7 +220,10 @@ impl<'a> LinkedSupplyPositionMut<'a> {
         self.position
             .borrow_asset_yield
             .accumulate(accumulation_record);
+    }
 
+    pub fn accumulate_yield(&mut self) -> YieldAccumulationProof {
+        self.accumulate_yield_partial(u32::MAX);
         YieldAccumulationProof(())
     }
 

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -1,15 +1,20 @@
+#![allow(clippy::unwrap_used)]
+
 use std::collections::HashMap;
 
 use near_sdk::{json_types::U64, Gas};
-use templar_common::time_chunk::TimeChunkConfiguration;
+use templar_common::{
+    fee::Fee, interest_rate_strategy::InterestRateStrategy, number::Decimal,
+    time_chunk::TimeChunkConfiguration,
+};
 use test_utils::{setup_everything, SetupEverything};
 use tokio::task::JoinSet;
 
 #[allow(clippy::unwrap_used)]
 #[tokio::main]
 async fn main() {
-    const STEP: usize = 10;
-    const COUNT: usize = 3;
+    const STEP: usize = 100;
+    const COUNT: usize = 4;
 
     let mut handles = JoinSet::new();
 
@@ -36,6 +41,30 @@ async fn main() {
     for i in 0..COUNT {
         println!("| {} | {} |", i * STEP, results.get(&i).unwrap());
     }
+
+    // Estimate `snapshot_limit` parameter of `harvest_yield` function that
+    // will maximize iterations while safely staying within the maximum gas limit.
+    let at_0 = results.get(&0).unwrap();
+    let max_snapshots = (COUNT - 1) * STEP;
+    let at_max_snapshots = results.get(&max_snapshots).unwrap();
+    let snapshot_limit = calculate_snapshot_limit(
+        *at_0,
+        max_snapshots as u64,
+        *at_max_snapshots,
+        Gas::from_tgas(285), // Max gas is 300, so this is a bit conservative
+    );
+    println!();
+    println!("Estimated `snapshot_limit`: {snapshot_limit}");
+}
+
+fn calculate_snapshot_limit(
+    at_0: Gas,
+    max_snapshots: u64,
+    at_max_snapshots: Gas,
+    target_gas: Gas,
+) -> u64 {
+    (target_gas.as_gas() - at_0.as_gas()) * max_snapshots
+        / (at_max_snapshots.as_gas() - at_0.as_gas())
 }
 
 async fn harvest_yield_gas(iterations: usize) -> Gas {
@@ -45,11 +74,14 @@ async fn harvest_yield_gas(iterations: usize) -> Gas {
         borrow_user,
         ..
     } = setup_everything(|c| {
+        c.borrow_interest_rate_strategy =
+            InterestRateStrategy::linear(Decimal::ZERO, Decimal::ZERO).unwrap();
+        c.borrow_origination_fee = Fee::zero();
         c.time_chunk_configuration = TimeChunkConfiguration::BlockHeight { divisor: U64(1) };
     })
     .await;
 
-    c.supply(&supply_user, 1200).await;
+    c.supply(&supply_user, 120_000).await;
     c.collateralize(&borrow_user, 2000).await;
 
     for _ in 0..iterations {

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -28,7 +28,7 @@ async fn main() {
 
     c.supply(&supply_user, 120_000).await;
     let harvest_yield_0 = c.harvest_yield_execution(&supply_user, true).await;
-    let snapshot_count_before = c.get_snapshots(None, None).await.len();
+    let snapshot_count_before = c.list_snapshots(None, None).await.len();
     c.collateralize(&borrow_user, 2000).await;
     c.collateralize(&borrow_user_2, 2000).await;
 
@@ -43,7 +43,7 @@ async fn main() {
     let apply_interest_max = c.apply_interest(&borrow_user_2, None).await;
     let harvest_yield_max = c.harvest_yield_execution(&supply_user, true).await;
 
-    let snapshot_count_after = c.get_snapshots(None, None).await.len();
+    let snapshot_count_after = c.list_snapshots(None, None).await.len();
     let snapshot_count = snapshot_count_after - snapshot_count_before;
     eprintln!("Snapshot count: {snapshot_count}");
     let target_gas = Gas::from_tgas(285); // Max gas is 300, so this is a bit conservative

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -1,77 +1,22 @@
 #![allow(clippy::unwrap_used)]
 
-use std::collections::HashMap;
-
 use near_sdk::{json_types::U64, Gas};
 use templar_common::{
     fee::Fee, interest_rate_strategy::InterestRateStrategy, number::Decimal,
     time_chunk::TimeChunkConfiguration,
 };
 use test_utils::{setup_everything, SetupEverything};
-use tokio::task::JoinSet;
 
 #[allow(clippy::unwrap_used)]
 #[tokio::main]
 async fn main() {
-    const STEP: usize = 100;
-    const COUNT: usize = 4;
+    const ITERATIONS: usize = 128;
 
-    let mut handles = JoinSet::new();
-
-    for i in 0..COUNT {
-        handles.spawn(async move {
-            let gas = harvest_yield_gas(i * STEP).await;
-            eprintln!("Completed {} iterations", i * STEP);
-            (i, gas)
-        });
-    }
-
-    let results = handles
-        .join_all()
-        .await
-        .into_iter()
-        .collect::<HashMap<_, _>>();
-
-    println!("**Gas Report**");
-    println!();
-    println!("`harvest_yield`");
-    println!();
-    println!("| Iterations | Gas  |");
-    println!("| ---------: | ---: |");
-    for i in 0..COUNT {
-        println!("| {} | {} |", i * STEP, results.get(&i).unwrap());
-    }
-
-    // Estimate `snapshot_limit` parameter of `harvest_yield` function that
-    // will maximize iterations while safely staying within the maximum gas limit.
-    let at_0 = results.get(&0).unwrap();
-    let max_snapshots = (COUNT - 1) * STEP;
-    let at_max_snapshots = results.get(&(COUNT - 1)).unwrap();
-    let snapshot_limit = calculate_snapshot_limit(
-        *at_0,
-        max_snapshots as u64,
-        *at_max_snapshots,
-        Gas::from_tgas(285), // Max gas is 300, so this is a bit conservative
-    );
-    println!();
-    println!("Estimated `snapshot_limit`: {snapshot_limit}");
-}
-
-fn calculate_snapshot_limit(
-    at_0: Gas,
-    max_snapshots: u64,
-    at_max_snapshots: Gas,
-    target_gas: Gas,
-) -> u64 {
-    (target_gas.as_gas() - at_0.as_gas()) * max_snapshots
-        / (at_max_snapshots.as_gas() - at_0.as_gas())
-}
-
-async fn harvest_yield_gas(iterations: usize) -> Gas {
     let SetupEverything {
         c,
         supply_user,
         borrow_user,
+        borrow_user_2,
         ..
     } = setup_everything(|c| {
         c.borrow_interest_rate_strategy =
@@ -82,14 +27,76 @@ async fn harvest_yield_gas(iterations: usize) -> Gas {
     .await;
 
     c.supply(&supply_user, 120_000).await;
+    let harvest_yield_0 = c.harvest_yield_execution(&supply_user, true).await;
+    let snapshot_count_before = c.get_snapshots(None, None).await.len();
     c.collateralize(&borrow_user, 2000).await;
+    c.collateralize(&borrow_user_2, 2000).await;
 
-    for _ in 0..iterations {
+    c.borrow(&borrow_user_2, 1000).await;
+    let apply_interest_0 = c.apply_interest(&borrow_user_2, None).await;
+
+    for _ in 0..ITERATIONS {
         c.borrow(&borrow_user, 1000).await;
         c.repay(&borrow_user, 1100).await;
     }
 
-    c.harvest_yield_execution(&supply_user, true)
-        .await
-        .total_gas_burnt
+    let apply_interest_max = c.apply_interest(&borrow_user_2, None).await;
+    let harvest_yield_max = c.harvest_yield_execution(&supply_user, true).await;
+
+    let snapshot_count_after = c.get_snapshots(None, None).await.len();
+    let snapshot_count = snapshot_count_after - snapshot_count_before;
+    eprintln!("Snapshot count: {snapshot_count}");
+    let target_gas = Gas::from_tgas(285); // Max gas is 300, so this is a bit conservative
+
+    let harvest_yield_snapshot_limit = calculate_snapshot_limit(
+        harvest_yield_0.total_gas_burnt,
+        snapshot_count as u64,
+        harvest_yield_max.total_gas_burnt,
+        target_gas,
+    );
+
+    let apply_interest_snapshot_limit = calculate_snapshot_limit(
+        apply_interest_0.total_gas_burnt,
+        snapshot_count as u64,
+        apply_interest_max.total_gas_burnt,
+        target_gas,
+    );
+
+    println!("**Gas Report**");
+    println!();
+    println!("`harvest_yield`");
+    println!();
+    println!("| Iterations | Gas  |");
+    println!("| ---------: | ---: |");
+    println!("| 0 | {} |", harvest_yield_0.total_gas_burnt);
+    println!(
+        "| {snapshot_count} | {} |",
+        harvest_yield_max.total_gas_burnt
+    );
+    println!();
+    println!("Estimated snapshot limit: {harvest_yield_snapshot_limit}");
+    println!();
+    println!("`apply_interest`");
+    println!();
+    println!("| Iterations | Gas  |");
+    println!("| ---------: | ---: |");
+    println!("| 0 | {} |", apply_interest_0.total_gas_burnt);
+    println!(
+        "| {snapshot_count} | {} |",
+        apply_interest_max.total_gas_burnt
+    );
+    println!();
+    println!("Estimated snapshot limit: {apply_interest_snapshot_limit}");
+}
+
+/// Estimate `snapshot_limit` that will maximize iterations while safely
+/// staying within the gas limit.
+fn calculate_snapshot_limit(
+    at_0: Gas,
+    max_snapshots: u64,
+    at_max_snapshots: Gas,
+    target_gas: Gas,
+) -> u64 {
+    (target_gas.as_gas() - at_0.as_gas()) * max_snapshots
+        / (at_max_snapshots.as_gas() - at_0.as_gas())
 }

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -46,7 +46,7 @@ async fn main() {
     // will maximize iterations while safely staying within the maximum gas limit.
     let at_0 = results.get(&0).unwrap();
     let max_snapshots = (COUNT - 1) * STEP;
-    let at_max_snapshots = results.get(&max_snapshots).unwrap();
+    let at_max_snapshots = results.get(&(COUNT - 1)).unwrap();
     let snapshot_limit = calculate_snapshot_limit(
         *at_0,
         max_snapshots as u64,

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -20,6 +20,10 @@ impl MarketExternalInterface for Contract {
         self.configuration.clone()
     }
 
+    fn get_snapshots_len(&self) -> u32 {
+        self.snapshots.len()
+    }
+
     fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot> {
         let offset = offset.map_or(0, |o| o as usize);
         let count = count.map_or(usize::MAX, |c| c as usize);

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -207,15 +207,26 @@ impl MarketExternalInterface for Contract {
         self.withdrawal_queue.get_status()
     }
 
-    fn harvest_yield(&mut self, compounding: Option<bool>) {
+    fn harvest_yield(&mut self, compounding: Option<bool>, snapshot_limit: Option<u32>) {
         let predecessor = env::predecessor_account_id();
-        if let Some(mut supply_position) = self.get_linked_supply_position_mut(predecessor) {
-            let proof = supply_position.accumulate_yield();
-            if compounding.unwrap_or(false) {
+        let Some(mut supply_position) = self.get_linked_supply_position_mut(predecessor) else {
+            return;
+        };
+
+        match (compounding.unwrap_or(false), snapshot_limit) {
+            (true, Some(_)) => env::panic_str("`compounding` and `snapshot_limit` are exclusive"),
+            (true, None) => {
+                let proof = supply_position.accumulate_yield();
                 // Compound yield by withdrawing it and recording it as an immediate deposit.
                 let total_yield = supply_position.inner().borrow_asset_yield.get_total();
                 supply_position.record_yield_withdrawal(total_yield);
                 supply_position.record_deposit(proof, total_yield, env::block_timestamp_ms());
+            }
+            (false, Some(snapshot_limit)) => {
+                supply_position.accumulate_yield_partial(snapshot_limit);
+            }
+            _ => {
+                supply_position.accumulate_yield();
             }
         }
     }

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -24,7 +24,7 @@ impl MarketExternalInterface for Contract {
         self.snapshots.len()
     }
 
-    fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot> {
+    fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot> {
         let offset = offset.map_or(0, |o| o as usize);
         let count = count.map_or(usize::MAX, |c| c as usize);
         self.snapshots

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -132,10 +132,10 @@ impl MarketExternalInterface for Contract {
         }
     }
 
-    fn apply_interest(&mut self) {
+    fn apply_interest(&mut self, snapshot_limit: Option<u32>) {
         let predecessor = env::predecessor_account_id();
         if let Some(mut borrow_position) = self.get_linked_borrow_position_mut(predecessor) {
-            borrow_position.accumulate_interest();
+            borrow_position.accumulate_interest_partial(snapshot_limit.unwrap_or(u32::MAX));
         }
     }
 

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -36,6 +36,15 @@ async fn test_happy() {
 
     assert!(configuration.borrow_mcr.near_equal(dec!("1.2")));
 
+    let snapshots_len = c.get_snapshots_len().await;
+    assert_eq!(snapshots_len, 1, "Should generate single snapshot on init");
+
+    let snapshots = c.get_snapshots(None, None).await;
+    assert_eq!(snapshots.len(), 1);
+    assert!(snapshots[0].yield_distribution.is_zero());
+    assert!(snapshots[0].deposited.is_zero());
+    assert!(snapshots[0].borrowed.is_zero());
+
     // Step 1: Supply user sends tokens to contract to use for borrows.
     c.supply(&supply_user, 1100).await;
 

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -39,7 +39,7 @@ async fn test_happy() {
     let snapshots_len = c.get_snapshots_len().await;
     assert_eq!(snapshots_len, 1, "Should generate single snapshot on init");
 
-    let snapshots = c.get_snapshots(None, None).await;
+    let snapshots = c.list_snapshots(None, None).await;
     assert_eq!(snapshots.len(), 1);
     assert!(snapshots[0].yield_distribution.is_zero());
     assert!(snapshots[0].deposited.is_zero());

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -56,7 +56,7 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
                 // They should accumulate (very nearly) the same amount of interest regardless.
                 while !done.load(Ordering::Relaxed) {
                     tokio::join!(
-                        c.apply_interest(&borrow_user_2),
+                        c.apply_interest(&borrow_user_2, None),
                         // No compounding so we get apples-to-apples comparison.
                         // Technically it should be optimal to harvest (and
                         // compound) occasionally throughout the duration of

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -76,6 +76,16 @@ impl TestController {
             .unwrap()
     }
 
+    pub async fn get_snapshots_len(&self) -> u32 {
+        self.contract
+            .view("get_snapshots_len")
+            .args_json(json!({}))
+            .await
+            .unwrap()
+            .json::<u32>()
+            .unwrap()
+    }
+
     pub async fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<Snapshot> {
         self.contract
             .view("get_snapshots")

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -86,9 +86,9 @@ impl TestController {
             .unwrap()
     }
 
-    pub async fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<Snapshot> {
+    pub async fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<Snapshot> {
         self.contract
-            .view("get_snapshots")
+            .view("list_snapshots")
             .args_json(json!({
                 "offset": offset,
                 "count": count,
@@ -592,7 +592,7 @@ impl TestController {
     pub async fn print_snapshots(&self) {
         let snapshots = self
             .contract
-            .view("get_snapshots")
+            .view("list_snapshots")
             .args_json(json!({}))
             .await
             .unwrap()

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -76,6 +76,19 @@ impl TestController {
             .unwrap()
     }
 
+    pub async fn get_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<Snapshot> {
+        self.contract
+            .view("get_snapshots")
+            .args_json(json!({
+                "offset": offset,
+                "count": count,
+            }))
+            .await
+            .unwrap()
+            .json::<Vec<Snapshot>>()
+            .unwrap()
+    }
+
     pub async fn set_collateral_asset_price(&self, price: f64) -> ExecutionSuccess {
         eprintln!("Setting collateral asset price...",);
         self.balance_oracle
@@ -340,11 +353,18 @@ impl TestController {
         .await
     }
 
-    pub async fn apply_interest(&self, borrow_user: &Account) -> ExecutionSuccess {
+    pub async fn apply_interest(
+        &self,
+        borrow_user: &Account,
+        snapshot_limit: Option<u32>,
+    ) -> ExecutionSuccess {
         eprintln!("{} applying interest...", borrow_user.id());
         borrow_user
             .call(self.contract.id(), "apply_interest")
-            .args_json(json!({}))
+            .args_json(json!({
+                "snapshot_limit": snapshot_limit,
+            }))
+            .max_gas()
             .transact()
             .await
             .unwrap()


### PR DESCRIPTION
This parameter allows the caller to specify an upper limit for the number of snapshots to process during the function call. This is useful in cases when the normal `harvest_yield` call might run out of gas.

This PR also adds this estimation calculation to the gas report generated as part of the CI/CD job.

# For UI

For now, it is probably easiest to make the "Harvest yield" button perform these two actions:

1. Call `harvest_yield(snapshot_limit: ...)` with `snapshot_limit` set to the value generated in the report below.
2. Call `harvest_yield(compounding: true)`.