### PR TITLE
Simplified snapshot handling

### DIFF
--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -203,8 +203,43 @@ impl<M> BorrowPositionRef<M> {
 
 impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
     pub fn with_pending_interest(&mut self) {
-        self.position.borrow_asset_fees.pending_estimate =
-            self.calculate_interest(u32::MAX).get_amount();
+        let mut pending_estimate = self.calculate_interest(u32::MAX).get_amount();
+        let prev_end_timestamp_ms = self.market.get_last_finalized_snapshot().end_timestamp_ms.0;
+        let interest_in_current_snapshot =
+            self.calculate_interest_rate_for_snapshot(
+                prev_end_timestamp_ms,
+                &self.market.current_snapshot,
+            ) * Decimal::from(self.position.get_borrow_asset_principal());
+        #[allow(clippy::unwrap_used, reason = "This is a view method")]
+        pending_estimate.join(interest_in_current_snapshot.to_u128_ceil().unwrap().into());
+
+        self.position.borrow_asset_fees.pending_estimate = pending_estimate;
+    }
+
+    pub(crate) fn calculate_interest_rate_for_snapshot(
+        &self,
+        prev_end_timestamp_ms: u64,
+        snapshot: &Snapshot,
+    ) -> Decimal {
+        let interest_rate_per_year = self
+            .market
+            .configuration
+            .borrow_interest_rate_strategy
+            .at(snapshot.usage_ratio());
+        let duration_ms = Decimal::from(
+            snapshot
+                .end_timestamp_ms
+                .0
+                .checked_sub(prev_end_timestamp_ms)
+                .unwrap_or_else(|| {
+                    env::panic_str(&format!(
+                        "Invariant violation: Snapshot timestamp decrease at time chunk #{}.",
+                        u64::from(snapshot.time_chunk.0),
+                    ))
+                }),
+        );
+
+        interest_rate_per_year * duration_ms / *MS_IN_A_YEAR
     }
 
     pub(crate) fn calculate_interest(
@@ -215,52 +250,32 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
         let mut next_snapshot_index = self.position.borrow_asset_fees.get_next_snapshot_index();
 
         let mut accumulated = Decimal::ZERO;
+        #[allow(clippy::unwrap_used, reason = "1 finalized snapshot guaranteed")]
+        let mut prev_end_timestamp_ms = self
+            .market
+            .finalized_snapshots
+            .get(next_snapshot_index.checked_sub(1).unwrap())
+            .unwrap()
+            .end_timestamp_ms
+            .0;
 
         #[allow(
             clippy::cast_possible_truncation,
             reason = "Assume # of snapshots will never be > u32::MAX"
         )]
-        let mut it = self
+        for (i, snapshot) in self
             .market
-            .snapshots
+            .finalized_snapshots
             .iter()
             .enumerate()
             .skip(next_snapshot_index as usize)
             .take(snapshot_limit as usize)
-            .map(|(i, s): (usize, &Snapshot)| (i as u32, s))
-            .peekable();
+        {
+            accumulated += principal
+                * self.calculate_interest_rate_for_snapshot(prev_end_timestamp_ms, snapshot);
 
-        let ms_in_a_year = Decimal::from(MS_IN_A_YEAR);
-
-        while let Some((i, snapshot)) = it.next() {
-            let Some(end_timestamp_ms) = it
-                .peek()
-                .map(|(_, next_snapshot)| next_snapshot.timestamp_ms.0)
-            else {
-                // Cannot calculate duration.
-                break;
-            };
-
-            let interest_rate_per_year: Decimal = self
-                .market
-                .configuration
-                .borrow_interest_rate_strategy
-                .at(snapshot.usage_ratio());
-            let duration_ms: Decimal = end_timestamp_ms
-                .checked_sub(snapshot.timestamp_ms.0)
-                .unwrap_or_else(|| {
-                    env::panic_str(&format!(
-                        "Invariant violation: Snapshot timestamp decrease at #{}.",
-                        i + 1,
-                    ))
-                })
-                .into();
-
-            let interest = principal * interest_rate_per_year * duration_ms / ms_in_a_year;
-
-            accumulated += interest;
-
-            next_snapshot_index = i + 1;
+            prev_end_timestamp_ms = snapshot.end_timestamp_ms.0;
+            next_snapshot_index = i as u32 + 1;
         }
 
         AccumulationRecord {

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -205,26 +205,6 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
     pub fn with_pending_interest(&mut self) {
         self.position.borrow_asset_fees.pending_estimate =
             self.calculate_interest(u32::MAX).get_amount();
-        self.position
-            .borrow_asset_fees
-            .pending_estimate
-            .join(self.calculate_last_snapshot_interest());
-    }
-
-    pub(crate) fn calculate_last_snapshot_interest(&self) -> BorrowAssetAmount {
-        let last_snapshot = self.market.get_last_snapshot();
-        let interest_rate = self.market.get_interest_rate_for_snapshot(last_snapshot);
-        let duration_ms = Decimal::from(env::block_timestamp_ms() - last_snapshot.timestamp_ms.0);
-        let ms_in_a_year = Decimal::from(MS_IN_A_YEAR);
-        let interest_rate_part: Decimal = interest_rate * duration_ms / ms_in_a_year;
-        let interest =
-            interest_rate_part * Decimal::from(self.position.get_borrow_asset_principal());
-
-        #[allow(
-            clippy::unwrap_used,
-            reason = "Assume interest will never exceed u128::MAX"
-        )]
-        interest.to_u128_ceil().unwrap().into()
     }
 
     pub(crate) fn calculate_interest(

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -14,4 +14,5 @@ pub mod supply;
 pub mod time_chunk;
 pub mod withdrawal_queue;
 
-pub const MS_IN_A_YEAR: u128 = 31_556_952_000; // 1000 * 60 * 60 * 24 * 365.2425
+pub static MS_IN_A_YEAR: std::sync::LazyLock<number::Decimal> =
+    std::sync::LazyLock::new(|| number::Decimal::from(31_556_952_000_u128)); // 1000 * 60 * 60 * 24 * 365.2425

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -29,8 +29,9 @@ pub trait MarketExternalInterface {
     // ========================
 
     fn get_configuration(&self) -> MarketConfiguration;
-    fn get_snapshots_len(&self) -> u32;
-    fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot>;
+    fn get_current_snapshot(&self) -> &Snapshot;
+    fn get_finalized_snapshots_len(&self) -> u32;
+    fn list_finalized_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot>;
     fn get_borrow_asset_metrics(&self) -> BorrowAssetMetrics;
 
     // ==================

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -1,7 +1,4 @@
-use near_sdk::{
-    collections::{LookupMap, UnorderedMap},
-    env, near, AccountId, BorshStorageKey, IntoStorageKey,
-};
+use near_sdk::{collections::LookupMap, env, near, AccountId, BorshStorageKey, IntoStorageKey};
 
 use crate::{
     asset::BorrowAssetAmount,
@@ -35,8 +32,9 @@ pub struct Market {
     pub borrow_asset_deposited: BorrowAssetAmount,
     pub borrow_asset_in_flight: BorrowAssetAmount,
     pub borrow_asset_borrowed: BorrowAssetAmount,
-    pub(crate) supply_positions: UnorderedMap<AccountId, SupplyPosition>,
-    pub(crate) borrow_positions: UnorderedMap<AccountId, BorrowPosition>,
+    pub(crate) supply_positions: LookupMap<AccountId, SupplyPosition>,
+    pub(crate) borrow_positions: LookupMap<AccountId, BorrowPosition>,
+    pub current_snapshot: Snapshot,
     pub snapshots: ChunkedAppendOnlyList<Snapshot, 128>,
     pub withdrawal_queue: WithdrawalQueue,
     pub static_yield: LookupMap<AccountId, StaticYieldRecord>,
@@ -48,6 +46,14 @@ impl Market {
             env::panic_str(&e.to_string());
         }
 
+        let time_chunk = configuration.time_chunk_configuration.now();
+        let snapshot = Snapshot {
+            time_chunk,
+            timestamp_ms: env::block_timestamp_ms().into(),
+            deposited: 0.into(),
+            borrowed: 0.into(),
+            yield_distribution: BorrowAssetAmount::zero(),
+        };
         let prefix = prefix.into_storage_key();
         macro_rules! key {
             ($key: ident) => {
@@ -64,23 +70,21 @@ impl Market {
             borrow_asset_deposited: 0.into(),
             borrow_asset_in_flight: 0.into(),
             borrow_asset_borrowed: 0.into(),
-            supply_positions: UnorderedMap::new(key!(SupplyPositions)),
-            borrow_positions: UnorderedMap::new(key!(BorrowPositions)),
+            supply_positions: LookupMap::new(key!(SupplyPositions)),
+            borrow_positions: LookupMap::new(key!(BorrowPositions)),
+            current_snapshot: snapshot.clone(),
             snapshots: ChunkedAppendOnlyList::new(key!(Snapshots)),
             withdrawal_queue: WithdrawalQueue::new(key!(WithdrawalQueue)),
             static_yield: LookupMap::new(key!(StaticYield)),
         };
 
-        // So we never have to worry about snapshots being empty.
-        // This means that expressions like `self.snapshots.len() - 1` will never
-        // underflow.
-        self_.snapshot();
+        self_.snapshots.push(snapshot.clone());
 
         self_
     }
 
-    #[allow(clippy::unwrap_used, reason = "Snapshots are never empty")]
     pub fn get_last_snapshot(&self) -> &Snapshot {
+        #[allow(clippy::unwrap_used, reason = "Snapshots are never empty")]
         self.snapshots.get(self.snapshots.len() - 1).unwrap()
     }
 
@@ -91,47 +95,33 @@ impl Market {
     fn snapshot_with_yield_distribution(&mut self, yield_distribution: BorrowAssetAmount) -> u32 {
         let time_chunk = self.configuration.time_chunk_configuration.now();
 
-        if let Some((last_index, old_snapshot)) =
-            self.snapshots.len().checked_sub(1).and_then(|last_index| {
-                self.snapshots
-                    .get(last_index)
-                    .filter(|s| s.time_chunk == time_chunk)
-                    .map(|s| (last_index, s))
-            })
-        {
-            let new_snapshot = Snapshot {
-                time_chunk,
-                timestamp_ms: old_snapshot.timestamp_ms,
-                deposited: self.borrow_asset_deposited,
-                borrowed: self.borrow_asset_borrowed,
-                yield_distribution: {
-                    let mut y = old_snapshot.yield_distribution;
-                    y.join(yield_distribution);
-                    y
-                },
-            };
-            self.snapshots.replace_last(new_snapshot);
-            return last_index;
+        // If still in current time chunk, just update the current snapshot.
+        if self.current_snapshot.time_chunk == time_chunk {
+            self.current_snapshot.timestamp_ms = env::block_timestamp_ms().into();
+            self.current_snapshot.deposited = self.borrow_asset_deposited;
+            self.current_snapshot.borrowed = self.borrow_asset_borrowed;
+            self.current_snapshot
+                .yield_distribution
+                .join(yield_distribution);
+            return self.snapshots.len() - 1;
         }
 
+        // Otherwise, finalize the current snapshot and create a new one.
         let index = self.snapshots.len();
-        let new_snapshot = Snapshot {
+        let previous_snapshot = self.current_snapshot.clone();
+        MarketEvent::SnapshotFinalized {
+            index,
+            snapshot: previous_snapshot.clone(),
+        }
+        .emit();
+        self.snapshots.push(previous_snapshot.clone());
+        self.current_snapshot = Snapshot {
             time_chunk,
-            timestamp_ms: env::block_timestamp_ms().into(),
+            yield_distribution,
             deposited: self.borrow_asset_deposited,
             borrowed: self.borrow_asset_borrowed,
-            yield_distribution,
+            timestamp_ms: env::block_timestamp_ms().into(),
         };
-        self.snapshots.push(new_snapshot);
-        if let Some(previous_snapshot_index) = index.checked_sub(1) {
-            if let Some(previous_snapshot) = self.snapshots.get(previous_snapshot_index) {
-                MarketEvent::SnapshotFinalized {
-                    index: previous_snapshot_index,
-                    snapshot: previous_snapshot.clone(),
-                }
-                .emit();
-            }
-        }
         index
     }
 
@@ -158,10 +148,6 @@ impl Market {
             .at(snapshot.usage_ratio())
     }
 
-    pub fn iter_supply_account_ids(&self) -> impl Iterator<Item = AccountId> + '_ {
-        self.supply_positions.keys()
-    }
-
     pub fn supply_position_ref(&self, account_id: AccountId) -> Option<SupplyPositionRef<&Self>> {
         self.supply_positions
             .get(&account_id)
@@ -184,10 +170,6 @@ impl Market {
             .unwrap_or_else(|| SupplyPosition::new(self.snapshot()));
 
         SupplyPositionGuard::new(self, account_id, position)
-    }
-
-    pub fn iter_borrow_account_ids(&self) -> impl Iterator<Item = AccountId> + '_ {
-        self.borrow_positions.keys()
     }
 
     pub fn borrow_position_ref(&self, account_id: AccountId) -> Option<BorrowPositionRef<&Self>> {

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -20,7 +20,7 @@ use super::WithdrawalResolution;
 enum StorageKey {
     SupplyPositions,
     BorrowPositions,
-    Snapshots,
+    FinalizedSnapshots,
     WithdrawalQueue,
     StaticYield,
 }
@@ -35,7 +35,7 @@ pub struct Market {
     pub(crate) supply_positions: LookupMap<AccountId, SupplyPosition>,
     pub(crate) borrow_positions: LookupMap<AccountId, BorrowPosition>,
     pub current_snapshot: Snapshot,
-    pub snapshots: ChunkedAppendOnlyList<Snapshot, 128>,
+    pub finalized_snapshots: ChunkedAppendOnlyList<Snapshot, 128>,
     pub withdrawal_queue: WithdrawalQueue,
     pub static_yield: LookupMap<AccountId, StaticYieldRecord>,
 }
@@ -46,14 +46,6 @@ impl Market {
             env::panic_str(&e.to_string());
         }
 
-        let time_chunk = configuration.time_chunk_configuration.now();
-        let snapshot = Snapshot {
-            time_chunk,
-            timestamp_ms: env::block_timestamp_ms().into(),
-            deposited: 0.into(),
-            borrowed: 0.into(),
-            yield_distribution: BorrowAssetAmount::zero(),
-        };
         let prefix = prefix.into_storage_key();
         macro_rules! key {
             ($key: ident) => {
@@ -64,6 +56,18 @@ impl Market {
                 .concat()
             };
         }
+
+        let first_snapshot = Snapshot {
+            time_chunk: configuration.time_chunk_configuration.previous(),
+            end_timestamp_ms: env::block_timestamp_ms().into(),
+            deposited: 0.into(),
+            borrowed: 0.into(),
+            yield_distribution: BorrowAssetAmount::zero(),
+        };
+        let current_snapshot = Snapshot {
+            time_chunk: configuration.time_chunk_configuration.now(),
+            ..first_snapshot.clone()
+        };
         let mut self_ = Self {
             prefix: prefix.clone(),
             configuration,
@@ -72,20 +76,22 @@ impl Market {
             borrow_asset_borrowed: 0.into(),
             supply_positions: LookupMap::new(key!(SupplyPositions)),
             borrow_positions: LookupMap::new(key!(BorrowPositions)),
-            current_snapshot: snapshot.clone(),
-            snapshots: ChunkedAppendOnlyList::new(key!(Snapshots)),
+            current_snapshot,
+            finalized_snapshots: ChunkedAppendOnlyList::new(key!(FinalizedSnapshots)),
             withdrawal_queue: WithdrawalQueue::new(key!(WithdrawalQueue)),
             static_yield: LookupMap::new(key!(StaticYield)),
         };
 
-        self_.snapshots.push(snapshot.clone());
+        self_.finalized_snapshots.push(first_snapshot);
 
         self_
     }
 
-    pub fn get_last_snapshot(&self) -> &Snapshot {
+    pub fn get_last_finalized_snapshot(&self) -> &Snapshot {
         #[allow(clippy::unwrap_used, reason = "Snapshots are never empty")]
-        self.snapshots.get(self.snapshots.len() - 1).unwrap()
+        self.finalized_snapshots
+            .get(self.finalized_snapshots.len() - 1)
+            .unwrap()
     }
 
     pub fn snapshot(&mut self) -> u32 {
@@ -97,32 +103,31 @@ impl Market {
 
         // If still in current time chunk, just update the current snapshot.
         if self.current_snapshot.time_chunk == time_chunk {
-            self.current_snapshot.timestamp_ms = env::block_timestamp_ms().into();
+            self.current_snapshot.end_timestamp_ms = env::block_timestamp_ms().into();
             self.current_snapshot.deposited = self.borrow_asset_deposited;
             self.current_snapshot.borrowed = self.borrow_asset_borrowed;
             self.current_snapshot
                 .yield_distribution
                 .join(yield_distribution);
-            return self.snapshots.len() - 1;
+        } else {
+            // Otherwise, finalize the current snapshot and create a new one.
+            let mut snapshot = Snapshot {
+                time_chunk,
+                yield_distribution,
+                deposited: self.borrow_asset_deposited,
+                borrowed: self.borrow_asset_borrowed,
+                end_timestamp_ms: env::block_timestamp_ms().into(),
+            };
+            std::mem::swap(&mut snapshot, &mut self.current_snapshot);
+            MarketEvent::SnapshotFinalized {
+                index: self.finalized_snapshots.len(),
+                snapshot: snapshot.clone(),
+            }
+            .emit();
+            self.finalized_snapshots.push(snapshot);
         }
 
-        // Otherwise, finalize the current snapshot and create a new one.
-        let index = self.snapshots.len();
-        let previous_snapshot = self.current_snapshot.clone();
-        MarketEvent::SnapshotFinalized {
-            index,
-            snapshot: previous_snapshot.clone(),
-        }
-        .emit();
-        self.snapshots.push(previous_snapshot.clone());
-        self.current_snapshot = Snapshot {
-            time_chunk,
-            yield_distribution,
-            deposited: self.borrow_asset_deposited,
-            borrowed: self.borrow_asset_borrowed,
-            timestamp_ms: env::block_timestamp_ms().into(),
-        };
-        index
+        self.finalized_snapshots.len()
     }
 
     pub fn get_borrow_asset_available_to_borrow(&self) -> BorrowAssetAmount {

--- a/common/src/snapshot.rs
+++ b/common/src/snapshot.rs
@@ -6,7 +6,7 @@ use crate::{asset::BorrowAssetAmount, number::Decimal, time_chunk::TimeChunk};
 #[near(serializers = [borsh, json])]
 pub struct Snapshot {
     pub time_chunk: TimeChunk,
-    pub timestamp_ms: U64,
+    pub end_timestamp_ms: U64,
     pub deposited: BorrowAssetAmount,
     pub borrowed: BorrowAssetAmount,
     pub yield_distribution: BorrowAssetAmount,

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -100,41 +100,6 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
     pub fn with_pending_yield_estimate(&mut self) {
         self.position.borrow_asset_yield.pending_estimate =
             self.calculate_yield(u32::MAX).get_amount();
-        self.position
-            .borrow_asset_yield
-            .pending_estimate
-            .join(self.calculate_last_snapshot_yield());
-    }
-
-    pub fn calculate_last_snapshot_yield(&self) -> BorrowAssetAmount {
-        let deposit: Decimal = self.position.get_borrow_asset_deposit().into();
-        if deposit.is_zero() {
-            return BorrowAssetAmount::zero();
-        }
-
-        let last_snapshot = self.market.get_last_snapshot();
-        let total_deposited: Decimal = last_snapshot.deposited.into();
-        if total_deposited.is_zero() {
-            // divzero safety
-            return BorrowAssetAmount::zero();
-        }
-        let supply_weight = Decimal::from(self.market.configuration.yield_weights.supply.get());
-        // This is guaranteed to be nonzero, so no divzero issue.
-        let total_weight =
-            Decimal::from(self.market.configuration.yield_weights.total_weight().get());
-        let total_yield_distribution: Decimal = last_snapshot.yield_distribution.into();
-        let estimate_current_snapshot =
-            total_yield_distribution * deposit * supply_weight / total_deposited / total_weight;
-
-        // We know this must be <= total_yield_distribution.
-        // We know that total_yield_distribution <= sum total of fees collected during a snapshot.
-        // Therefore, assuming the underlying token is (correctly) represented
-        // in u128, this will never panic.
-        #[allow(
-            clippy::unwrap_used,
-            reason = "Assume underlying token is implemented correctly"
-        )]
-        estimate_current_snapshot.to_u128_floor().unwrap().into()
     }
 
     pub fn calculate_yield(&self, snapshot_limit: u32) -> AccumulationRecord<BorrowAsset> {
@@ -144,15 +109,14 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
 
         let mut accumulated = Decimal::ZERO;
 
-        let mut it = self.market.snapshots.iter();
-        // Skip the last snapshot, which may be incomplete.
-        it.next_back();
-
         #[allow(
             clippy::cast_possible_truncation,
             reason = "Assume # of snapshots is never >u32::MAX"
         )]
-        for (i, snapshot) in it
+        for (i, snapshot) in self
+            .market
+            .snapshots
+            .iter()
             .enumerate()
             .skip(next_snapshot_index as usize)
             .take(snapshot_limit as usize)

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -98,8 +98,15 @@ impl<M> SupplyPositionRef<M> {
 
 impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
     pub fn with_pending_yield_estimate(&mut self) {
-        self.position.borrow_asset_yield.pending_estimate =
-            self.calculate_yield(u32::MAX).get_amount();
+        let mut pending_estimate = self.calculate_yield(u32::MAX).get_amount();
+        if !self.market.current_snapshot.deposited.is_zero() {
+            let yield_in_current_snapshot =
+                u128::from(self.market.current_snapshot.yield_distribution)
+                    * u128::from(self.position.get_borrow_asset_deposit())
+                    / u128::from(self.market.current_snapshot.deposited);
+            pending_estimate.join(yield_in_current_snapshot.into());
+        }
+        self.position.borrow_asset_yield.pending_estimate = pending_estimate;
     }
 
     pub fn calculate_yield(&self, snapshot_limit: u32) -> AccumulationRecord<BorrowAsset> {
@@ -115,7 +122,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
         )]
         for (i, snapshot) in self
             .market
-            .snapshots
+            .finalized_snapshots
             .iter()
             .enumerate()
             .skip(next_snapshot_index as usize)

--- a/common/src/time_chunk.rs
+++ b/common/src/time_chunk.rs
@@ -21,6 +21,12 @@ impl TimeChunkConfiguration {
         }
         TimeChunk(U64(time / divisor))
     }
+
+    pub fn previous(&self) -> TimeChunk {
+        let TimeChunk(U64(time)) = self.now();
+        #[allow(clippy::unwrap_used, reason = "Assume now > 0")]
+        TimeChunk(U64(time.checked_sub(1).unwrap()))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -30,7 +30,7 @@ async fn main() {
     let harvest_yield_0 = c
         .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
         .await;
-    let snapshot_count_before = c.list_snapshots(None, None).await.len();
+    let snapshot_count_before = c.list_finalized_snapshots(None, None).await.len();
     c.collateralize(&borrow_user, 2000).await;
     c.collateralize(&borrow_user_2, 2000).await;
 
@@ -47,7 +47,7 @@ async fn main() {
         .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
         .await;
 
-    let snapshot_count_after = c.list_snapshots(None, None).await.len();
+    let snapshot_count_after = c.list_finalized_snapshots(None, None).await.len();
     let snapshot_count = snapshot_count_after - snapshot_count_before;
     eprintln!("Snapshot count: {snapshot_count}");
     let target_gas = Gas::from_tgas(285); // Max gas is 300, so this is a bit conservative

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -19,14 +19,18 @@ impl MarketExternalInterface for Contract {
         self.configuration.clone()
     }
 
-    fn get_snapshots_len(&self) -> u32 {
-        self.snapshots.len()
+    fn get_current_snapshot(&self) -> &Snapshot {
+        &self.current_snapshot
     }
 
-    fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot> {
+    fn get_finalized_snapshots_len(&self) -> u32 {
+        self.finalized_snapshots.len()
+    }
+
+    fn list_finalized_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<&Snapshot> {
         let offset = offset.map_or(0, |o| o as usize);
         let count = count.map_or(usize::MAX, |c| c as usize);
-        self.snapshots
+        self.finalized_snapshots
             .iter()
             .skip(offset)
             .take(count)
@@ -134,7 +138,7 @@ impl MarketExternalInterface for Contract {
     }
 
     fn get_last_interest_rate(&self) -> Decimal {
-        self.get_interest_rate_for_snapshot(self.get_last_snapshot())
+        self.get_interest_rate_for_snapshot(&self.current_snapshot)
     }
 
     fn get_supply_position(&self, account_id: AccountId) -> Option<SupplyPosition> {
@@ -237,7 +241,7 @@ impl MarketExternalInterface for Contract {
     }
 
     fn get_last_yield_rate(&self) -> Decimal {
-        let last_snapshot = self.get_last_snapshot();
+        let last_snapshot = &self.current_snapshot;
         let last_interest_rate = self.get_interest_rate_for_snapshot(last_snapshot);
         let deposited: Decimal = last_snapshot.deposited.into();
         if deposited.is_zero() {

--- a/contract/market/src/lib.rs
+++ b/contract/market/src/lib.rs
@@ -37,7 +37,7 @@ impl Contract {
     pub fn new(configuration: MarketConfiguration) -> Self {
         let mut market = Market::new(StorageKey::Market, configuration);
         let storage_usage_1 = env::storage_usage();
-        market.snapshots.flush();
+        market.finalized_snapshots.flush();
         let storage_usage_2 = env::storage_usage();
         let storage_usage_snapshot = storage_usage_2.saturating_sub(storage_usage_1);
 

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -50,10 +50,10 @@ async fn test_happy() {
 
     assert!(!bounds.min.is_zero());
 
-    let snapshots_len = c.get_snapshots_len().await;
+    let snapshots_len = c.get_finalized_snapshots_len().await;
     assert_eq!(snapshots_len, 1, "Should generate single snapshot on init");
 
-    let snapshots = c.list_snapshots(None, None).await;
+    let snapshots = c.list_finalized_snapshots(None, None).await;
     assert_eq!(snapshots.len(), 1);
     assert!(snapshots[0].yield_distribution.is_zero());
     assert!(snapshots[0].deposited.is_zero());

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -97,7 +97,7 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
         eprintln!("Borrow position 1: {borrow_position_1:#?}");
         eprintln!("Borrow position 2: {borrow_position_2:#?}");
 
-        let f = principal * strategy.at(dec!("0.2")) / Decimal::from(MS_IN_A_YEAR);
+        let f = principal * strategy.at(dec!("0.2")) / *MS_IN_A_YEAR;
 
         let approximation_below = (f * duration_inner.as_millis()).to_u128_ceil().unwrap();
         let approximation_above = (f * duration_outer.as_millis()).to_u128_ceil().unwrap();

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -94,9 +94,9 @@ impl TestController {
             .unwrap()
     }
 
-    pub async fn get_snapshots_len(&self) -> u32 {
+    pub async fn get_finalized_snapshots_len(&self) -> u32 {
         self.contract
-            .view("get_snapshots_len")
+            .view("get_finalized_snapshots_len")
             .args_json(json!({}))
             .await
             .unwrap()
@@ -104,9 +104,13 @@ impl TestController {
             .unwrap()
     }
 
-    pub async fn list_snapshots(&self, offset: Option<u32>, count: Option<u32>) -> Vec<Snapshot> {
+    pub async fn list_finalized_snapshots(
+        &self,
+        offset: Option<u32>,
+        count: Option<u32>,
+    ) -> Vec<Snapshot> {
         self.contract
-            .view("list_snapshots")
+            .view("list_finalized_snapshots")
             .args_json(json!({
                 "offset": offset,
                 "count": count,
@@ -596,7 +600,7 @@ impl TestController {
     pub async fn print_snapshots(&self) {
         let snapshots = self
             .contract
-            .view("list_snapshots")
+            .view("list_finalized_snapshots")
             .args_json(json!({}))
             .await
             .unwrap()
@@ -606,7 +610,7 @@ impl TestController {
         eprintln!("Market snapshots:");
         for (i, snapshot) in snapshots.iter().enumerate() {
             eprintln!("\t{i}: {}", snapshot.time_chunk.0 .0);
-            eprintln!("\t\tTimestamp:\t{}", snapshot.timestamp_ms.0);
+            eprintln!("\t\tTimestamp:\t{}", snapshot.end_timestamp_ms.0);
             eprintln!("\t\tDeposited:\t{}", snapshot.deposited);
             eprintln!("\t\tBorrowed:\t{}", snapshot.borrowed);
             eprintln!("\t\tDistribution:\t{}", snapshot.yield_distribution);


### PR DESCRIPTION
- Introduce `current_snapshot` field.
- Change semantics of timestamp field from "beginning of time chunk" to "end of time chunk."
- Associated algorithmic simplifications.

# API Changes

- New function: `get_current_snapshot()`
- Rename `get_snapshots_len` &rarr; `get_finalized_snapshots_len`
- Rename `list_snapshots` &rarr; `list_finalized_snapshots`