### PR TITLE
chore: Remove unnecessary promise results count check

### DIFF
--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -45,14 +45,13 @@ impl Contract {
         account_id: AccountId,
         amount: BorrowAssetAmount,
     ) -> BorrowAssetAmount {
-        if let Some(mut borrow_position) = self.borrow_position_guard(account_id) {
-            let proof = borrow_position.accumulate_interest();
-            // Returns the amount that should be returned to the borrower.
-            borrow_position.record_repay(proof, amount)
-        } else {
+        let Some(mut borrow_position) = self.borrow_position_guard(account_id) else {
             // No borrow exists: just return the whole amount.
-            amount
-        }
+            return amount;
+        };
+        let proof = borrow_position.accumulate_interest();
+        // Returns the amount that should be returned to the borrower.
+        borrow_position.record_repay(proof, amount)
     }
 
     pub fn execute_liquidate_initial(
@@ -237,9 +236,6 @@ impl Contract {
         &mut self,
         withdrawal_resolution: WithdrawalResolution,
     ) {
-        // TODO: Is this check even necessary in a #[private] function?
-        require!(env::promise_results_count() == 1);
-
         match env::promise_result(0) {
             PromiseResult::Successful(_) => {
                 // Withdrawal succeeded: remove the withdrawal request from the queue.

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -185,8 +185,6 @@ impl Contract {
         amount: BorrowAssetAmount,
         fees: BorrowAssetAmount,
     ) {
-        require!(env::promise_results_count() == 1);
-
         let Some(mut borrow_position) = self.borrow_position_guard(account_id) else {
             env::panic_str("Invariant violation: borrow position does not exist after transfer.");
         };
@@ -324,8 +322,6 @@ impl Contract {
         account_id: AccountId,
         borrow_asset_amount: BorrowAssetAmount,
     ) -> U128 {
-        require!(env::promise_results_count() == 1);
-
         let success = matches!(env::promise_result(0), PromiseResult::Successful(_));
 
         let refund_to_liquidator =
@@ -384,7 +380,6 @@ impl Contract {
         account_id: AccountId,
         amount: CollateralAssetAmount,
     ) {
-        require!(env::promise_results_count() == 1);
         let transfer_was_successful =
             matches!(env::promise_result(0), PromiseResult::Successful(_));
 


### PR DESCRIPTION
Removal of `promise_results_count` check because of this [test](https://github.com/near/near-sdk-rs/blob/09ab9ce5f9c0432d5b1914e0344f6d174956eb1a/near-sdk-macros/src/core_impl/code_generator/item_impl_info.rs#L266) and the corresponding [snapshot](https://github.com/near/near-sdk-rs/blob/09ab9ce5f9c0432d5b1914e0344f6d174956eb1a/near-sdk-macros/src/core_impl/code_generator/snapshots/private_method.snap#L9) which shows that there is a generated check for private functions which would make this invariant impossible to get to.