### PR TITLE
Fixing Broken Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ cargo near deploy <account-id>
 
 - [cargo-near](https://github.com/near/cargo-near) - NEAR smart contract development toolkit for Rust
 - [near CLI](https://near.cli.rs) - Interact with NEAR blockchain from command line
-- [NEAR Rust SDK Documentation](https://docs.near.org/sdk/rust/introduction)
+- [NEAR Rust SDK Documentation](https://docs.near.org/tools/sdk)
 - [NEAR Documentation](https://docs.near.org)
 - [NEAR StackOverflow](https://stackoverflow.com/questions/tagged/nearprotocol)
-- [NEAR Discord](https://near.chat)
+- [NEAR Discord](https://discord.com/invite/nearprotocol)
 - [NEAR Telegram Developers Community Group](https://t.me/neardev)
 - NEAR DevHub: [Telegram](https://t.me/neardevhub), [Twitter](https://twitter.com/neardevhub)


### PR DESCRIPTION
In the "Useful Links" section, i've fixed the link to; Near Rust Documentation and Near Discord.