### PR TITLE
Adds range limits for borrow, supply, withdrawal

### DIFF
--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -96,6 +96,7 @@ impl<T: AssetClass> Accumulator<T> {
 }
 
 #[must_use]
+#[derive(Debug, Clone)]
 pub struct AccumulationRecord<T: AssetClass> {
     pub(crate) amount: FungibleAssetAmount<T>,
     pub(crate) fraction_as_u128_dividend: u128,

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -461,7 +461,7 @@ impl<'a> BorrowPositionGuard<'a> {
             .borrow_asset_fees
             .amortize(current_snapshot_interest);
 
-        let borrow_minimum_amount = self.market.configuration.borrow_minimum_amount;
+        let borrow_minimum_amount = self.market.configuration.borrow_range.minimum;
         let liability_reduction = self
             .position
             .reduce_borrow_asset_liability(proof, amount, borrow_minimum_amount)

--- a/common/src/event.rs
+++ b/common/src/event.rs
@@ -39,12 +39,6 @@ pub enum MarketEvent {
         borrow_asset_amount_to_fees: BorrowAssetAmount,
     },
     #[event_version("1.0.0")]
-    SupplyWithdrawalResolution {
-        account_id: AccountId,
-        success: bool,
-        expected_success: bool,
-    },
-    #[event_version("1.0.0")]
     CollateralDeposited {
         account_id: AccountId,
         collateral_asset_amount: CollateralAssetAmount,

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -1,8 +1,11 @@
-use near_sdk::{json_types::U64, near, AccountId};
+use std::{io::ErrorKind, ops::Deref};
+
+use near_sdk::{borsh, json_types::U64, near, AccountId};
 
 use crate::{
     asset::{
-        BorrowAsset, BorrowAssetAmount, CollateralAsset, CollateralAssetAmount, FungibleAsset,
+        AssetClass, BorrowAsset, BorrowAssetAmount, CollateralAsset, CollateralAssetAmount,
+        FungibleAsset, FungibleAssetAmount,
     },
     borrow::{BorrowPosition, BorrowStatus, LiquidationReason},
     fee::{Fee, TimeBasedFee},
@@ -17,6 +20,88 @@ use super::{BalanceOracleConfiguration, YieldWeights};
 /// Reject >10,000,000% APY interest rates as misconfigurations.
 /// This also guarantees a reasonable upper-limit to interest rates to help avoid overflows.
 pub const APY_LIMIT: u128 = 100_000;
+
+#[derive(Clone, Debug)]
+#[near(serializers = [borsh, json])]
+#[serde(try_from = "AmountRange::<A>")]
+pub struct ValidAmountRange<A: AssetClass + PartialOrd>(
+    #[borsh(deserialize_with = "deserialize_valid_amount_range")] AmountRange<A>,
+);
+
+fn deserialize_valid_amount_range<
+    R: borsh::io::Read,
+    A: AssetClass + PartialOrd + borsh::BorshDeserialize,
+>(
+    reader: &mut R,
+) -> ::core::result::Result<AmountRange<A>, borsh::io::Error> {
+    <AmountRange<A> as borsh::BorshDeserialize>::deserialize_reader(reader)?.validate()
+}
+
+impl<A: AssetClass + PartialOrd> Deref for ValidAmountRange<A> {
+    type Target = AmountRange<A>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<A: AssetClass + PartialOrd> TryFrom<AmountRange<A>> for ValidAmountRange<A> {
+    type Error = std::io::Error;
+
+    fn try_from(value: AmountRange<A>) -> Result<Self, Self::Error> {
+        Ok(Self(value.validate()?))
+    }
+}
+
+impl<A: AssetClass + PartialOrd, T: Into<FungibleAssetAmount<A>>> TryFrom<(T, Option<T>)>
+    for ValidAmountRange<A>
+{
+    type Error = std::io::Error;
+
+    fn try_from((minimum, maximum): (T, Option<T>)) -> Result<Self, Self::Error> {
+        AmountRange {
+            minimum: minimum.into(),
+            maximum: maximum.map(Into::into),
+        }
+        .try_into()
+    }
+}
+
+#[derive(Clone, Debug)]
+#[near(serializers = [borsh, json])]
+pub struct AmountRange<A: AssetClass> {
+    minimum: FungibleAssetAmount<A>,
+    maximum: Option<FungibleAssetAmount<A>>,
+}
+
+impl<A: AssetClass + PartialOrd> AmountRange<A> {
+    pub fn contains(&self, amount: FungibleAssetAmount<A>) -> bool {
+        amount >= self.minimum && self.maximum.is_none_or(|max| amount <= max)
+    }
+
+    pub fn validate(self) -> std::io::Result<Self> {
+        if self.is_valid() {
+            Ok(self)
+        } else {
+            Err(std::io::Error::new(
+                ErrorKind::InvalidInput,
+                "Invalid range specified",
+            ))
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.maximum
+            .is_none_or(|max| !max.is_zero() && max >= self.minimum)
+    }
+
+    pub fn new(
+        minimum: FungibleAssetAmount<A>,
+        maximum: Option<FungibleAssetAmount<A>>,
+    ) -> std::io::Result<Self> {
+        Self { minimum, maximum }.validate()
+    }
+}
 
 #[derive(Clone, Debug)]
 #[near(serializers = [json, borsh])]
@@ -38,10 +123,10 @@ pub struct MarketConfiguration {
     pub borrow_origination_fee: Fee<BorrowAsset>,
     pub borrow_interest_rate_strategy: InterestRateStrategy,
     pub borrow_maximum_duration_ms: Option<U64>,
-    pub borrow_minimum_amount: BorrowAssetAmount,
-    pub borrow_maximum_amount: BorrowAssetAmount,
+    pub borrow_range: ValidAmountRange<BorrowAsset>,
+    pub supply_range: ValidAmountRange<BorrowAsset>,
+    pub supply_withdrawal_range: ValidAmountRange<BorrowAsset>,
     pub supply_withdrawal_fee: TimeBasedFee<BorrowAsset>,
-    pub supply_maximum_amount: Option<BorrowAssetAmount>,
     pub yield_weights: YieldWeights,
     pub protocol_account_id: AccountId,
     /// How far below market rate to accept liquidation? This is effectively the liquidator's spread.
@@ -125,10 +210,8 @@ impl MarketConfiguration {
             return Err(error::out_of_bounds("borrow_interest_rate_strategy"));
         }
 
-        if self.borrow_maximum_amount < self.borrow_minimum_amount
-            || self.borrow_maximum_amount.is_zero()
-        {
-            return Err(error::out_of_bounds("borrow_maximum_amount"));
+        if self.supply_withdrawal_range.minimum > self.supply_range.minimum {
+            return Err(error::out_of_bounds("supply_withdrawal_range.minimum"));
         }
 
         if self.liquidation_maximum_spread >= 1u32 {
@@ -226,6 +309,12 @@ fn satisfies_minimum_collateral_ratio(
 
 #[cfg(test)]
 mod tests {
+    use near_sdk::{
+        json_types::U128,
+        serde_json::{self, json},
+    };
+    use rstest::rstest;
+
     use crate::{borrow::InterestAccumulationProof, dec, oracle::pyth};
 
     use super::*;
@@ -256,5 +345,57 @@ mod tests {
             )
             .unwrap()
         ));
+    }
+
+    #[rstest]
+    #[case(1, 0)]
+    #[case(0, 0)]
+    #[case(u128::MAX, 0)]
+    #[case(u128::MAX, u128::MAX - 1)]
+    #[case(500, 10)]
+    #[should_panic = "Invalid range specified"]
+    fn invalid_amount_range(#[case] min: u128, #[case] max: u128) {
+        ValidAmountRange::<BorrowAsset>::try_from((min, Some(max))).unwrap();
+    }
+
+    #[rstest]
+    #[case(1, 0)]
+    #[case(0, 0)]
+    #[case(u128::MAX, 0)]
+    #[case(u128::MAX, u128::MAX - 1)]
+    #[case(500, 10)]
+    #[should_panic = "Invalid range specified"]
+    fn invalid_amount_range_json(#[case] min: u128, #[case] max: u128) {
+        serde_json::from_value::<ValidAmountRange<BorrowAsset>>(json!({
+            "minimum": U128(min),
+            "maximum": U128(max),
+        }))
+        .unwrap();
+    }
+
+    #[rstest]
+    #[case(1, 1)]
+    #[case(0, u128::MAX)]
+    #[case(1, u128::MAX)]
+    #[case(u128::MAX, u128::MAX)]
+    #[case(u128::MAX - 1, u128::MAX)]
+    #[case(10, 500)]
+    fn valid_amount_range(#[case] min: u128, #[case] max: u128) {
+        ValidAmountRange::<BorrowAsset>::try_from((min, Some(max))).unwrap();
+    }
+
+    #[rstest]
+    #[case(1, 1)]
+    #[case(0, u128::MAX)]
+    #[case(1, u128::MAX)]
+    #[case(u128::MAX, u128::MAX)]
+    #[case(u128::MAX - 1, u128::MAX)]
+    #[case(10, 500)]
+    fn valid_amount_range_json(#[case] min: u128, #[case] max: u128) {
+        serde_json::from_value::<ValidAmountRange<BorrowAsset>>(json!({
+            "minimum": U128(min),
+            "maximum": U128(max),
+        }))
+        .unwrap();
     }
 }

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -70,8 +70,8 @@ impl<A: AssetClass + PartialOrd, T: Into<FungibleAssetAmount<A>>> TryFrom<(T, Op
 #[derive(Clone, Debug)]
 #[near(serializers = [borsh, json])]
 pub struct AmountRange<A: AssetClass> {
-    minimum: FungibleAssetAmount<A>,
-    maximum: Option<FungibleAssetAmount<A>>,
+    pub minimum: FungibleAssetAmount<A>,
+    pub maximum: Option<FungibleAssetAmount<A>>,
 }
 
 impl<A: AssetClass + PartialOrd> AmountRange<A> {

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -224,10 +224,7 @@ impl Market {
             self.supply_position_guard(account_id)
                 .and_then(|supply_position| {
                     // Cap withdrawal amount to deposit amount at most.
-                    let amount = supply_position
-                        .inner()
-                        .get_borrow_asset_deposit_total()
-                        .min(requested_amount);
+                    let amount = supply_position.total_deposit().min(requested_amount);
 
                     (!amount.is_zero()).then_some((amount, supply_position))
                 })
@@ -240,8 +237,13 @@ impl Market {
         };
 
         let proof = supply_position.accumulate_yield();
-        let resolution =
-            supply_position.record_withdrawal(proof, amount, env::block_timestamp_ms());
+        let resolution = supply_position
+            .try_start_withdrawal(proof, amount, env::block_timestamp_ms())
+            .unwrap_or_else(|e| {
+                env::panic_str(&format!(
+                    "Invariant violation: Position cannot withdraw: {e}"
+                ))
+            });
 
         Ok(Some(resolution))
     }

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use near_sdk::{collections::LookupMap, env, near, AccountId, BorshStorageKey, IntoStorageKey};
 
 use crate::{
@@ -30,7 +32,7 @@ pub struct Market {
     prefix: Vec<u8>,
     pub configuration: MarketConfiguration,
     pub borrow_asset_deposited_active: BorrowAssetAmount,
-    pub borrow_asset_deposited_incoming: BorrowAssetAmount,
+    pub borrow_asset_deposited_incoming: HashMap<u32, BorrowAssetAmount>,
     pub borrow_asset_in_flight: BorrowAssetAmount,
     pub borrow_asset_borrowed: BorrowAssetAmount,
     pub(crate) supply_positions: LookupMap<AccountId, SupplyPosition>,
@@ -77,7 +79,7 @@ impl Market {
             prefix: prefix.clone(),
             configuration,
             borrow_asset_deposited_active: 0.into(),
-            borrow_asset_deposited_incoming: 0.into(),
+            borrow_asset_deposited_incoming: HashMap::new(),
             borrow_asset_in_flight: 0.into(),
             borrow_asset_borrowed: 0.into(),
             supply_positions: LookupMap::new(key!(SupplyPositions)),
@@ -91,6 +93,15 @@ impl Market {
         self_.finalized_snapshots.push(first_snapshot);
 
         self_
+    }
+
+    pub fn total_incoming(&self) -> BorrowAssetAmount {
+        self.borrow_asset_deposited_incoming
+            .values()
+            .fold(BorrowAssetAmount::zero(), |mut a, b| {
+                a.join(*b);
+                a
+            })
     }
 
     pub fn get_last_finalized_snapshot(&self) -> &Snapshot {
@@ -111,7 +122,10 @@ impl Market {
         if self.current_snapshot.time_chunk == time_chunk {
             self.current_snapshot.end_timestamp_ms = env::block_timestamp_ms().into();
             self.current_snapshot.deposited_active = self.borrow_asset_deposited_active;
-            self.current_snapshot.deposited_incoming = self.borrow_asset_deposited_incoming;
+            self.current_snapshot.deposited_incoming = *self
+                .borrow_asset_deposited_incoming
+                .get(&self.finalized_snapshots.len())
+                .unwrap_or(&0.into());
             self.current_snapshot.borrowed = self.borrow_asset_borrowed;
             self.current_snapshot
                 .yield_distribution
@@ -122,14 +136,16 @@ impl Market {
                 .at(self.current_snapshot.usage_ratio());
         } else {
             // Otherwise, finalize the current snapshot and create a new one.
-            self.borrow_asset_deposited_active
-                .join(self.borrow_asset_deposited_incoming);
-            self.borrow_asset_deposited_incoming = BorrowAssetAmount::zero();
+            let deposited_incoming = self
+                .borrow_asset_deposited_incoming
+                .remove(&self.finalized_snapshots.len())
+                .unwrap_or(0.into());
+            self.borrow_asset_deposited_active.join(deposited_incoming);
             let mut snapshot = Snapshot {
                 time_chunk,
                 yield_distribution,
                 deposited_active: self.borrow_asset_deposited_active,
-                deposited_incoming: self.borrow_asset_deposited_incoming,
+                deposited_incoming,
                 borrowed: self.borrow_asset_borrowed,
                 end_timestamp_ms: env::block_timestamp_ms().into(),
                 interest_rate: Decimal::ZERO,

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -30,7 +30,7 @@ pub struct Market {
     prefix: Vec<u8>,
     pub configuration: MarketConfiguration,
     pub borrow_asset_deposited_active: BorrowAssetAmount,
-    pub borrow_asset_deposited_inactive: BorrowAssetAmount,
+    pub borrow_asset_deposited_incoming: BorrowAssetAmount,
     pub borrow_asset_in_flight: BorrowAssetAmount,
     pub borrow_asset_borrowed: BorrowAssetAmount,
     pub(crate) supply_positions: LookupMap<AccountId, SupplyPosition>,
@@ -62,6 +62,7 @@ impl Market {
             time_chunk: configuration.time_chunk_configuration.previous(),
             end_timestamp_ms: env::block_timestamp_ms().into(),
             deposited_active: 0.into(),
+            deposited_incoming: 0.into(),
             borrowed: 0.into(),
             yield_distribution: BorrowAssetAmount::zero(),
             interest_rate: configuration
@@ -76,7 +77,7 @@ impl Market {
             prefix: prefix.clone(),
             configuration,
             borrow_asset_deposited_active: 0.into(),
-            borrow_asset_deposited_inactive: 0.into(),
+            borrow_asset_deposited_incoming: 0.into(),
             borrow_asset_in_flight: 0.into(),
             borrow_asset_borrowed: 0.into(),
             supply_positions: LookupMap::new(key!(SupplyPositions)),
@@ -110,6 +111,7 @@ impl Market {
         if self.current_snapshot.time_chunk == time_chunk {
             self.current_snapshot.end_timestamp_ms = env::block_timestamp_ms().into();
             self.current_snapshot.deposited_active = self.borrow_asset_deposited_active;
+            self.current_snapshot.deposited_incoming = self.borrow_asset_deposited_incoming;
             self.current_snapshot.borrowed = self.borrow_asset_borrowed;
             self.current_snapshot
                 .yield_distribution
@@ -121,12 +123,13 @@ impl Market {
         } else {
             // Otherwise, finalize the current snapshot and create a new one.
             self.borrow_asset_deposited_active
-                .join(self.borrow_asset_deposited_inactive);
-            self.borrow_asset_deposited_inactive = BorrowAssetAmount::zero();
+                .join(self.borrow_asset_deposited_incoming);
+            self.borrow_asset_deposited_incoming = BorrowAssetAmount::zero();
             let mut snapshot = Snapshot {
                 time_chunk,
                 yield_distribution,
                 deposited_active: self.borrow_asset_deposited_active,
+                deposited_incoming: self.borrow_asset_deposited_incoming,
                 borrowed: self.borrow_asset_borrowed,
                 end_timestamp_ms: env::block_timestamp_ms().into(),
                 interest_rate: Decimal::ZERO,
@@ -237,13 +240,8 @@ impl Market {
         };
 
         let proof = supply_position.accumulate_yield();
-        let resolution = supply_position
-            .try_start_withdrawal(proof, amount, env::block_timestamp_ms())
-            .unwrap_or_else(|e| {
-                env::panic_str(&format!(
-                    "Invariant violation: Position cannot withdraw: {e}"
-                ))
-            });
+        let resolution =
+            supply_position.record_withdrawal_initial(proof, amount, env::block_timestamp_ms());
 
         Ok(Some(resolution))
     }

--- a/common/src/market/mod.rs
+++ b/common/src/market/mod.rs
@@ -24,7 +24,7 @@ pub mod error {
 pub struct BorrowAssetMetrics {
     pub available: BorrowAssetAmount,
     pub deposited_active: BorrowAssetAmount,
-    pub deposited_incoming: BorrowAssetAmount,
+    pub deposited_incoming: HashMap<u32, BorrowAssetAmount>,
     pub borrowed: BorrowAssetAmount,
 }
 

--- a/common/src/market/mod.rs
+++ b/common/src/market/mod.rs
@@ -24,7 +24,7 @@ pub mod error {
 pub struct BorrowAssetMetrics {
     pub available: BorrowAssetAmount,
     pub deposited_active: BorrowAssetAmount,
-    pub deposited_inactive: BorrowAssetAmount,
+    pub deposited_incoming: BorrowAssetAmount,
     pub borrowed: BorrowAssetAmount,
 }
 

--- a/common/src/snapshot.rs
+++ b/common/src/snapshot.rs
@@ -8,6 +8,7 @@ pub struct Snapshot {
     pub time_chunk: TimeChunk,
     pub end_timestamp_ms: U64,
     pub deposited_active: BorrowAssetAmount,
+    pub deposited_incoming: BorrowAssetAmount,
     pub borrowed: BorrowAssetAmount,
     pub yield_distribution: BorrowAssetAmount,
     pub interest_rate: Decimal,

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -210,7 +210,17 @@ impl<'a> SupplyPositionGuard<'a> {
         Self(SupplyPositionRef::new(market, account_id, position))
     }
 
-    fn add_active(&mut self, amount: BorrowAssetAmount) {
+    fn activate_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
+        self.position
+            .borrow_asset_deposit
+            .incoming
+            .split(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.incoming` underflow")
+            });
+        self.position
+            .borrow_asset_deposit
+            .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
         self.position
             .borrow_asset_deposit
             .active
@@ -218,10 +228,7 @@ impl<'a> SupplyPositionGuard<'a> {
             .unwrap_or_else(|| {
                 env::panic_str("Supply position `borrow_asset_deposit.active` overflow")
             });
-        self.market
-            .borrow_asset_deposited_active
-            .join(amount)
-            .unwrap_or_else(|| env::panic_str("Market `borrow_asset_deposited_active` overflow"));
+        // Calling market.snapshot() performs the market accounting
     }
 
     fn remove_active(&mut self, amount: BorrowAssetAmount) {
@@ -249,6 +256,10 @@ impl<'a> SupplyPositionGuard<'a> {
         self.position
             .borrow_asset_deposit
             .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
+        self.market
+            .borrow_asset_deposited_incoming
+            .join(amount)
+            .unwrap_or_else(|| env::panic_str("Market `borrow_asset_deposited_incoming` overflow"));
     }
 
     fn remove_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
@@ -262,6 +273,12 @@ impl<'a> SupplyPositionGuard<'a> {
         self.position
             .borrow_asset_deposit
             .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
+        self.market
+            .borrow_asset_deposited_incoming
+            .split(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Market `borrow_asset_deposited_incoming` underflow")
+            });
     }
 
     pub fn accumulate_yield_partial(&mut self, snapshot_limit: u32) {
@@ -269,16 +286,31 @@ impl<'a> SupplyPositionGuard<'a> {
         self.market.snapshot();
 
         let accumulation_record = self.calculate_yield(snapshot_limit);
+        near_sdk::log!("accumulation_record = {accumulation_record:#?}");
         let until_snapshot_index = accumulation_record.next_snapshot_index;
+        near_sdk::log!(
+            "{until_snapshot_index} > {}?",
+            self.position
+                .borrow_asset_deposit
+                .activate_incoming_at_snapshot_index
+        );
         if until_snapshot_index
             > self
                 .position
                 .borrow_asset_deposit
                 .activate_incoming_at_snapshot_index
         {
+            near_sdk::log!(
+                "borrow_asset_deposit: {:?}",
+                self.position.borrow_asset_deposit,
+            );
             let amount = self.position.borrow_asset_deposit.incoming;
-            self.remove_incoming(amount, until_snapshot_index);
-            self.add_active(amount);
+            near_sdk::log!("activate_incoming({amount}, {until_snapshot_index})");
+            self.activate_incoming(amount, until_snapshot_index);
+            near_sdk::log!(
+                "borrow_asset_deposit: {:?}",
+                self.position.borrow_asset_deposit,
+            );
         }
 
         if !accumulation_record.amount.is_zero() {
@@ -310,7 +342,7 @@ impl<'a> SupplyPositionGuard<'a> {
             .outgoing
             .join(amount)
             .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit.withdrawing` overflow")
+                env::panic_str("Supply position `borrow_asset_deposit.outgoing` overflow")
             });
 
         if self.position.borrow_asset_deposit.incoming > amount {
@@ -363,7 +395,7 @@ impl<'a> SupplyPositionGuard<'a> {
             .outgoing
             .split(amount)
             .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit.withdrawing` underflow")
+                env::panic_str("Supply position `borrow_asset_deposit.outgoing` underflow")
             });
 
         if success {

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -15,32 +15,29 @@ use crate::{
 /// is safe to perform certain other operations.
 pub struct YieldAccumulationProof(());
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[near(serializers = [json, borsh])]
+pub struct IncomingDeposit {
+    pub amount: BorrowAssetAmount,
+    pub activate_at_snapshot_index: u32,
+}
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[near(serializers = [json, borsh])]
 pub struct Deposit {
     pub active: BorrowAssetAmount,
-    pub incoming: BorrowAssetAmount,
-    pub activate_incoming_at_snapshot_index: u32,
+    pub incoming: Vec<IncomingDeposit>,
     pub outgoing: BorrowAssetAmount,
 }
 
 impl Deposit {
     pub fn total(&self) -> BorrowAssetAmount {
         let mut total = self.active;
-        total.join(self.incoming);
+        for incoming in &self.incoming {
+            total.join(incoming.amount);
+        }
         total.join(self.outgoing);
         total
-    }
-}
-
-impl Deposit {
-    pub fn new(snapshot_index: u32) -> Self {
-        Self {
-            active: 0.into(),
-            incoming: 0.into(),
-            activate_incoming_at_snapshot_index: snapshot_index,
-            outgoing: 0.into(),
-        }
     }
 }
 
@@ -56,13 +53,23 @@ impl SupplyPosition {
     pub fn new(current_snapshot_index: u32) -> Self {
         Self {
             started_at_block_timestamp_ms: None,
-            borrow_asset_deposit: Deposit::new(current_snapshot_index),
+            borrow_asset_deposit: Deposit::default(),
             borrow_asset_yield: Accumulator::new(current_snapshot_index),
         }
     }
 
     pub fn get_deposit(&self) -> &Deposit {
         &self.borrow_asset_deposit
+    }
+
+    pub fn total_incoming(&self) -> BorrowAssetAmount {
+        self.borrow_asset_deposit
+            .incoming
+            .iter()
+            .fold(BorrowAssetAmount::zero(), |mut a, b| {
+                a.join(b.amount);
+                a
+            })
     }
 
     pub fn get_started_at_block_timestamp_ms(&self) -> Option<u64> {
@@ -119,13 +126,15 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
         let mut pending_estimate = self.calculate_yield(u32::MAX).get_amount();
         if !self.market.current_snapshot.deposited_active.is_zero() {
             let mut amount = u128::from(self.position.borrow_asset_deposit.active);
-            if self
+            let current_snapshot_index = self.market.finalized_snapshots.len();
+            for incoming in self
                 .position
                 .borrow_asset_deposit
-                .activate_incoming_at_snapshot_index
-                == self.market.finalized_snapshots.len()
+                .incoming
+                .iter()
+                .take_while(|i| i.activate_at_snapshot_index <= current_snapshot_index)
             {
-                amount += u128::from(self.position.borrow_asset_deposit.incoming);
+                amount += u128::from(incoming.amount);
             }
             let yield_in_current_snapshot =
                 u128::from(self.market.current_snapshot.yield_distribution) * amount
@@ -140,6 +149,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
 
         let mut amount = u128::from(self.position.borrow_asset_deposit.active);
         let mut accumulated = Decimal::ZERO;
+        let mut next_incoming = 0;
 
         #[allow(
             clippy::cast_possible_truncation,
@@ -153,12 +163,15 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
             .skip(next_snapshot_index as usize)
             .take(snapshot_limit as usize)
         {
-            if i == self
+            while let Some(incoming) = self
                 .position
                 .borrow_asset_deposit
-                .activate_incoming_at_snapshot_index as usize
+                .incoming
+                .get(next_incoming)
+                .filter(|incoming| incoming.activate_at_snapshot_index as usize == i)
             {
-                amount += u128::from(self.position.borrow_asset_deposit.incoming);
+                next_incoming += 1;
+                amount += u128::from(incoming.amount);
             }
 
             if !snapshot.deposited_active.is_zero() {
@@ -210,24 +223,27 @@ impl<'a> SupplyPositionGuard<'a> {
         Self(SupplyPositionRef::new(market, account_id, position))
     }
 
-    fn activate_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
-        self.position
+    fn activate_incoming(&mut self, until_snapshot_index: u32) {
+        let mut incoming = self
+            .position
             .borrow_asset_deposit
             .incoming
-            .split(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit.incoming` underflow")
-            });
-        self.position
-            .borrow_asset_deposit
-            .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
-        self.position
-            .borrow_asset_deposit
-            .active
-            .join(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit.active` overflow")
-            });
+            .clone()
+            .into_iter()
+            .peekable();
+        while let Some(deposit) =
+            incoming.next_if(|d| d.activate_at_snapshot_index < until_snapshot_index)
+        {
+            self.position
+                .borrow_asset_deposit
+                .active
+                .join(deposit.amount)
+                .unwrap_or_else(|| {
+                    env::panic_str("Supply position `borrow_asset_deposit.active` overflow")
+                });
+        }
+        self.position.borrow_asset_deposit.incoming = incoming.collect();
+
         // Calling market.snapshot() performs the market accounting
     }
 
@@ -246,39 +262,62 @@ impl<'a> SupplyPositionGuard<'a> {
     }
 
     fn add_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
-        self.position
-            .borrow_asset_deposit
-            .incoming
-            .join(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit.incoming` overflow")
+        let incoming = &mut self.position.borrow_asset_deposit.incoming;
+        if let Some(deposit) = incoming
+            .last_mut()
+            .filter(|i| i.activate_at_snapshot_index == activate_at_snapshot_index)
+        {
+            deposit
+                .amount
+                .join(amount)
+                .unwrap_or_else(|| env::panic_str("Supply position incoming overflow"));
+        } else {
+            const MAX_INCOMING: usize = 4;
+            require!(
+                incoming.len() < MAX_INCOMING,
+                "Too many deposits without running accumulation",
+            );
+            incoming.push(IncomingDeposit {
+                amount,
+                activate_at_snapshot_index,
             });
-        self.position
-            .borrow_asset_deposit
-            .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
+        }
+
         self.market
             .borrow_asset_deposited_incoming
+            .entry(activate_at_snapshot_index)
+            .or_insert(BorrowAssetAmount::zero())
             .join(amount)
             .unwrap_or_else(|| env::panic_str("Market `borrow_asset_deposited_incoming` overflow"));
     }
 
-    fn remove_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
-        self.position
-            .borrow_asset_deposit
-            .incoming
-            .split(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit.incoming` underflow")
-            });
-        self.position
-            .borrow_asset_deposit
-            .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
-        self.market
-            .borrow_asset_deposited_incoming
-            .split(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Market `borrow_asset_deposited_incoming` underflow")
-            });
+    /// Returns the amount successfully removed from incoming.
+    fn remove_incoming(&mut self, amount: BorrowAssetAmount) -> BorrowAssetAmount {
+        let mut total = BorrowAssetAmount::zero();
+        while let Some(newest) = self.position.borrow_asset_deposit.incoming.pop() {
+            total.join(newest.amount);
+
+            self.market
+                .borrow_asset_deposited_incoming
+                .entry(newest.activate_at_snapshot_index)
+                .and_modify(|a| {
+                    a.split(newest.amount).unwrap_or_else(|| {
+                        env::panic_str("Market `borrow_asset_deposited_incoming` underflow")
+                    });
+                });
+
+            #[allow(clippy::comparison_chain)]
+            if total == amount {
+                return amount;
+            } else if total > amount {
+                let mut remainder = total;
+                remainder.split(amount);
+                self.add_incoming(remainder, newest.activate_at_snapshot_index);
+                return amount;
+            }
+        }
+
+        total
     }
 
     pub fn accumulate_yield_partial(&mut self, snapshot_limit: u32) {
@@ -287,31 +326,7 @@ impl<'a> SupplyPositionGuard<'a> {
 
         let accumulation_record = self.calculate_yield(snapshot_limit);
         near_sdk::log!("accumulation_record = {accumulation_record:#?}");
-        let until_snapshot_index = accumulation_record.next_snapshot_index;
-        near_sdk::log!(
-            "{until_snapshot_index} > {}?",
-            self.position
-                .borrow_asset_deposit
-                .activate_incoming_at_snapshot_index
-        );
-        if until_snapshot_index
-            > self
-                .position
-                .borrow_asset_deposit
-                .activate_incoming_at_snapshot_index
-        {
-            near_sdk::log!(
-                "borrow_asset_deposit: {:?}",
-                self.position.borrow_asset_deposit,
-            );
-            let amount = self.position.borrow_asset_deposit.incoming;
-            near_sdk::log!("activate_incoming({amount}, {until_snapshot_index})");
-            self.activate_incoming(amount, until_snapshot_index);
-            near_sdk::log!(
-                "borrow_asset_deposit: {:?}",
-                self.position.borrow_asset_deposit,
-            );
-        }
+        self.activate_incoming(accumulation_record.next_snapshot_index);
 
         if !accumulation_record.amount.is_zero() {
             MarketEvent::YieldAccumulated {
@@ -345,14 +360,10 @@ impl<'a> SupplyPositionGuard<'a> {
                 env::panic_str("Supply position `borrow_asset_deposit.outgoing` overflow")
             });
 
-        if self.position.borrow_asset_deposit.incoming > amount {
-            self.remove_incoming(amount, self.market.finalized_snapshots.len() + 1);
-        } else {
-            let amount_incoming = self.position.borrow_asset_deposit.incoming;
-            let mut amount_remaining = amount;
-            self.remove_incoming(amount_incoming, self.market.finalized_snapshots.len() + 1);
-            amount_remaining.split(amount_incoming);
-            self.remove_active(amount_remaining);
+        let mut amount_to_remove = amount;
+        amount_to_remove.split(self.remove_incoming(amount));
+        if !amount_to_remove.is_zero() {
+            self.remove_active(amount_to_remove);
         }
 
         self.market.snapshot();

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -118,9 +118,17 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
     pub fn with_pending_yield_estimate(&mut self) {
         let mut pending_estimate = self.calculate_yield(u32::MAX).get_amount();
         if !self.market.current_snapshot.deposited_active.is_zero() {
+            let mut amount = u128::from(self.position.borrow_asset_deposit.active);
+            if self
+                .position
+                .borrow_asset_deposit
+                .activate_incoming_at_snapshot_index
+                == self.market.finalized_snapshots.len()
+            {
+                amount += u128::from(self.position.borrow_asset_deposit.incoming);
+            }
             let yield_in_current_snapshot =
-                u128::from(self.market.current_snapshot.yield_distribution)
-                    * u128::from(self.position.borrow_asset_deposit.active)
+                u128::from(self.market.current_snapshot.yield_distribution) * amount
                     / u128::from(self.market.current_snapshot.deposited_active);
             pending_estimate.join(yield_in_current_snapshot.into());
         }

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -325,7 +325,6 @@ impl<'a> SupplyPositionGuard<'a> {
         self.market.snapshot();
 
         let accumulation_record = self.calculate_yield(snapshot_limit);
-        near_sdk::log!("accumulation_record = {accumulation_record:#?}");
         self.activate_incoming(accumulation_record.next_snapshot_index);
 
         if !accumulation_record.amount.is_zero() {

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -378,15 +378,6 @@ impl<'a> SupplyPositionGuard<'a> {
         Ok(())
     }
 
-    // pub fn record_withdrawal_refund(
-    //     &mut self,
-    //     proof: YieldAccumulationProof,
-    //     amount: BorrowAssetAmount,
-    //     block_timestamp_ms: u64,
-    // ) {
-    //     self.record_deposit_inner(proof, amount, block_timestamp_ms);
-    // }
-
     fn record_deposit_inner(
         &mut self,
         _proof: YieldAccumulationProof,

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -1,7 +1,4 @@
-use std::{
-    fmt::Display,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use near_sdk::{env, json_types::U64, near, require, AccountId};
 
@@ -22,23 +19,17 @@ pub struct YieldAccumulationProof(());
 #[near(serializers = [json, borsh])]
 pub struct Deposit {
     pub active: BorrowAssetAmount,
-    pub inactive: BorrowAssetAmount,
-    pub activate_at_snapshot_index: u32,
+    pub incoming: BorrowAssetAmount,
+    pub activate_incoming_at_snapshot_index: u32,
+    pub outgoing: BorrowAssetAmount,
 }
 
 impl Deposit {
     pub fn total(&self) -> BorrowAssetAmount {
         let mut total = self.active;
-        total.join(self.inactive);
+        total.join(self.incoming);
+        total.join(self.outgoing);
         total
-    }
-
-    pub fn activate_until(&mut self, until_snapshot_index: u32) {
-        if until_snapshot_index > self.activate_at_snapshot_index {
-            self.active.join(self.inactive);
-            self.inactive = BorrowAssetAmount::zero();
-            self.activate_at_snapshot_index = until_snapshot_index;
-        }
     }
 }
 
@@ -46,47 +37,16 @@ impl Deposit {
     pub fn new(snapshot_index: u32) -> Self {
         Self {
             active: 0.into(),
-            inactive: 0.into(),
-            activate_at_snapshot_index: snapshot_index,
+            incoming: 0.into(),
+            activate_incoming_at_snapshot_index: snapshot_index,
+            outgoing: 0.into(),
         }
     }
-}
-
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-#[near(serializers = [json, borsh])]
-pub enum SupplyPositionStatus {
-    #[default]
-    Ready,
-    Withdrawing,
-}
-
-impl Display for SupplyPositionStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                SupplyPositionStatus::Ready => "Ready",
-                SupplyPositionStatus::Withdrawing => "Withdrawing",
-            }
-        )
-    }
-}
-
-pub mod error {
-    use thiserror::Error;
-
-    use super::SupplyPositionStatus;
-
-    #[derive(Debug, Error)]
-    #[error("This operation cannot be performed during `{0}` status")]
-    pub struct InvalidOperationDuringStatusError(pub SupplyPositionStatus);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[near(serializers = [json, borsh])]
 pub struct SupplyPosition {
-    status: SupplyPositionStatus,
     started_at_block_timestamp_ms: Option<U64>,
     borrow_asset_deposit: Deposit,
     pub borrow_asset_yield: Accumulator<BorrowAsset>,
@@ -95,7 +55,6 @@ pub struct SupplyPosition {
 impl SupplyPosition {
     pub fn new(current_snapshot_index: u32) -> Self {
         Self {
-            status: SupplyPositionStatus::Ready,
             started_at_block_timestamp_ms: None,
             borrow_asset_deposit: Deposit::new(current_snapshot_index),
             borrow_asset_yield: Accumulator::new(current_snapshot_index),
@@ -189,9 +148,9 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
             if i == self
                 .position
                 .borrow_asset_deposit
-                .activate_at_snapshot_index as usize
+                .activate_incoming_at_snapshot_index as usize
             {
-                amount += u128::from(self.position.borrow_asset_deposit.inactive);
+                amount += u128::from(self.position.borrow_asset_deposit.incoming);
             }
 
             if !snapshot.deposited_active.is_zero() {
@@ -242,14 +201,76 @@ impl<'a> SupplyPositionGuard<'a> {
         Self(SupplyPositionRef::new(market, account_id, position))
     }
 
+    fn add_active(&mut self, amount: BorrowAssetAmount) {
+        self.position
+            .borrow_asset_deposit
+            .active
+            .join(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.active` overflow")
+            });
+        self.market
+            .borrow_asset_deposited_active
+            .join(amount)
+            .unwrap_or_else(|| env::panic_str("Market `borrow_asset_deposited_active` overflow"));
+    }
+
+    fn remove_active(&mut self, amount: BorrowAssetAmount) {
+        self.position
+            .borrow_asset_deposit
+            .active
+            .split(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.active` underflow")
+            });
+        self.market
+            .borrow_asset_deposited_active
+            .split(amount)
+            .unwrap_or_else(|| env::panic_str("Market `borrow_asset_deposited_active` underflow"));
+    }
+
+    fn add_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
+        self.position
+            .borrow_asset_deposit
+            .incoming
+            .join(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.incoming` overflow")
+            });
+        self.position
+            .borrow_asset_deposit
+            .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
+    }
+
+    fn remove_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
+        self.position
+            .borrow_asset_deposit
+            .incoming
+            .split(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.incoming` underflow")
+            });
+        self.position
+            .borrow_asset_deposit
+            .activate_incoming_at_snapshot_index = activate_at_snapshot_index;
+    }
+
     pub fn accumulate_yield_partial(&mut self, snapshot_limit: u32) {
         require!(snapshot_limit > 0, "snapshot_limit must be nonzero");
         self.market.snapshot();
 
         let accumulation_record = self.calculate_yield(snapshot_limit);
-        self.position
-            .borrow_asset_deposit
-            .activate_until(accumulation_record.next_snapshot_index);
+        let until_snapshot_index = accumulation_record.next_snapshot_index;
+        if until_snapshot_index
+            > self
+                .position
+                .borrow_asset_deposit
+                .activate_incoming_at_snapshot_index
+        {
+            let amount = self.position.borrow_asset_deposit.incoming;
+            self.remove_incoming(amount, until_snapshot_index);
+            self.add_active(amount);
+        }
 
         if !accumulation_record.amount.is_zero() {
             MarketEvent::YieldAccumulated {
@@ -269,60 +290,28 @@ impl<'a> SupplyPositionGuard<'a> {
         YieldAccumulationProof(())
     }
 
-    /// # Errors
-    ///
-    /// - If the position is not marked as withdrawing.
-    pub fn try_end_withdrawal(&mut self) -> Result<(), error::InvalidOperationDuringStatusError> {
-        if self.position.status != SupplyPositionStatus::Withdrawing {
-            return Err(error::InvalidOperationDuringStatusError(
-                self.position.status,
-            ));
-        }
-
-        self.position.status = SupplyPositionStatus::Ready;
-        Ok(())
-    }
-
-    /// # Errors
-    ///
-    ///  - If the position is already marked as withdrawing.
-    pub fn try_start_withdrawal(
+    pub fn record_withdrawal_initial(
         &mut self,
         _proof: YieldAccumulationProof,
         mut amount: BorrowAssetAmount,
         block_timestamp_ms: u64,
-    ) -> Result<WithdrawalResolution, error::InvalidOperationDuringStatusError> {
-        if self.position.status != SupplyPositionStatus::Ready {
-            return Err(error::InvalidOperationDuringStatusError(
-                self.position.status,
-            ));
-        }
+    ) -> WithdrawalResolution {
+        self.position
+            .borrow_asset_deposit
+            .outgoing
+            .join(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.withdrawing` overflow")
+            });
 
-        self.position.status = SupplyPositionStatus::Withdrawing;
-
-        if self.position.borrow_asset_deposit.inactive > amount {
-            self.position.borrow_asset_deposit.inactive.split(amount);
-            self.market.borrow_asset_deposited_inactive.split(amount);
+        if self.position.borrow_asset_deposit.incoming > amount {
+            self.remove_incoming(amount, self.market.finalized_snapshots.len() + 1);
         } else {
-            let amount_inactive = self.position.borrow_asset_deposit.inactive;
+            let amount_incoming = self.position.borrow_asset_deposit.incoming;
             let mut amount_remaining = amount;
-            amount_remaining.split(amount_inactive);
-            self.market
-                .borrow_asset_deposited_inactive
-                .split(amount_inactive);
-            self.position.borrow_asset_deposit.inactive = 0.into();
-
-            self.position
-                .borrow_asset_deposit
-                .active
-                .split(amount_remaining)
-                .unwrap_or_else(|| env::panic_str("Supply position `deposit.active` underflow"));
-            self.market
-                .borrow_asset_deposited_active
-                .split(amount_remaining)
-                .unwrap_or_else(|| {
-                    env::panic_str("Market `borrow_asset_deposited_active` underflow")
-                });
+            self.remove_incoming(amount_incoming, self.market.finalized_snapshots.len() + 1);
+            amount_remaining.split(amount_incoming);
+            self.remove_active(amount_remaining);
         }
 
         self.market.snapshot();
@@ -345,40 +334,42 @@ impl<'a> SupplyPositionGuard<'a> {
             amount = FungibleAssetAmount::zero();
         }
 
-        MarketEvent::SupplyWithdrawn {
-            account_id: self.account_id.clone(),
-            borrow_asset_amount_to_account: amount,
-            borrow_asset_amount_to_fees: amount_to_fees,
-        }
-        .emit();
-
-        Ok(WithdrawalResolution {
+        WithdrawalResolution {
             account_id: self.account_id.clone(),
             amount_to_account: amount,
             amount_to_fees,
-        })
-    }
-
-    /// # Errors
-    ///
-    /// - If the position is currently withdrawing.
-    pub fn try_record_deposit(
-        &mut self,
-        proof: YieldAccumulationProof,
-        amount: BorrowAssetAmount,
-        block_timestamp_ms: u64,
-    ) -> Result<(), error::InvalidOperationDuringStatusError> {
-        if self.position.status != SupplyPositionStatus::Ready {
-            return Err(error::InvalidOperationDuringStatusError(
-                self.position.status,
-            ));
         }
-
-        self.record_deposit_inner(proof, amount, block_timestamp_ms);
-        Ok(())
     }
 
-    fn record_deposit_inner(
+    pub fn record_withdrawal_final(
+        &mut self,
+        withdrawal_resolution: &WithdrawalResolution,
+        success: bool,
+    ) {
+        let mut amount = withdrawal_resolution.amount_to_account;
+        amount.join(withdrawal_resolution.amount_to_fees);
+
+        self.position
+            .borrow_asset_deposit
+            .outgoing
+            .split(amount)
+            .unwrap_or_else(|| {
+                env::panic_str("Supply position `borrow_asset_deposit.withdrawing` underflow")
+            });
+
+        if success {
+            MarketEvent::SupplyWithdrawn {
+                account_id: self.account_id.clone(),
+                borrow_asset_amount_to_account: withdrawal_resolution.amount_to_account,
+                borrow_asset_amount_to_fees: withdrawal_resolution.amount_to_fees,
+            }
+            .emit();
+        } else {
+            self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
+        }
+    }
+
+    pub fn record_deposit(
         &mut self,
         _proof: YieldAccumulationProof,
         amount: BorrowAssetAmount,
@@ -390,20 +381,7 @@ impl<'a> SupplyPositionGuard<'a> {
             self.position.started_at_block_timestamp_ms = Some(block_timestamp_ms.into());
         }
 
-        self.position
-            .borrow_asset_deposit
-            .inactive
-            .join(amount)
-            .unwrap_or_else(|| env::panic_str("Supply position `deposit.inactive` overflow"));
-
-        self.position
-            .borrow_asset_deposit
-            .activate_at_snapshot_index = self.market.finalized_snapshots.len() + 1;
-
-        self.market
-            .borrow_asset_deposited_inactive
-            .join(amount)
-            .unwrap_or_else(|| env::panic_str("Market `borrow_asset_deposited_inactive` overflow"));
+        self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
 
         self.market.snapshot();
 

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -1,4 +1,7 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    fmt::Display,
+    ops::{Deref, DerefMut},
+};
 
 use near_sdk::{env, json_types::U64, near, require, AccountId};
 
@@ -17,45 +20,90 @@ pub struct YieldAccumulationProof(());
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[near(serializers = [json, borsh])]
-pub struct InactiveDeposit {
-    pub amount: BorrowAssetAmount,
+pub struct Deposit {
+    pub active: BorrowAssetAmount,
+    pub inactive: BorrowAssetAmount,
     pub activate_at_snapshot_index: u32,
+}
+
+impl Deposit {
+    pub fn total(&self) -> BorrowAssetAmount {
+        let mut total = self.active;
+        total.join(self.inactive);
+        total
+    }
+
+    pub fn activate_until(&mut self, until_snapshot_index: u32) {
+        if until_snapshot_index > self.activate_at_snapshot_index {
+            self.active.join(self.inactive);
+            self.inactive = BorrowAssetAmount::zero();
+            self.activate_at_snapshot_index = until_snapshot_index;
+        }
+    }
+}
+
+impl Deposit {
+    pub fn new(snapshot_index: u32) -> Self {
+        Self {
+            active: 0.into(),
+            inactive: 0.into(),
+            activate_at_snapshot_index: snapshot_index,
+        }
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[near(serializers = [json, borsh])]
+pub enum SupplyPositionStatus {
+    #[default]
+    Ready,
+    Withdrawing,
+}
+
+impl Display for SupplyPositionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                SupplyPositionStatus::Ready => "Ready",
+                SupplyPositionStatus::Withdrawing => "Withdrawing",
+            }
+        )
+    }
+}
+
+pub mod error {
+    use thiserror::Error;
+
+    use super::SupplyPositionStatus;
+
+    #[derive(Debug, Error)]
+    #[error("This operation cannot be performed during `{0}` status")]
+    pub struct InvalidOperationDuringStatusError(pub SupplyPositionStatus);
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[near(serializers = [json, borsh])]
 pub struct SupplyPosition {
+    status: SupplyPositionStatus,
     started_at_block_timestamp_ms: Option<U64>,
-    borrow_asset_deposit_active: BorrowAssetAmount,
-    inactive_deposit: InactiveDeposit,
+    borrow_asset_deposit: Deposit,
     pub borrow_asset_yield: Accumulator<BorrowAsset>,
 }
 
 impl SupplyPosition {
     pub fn new(current_snapshot_index: u32) -> Self {
         Self {
+            status: SupplyPositionStatus::Ready,
             started_at_block_timestamp_ms: None,
-            borrow_asset_deposit_active: 0.into(),
-            inactive_deposit: InactiveDeposit {
-                amount: 0.into(),
-                activate_at_snapshot_index: current_snapshot_index,
-            },
+            borrow_asset_deposit: Deposit::new(current_snapshot_index),
             borrow_asset_yield: Accumulator::new(current_snapshot_index),
         }
     }
 
-    pub fn get_borrow_asset_deposit_active(&self) -> BorrowAssetAmount {
-        self.borrow_asset_deposit_active
-    }
-
-    pub fn get_inactive_deposit(&self) -> InactiveDeposit {
-        self.inactive_deposit
-    }
-
-    pub fn get_borrow_asset_deposit_total(&self) -> BorrowAssetAmount {
-        let mut a = self.borrow_asset_deposit_active;
-        a.join(self.inactive_deposit.amount);
-        a
+    pub fn get_deposit(&self) -> &Deposit {
+        &self.borrow_asset_deposit
     }
 
     pub fn get_started_at_block_timestamp_ms(&self) -> Option<u64> {
@@ -63,8 +111,7 @@ impl SupplyPosition {
     }
 
     pub fn exists(&self) -> bool {
-        !self.borrow_asset_deposit_active.is_zero()
-            || !self.inactive_deposit.amount.is_zero()
+        !self.borrow_asset_deposit.total().is_zero()
             || !self.borrow_asset_yield.get_total().is_zero()
     }
 }
@@ -88,18 +135,33 @@ impl<M> SupplyPositionRef<M> {
         &self.account_id
     }
 
+    pub fn total_deposit(&self) -> BorrowAssetAmount {
+        self.position.borrow_asset_deposit.total()
+    }
+
+    pub fn total_yield(&self) -> BorrowAssetAmount {
+        self.position.borrow_asset_yield.get_total()
+    }
+
     pub fn inner(&self) -> &SupplyPosition {
         &self.position
     }
 }
 
 impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
+    pub fn is_within_allowable_range(&self) -> bool {
+        self.market
+            .configuration
+            .supply_range
+            .contains(self.position.borrow_asset_deposit.total())
+    }
+
     pub fn with_pending_yield_estimate(&mut self) {
         let mut pending_estimate = self.calculate_yield(u32::MAX).get_amount();
         if !self.market.current_snapshot.deposited_active.is_zero() {
             let yield_in_current_snapshot =
                 u128::from(self.market.current_snapshot.yield_distribution)
-                    * u128::from(self.position.get_borrow_asset_deposit_active())
+                    * u128::from(self.position.borrow_asset_deposit.active)
                     / u128::from(self.market.current_snapshot.deposited_active);
             pending_estimate.join(yield_in_current_snapshot.into());
         }
@@ -109,8 +171,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
     pub fn calculate_yield(&self, snapshot_limit: u32) -> AccumulationRecord<BorrowAsset> {
         let mut next_snapshot_index = self.position.borrow_asset_yield.get_next_snapshot_index();
 
-        let mut amount = u128::from(self.position.get_borrow_asset_deposit_active());
-        let amount_inactive = self.position.get_inactive_deposit();
+        let mut amount = u128::from(self.position.borrow_asset_deposit.active);
         let mut accumulated = Decimal::ZERO;
 
         #[allow(
@@ -125,8 +186,12 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
             .skip(next_snapshot_index as usize)
             .take(snapshot_limit as usize)
         {
-            if i == amount_inactive.activate_at_snapshot_index as usize {
-                amount += u128::from(amount_inactive.amount);
+            if i == self
+                .position
+                .borrow_asset_deposit
+                .activate_at_snapshot_index as usize
+            {
+                amount += u128::from(self.position.borrow_asset_deposit.inactive);
             }
 
             if !snapshot.deposited_active.is_zero() {
@@ -182,18 +247,9 @@ impl<'a> SupplyPositionGuard<'a> {
         self.market.snapshot();
 
         let accumulation_record = self.calculate_yield(snapshot_limit);
-        if accumulation_record.next_snapshot_index
-            > self.position.inactive_deposit.activate_at_snapshot_index
-        {
-            // Moved to the next snapshot.
-            let amount_inactive = self.position.inactive_deposit.amount;
-            self.position.inactive_deposit.amount = 0.into();
-            self.position
-                .borrow_asset_deposit_active
-                .join(amount_inactive);
-            self.position.inactive_deposit.activate_at_snapshot_index =
-                accumulation_record.next_snapshot_index;
-        }
+        self.position
+            .borrow_asset_deposit
+            .activate_until(accumulation_record.next_snapshot_index);
 
         if !accumulation_record.amount.is_zero() {
             MarketEvent::YieldAccumulated {
@@ -213,30 +269,54 @@ impl<'a> SupplyPositionGuard<'a> {
         YieldAccumulationProof(())
     }
 
-    pub fn record_withdrawal(
+    /// # Errors
+    ///
+    /// - If the position is not marked as withdrawing.
+    pub fn try_end_withdrawal(&mut self) -> Result<(), error::InvalidOperationDuringStatusError> {
+        if self.position.status != SupplyPositionStatus::Withdrawing {
+            return Err(error::InvalidOperationDuringStatusError(
+                self.position.status,
+            ));
+        }
+
+        self.position.status = SupplyPositionStatus::Ready;
+        Ok(())
+    }
+
+    /// # Errors
+    ///
+    ///  - If the position is already marked as withdrawing.
+    pub fn try_start_withdrawal(
         &mut self,
         _proof: YieldAccumulationProof,
         mut amount: BorrowAssetAmount,
         block_timestamp_ms: u64,
-    ) -> WithdrawalResolution {
-        if self.position.inactive_deposit.amount > amount {
-            self.position.inactive_deposit.amount.split(amount);
+    ) -> Result<WithdrawalResolution, error::InvalidOperationDuringStatusError> {
+        if self.position.status != SupplyPositionStatus::Ready {
+            return Err(error::InvalidOperationDuringStatusError(
+                self.position.status,
+            ));
+        }
+
+        self.position.status = SupplyPositionStatus::Withdrawing;
+
+        if self.position.borrow_asset_deposit.inactive > amount {
+            self.position.borrow_asset_deposit.inactive.split(amount);
             self.market.borrow_asset_deposited_inactive.split(amount);
         } else {
-            let amount_inactive = self.position.inactive_deposit.amount;
+            let amount_inactive = self.position.borrow_asset_deposit.inactive;
             let mut amount_remaining = amount;
             amount_remaining.split(amount_inactive);
             self.market
                 .borrow_asset_deposited_inactive
                 .split(amount_inactive);
-            self.position.inactive_deposit.amount = 0.into();
+            self.position.borrow_asset_deposit.inactive = 0.into();
 
             self.position
-                .borrow_asset_deposit_active
+                .borrow_asset_deposit
+                .active
                 .split(amount_remaining)
-                .unwrap_or_else(|| {
-                    env::panic_str("Supply position `borrow_asset_deposit_active` underflow")
-                });
+                .unwrap_or_else(|| env::panic_str("Supply position `deposit.active` underflow"));
             self.market
                 .borrow_asset_deposited_active
                 .split(amount_remaining)
@@ -272,35 +352,62 @@ impl<'a> SupplyPositionGuard<'a> {
         }
         .emit();
 
-        WithdrawalResolution {
+        Ok(WithdrawalResolution {
             account_id: self.account_id.clone(),
             amount_to_account: amount,
             amount_to_fees,
-        }
+        })
     }
 
-    pub fn record_deposit(
+    /// # Errors
+    ///
+    /// - If the position is currently withdrawing.
+    pub fn try_record_deposit(
+        &mut self,
+        proof: YieldAccumulationProof,
+        amount: BorrowAssetAmount,
+        block_timestamp_ms: u64,
+    ) -> Result<(), error::InvalidOperationDuringStatusError> {
+        if self.position.status != SupplyPositionStatus::Ready {
+            return Err(error::InvalidOperationDuringStatusError(
+                self.position.status,
+            ));
+        }
+
+        self.record_deposit_inner(proof, amount, block_timestamp_ms);
+        Ok(())
+    }
+
+    // pub fn record_withdrawal_refund(
+    //     &mut self,
+    //     proof: YieldAccumulationProof,
+    //     amount: BorrowAssetAmount,
+    //     block_timestamp_ms: u64,
+    // ) {
+    //     self.record_deposit_inner(proof, amount, block_timestamp_ms);
+    // }
+
+    fn record_deposit_inner(
         &mut self,
         _proof: YieldAccumulationProof,
         amount: BorrowAssetAmount,
         block_timestamp_ms: u64,
     ) {
         if self.position.started_at_block_timestamp_ms.is_none()
-            || self.position.borrow_asset_deposit_active.is_zero()
+            || self.position.borrow_asset_deposit.active.is_zero()
         {
             self.position.started_at_block_timestamp_ms = Some(block_timestamp_ms.into());
         }
 
         self.position
-            .inactive_deposit
-            .amount
+            .borrow_asset_deposit
+            .inactive
             .join(amount)
-            .unwrap_or_else(|| {
-                env::panic_str("Supply position `borrow_asset_deposit_inactive` overflow")
-            });
+            .unwrap_or_else(|| env::panic_str("Supply position `deposit.inactive` overflow"));
 
-        self.position.inactive_deposit.activate_at_snapshot_index =
-            self.market.finalized_snapshots.len() + 1;
+        self.position
+            .borrow_asset_deposit
+            .activate_at_snapshot_index = self.market.finalized_snapshots.len() + 1;
 
         self.market
             .borrow_asset_deposited_inactive

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -23,7 +23,8 @@ async fn main() {
         })
     );
 
-    c.supply(&supply_user, 120_000).await;
+    c.supply_and_harvest_until_activation(&supply_user, 120_000)
+        .await;
     let harvest_yield_0 = c
         .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
         .await;

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -26,7 +26,7 @@ async fn main() {
     c.supply_and_harvest_until_activation(&supply_user, 120_000)
         .await;
     let harvest_yield_0 = c
-        .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
+        .harvest_yield_execution(&supply_user, None, Some(HarvestYieldMode::Compounding))
         .await;
     let snapshot_count_before = c.list_finalized_snapshots(None, None).await.len();
     c.collateralize(&borrow_user, 2000).await;
@@ -42,7 +42,7 @@ async fn main() {
 
     let apply_interest_max = c.apply_interest(&borrow_user_2, None, None).await;
     let harvest_yield_max = c
-        .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
+        .harvest_yield_execution(&supply_user, None, Some(HarvestYieldMode::Compounding))
         .await;
 
     let snapshot_count_after = c.list_finalized_snapshots(None, None).await.len();

--- a/contract/market/examples/receipt_gas.rs
+++ b/contract/market/examples/receipt_gas.rs
@@ -13,8 +13,11 @@ async fn main() {
         })
     );
 
-    c.supply(&supply_user, 20_000).await;
-    c.collateralize(&borrow_user, 13_000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 20_000),
+        c.collateralize(&borrow_user, 13_000),
+    );
+
     c.borrow(&borrow_user, 10_000).await;
 
     c.set_collateral_asset_price(0.85).await;

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -28,16 +28,18 @@ impl Contract {
             );
         }
 
-        let supply_maximum_amount = self.configuration.supply_maximum_amount;
-        let mut supply_position = self.get_or_create_supply_position_guard(account_id);
-        let proof = supply_position.accumulate_yield();
-        supply_position.record_deposit(proof, amount, env::block_timestamp_ms());
-        if let Some(ref supply_maximum_amount) = supply_maximum_amount {
-            require!(
-                supply_position.inner().get_borrow_asset_deposit_total() <= *supply_maximum_amount,
-                "New supply position cannot exceed configured supply maximum",
-            );
-        }
+        let borrow_asset_deposit_total = {
+            let mut supply_position = self.get_or_create_supply_position_guard(account_id);
+            let proof = supply_position.accumulate_yield();
+            supply_position.record_deposit(proof, amount, env::block_timestamp_ms());
+            supply_position.inner().get_borrow_asset_deposit_total()
+        };
+        require!(
+            self.configuration
+                .supply_range
+                .contains(borrow_asset_deposit_total),
+            "New supply position is outside of allowable range",
+        );
     }
 
     pub fn execute_collateralize(

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -28,16 +28,13 @@ impl Contract {
             );
         }
 
-        let borrow_asset_deposit_total = {
-            let mut supply_position = self.get_or_create_supply_position_guard(account_id);
-            let proof = supply_position.accumulate_yield();
-            supply_position.record_deposit(proof, amount, env::block_timestamp_ms());
-            supply_position.inner().get_borrow_asset_deposit_total()
-        };
+        let mut supply_position = self.get_or_create_supply_position_guard(account_id);
+        let proof = supply_position.accumulate_yield();
+        supply_position
+            .try_record_deposit(proof, amount, env::block_timestamp_ms())
+            .unwrap_or_else(|e| env::panic_str(&e.to_string()));
         require!(
-            self.configuration
-                .supply_range
-                .contains(borrow_asset_deposit_total),
+            supply_position.is_within_allowable_range(),
             "New supply position is outside of allowable range",
         );
     }
@@ -294,6 +291,14 @@ impl Contract {
         }
         .emit();
 
+        if let Some(mut supply_position) =
+            self.supply_position_guard(withdrawal_resolution.account_id.clone())
+        {
+            supply_position
+                .try_end_withdrawal()
+                .unwrap_or_else(|e| env::panic_str(&e.to_string()));
+        }
+
         if withdrawal_succeeded || expected_success {
             // TODO: If this panics, this is BIG BAD, as it means there is
             // some way to unlock the queue while a withdrawal is in-flight.
@@ -334,7 +339,9 @@ impl Contract {
                 let proof = supply_position.accumulate_yield();
                 let mut amount = withdrawal_resolution.amount_to_account;
                 amount.join(withdrawal_resolution.amount_to_fees);
-                supply_position.record_deposit(proof, amount, env::block_timestamp_ms());
+                supply_position
+                    .try_record_deposit(proof, amount, env::block_timestamp_ms())
+                    .unwrap_or_else(|e| env::panic_str(&e.to_string()));
             }
         }
     }

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -3,7 +3,6 @@ use templar_common::{
     asset::{
         BorrowAsset, BorrowAssetAmount, CollateralAsset, CollateralAssetAmount, FungibleAsset,
     },
-    event::MarketEvent,
     market::WithdrawalResolution,
     oracle::pyth::OracleResponse,
     price::PricePair,
@@ -30,9 +29,7 @@ impl Contract {
 
         let mut supply_position = self.get_or_create_supply_position_guard(account_id);
         let proof = supply_position.accumulate_yield();
-        supply_position
-            .try_record_deposit(proof, amount, env::block_timestamp_ms())
-            .unwrap_or_else(|e| env::panic_str(&e.to_string()));
+        supply_position.record_deposit(proof, amount, env::block_timestamp_ms());
         require!(
             supply_position.is_within_allowable_range(),
             "New supply position is outside of allowable range",
@@ -284,19 +281,10 @@ impl Contract {
 
         let withdrawal_succeeded = matches!(env::promise_result(0), PromiseResult::Successful(_));
 
-        MarketEvent::SupplyWithdrawalResolution {
-            account_id: withdrawal_resolution.account_id.clone(),
-            success: withdrawal_succeeded,
-            expected_success,
-        }
-        .emit();
-
         if let Some(mut supply_position) =
             self.supply_position_guard(withdrawal_resolution.account_id.clone())
         {
-            supply_position
-                .try_end_withdrawal()
-                .unwrap_or_else(|e| env::panic_str(&e.to_string()));
+            supply_position.record_withdrawal_final(&withdrawal_resolution, withdrawal_succeeded);
         }
 
         if withdrawal_succeeded || expected_success {
@@ -331,18 +319,6 @@ impl Contract {
 
             env::log_str("The withdrawal request cannot be fulfilled at this time.");
             self.withdrawal_queue.unlock();
-            if let Some(mut supply_position) =
-                self.supply_position_guard(withdrawal_resolution.account_id.clone())
-            {
-                // This should not do very much since we also accumulate
-                // yield in the initial function call of execute_next_supply_withdrawal_request()
-                let proof = supply_position.accumulate_yield();
-                let mut amount = withdrawal_resolution.amount_to_account;
-                amount.join(withdrawal_resolution.amount_to_fees);
-                supply_position
-                    .try_record_deposit(proof, amount, env::block_timestamp_ms())
-                    .unwrap_or_else(|e| env::panic_str(&e.to_string()));
-            }
         }
     }
 

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -74,10 +74,6 @@ impl MarketExternalInterface for Contract {
 
     fn borrow(&mut self, amount: BorrowAssetAmount) -> Promise {
         require!(!amount.is_zero(), "Borrow amount must be greater than zero");
-        require!(
-            amount >= self.configuration.borrow_minimum_amount,
-            "Borrow amount is smaller than minimum allowed",
-        );
 
         let account_id = env::predecessor_account_id();
 
@@ -93,8 +89,8 @@ impl MarketExternalInterface for Contract {
         };
 
         require!(
-            proposed_amount <= self.configuration.borrow_maximum_amount,
-            "Borrow amount is greater than maximum allowed",
+            self.configuration.borrow_range.contains(proposed_amount),
+            "New borrow position is outside of allowable range",
         );
 
         self.configuration
@@ -182,6 +178,10 @@ impl MarketExternalInterface for Contract {
         require!(
             supply_position.inner().get_borrow_asset_deposit_total() >= amount,
             "Attempt to withdraw more than current deposit",
+        );
+        require!(
+            self.configuration.supply_withdrawal_range.contains(amount),
+            "Withdrawal amount is outside of allowable range",
         );
 
         self.withdrawal_queue.remove(&predecessor);

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -41,7 +41,7 @@ impl MarketExternalInterface for Contract {
         BorrowAssetMetrics {
             available: self.get_borrow_asset_available_to_borrow(),
             deposited_active: self.borrow_asset_deposited_active,
-            deposited_inactive: self.borrow_asset_deposited_inactive,
+            deposited_incoming: self.borrow_asset_deposited_incoming,
             borrowed: self.borrow_asset_borrowed,
         }
     }
@@ -199,7 +199,7 @@ impl MarketExternalInterface for Contract {
         // There may be loose/untracked funds that the contract controls but
         // does not account for in internal accounting.
         let expect_success = u128::from(self.borrow_asset_deposited_active)
-            .saturating_add(u128::from(self.borrow_asset_deposited_inactive))
+            .saturating_add(u128::from(self.borrow_asset_deposited_incoming))
             .checked_sub(
                 u128::from(self.borrow_asset_borrowed)
                     .saturating_add(self.borrow_asset_in_flight.into()),
@@ -250,9 +250,7 @@ impl MarketExternalInterface for Contract {
                 // Compound yield by withdrawing it and recording it as an immediate deposit.
                 let total_yield = supply_position.total_yield();
                 supply_position.record_yield_withdrawal(total_yield);
-                supply_position
-                    .try_record_deposit(proof, total_yield, env::block_timestamp_ms())
-                    .unwrap_or_else(|e| env::panic_str(&e.to_string()));
+                supply_position.record_deposit(proof, total_yield, env::block_timestamp_ms());
                 require!(
                     supply_position.is_within_allowable_range(),
                     "New supply position is outside of allowable range",

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -160,14 +160,9 @@ impl MarketExternalInterface for Contract {
             "Amount to withdraw must be greater than zero",
         );
         let predecessor = env::predecessor_account_id();
-        let Some(supply_position) =
-            self.supply_position_ref(predecessor.clone())
-                .filter(|supply_position| {
-                    !supply_position
-                        .inner()
-                        .get_borrow_asset_deposit_total()
-                        .is_zero()
-                })
+        let Some(supply_position) = self
+            .supply_position_ref(predecessor.clone())
+            .filter(|supply_position| !supply_position.total_deposit().is_zero())
         else {
             env::panic_str("Supply position does not exist");
         };
@@ -176,7 +171,7 @@ impl MarketExternalInterface for Contract {
         // This check really only ensures that the `depth` reported by
         // get_supply_withdrawal_queue_status() is realistically accurate.
         require!(
-            supply_position.inner().get_borrow_asset_deposit_total() >= amount,
+            supply_position.total_deposit() >= amount,
             "Attempt to withdraw more than current deposit",
         );
         require!(
@@ -253,9 +248,15 @@ impl MarketExternalInterface for Contract {
             HarvestYieldMode::Compounding => {
                 let proof = supply_position.accumulate_yield();
                 // Compound yield by withdrawing it and recording it as an immediate deposit.
-                let total_yield = supply_position.inner().borrow_asset_yield.get_total();
+                let total_yield = supply_position.total_yield();
                 supply_position.record_yield_withdrawal(total_yield);
-                supply_position.record_deposit(proof, total_yield, env::block_timestamp_ms());
+                supply_position
+                    .try_record_deposit(proof, total_yield, env::block_timestamp_ms())
+                    .unwrap_or_else(|e| env::panic_str(&e.to_string()));
+                require!(
+                    supply_position.is_within_allowable_range(),
+                    "New supply position is outside of allowable range",
+                );
                 return total_yield;
             }
             HarvestYieldMode::SnapshotLimit(limit) => {

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -41,7 +41,7 @@ impl MarketExternalInterface for Contract {
         BorrowAssetMetrics {
             available: self.get_borrow_asset_available_to_borrow(),
             deposited_active: self.borrow_asset_deposited_active,
-            deposited_incoming: self.total_incoming(),
+            deposited_incoming: self.borrow_asset_deposited_incoming.clone(),
             borrowed: self.borrow_asset_borrowed,
         }
     }

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -41,7 +41,7 @@ impl MarketExternalInterface for Contract {
         BorrowAssetMetrics {
             available: self.get_borrow_asset_available_to_borrow(),
             deposited_active: self.borrow_asset_deposited_active,
-            deposited_incoming: self.borrow_asset_deposited_incoming,
+            deposited_incoming: self.total_incoming(),
             borrowed: self.borrow_asset_borrowed,
         }
     }
@@ -199,7 +199,7 @@ impl MarketExternalInterface for Contract {
         // There may be loose/untracked funds that the contract controls but
         // does not account for in internal accounting.
         let expect_success = u128::from(self.borrow_asset_deposited_active)
-            .saturating_add(u128::from(self.borrow_asset_deposited_incoming))
+            .saturating_add(u128::from(self.total_incoming()))
             .checked_sub(
                 u128::from(self.borrow_asset_borrowed)
                     .saturating_add(self.borrow_asset_in_flight.into()),

--- a/contract/market/tests/0_many_snapshots.rs
+++ b/contract/market/tests/0_many_snapshots.rs
@@ -33,8 +33,10 @@ async fn many_snapshots() {
         })
     );
 
-    c.supply(&supply_user, 100_000).await;
-    c.collateralize(&borrow_user, 200_000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 100_000),
+        c.collateralize(&borrow_user, 200_000),
+    );
     let r = c.borrow(&borrow_user, 100).await;
     let base_gas = r.total_gas_burnt.as_gas();
     eprintln!("Base gas: {base_gas}");

--- a/contract/market/tests/borrow_limits.rs
+++ b/contract/market/tests/borrow_limits.rs
@@ -21,8 +21,10 @@ async fn borrow_within_bounds(
         })
     );
 
-    c.supply(&supply_user, 1000).await;
-    c.collateralize(&borrow_user, 2000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 1000),
+        c.collateralize(&borrow_user, 2000),
+    );
 
     for amount in amounts {
         c.borrow(&borrow_user, *amount).await;
@@ -51,8 +53,11 @@ async fn borrow_below_minimum(#[case] minimum: u128, #[case] amount: u128, #[cas
         })
     );
 
-    c.supply(&supply_user, 1000).await;
-    c.collateralize(&borrow_user, 2000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 1000),
+        c.collateralize(&borrow_user, 2000),
+    );
+
     c.borrow(&borrow_user, amount).await;
 }
 
@@ -80,8 +85,10 @@ async fn borrow_above_maximum(
         })
     );
 
-    c.supply(&supply_user, 10000).await;
-    c.collateralize(&borrow_user, 2000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 10_000),
+        c.collateralize(&borrow_user, 2000),
+    );
 
     for amount in amounts {
         c.borrow(&borrow_user, *amount).await;

--- a/contract/market/tests/borrow_limits.rs
+++ b/contract/market/tests/borrow_limits.rs
@@ -16,8 +16,7 @@ async fn borrow_within_bounds(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
-            c.borrow_maximum_amount = maximum.into();
-            c.borrow_minimum_amount = minimum.into();
+            c.borrow_range = (minimum, Some(maximum)).try_into().unwrap();
         })
     );
 
@@ -41,14 +40,13 @@ async fn borrow_within_bounds(
 #[case(u128::MAX, 1, u128::MAX)]
 #[case(1000, 738, u128::MAX)]
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Borrow amount is smaller than minimum allowed"]
+#[should_panic = "Smart contract panicked: New borrow position is outside of allowable range"]
 async fn borrow_below_minimum(#[case] minimum: u128, #[case] amount: u128, #[case] maximum: u128) {
     setup_test!(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
-            c.borrow_maximum_amount = maximum.into();
-            c.borrow_minimum_amount = minimum.into();
+            c.borrow_range = (minimum, Some(maximum)).try_into().unwrap();
         })
     );
 
@@ -67,7 +65,7 @@ async fn borrow_below_minimum(#[case] minimum: u128, #[case] amount: u128, #[cas
 #[case(100, &[1001], 500)]
 #[case(100, &[100, 100, 100, 100, 100, 100, 100], 500)]
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Borrow amount is greater than maximum allowed"]
+#[should_panic = "Smart contract panicked: New borrow position is outside of allowable range"]
 async fn borrow_above_maximum(
     #[case] minimum: u128,
     #[case] amounts: &[u128],
@@ -77,8 +75,7 @@ async fn borrow_above_maximum(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
-            c.borrow_maximum_amount = maximum.into();
-            c.borrow_minimum_amount = minimum.into();
+            c.borrow_range = (minimum, Some(maximum)).try_into().unwrap();
         })
     );
 

--- a/contract/market/tests/borrow_limits.rs
+++ b/contract/market/tests/borrow_limits.rs
@@ -95,7 +95,7 @@ async fn withdraw_below_minimum() {
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
-            c.borrow_minimum_amount = 10.into();
+            c.borrow_range = (10, None).try_into().unwrap();
             c.borrow_origination_fee = Fee::zero();
             c.borrow_interest_rate_strategy = InterestRateStrategy::linear(Decimal::ZERO, Decimal::ZERO).unwrap();
         })
@@ -111,8 +111,7 @@ async fn withdraw_below_minimum() {
         borrow_position_before.get_total_borrow_asset_liability(),
         100.into()
     );
-    let r = c.repay(&borrow_user, 91).await;
-    eprintln!("{r:#?}");
+    c.repay(&borrow_user, 91).await;
     let borrow_position_after = c.get_borrow_position(borrow_user.id()).await.unwrap();
 
     assert_eq!(

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -76,11 +76,11 @@ async fn compounding_yield(
         async { c.get_supply_position(supply_user_2.id()).await.unwrap() },
     );
 
-    let supply_yield_1 = u128::from(supply_position_1_after.get_borrow_asset_deposit_total())
+    let supply_yield_1 = u128::from(supply_position_1_after.get_deposit().total())
         + u128::from(supply_position_1_after.borrow_asset_yield.get_total())
         + u128::from(supply_position_1_after.borrow_asset_yield.pending_estimate)
         - principal * 5;
-    let supply_yield_2 = u128::from(supply_position_2_after.get_borrow_asset_deposit_total())
+    let supply_yield_2 = u128::from(supply_position_2_after.get_deposit().total())
         + u128::from(supply_position_2_after.borrow_asset_yield.get_total())
         + u128::from(supply_position_2_after.borrow_asset_yield.pending_estimate)
         - principal * 5;

--- a/contract/market/tests/configuration_validation.rs
+++ b/contract/market/tests/configuration_validation.rs
@@ -68,21 +68,11 @@ async fn borrow_asset_maximum_usage_ratio_greater_than_1() {
 }
 
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_maximum_amount`: out of bounds"]
-async fn borrow_maximum_amount_zero() {
+#[should_panic = "Smart contract panicked: Invalid configuration field `supply_withdrawal_range.minimum`: out of bounds"]
+async fn withdrawal_minimum_greater_than_supply_minimum() {
     setup_everything(|c| {
-        c.borrow_maximum_amount = 0.into();
-        c.borrow_minimum_amount = 0.into();
-    })
-    .await;
-}
-
-#[tokio::test]
-#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_maximum_amount`: out of bounds"]
-async fn borrow_maximum_amount_less_than_minimum() {
-    setup_everything(|c| {
-        c.borrow_maximum_amount = 10000.into();
-        c.borrow_minimum_amount = 99999.into();
+        c.supply_range = (1, None).try_into().unwrap();
+        c.supply_withdrawal_range = (2, None).try_into().unwrap();
     })
     .await;
 }

--- a/contract/market/tests/disabled_when_liquidatable.rs
+++ b/contract/market/tests/disabled_when_liquidatable.rs
@@ -4,8 +4,11 @@ use test_utils::*;
 async fn collateralization() {
     setup_test!(extract(c) accounts(borrow_user, supply_user));
 
-    c.supply(&supply_user, 2_000_000).await;
-    c.collateralize(&borrow_user, 2_000_000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 2_000_000),
+        c.collateralize(&borrow_user, 2_000_000),
+    );
+
     c.borrow(&borrow_user, 1_000_000).await;
     c.set_collateral_asset_price(0.5).await;
     let collateral_before = c
@@ -30,8 +33,11 @@ async fn collateralization() {
 async fn repayment() {
     setup_test!(extract(c) accounts(borrow_user, supply_user));
 
-    c.supply(&supply_user, 2_000_000).await;
-    c.collateralize(&borrow_user, 2_000_000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 2_000_000),
+        c.collateralize(&borrow_user, 2_000_000),
+    );
+
     c.borrow(&borrow_user, 1_000_000).await;
     c.set_collateral_asset_price(0.5).await;
 

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -52,7 +52,7 @@ async fn test_happy() {
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.get_deposit().inactive),
+        u128::from(supply_position.get_deposit().incoming),
         1100,
         "Supply position should match amount of tokens supplied to contract",
     );
@@ -63,7 +63,7 @@ async fn test_happy() {
         .await
         .unwrap()
         .get_deposit()
-        .inactive
+        .incoming
         .is_zero()
     {
         c.harvest_yield(&supply_user, None).await;

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -52,7 +52,7 @@ async fn test_happy() {
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.get_inactive_deposit().amount),
+        u128::from(supply_position.get_deposit().inactive),
         1100,
         "Supply position should match amount of tokens supplied to contract",
     );
@@ -62,8 +62,8 @@ async fn test_happy() {
         .get_supply_position(supply_user.id())
         .await
         .unwrap()
-        .get_inactive_deposit()
-        .amount
+        .get_deposit()
+        .inactive
         .is_zero()
     {
         c.harvest_yield(&supply_user, None).await;
@@ -72,7 +72,7 @@ async fn test_happy() {
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.get_borrow_asset_deposit_active()),
+        u128::from(supply_position.get_deposit().active),
         1100,
         "Supply position should match amount of tokens supplied to contract",
     );
@@ -226,7 +226,7 @@ async fn test_happy() {
             // Check that supply position is closed.
             {
                 let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
-                assert!(supply_position.get_borrow_asset_deposit_active().is_zero());
+                assert!(supply_position.get_deposit().active.is_zero());
             }
         },
         // Protocol yield.

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -52,7 +52,7 @@ async fn test_happy() {
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.get_deposit().incoming),
+        u128::from(supply_position.total_incoming()),
         1100,
         "Supply position should match amount of tokens supplied to contract",
     );
@@ -64,7 +64,7 @@ async fn test_happy() {
         .unwrap()
         .get_deposit()
         .incoming
-        .is_zero()
+        .is_empty()
     {
         c.harvest_yield(&supply_user, None, None).await;
     }

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -85,8 +85,10 @@ async fn successful_liquidation_good_debt_under_mcr(
         })
     );
 
-    c.supply(&supply_user, 10000).await;
-    c.collateralize(&borrow_user, collateral_amount).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 10_000),
+        c.collateralize(&borrow_user, collateral_amount),
+    );
     c.borrow(&borrow_user, borrow_amount).await;
 
     let collateral_balance_before = c
@@ -172,8 +174,10 @@ async fn successful_liquidation_with_spread(
         })
     );
 
-    c.supply(&supply_user, 10000).await;
-    c.collateralize(&borrow_user, 2000).await; // 2:1 collateralization
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 10_000),
+        c.collateralize(&borrow_user, 2000), // 2:1 collateralization
+    );
     c.borrow(&borrow_user, 1000).await;
 
     let collateral_balance_before = c
@@ -222,8 +226,10 @@ async fn fail_liquidation_too_little_attached() {
         accounts(borrow_user, supply_user, liquidator_user)
     );
 
-    c.supply(&supply_user, 1000).await;
-    c.collateralize(&borrow_user, 500).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 1000),
+        c.collateralize(&borrow_user, 500),
+    );
     c.borrow(&borrow_user, 300).await;
 
     let collateral_balance_before = c
@@ -268,8 +274,10 @@ async fn fail_liquidation_healthy_borrow() {
         accounts(borrow_user, supply_user, liquidator_user)
     );
 
-    c.supply(&supply_user, 1000).await;
-    c.collateralize(&borrow_user, 500).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 1000),
+        c.collateralize(&borrow_user, 500),
+    );
     c.borrow(&borrow_user, 300).await;
 
     let collateral_balance_before = c
@@ -314,8 +322,10 @@ async fn liquidators_race() {
         accounts(borrow_user, supply_user, liquidator_user)
     );
 
-    c.supply(&supply_user, 1000).await;
-    c.collateralize(&borrow_user, 500).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 1000),
+        c.collateralize(&borrow_user, 500),
+    );
     c.borrow(&borrow_user, 300).await;
     c.set_collateral_asset_price(0.5).await;
 
@@ -366,8 +376,10 @@ async fn successful_liquidation_only_from_interest() {
         })
     );
 
-    c.supply(&supply_user, 10_000_000).await;
-    c.collateralize(&borrow_user, 2_000_000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 10_000_000),
+        c.collateralize(&borrow_user, 2_000_000),
+    );
     c.borrow(&borrow_user, 1_000_000 - 1).await;
 
     let collateral_balance_before = c
@@ -452,8 +464,10 @@ async fn extreme_prices(
     })
     .await;
 
-    c.supply(&supply_user, 1_000_000).await;
-    c.collateralize(&borrow_user, 2000).await;
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 1_000_000),
+        c.collateralize(&borrow_user, 2000),
+    );
     c.borrow(&borrow_user, 1000).await;
 
     let collateral_balance_before = c

--- a/contract/market/tests/supply_maximum_amount.rs
+++ b/contract/market/tests/supply_maximum_amount.rs
@@ -75,6 +75,6 @@ async fn harvest_yield_beyond_maximum() {
     c.borrow(&borrow_user, LIMIT * 4 / 5).await;
     c.repay(&borrow_user, LIMIT).await;
 
-    c.harvest_yield(&supply_user, Some(HarvestYieldMode::Compounding))
+    c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Compounding))
         .await;
 }

--- a/contract/market/tests/supply_maximum_amount.rs
+++ b/contract/market/tests/supply_maximum_amount.rs
@@ -1,10 +1,12 @@
+use near_sdk::json_types::U64;
 use rstest::rstest;
-use templar_common::market::HarvestYieldMode;
+use templar_common::{market::HarvestYieldMode, time_chunk::TimeChunkConfiguration};
 use test_utils::*;
 
 #[rstest]
 #[case([10_000], 10_000)]
 #[case([1_000, 9_000], 10_000)]
+#[case([1; 25], 10_000)]
 #[tokio::test]
 async fn supply_within_maximum(
     #[case] deposits: impl IntoIterator<Item = u128>,
@@ -15,6 +17,9 @@ async fn supply_within_maximum(
         accounts(supply_user)
         config(|c| {
             c.supply_range = (1, Some(supply_maximum)).try_into().unwrap();
+            c.time_chunk_configuration = TimeChunkConfiguration::BlockTimestampMs {
+                divisor: U64(1000 * 20),
+            };
         })
     );
 

--- a/contract/market/tests/supply_maximum_amount.rs
+++ b/contract/market/tests/supply_maximum_amount.rs
@@ -1,5 +1,4 @@
 use rstest::rstest;
-use templar_common::asset::FungibleAssetAmount;
 use test_utils::*;
 
 #[rstest]
@@ -14,7 +13,7 @@ async fn supply_within_maximum(
         extract(c)
         accounts(supply_user)
         config(|c| {
-            c.supply_maximum_amount = Some(FungibleAssetAmount::new(supply_maximum));
+            c.supply_range = (1, Some(supply_maximum)).try_into().unwrap();
         })
     );
 
@@ -35,9 +34,9 @@ async fn supply_within_maximum(
 #[case([10_001], 10_000)]
 #[case([1, 100_000], 10_000)]
 #[case([9_001, 500, 500], 10_000)]
-#[case([1], 0)]
+#[case([2], 1)]
 #[tokio::test]
-#[should_panic = "Smart contract panicked: New supply position cannot exceed configured supply maximum"]
+#[should_panic = "Smart contract panicked: New supply position is outside of allowable range"]
 async fn supply_beyond_maximum(
     #[case] deposits: impl IntoIterator<Item = u128>,
     #[case] supply_maximum: u128,
@@ -46,7 +45,7 @@ async fn supply_beyond_maximum(
         extract(c)
         accounts(supply_user)
         config(|c| {
-            c.supply_maximum_amount = Some(FungibleAssetAmount::new(supply_maximum));
+            c.supply_range = (1, Some(supply_maximum)).try_into().unwrap();
         })
     );
 

--- a/contract/market/tests/supply_maximum_amount.rs
+++ b/contract/market/tests/supply_maximum_amount.rs
@@ -1,4 +1,5 @@
 use rstest::rstest;
+use templar_common::market::HarvestYieldMode;
 use test_utils::*;
 
 #[rstest]
@@ -24,10 +25,7 @@ async fn supply_within_maximum(
     }
 
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
-    assert_eq!(
-        u128::from(supply_position.get_borrow_asset_deposit_total()),
-        sum,
-    );
+    assert_eq!(u128::from(supply_position.get_deposit().total()), sum);
 }
 
 #[rstest]
@@ -55,4 +53,28 @@ async fn supply_beyond_maximum(
             o.clone().into_result().unwrap();
         }
     }
+}
+
+#[tokio::test]
+#[should_panic = "Smart contract panicked: New supply position is outside of allowable range"]
+async fn harvest_yield_beyond_maximum() {
+    const LIMIT: u128 = 1_000_000;
+    setup_test!(
+        extract(c)
+        accounts(supply_user, borrow_user)
+        config(|c| {
+            c.supply_range = (LIMIT, Some(LIMIT)).try_into().unwrap();
+        })
+    );
+
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, LIMIT),
+        c.collateralize(&borrow_user, LIMIT * 2),
+    );
+
+    c.borrow(&borrow_user, LIMIT * 4 / 5).await;
+    c.repay(&borrow_user, LIMIT).await;
+
+    c.harvest_yield(&supply_user, Some(HarvestYieldMode::Compounding))
+        .await;
 }

--- a/contract/market/tests/supply_withdrawal_queue.rs
+++ b/contract/market/tests/supply_withdrawal_queue.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, time::Duration};
+use std::time::Duration;
 
 use near_sdk::{serde_json::json, NearToken};
 use rstest::rstest;
@@ -191,22 +191,11 @@ async fn deposit_during_withdrawal() {
         async {
             tokio::time::sleep(Duration::from_millis(100)).await;
             let r = c.supply(&supply_user, 1_000).await;
-            let failures = r
-                .failures()
-                .into_iter()
-                .filter_map(|a| a.clone().into_result().err())
-                .filter_map(|e| e.source().map(|s| s.to_string()))
-                .collect::<Vec<_>>();
-            assert_eq!(failures, [
-                "Action #0: ExecutionError(\"Smart contract panicked: This operation cannot be performed during `Withdrawing` status\")",
-            ]);
+            assert!(r.failures().is_empty());
         },
     );
 
     let position = c.get_supply_position(supply_user.id()).await.unwrap();
 
-    assert!(
-        position.get_deposit().total().is_zero(),
-        "Only withdrawal should succeed",
-    );
+    assert_eq!(position.get_deposit().total(), 1_000.into());
 }

--- a/contract/market/tests/supply_withdrawal_queue.rs
+++ b/contract/market/tests/supply_withdrawal_queue.rs
@@ -77,7 +77,7 @@ async fn unsuccessful_withdrawal() {
 #[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Attempt to withdraw more than current deposit"]
-async fn attempt_to_withdraw_more_than_deposit_inactive() {
+async fn attempt_to_withdraw_more_than_deposit_incoming() {
     setup_test!(extract(c) accounts(supply_user));
 
     c.supply(&supply_user, 10_000).await;

--- a/contract/market/tests/supply_withdrawal_queue.rs
+++ b/contract/market/tests/supply_withdrawal_queue.rs
@@ -95,6 +95,24 @@ async fn attempt_to_withdraw_more_than_deposit() {
         .await;
 }
 
+#[rstest]
+#[tokio::test]
+#[should_panic = "Smart contract panicked: Withdrawal amount is outside of allowable range"]
+async fn attempt_to_withdraw_outside_configured_range() {
+    setup_test!(
+        extract(c)
+        accounts(supply_user)
+        config(|c| {
+            c.supply_range = (2000, None).try_into().unwrap();
+            c.supply_withdrawal_range = (2000, None).try_into().unwrap();
+        })
+    );
+
+    c.supply_and_harvest_until_activation(&supply_user, 10_000)
+        .await;
+    c.create_supply_withdrawal_request(&supply_user, 1000).await;
+}
+
 #[tokio::test]
 async fn supply_withdrawal_after_storage_unregister() {
     setup_test!(extract(c) accounts(supply_user, supply_user_2));

--- a/contract/market/tests/supply_withdrawal_queue.rs
+++ b/contract/market/tests/supply_withdrawal_queue.rs
@@ -1,3 +1,5 @@
+use std::{error::Error, time::Duration};
+
 use near_sdk::{serde_json::json, NearToken};
 use rstest::rstest;
 
@@ -96,21 +98,24 @@ async fn attempt_to_withdraw_more_than_deposit() {
 }
 
 #[rstest]
+#[case(1_000)]
+#[case(2_500)]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Withdrawal amount is outside of allowable range"]
-async fn attempt_to_withdraw_outside_configured_range() {
+async fn attempt_to_withdraw_outside_configured_range(#[case] amount: u128) {
     setup_test!(
         extract(c)
         accounts(supply_user)
         config(|c| {
-            c.supply_range = (2000, None).try_into().unwrap();
-            c.supply_withdrawal_range = (2000, None).try_into().unwrap();
+            c.supply_range = (2000, Some(3000)).try_into().unwrap();
+            c.supply_withdrawal_range = (2000, Some(2000)).try_into().unwrap();
         })
     );
 
-    c.supply_and_harvest_until_activation(&supply_user, 10_000)
+    c.supply_and_harvest_until_activation(&supply_user, 2_500)
         .await;
-    c.create_supply_withdrawal_request(&supply_user, 1000).await;
+    c.create_supply_withdrawal_request(&supply_user, amount)
+        .await;
 }
 
 #[tokio::test]
@@ -168,4 +173,40 @@ async fn supply_withdrawal_after_storage_unregister() {
     let status = c.get_supply_withdrawal_queue_status().await;
     assert!(status.depth.is_zero());
     assert_eq!(status.length, 0);
+}
+
+#[tokio::test]
+async fn deposit_during_withdrawal() {
+    setup_test!(extract(c) accounts(supply_user, borrow_user));
+
+    c.supply(&supply_user, 10_000).await;
+    c.create_supply_withdrawal_request(&supply_user, 10_000)
+        .await;
+
+    tokio::join!(
+        async {
+            let r = c.execute_next_supply_withdrawal_request(&supply_user).await;
+            assert!(r.failures().is_empty());
+        },
+        async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let r = c.supply(&supply_user, 1_000).await;
+            let failures = r
+                .failures()
+                .into_iter()
+                .filter_map(|a| a.clone().into_result().err())
+                .filter_map(|e| e.source().map(|s| s.to_string()))
+                .collect::<Vec<_>>();
+            assert_eq!(failures, [
+                "Action #0: ExecutionError(\"Smart contract panicked: This operation cannot be performed during `Withdrawing` status\")",
+            ]);
+        },
+    );
+
+    let position = c.get_supply_position(supply_user.id()).await.unwrap();
+
+    assert!(
+        position.get_deposit().total().is_zero(),
+        "Only withdrawal should succeed",
+    );
 }

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -142,6 +142,7 @@ async fn partial_snapshot_no_earnings() {
     c.supply(&supply_user_2, 100_000_000).await;
 
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
+    let mut earned_in_first_snapshot = 0u128;
     while !c
         .get_supply_position(supply_user_2.id())
         .await
@@ -157,22 +158,50 @@ async fn partial_snapshot_no_earnings() {
                 c.repay(&borrow_user, 10_000).await;
                 c.borrow(&borrow_user, 10_000).await;
             },
+            async {
+                let position = c.get_supply_position(supply_user.id()).await.unwrap();
+                let total = position.borrow_asset_yield.get_total();
+                let pending = position.borrow_asset_yield.pending_estimate;
+                eprintln!("Older position total: {total}");
+                eprintln!("Older position pending: {pending}");
+
+                if !total.is_zero() && earned_in_first_snapshot == 0 {
+                    earned_in_first_snapshot = total.into();
+                }
+            },
+            async {
+                let position = c.get_supply_position(supply_user_2.id()).await.unwrap();
+                let total = position.borrow_asset_yield.get_total();
+                let pending = position.borrow_asset_yield.pending_estimate;
+                eprintln!("Newer position total: {total}");
+                eprintln!("Newer position pending: {pending}");
+            },
         );
     }
     let snapshot_supply_end = c.get_finalized_snapshots_len().await;
     println!("Activation: {snapshot_supply_start} -> {snapshot_supply_end}");
 
-    let (amount_1_end, amount_2_end) = tokio::join!(
+    let (position_1_end, position_2_end) = tokio::join!(
         async { c.get_supply_position(supply_user.id()).await.unwrap() },
         async { c.get_supply_position(supply_user_2.id()).await.unwrap() },
     );
 
-    assert!(
-        u128::from(amount_2_end.borrow_asset_yield.get_total()) * 2
-            <= u128::from(amount_1_end.borrow_asset_yield.get_total())
+    eprintln!("Position 1 end: {position_1_end:#?}");
+    eprintln!("Position 2 end: {position_2_end:#?}");
+
+    let amount_1_end = position_1_end.borrow_asset_yield.get_total();
+    let amount_2_end = position_2_end.borrow_asset_yield.get_total();
+
+    eprintln!("Amount earned in first snapshot: {earned_in_first_snapshot}");
+    eprintln!("Amount 1 end: {amount_1_end}");
+    eprintln!("Amount 2 end: {amount_2_end}");
+    // assert!(u128::from(amount_2_end) * 2 <= u128::from(amount_1_end));
+    assert_eq!(
+        u128::from(amount_1_end),
+        u128::from(amount_2_end) + earned_in_first_snapshot,
     );
     assert_eq!(
-        amount_1_end.borrow_asset_yield.pending_estimate,
-        amount_2_end.borrow_asset_yield.pending_estimate,
+        position_1_end.borrow_asset_yield.pending_estimate,
+        position_2_end.borrow_asset_yield.pending_estimate,
     );
 }

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -30,7 +30,7 @@ async fn funds_activation() {
         c.get_supply_position(supply_user.id())
             .await
             .unwrap()
-            .get_inactive_deposit()
+            .get_deposit()
             .activate_at_snapshot_index
     );
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
@@ -40,8 +40,8 @@ async fn funds_activation() {
         .get_supply_position(supply_user.id())
         .await
         .unwrap()
-        .get_inactive_deposit()
-        .amount
+        .get_deposit()
+        .inactive
         .is_zero()
     {
         tokio::join!(
@@ -69,7 +69,7 @@ async fn funds_activation() {
         c.get_supply_position(supply_user.id())
             .await
             .unwrap()
-            .get_inactive_deposit()
+            .get_deposit()
             .activate_at_snapshot_index
     );
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
@@ -79,8 +79,8 @@ async fn funds_activation() {
         .get_supply_position(supply_user.id())
         .await
         .unwrap()
-        .get_inactive_deposit()
-        .amount
+        .get_deposit()
+        .inactive
         .is_zero()
     {
         tokio::join!(
@@ -126,8 +126,8 @@ async fn partial_snapshot_no_earnings() {
         .get_supply_position(supply_user.id())
         .await
         .unwrap()
-        .get_inactive_deposit()
-        .amount
+        .get_deposit()
+        .inactive
         .is_zero()
     {
         c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
@@ -146,8 +146,8 @@ async fn partial_snapshot_no_earnings() {
         .get_supply_position(supply_user_2.id())
         .await
         .unwrap()
-        .get_inactive_deposit()
-        .amount
+        .get_deposit()
+        .inactive
         .is_zero()
     {
         tokio::join!(

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -31,7 +31,7 @@ async fn funds_activation() {
             .await
             .unwrap()
             .get_deposit()
-            .activate_at_snapshot_index
+            .activate_incoming_at_snapshot_index
     );
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
 
@@ -41,7 +41,7 @@ async fn funds_activation() {
         .await
         .unwrap()
         .get_deposit()
-        .inactive
+        .incoming
         .is_zero()
     {
         tokio::join!(
@@ -70,7 +70,7 @@ async fn funds_activation() {
             .await
             .unwrap()
             .get_deposit()
-            .activate_at_snapshot_index
+            .activate_incoming_at_snapshot_index
     );
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
 
@@ -80,7 +80,7 @@ async fn funds_activation() {
         .await
         .unwrap()
         .get_deposit()
-        .inactive
+        .incoming
         .is_zero()
     {
         tokio::join!(
@@ -127,7 +127,7 @@ async fn partial_snapshot_no_earnings() {
         .await
         .unwrap()
         .get_deposit()
-        .inactive
+        .incoming
         .is_zero()
     {
         c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
@@ -147,7 +147,7 @@ async fn partial_snapshot_no_earnings() {
         .await
         .unwrap()
         .get_deposit()
-        .inactive
+        .incoming
         .is_zero()
     {
         tokio::join!(

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -195,7 +195,6 @@ async fn partial_snapshot_no_earnings() {
     eprintln!("Amount earned in first snapshot: {earned_in_first_snapshot}");
     eprintln!("Amount 1 end: {amount_1_end}");
     eprintln!("Amount 2 end: {amount_2_end}");
-    // assert!(u128::from(amount_2_end) * 2 <= u128::from(amount_1_end));
     assert_eq!(
         u128::from(amount_1_end),
         u128::from(amount_2_end) + earned_in_first_snapshot,

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -31,7 +31,8 @@ async fn funds_activation() {
             .await
             .unwrap()
             .get_deposit()
-            .activate_incoming_at_snapshot_index
+            .incoming[0]
+            .activate_at_snapshot_index
     );
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
 
@@ -42,7 +43,7 @@ async fn funds_activation() {
         .unwrap()
         .get_deposit()
         .incoming
-        .is_zero()
+        .is_empty()
     {
         tokio::join!(
             async {
@@ -70,7 +71,8 @@ async fn funds_activation() {
             .await
             .unwrap()
             .get_deposit()
-            .activate_incoming_at_snapshot_index
+            .incoming[0]
+            .activate_at_snapshot_index
     );
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
 
@@ -81,7 +83,7 @@ async fn funds_activation() {
         .unwrap()
         .get_deposit()
         .incoming
-        .is_zero()
+        .is_empty()
     {
         tokio::join!(
             async {
@@ -128,7 +130,7 @@ async fn partial_snapshot_no_earnings() {
         .unwrap()
         .get_deposit()
         .incoming
-        .is_zero()
+        .is_empty()
     {
         c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
             .await;
@@ -149,7 +151,7 @@ async fn partial_snapshot_no_earnings() {
         .unwrap()
         .get_deposit()
         .incoming
-        .is_zero()
+        .is_empty()
     {
         tokio::join!(
             c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default)),

--- a/test-utils/examples/generate_testnet_configuration.rs
+++ b/test-utils/examples/generate_testnet_configuration.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use near_sdk::serde_json;
 use templar_common::{
-    asset::{FungibleAsset, FungibleAssetAmount},
+    asset::FungibleAsset,
     dec,
     fee::{Fee, TimeBasedFee},
     interest_rate_strategy::InterestRateStrategy,
@@ -48,10 +48,10 @@ pub fn main() {
             )
             .unwrap(),
             borrow_maximum_duration_ms: None,
-            borrow_minimum_amount: FungibleAssetAmount::new(1),
-            borrow_maximum_amount: FungibleAssetAmount::new(u128::MAX),
+            borrow_range: (1, None).try_into().unwrap(),
+            supply_range: (1, Some(500 * 10u128.pow(6))).try_into().unwrap(),
+            supply_withdrawal_range: (1, None).try_into().unwrap(),
             supply_withdrawal_fee: TimeBasedFee::zero(),
-            supply_maximum_amount: Some(FungibleAssetAmount::new(500 * 10u128.pow(6))),
             yield_weights: YieldWeights::new_with_supply_weight(1),
             liquidation_maximum_spread: Decimal::from_str("0.05").unwrap(),
             protocol_account_id: "templar-in-training.testnet".parse().unwrap(),

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -312,7 +312,7 @@ impl UnifiedMarketController {
             .await
             .unwrap()
             .get_deposit()
-            .inactive
+            .incoming
             .is_zero()
         {
             self.harvest_yield(supply_user, None).await;

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -311,8 +311,8 @@ impl UnifiedMarketController {
             .get_supply_position(supply_user.id())
             .await
             .unwrap()
-            .get_inactive_deposit()
-            .amount
+            .get_deposit()
+            .inactive
             .is_zero()
         {
             self.harvest_yield(supply_user, None).await;

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -95,13 +95,18 @@ impl MarketController {
     pub async fn harvest_yield_execution(
         &self,
         supply_user: &Account,
+        account_id: Option<&AccountId>,
         mode: Option<HarvestYieldMode>,
     ) -> ExecutionSuccess {
         eprintln!("{} harvesting yield...", supply_user.id());
         self.call_exec(
             supply_user,
             "harvest_yield",
-            serde_json::to_vec(&json!({ "mode": mode })).unwrap(),
+            serde_json::to_vec(&json!({
+                "account_id": account_id,
+                "mode": mode,
+            }))
+            .unwrap(),
             NearToken::from_near(0),
             Gas::from_tgas(300),
         )

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -318,7 +318,7 @@ impl UnifiedMarketController {
             .unwrap()
             .get_deposit()
             .incoming
-            .is_zero()
+            .is_empty()
         {
             self.harvest_yield(supply_user, None, None).await;
         }

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -103,11 +103,11 @@ pub fn market_configuration(
         )
         .unwrap(),
         borrow_maximum_duration_ms: None,
-        borrow_minimum_amount: 1.into(),
-        borrow_maximum_amount: u128::MAX.into(),
-        liquidation_maximum_spread: Decimal::from_str("0.05").unwrap(),
+        borrow_range: (1, None).try_into().unwrap(),
+        supply_range: (1, None).try_into().unwrap(),
+        supply_withdrawal_range: (1, None).try_into().unwrap(),
         supply_withdrawal_fee: TimeBasedFee::zero(),
-        supply_maximum_amount: None,
+        liquidation_maximum_spread: Decimal::from_str("0.05").unwrap(),
         yield_weights,
         protocol_account_id,
     }


### PR DESCRIPTION
**This PR is as large as it is because enforcing these new limits requires adding a lot of additional locking logic.**

- Introduces the `[Valid]AmountRange` structs, which represent _inclusive_ ranges of token amounts.
- Changes the `*_maximum_*` and `*_minimum_*` configuration fields to use the aforementioned range struct, for a consistent API:
    - Introduces `borrow_range`, replacing `borrow_minimum_amount` and `borrow_maximum_amount`.
    - Introduces `supply_range`, replacing and augmenting `supply_maximum_amount`.
    - Introduces `supply_withdrawal_range`, introducing a configurable range of allowable amounts that can be withdrawn at a time.
 - Changes the deposit representation in supply records, unifying the active & inactive deposit fields under the same struct.
 - Introduces supply position amount locking, preventing supply positions from depositing above configured limits during failed withdrawals.
 - Renames `inactive` funds to `incoming` funds.
     - Incoming funds are segmented by snapshot index of activation instead of lumped into one.
 - Introduces `outgoing` lock amount (used during withdrawals).
 - Removes the `SupplyWithdrawalResolution` event type; the semantics of the `SupplyWithdrawn` are now consistent with the other events: it is only emitted on success.