### PR TITLE
feat: Use `LookupMap` instead of `UnorderedMap` for storing positions

### DIFF
--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -33,9 +33,6 @@ pub trait MarketExternalInterface {
     fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot>;
     fn get_borrow_asset_metrics(&self) -> BorrowAssetMetrics;
 
-    fn list_borrows(&self, offset: Option<u32>, count: Option<u32>) -> Vec<AccountId>;
-    fn list_supplys(&self, offset: Option<u32>, count: Option<u32>) -> Vec<AccountId>;
-
     // ==================
     // BORROW FUNCTIONS
     // ==================

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -1,7 +1,4 @@
-use near_sdk::{
-    collections::{LookupMap, UnorderedMap},
-    env, near, AccountId, BorshStorageKey, IntoStorageKey,
-};
+use near_sdk::{collections::LookupMap, env, near, AccountId, BorshStorageKey, IntoStorageKey};
 
 use crate::{
     asset::BorrowAssetAmount,
@@ -35,8 +32,8 @@ pub struct Market {
     pub borrow_asset_deposited: BorrowAssetAmount,
     pub borrow_asset_in_flight: BorrowAssetAmount,
     pub borrow_asset_borrowed: BorrowAssetAmount,
-    pub(crate) supply_positions: UnorderedMap<AccountId, SupplyPosition>,
-    pub(crate) borrow_positions: UnorderedMap<AccountId, BorrowPosition>,
+    pub(crate) supply_positions: LookupMap<AccountId, SupplyPosition>,
+    pub(crate) borrow_positions: LookupMap<AccountId, BorrowPosition>,
     pub snapshots: ChunkedAppendOnlyList<Snapshot, 128>,
     pub withdrawal_queue: WithdrawalQueue,
     pub static_yield: LookupMap<AccountId, StaticYieldRecord>,
@@ -64,8 +61,8 @@ impl Market {
             borrow_asset_deposited: 0.into(),
             borrow_asset_in_flight: 0.into(),
             borrow_asset_borrowed: 0.into(),
-            supply_positions: UnorderedMap::new(key!(SupplyPositions)),
-            borrow_positions: UnorderedMap::new(key!(BorrowPositions)),
+            supply_positions: LookupMap::new(key!(SupplyPositions)),
+            borrow_positions: LookupMap::new(key!(BorrowPositions)),
             snapshots: ChunkedAppendOnlyList::new(key!(Snapshots)),
             withdrawal_queue: WithdrawalQueue::new(key!(WithdrawalQueue)),
             static_yield: LookupMap::new(key!(StaticYield)),
@@ -158,10 +155,6 @@ impl Market {
             .at(snapshot.usage_ratio())
     }
 
-    pub fn iter_supply_account_ids(&self) -> impl Iterator<Item = AccountId> + '_ {
-        self.supply_positions.keys()
-    }
-
     pub fn supply_position_ref(&self, account_id: AccountId) -> Option<SupplyPositionRef<&Self>> {
         self.supply_positions
             .get(&account_id)
@@ -184,10 +177,6 @@ impl Market {
             .unwrap_or_else(|| SupplyPosition::new(self.snapshot()));
 
         SupplyPositionGuard::new(self, account_id, position)
-    }
-
-    pub fn iter_borrow_account_ids(&self) -> impl Iterator<Item = AccountId> + '_ {
-        self.borrow_positions.keys()
     }
 
     pub fn borrow_position_ref(&self, account_id: AccountId) -> Option<BorrowPositionRef<&Self>> {

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -41,24 +41,6 @@ impl MarketExternalInterface for Contract {
         }
     }
 
-    fn list_borrows(&self, offset: Option<u32>, count: Option<u32>) -> Vec<AccountId> {
-        let offset = offset.map_or(0, |o| o as usize);
-        let count = count.map_or(usize::MAX, |c| c as usize);
-        self.iter_borrow_account_ids()
-            .skip(offset)
-            .take(count)
-            .collect()
-    }
-
-    fn list_supplys(&self, offset: Option<u32>, count: Option<u32>) -> Vec<AccountId> {
-        let offset = offset.map_or(0, |o| o as usize);
-        let count = count.map_or(usize::MAX, |c| c as usize);
-        self.iter_supply_account_ids()
-            .skip(offset)
-            .take(count)
-            .collect()
-    }
-
     fn get_borrow_position(&self, account_id: AccountId) -> Option<BorrowPosition> {
         let mut borrow_position = self.borrow_position_ref(account_id)?;
         borrow_position.with_pending_interest();

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -70,14 +70,6 @@ async fn test_happy() {
         "Supply position should match amount of tokens supplied to contract",
     );
 
-    let list_supplys = c.list_supplys().await;
-
-    assert_eq!(
-        list_supplys,
-        ["0".repeat(64).parse().unwrap(), supply_user.id().clone()],
-        "Supply user should be the only account listed",
-    );
-
     // Step 2: Borrow user deposits collateral
 
     c.collateralize(&borrow_user, 2000).await;
@@ -88,14 +80,6 @@ async fn test_happy() {
         u128::from(borrow_position.collateral_asset_deposit),
         2000,
         "Collateral asset deposit should be equal to the number of collateral tokens sent",
-    );
-
-    let list_borrows = c.list_borrows().await;
-
-    assert_eq!(
-        list_borrows,
-        ["0".repeat(64).parse().unwrap(), borrow_user.id().clone()],
-        "Borrow user should be the only account listed",
     );
 
     let borrow_status = c

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -184,16 +184,6 @@ impl TestController {
             .unwrap()
     }
 
-    pub async fn list_supplys(&self) -> Vec<AccountId> {
-        self.contract
-            .view("list_supplys")
-            .args_json(json!({}))
-            .await
-            .unwrap()
-            .json::<Vec<AccountId>>()
-            .unwrap()
-    }
-
     pub async fn collateralize(&self, borrow_user: &Account, amount: u128) {
         eprintln!(
             "{} transferring {amount} tokens for collateral...",
@@ -217,16 +207,6 @@ impl TestController {
             .await
             .unwrap()
             .json::<Option<BorrowPosition>>()
-            .unwrap()
-    }
-
-    pub async fn list_borrows(&self) -> Vec<AccountId> {
-        self.contract
-            .view("list_borrows")
-            .args_json(json!({}))
-            .await
-            .unwrap()
-            .json::<Vec<AccountId>>()
             .unwrap()
     }
 


### PR DESCRIPTION
# API Changes
Removes the `list_borrows` and `list_supplys` methods