### PR TITLE
feat: Simplify harvest yield args

### DIFF
--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -89,7 +89,7 @@ pub trait MarketExternalInterface {
     /// harvested in previous, non-compounding `harvest_yield` calls) is
     /// deposited to the supply record, so it will contribute to future yield
     /// calculations.
-    fn harvest_yield(&mut self, mode: HarvestYieldMode) -> BorrowAssetAmount;
+    fn harvest_yield(&mut self, mode: Option<HarvestYieldMode>) -> BorrowAssetAmount;
 
     /// This value is an *expected average over time*.
     /// Supply positions actually earn all of their yield the instant it is

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -1,4 +1,4 @@
-use near_sdk::{AccountId, Promise, PromiseOrValue};
+use near_sdk::{near, AccountId, Promise, PromiseOrValue};
 
 use crate::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
@@ -12,6 +12,15 @@ use crate::{
 };
 
 use super::{BorrowAssetMetrics, MarketConfiguration};
+
+#[derive(Debug, Clone, Default)]
+#[near(serializers = [json, borsh])]
+pub enum HarvestYieldMode {
+    #[default]
+    Default,
+    Compounding,
+    Snapshot(u32),
+}
 
 #[near_sdk::ext_contract(ext_market)]
 pub trait MarketExternalInterface {
@@ -76,15 +85,11 @@ pub trait MarketExternalInterface {
     fn get_supply_withdrawal_queue_status(&self) -> WithdrawalQueueStatus;
 
     /// Claim any distributed yield to the supply record.
-    /// If `compounding` is `true`, the all of the yield (including any
+    /// If mode is set to `compounding`, the all of the yield (including any
     /// harvested in previous, non-compounding `harvest_yield` calls) is
     /// deposited to the supply record, so it will contribute to future yield
     /// calculations.
-    fn harvest_yield(
-        &mut self,
-        compounding: Option<bool>,
-        snapshot_limit: Option<u32>,
-    ) -> BorrowAssetAmount;
+    fn harvest_yield(&mut self, mode: HarvestYieldMode) -> BorrowAssetAmount;
 
     /// This value is an *expected average over time*.
     /// Supply positions actually earn all of their yield the instant it is

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -19,7 +19,7 @@ pub enum HarvestYieldMode {
     #[default]
     Default,
     Compounding,
-    Snapshot(u32),
+    SnapshotLimit(u32),
 }
 
 #[near_sdk::ext_contract(ext_market)]

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -13,7 +13,7 @@ use crate::{
 
 use super::{BorrowAssetMetrics, MarketConfiguration};
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Copy, Default)]
 #[near(serializers = [json, borsh])]
 pub enum HarvestYieldMode {
     #[default]

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -28,7 +28,7 @@ async fn main() {
 
     c.supply(&supply_user, 120_000).await;
     let harvest_yield_0 = c
-        .harvest_yield_execution(&supply_user, HarvestYieldMode::Compounding)
+        .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
         .await;
     let snapshot_count_before = c.list_snapshots(None, None).await.len();
     c.collateralize(&borrow_user, 2000).await;
@@ -44,7 +44,7 @@ async fn main() {
 
     let apply_interest_max = c.apply_interest(&borrow_user_2, None).await;
     let harvest_yield_max = c
-        .harvest_yield_execution(&supply_user, HarvestYieldMode::Compounding)
+        .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
         .await;
 
     let snapshot_count_after = c.list_snapshots(None, None).await.len();

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -2,8 +2,8 @@
 
 use near_sdk::{json_types::U64, Gas};
 use templar_common::{
-    fee::Fee, interest_rate_strategy::InterestRateStrategy, number::Decimal,
-    time_chunk::TimeChunkConfiguration,
+    fee::Fee, interest_rate_strategy::InterestRateStrategy, market::HarvestYieldMode,
+    number::Decimal, time_chunk::TimeChunkConfiguration,
 };
 use test_utils::{setup_everything, SetupEverything};
 
@@ -27,7 +27,9 @@ async fn main() {
     .await;
 
     c.supply(&supply_user, 120_000).await;
-    let harvest_yield_0 = c.harvest_yield_execution(&supply_user, true).await;
+    let harvest_yield_0 = c
+        .harvest_yield_execution(&supply_user, HarvestYieldMode::Compounding)
+        .await;
     let snapshot_count_before = c.list_snapshots(None, None).await.len();
     c.collateralize(&borrow_user, 2000).await;
     c.collateralize(&borrow_user_2, 2000).await;
@@ -41,7 +43,9 @@ async fn main() {
     }
 
     let apply_interest_max = c.apply_interest(&borrow_user_2, None).await;
-    let harvest_yield_max = c.harvest_yield_execution(&supply_user, true).await;
+    let harvest_yield_max = c
+        .harvest_yield_execution(&supply_user, HarvestYieldMode::Compounding)
+        .await;
 
     let snapshot_count_after = c.list_snapshots(None, None).await.len();
     let snapshot_count = snapshot_count_after - snapshot_count_before;

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -2,7 +2,7 @@ use near_sdk::{env, near, require, AccountId, Promise, PromiseOrValue};
 use templar_common::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
     borrow::{BorrowPosition, BorrowStatus},
-    market::{BorrowAssetMetrics, MarketConfiguration, MarketExternalInterface},
+    market::{BorrowAssetMetrics, HarvestYieldMode, MarketConfiguration, MarketExternalInterface},
     number::Decimal,
     oracle::pyth::OracleResponse,
     snapshot::Snapshot,
@@ -228,19 +228,14 @@ impl MarketExternalInterface for Contract {
         self.withdrawal_queue.get_status()
     }
 
-    fn harvest_yield(
-        &mut self,
-        compounding: Option<bool>,
-        snapshot_limit: Option<u32>,
-    ) -> BorrowAssetAmount {
+    fn harvest_yield(&mut self, mode: HarvestYieldMode) -> BorrowAssetAmount {
         let predecessor = env::predecessor_account_id();
         let Some(mut supply_position) = self.supply_position_guard(predecessor) else {
             return BorrowAssetAmount::zero();
         };
 
-        match (compounding.unwrap_or(false), snapshot_limit) {
-            (true, Some(_)) => env::panic_str("`compounding` and `snapshot_limit` are exclusive"),
-            (true, None) => {
+        match mode {
+            HarvestYieldMode::Compounding => {
                 let proof = supply_position.accumulate_yield();
                 // Compound yield by withdrawing it and recording it as an immediate deposit.
                 let total_yield = supply_position.inner().borrow_asset_yield.get_total();
@@ -248,10 +243,10 @@ impl MarketExternalInterface for Contract {
                 supply_position.record_deposit(proof, total_yield, env::block_timestamp_ms());
                 return total_yield;
             }
-            (false, Some(snapshot_limit)) => {
-                supply_position.accumulate_yield_partial(snapshot_limit);
+            HarvestYieldMode::Snapshot(limit) => {
+                supply_position.accumulate_yield_partial(limit);
             }
-            _ => {
+            HarvestYieldMode::Default => {
                 supply_position.accumulate_yield();
             }
         }
@@ -312,25 +307,17 @@ impl MarketExternalInterface for Contract {
 
         self.static_yield.insert(&predecessor, &static_yield_record);
 
-        let borrow_promise = if borrow_asset_amount.is_zero() {
-            None
-        } else {
-            Some(
-                self.configuration
-                    .borrow_asset
-                    .transfer(predecessor.clone(), borrow_asset_amount),
-            )
-        };
+        let borrow_promise = (!borrow_asset_amount.is_zero()).then_some(
+            self.configuration
+                .borrow_asset
+                .transfer(predecessor.clone(), borrow_asset_amount),
+        );
 
-        let collateral_promise = if collateral_asset_amount.is_zero() {
-            None
-        } else {
-            Some(
-                self.configuration
-                    .collateral_asset
-                    .transfer(predecessor.clone(), collateral_asset_amount),
-            )
-        };
+        let collateral_promise = (!collateral_asset_amount.is_zero()).then_some(
+            self.configuration
+                .collateral_asset
+                .transfer(predecessor.clone(), collateral_asset_amount),
+        );
 
         match (borrow_promise, collateral_promise) {
             (Some(b), Some(c)) => b.and(c),

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -228,13 +228,13 @@ impl MarketExternalInterface for Contract {
         self.withdrawal_queue.get_status()
     }
 
-    fn harvest_yield(&mut self, mode: HarvestYieldMode) -> BorrowAssetAmount {
+    fn harvest_yield(&mut self, mode: Option<HarvestYieldMode>) -> BorrowAssetAmount {
         let predecessor = env::predecessor_account_id();
         let Some(mut supply_position) = self.supply_position_guard(predecessor) else {
             return BorrowAssetAmount::zero();
         };
 
-        match mode {
+        match mode.unwrap_or_default() {
             HarvestYieldMode::Compounding => {
                 let proof = supply_position.accumulate_yield();
                 // Compound yield by withdrawing it and recording it as an immediate deposit.

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -307,17 +307,17 @@ impl MarketExternalInterface for Contract {
 
         self.static_yield.insert(&predecessor, &static_yield_record);
 
-        let borrow_promise = (!borrow_asset_amount.is_zero()).then_some(
+        let borrow_promise = (!borrow_asset_amount.is_zero()).then(|| {
             self.configuration
                 .borrow_asset
-                .transfer(predecessor.clone(), borrow_asset_amount),
-        );
+                .transfer(predecessor.clone(), borrow_asset_amount)
+        });
 
-        let collateral_promise = (!collateral_asset_amount.is_zero()).then_some(
+        let collateral_promise = (!collateral_asset_amount.is_zero()).then(|| {
             self.configuration
                 .collateral_asset
-                .transfer(predecessor.clone(), collateral_asset_amount),
-        );
+                .transfer(predecessor.clone(), collateral_asset_amount)
+        });
 
         match (borrow_promise, collateral_promise) {
             (Some(b), Some(c)) => b.and(c),

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -243,7 +243,7 @@ impl MarketExternalInterface for Contract {
                 supply_position.record_deposit(proof, total_yield, env::block_timestamp_ms());
                 return total_yield;
             }
-            HarvestYieldMode::Snapshot(limit) => {
+            HarvestYieldMode::SnapshotLimit(limit) => {
                 supply_position.accumulate_yield_partial(limit);
             }
             HarvestYieldMode::Default => {

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -1,17 +1,19 @@
 use std::{sync::atomic::Ordering, time::Duration};
 
 use rstest::rstest;
-use templar_common::{dec, fee::Fee, interest_rate_strategy::InterestRateStrategy};
+use templar_common::{
+    dec, fee::Fee, interest_rate_strategy::InterestRateStrategy, market::HarvestYieldMode,
+};
 use test_utils::*;
 
 #[rstest]
-#[case(1_000_000, InterestRateStrategy::linear(dec!("1000000"), dec!("1000000")).unwrap(), true)]
-#[case(1_000_000, InterestRateStrategy::linear(dec!("1000000"), dec!("1000000")).unwrap(), false)]
+#[case(1_000_000, InterestRateStrategy::linear(dec!("1000000"), dec!("1000000")).unwrap(), HarvestYieldMode::Compounding)]
+#[case(1_000_000, InterestRateStrategy::linear(dec!("1000000"), dec!("1000000")).unwrap(), HarvestYieldMode::Default)]
 #[tokio::test]
 async fn compounding_yield(
     #[case] principal: u128,
     #[case] strategy: InterestRateStrategy,
-    #[case] compounding: bool,
+    #[case] compounding: HarvestYieldMode,
 ) {
     let SetupEverything {
         c,
@@ -59,7 +61,8 @@ async fn compounding_yield(
     );
     eprintln!("Done sleeping!");
 
-    c.harvest_yield(&supply_user, false).await;
+    c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+        .await;
 
     let (supply_position_1_after, supply_position_2_after) = tokio::join!(
         async { c.get_supply_position(supply_user.id()).await.unwrap() },

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -39,7 +39,7 @@ async fn compounding_yield(
     tokio::join!(
         async {
             while !done.load(Ordering::Relaxed) {
-                c.harvest_yield(&supply_user_2, compounding).await;
+                c.harvest_yield(&supply_user_2, Some(compounding)).await;
                 iters += 1;
             }
         },
@@ -61,7 +61,7 @@ async fn compounding_yield(
     );
     eprintln!("Done sleeping!");
 
-    c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+    c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
         .await;
 
     let (supply_position_1_after, supply_position_2_after) = tokio::join!(

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -82,7 +82,7 @@ async fn compounding_yield(
     eprintln!("supply 2 yield: {supply_yield_2:#?}");
     eprintln!("iterations: {iters}");
 
-    if compounding {
+    if matches!(compounding, HarvestYieldMode::Compounding) {
         // Supply user 2 will be rounded DOWN each iteration.
         // Ensure that it is compounding, so each iteration should add (much) more
         // than 1.

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -138,7 +138,7 @@ async fn test_happy() {
         async {
             // Withdraw yield.
             {
-                c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+                c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
                     .await;
                 let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
                 assert_eq!(
@@ -147,7 +147,7 @@ async fn test_happy() {
                 );
                 // Move the yield to the principal so that it can be withdrawn
                 let amount_moved_to_principal = c
-                    .harvest_yield(&supply_user, HarvestYieldMode::Compounding)
+                    .harvest_yield(&supply_user, Some(HarvestYieldMode::Compounding))
                     .await;
 
                 assert_eq!(

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -230,20 +230,32 @@ async fn test_happy() {
         // Protocol yield.
         async {
             let protocol_yield = c.get_static_yield(protocol_yield_user.id()).await.unwrap();
+            assert!(protocol_yield.collateral_asset.is_zero());
             assert_eq!(u128::from(protocol_yield.borrow_asset), 10);
             let balance_before = c.borrow_asset_balance_of(protocol_yield_user.id()).await;
-            c.withdraw_static_yield(&protocol_yield_user, None, None)
+            let result = c
+                .withdraw_static_yield(&protocol_yield_user, None, None)
                 .await;
+            for receipt in result.receipt_outcomes() {
+                assert!(&receipt.executor_id != c.collateral_asset.id());
+            }
+            assert!(result.failures().is_empty());
             let balance_after = c.borrow_asset_balance_of(protocol_yield_user.id()).await;
             assert_eq!(balance_after - balance_before, 10);
         },
         // Insurance yield.
         async {
             let insurance_yield = c.get_static_yield(insurance_yield_user.id()).await.unwrap();
+            assert!(insurance_yield.collateral_asset.is_zero());
             assert_eq!(u128::from(insurance_yield.borrow_asset), 10);
             let balance_before = c.borrow_asset_balance_of(insurance_yield_user.id()).await;
-            c.withdraw_static_yield(&insurance_yield_user, None, None)
+            let result = c
+                .withdraw_static_yield(&insurance_yield_user, None, None)
                 .await;
+            for receipt in result.receipt_outcomes() {
+                assert!(&receipt.executor_id != c.collateral_asset.id());
+            }
+            assert!(result.failures().is_empty());
             let balance_after = c.borrow_asset_balance_of(insurance_yield_user.id()).await;
             assert_eq!(balance_after - balance_before, 10);
         },

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -2,7 +2,8 @@ use rstest::rstest;
 use tokio::join;
 
 use templar_common::{
-    borrow::BorrowStatus, dec, interest_rate_strategy::InterestRateStrategy, number::Decimal,
+    borrow::BorrowStatus, dec, interest_rate_strategy::InterestRateStrategy,
+    market::HarvestYieldMode, number::Decimal,
 };
 use test_utils::*;
 
@@ -137,14 +138,17 @@ async fn test_happy() {
         async {
             // Withdraw yield.
             {
-                c.harvest_yield(&supply_user, false).await;
+                c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+                    .await;
                 let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
                 assert_eq!(
                     u128::from(supply_position.borrow_asset_yield.get_total()),
                     80,
                 );
                 // Move the yield to the principal so that it can be withdrawn
-                let amount_moved_to_principal = c.harvest_yield(&supply_user, true).await;
+                let amount_moved_to_principal = c
+                    .harvest_yield(&supply_user, HarvestYieldMode::Compounding)
+                    .await;
 
                 assert_eq!(
                     amount_moved_to_principal,

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -63,7 +63,7 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
                         // Technically it should be optimal to harvest (and
                         // compound) occasionally throughout the duration of
                         // the supply.
-                        c.harvest_yield(&supply_user_2, HarvestYieldMode::Default),
+                        c.harvest_yield(&supply_user_2, Some(HarvestYieldMode::Default)),
                     );
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     iters += 1;
@@ -173,12 +173,12 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
 
     let (supply_position_1, supply_position_2) = tokio::join!(
         async {
-            c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+            c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
                 .await;
             c.get_supply_position(supply_user.id()).await.unwrap()
         },
         async {
-            c.harvest_yield(&supply_user_2, HarvestYieldMode::Default)
+            c.harvest_yield(&supply_user_2, Some(HarvestYieldMode::Default))
                 .await;
             c.get_supply_position(supply_user_2.id()).await.unwrap()
         },

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -18,6 +18,8 @@ use test_utils::*;
 )]
 #[tokio::test]
 async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateStrategy) {
+    use templar_common::market::HarvestYieldMode;
+
     let SetupEverything {
         c,
         supply_user,
@@ -61,7 +63,7 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
                         // Technically it should be optimal to harvest (and
                         // compound) occasionally throughout the duration of
                         // the supply.
-                        c.harvest_yield(&supply_user_2, false),
+                        c.harvest_yield(&supply_user_2, HarvestYieldMode::Default),
                     );
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     iters += 1;
@@ -171,11 +173,13 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
 
     let (supply_position_1, supply_position_2) = tokio::join!(
         async {
-            c.harvest_yield(&supply_user, false).await;
+            c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+                .await;
             c.get_supply_position(supply_user.id()).await.unwrap()
         },
         async {
-            c.harvest_yield(&supply_user_2, false).await;
+            c.harvest_yield(&supply_user_2, HarvestYieldMode::Default)
+                .await;
             c.get_supply_position(supply_user_2.id()).await.unwrap()
         },
     );

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -110,7 +110,7 @@ async fn successful_liquidation_good_debt_under_mcr(
 
     tokio::join!(
         async {
-            c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+            c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
                 .await;
             let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
             assert_eq!(

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -61,6 +61,8 @@ async fn successful_liquidation_good_debt_under_mcr(
     #[case] collateral_asset_price_pct: u128,
     #[case] liquidation_amount: u128,
 ) {
+    use templar_common::market::HarvestYieldMode;
+
     let SetupEverything {
         c,
         liquidator_user,
@@ -108,7 +110,8 @@ async fn successful_liquidation_good_debt_under_mcr(
 
     tokio::join!(
         async {
-            c.harvest_yield(&supply_user, false).await;
+            c.harvest_yield(&supply_user, HarvestYieldMode::Default)
+                .await;
             let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
             assert_eq!(
                 u128::from(supply_position.borrow_asset_yield.get_total()),

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -15,8 +15,8 @@ use templar_common::{
     fee::{Fee, TimeBasedFee},
     interest_rate_strategy::InterestRateStrategy,
     market::{
-        BalanceOracleConfiguration, LiquidateMsg, MarketConfiguration, Nep141MarketDepositMessage,
-        YieldWeights,
+        BalanceOracleConfiguration, HarvestYieldMode, LiquidateMsg, MarketConfiguration,
+        Nep141MarketDepositMessage, YieldWeights,
     },
     number::Decimal,
     oracle::pyth::{self, OracleResponse, PriceIdentifier},
@@ -384,13 +384,13 @@ impl TestController {
     pub async fn harvest_yield_execution(
         &self,
         supply_user: &Account,
-        compounding: bool,
+        mode: HarvestYieldMode,
     ) -> ExecutionSuccess {
         eprintln!("{} harvesting yield...", supply_user.id());
         supply_user
             .call(self.contract.id(), "harvest_yield")
             .args_json(json!({
-                "compounding": compounding,
+                "mode": mode,
             }))
             .max_gas()
             .transact()
@@ -402,13 +402,13 @@ impl TestController {
     pub async fn harvest_yield(
         &self,
         supply_user: &Account,
-        compounding: bool,
+        mode: HarvestYieldMode,
     ) -> BorrowAssetAmount {
         eprintln!("{} harvesting yield...", supply_user.id());
         supply_user
             .call(self.contract.id(), "harvest_yield")
             .args_json(json!({
-                "compounding": compounding,
+                "mode": mode,
             }))
             .max_gas()
             .transact()

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -384,7 +384,7 @@ impl TestController {
     pub async fn harvest_yield_execution(
         &self,
         supply_user: &Account,
-        mode: HarvestYieldMode,
+        mode: Option<HarvestYieldMode>,
     ) -> ExecutionSuccess {
         eprintln!("{} harvesting yield...", supply_user.id());
         supply_user
@@ -402,7 +402,7 @@ impl TestController {
     pub async fn harvest_yield(
         &self,
         supply_user: &Account,
-        mode: HarvestYieldMode,
+        mode: Option<HarvestYieldMode>,
     ) -> BorrowAssetAmount {
         eprintln!("{} harvesting yield...", supply_user.id());
         supply_user


### PR DESCRIPTION
There was some logic which disallowed usage of both optional parameters, so I just created an enum which satisfies all three possible choices and lets the RPCs handle our first case (where we panicked - now the call wouldn't even get to the contract).

---

# API Changes

`harvest_yield` arguments are changed:

- `harvest_yield(compounding: true)` &rarr; `harvest_yield(mode: Compounding)`
- `harvest_yield(snapshot_limit: 123)` &rarr; `harvest_yield(mode: { SnapshotLimit: 123 })`