### PR TITLE
Allow anyone to run accumulations on positions

### DIFF
--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -1,4 +1,4 @@
-use near_sdk::{near, require};
+use near_sdk::{json_types::U128, near, require};
 
 use crate::asset::{AssetClass, FungibleAssetAmount};
 
@@ -6,6 +6,7 @@ use crate::asset::{AssetClass, FungibleAssetAmount};
 #[near(serializers = [borsh, json])]
 pub struct Accumulator<T: AssetClass> {
     total: FungibleAssetAmount<T>,
+    fraction_as_u128_dividend: U128,
     next_snapshot_index: u32,
     #[borsh(skip)]
     #[serde(default, skip_serializing_if = "FungibleAssetAmount::is_zero")]
@@ -17,6 +18,7 @@ impl<T: AssetClass> Accumulator<T> {
     pub fn new(next_snapshot_index: u32) -> Self {
         Self {
             total: 0.into(),
+            fraction_as_u128_dividend: U128(0),
             next_snapshot_index,
             pending_estimate: 0.into(),
             amortized: 0.into(),
@@ -70,7 +72,8 @@ impl<T: AssetClass> Accumulator<T> {
     pub fn accumulate(
         &mut self,
         AccumulationRecord {
-            amount,
+            mut amount,
+            fraction_as_u128_dividend: fraction,
             next_snapshot_index,
         }: AccumulationRecord<T>,
     ) -> Option<()>
@@ -81,7 +84,12 @@ impl<T: AssetClass> Accumulator<T> {
             next_snapshot_index >= self.next_snapshot_index,
             "Invariant violation: Asset accumulations cannot occur retroactively.",
         );
+        let (fraction, carry) = self.fraction_as_u128_dividend.0.overflowing_add(fraction);
+        if carry {
+            amount.join(1.into())?;
+        }
         self.add_once(amount)?;
+        self.fraction_as_u128_dividend.0 = fraction;
         self.next_snapshot_index = next_snapshot_index;
         Some(())
     }
@@ -90,6 +98,7 @@ impl<T: AssetClass> Accumulator<T> {
 #[must_use]
 pub struct AccumulationRecord<T: AssetClass> {
     pub(crate) amount: FungibleAssetAmount<T>,
+    pub(crate) fraction_as_u128_dividend: u128,
     pub(crate) next_snapshot_index: u32,
 }
 
@@ -109,6 +118,7 @@ mod tests {
 
         a.accumulate(AccumulationRecord {
             amount: 100.into(),
+            fraction_as_u128_dividend: 0,
             next_snapshot_index: 2,
         });
 
@@ -120,9 +130,31 @@ mod tests {
 
         a.accumulate(AccumulationRecord {
             amount: 100.into(),
+            fraction_as_u128_dividend: 0,
             next_snapshot_index: 3,
         });
 
         assert_eq!(a.get_total(), 200.into());
+    }
+
+    #[test]
+    fn fraction() {
+        let mut a = Accumulator::<crate::asset::BorrowAsset>::new(1);
+
+        a.accumulate(AccumulationRecord {
+            amount: 100.into(),
+            fraction_as_u128_dividend: 1 << 127,
+            next_snapshot_index: 2,
+        });
+
+        assert_eq!(a.get_total(), 100.into());
+
+        a.accumulate(AccumulationRecord {
+            amount: 100.into(),
+            fraction_as_u128_dividend: 1 << 127,
+            next_snapshot_index: 3,
+        });
+
+        assert_eq!(a.get_total(), 201.into());
     }
 }

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -283,7 +283,8 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
                 clippy::unwrap_used,
                 reason = "Assume accumulated interest will never exceed u128::MAX"
             )]
-            amount: accumulated.to_u128_ceil().unwrap().into(),
+            amount: accumulated.to_u128_floor().unwrap().into(),
+            fraction_as_u128_dividend: accumulated.fractional_part_as_u128_dividend(),
             next_snapshot_index,
         }
     }

--- a/common/src/market/external.rs
+++ b/common/src/market/external.rs
@@ -59,7 +59,7 @@ pub trait MarketExternalInterface {
     /// Applies interest to the predecessor's borrow record.
     /// Not likely to be used in real life, since there it does not affect the
     /// final interest calculation, and rounds fractional interest UP.
-    fn apply_interest(&mut self, snapshot_limit: Option<u32>);
+    fn apply_interest(&mut self, account_id: Option<AccountId>, snapshot_limit: Option<u32>);
 
     // ================
     // SUPPLY FUNCTIONS
@@ -85,7 +85,11 @@ pub trait MarketExternalInterface {
     /// harvested in previous, non-compounding `harvest_yield` calls) is
     /// deposited to the supply record, so it will contribute to future yield
     /// calculations.
-    fn harvest_yield(&mut self, mode: Option<HarvestYieldMode>) -> BorrowAssetAmount;
+    fn harvest_yield(
+        &mut self,
+        account_id: Option<AccountId>,
+        mode: Option<HarvestYieldMode>,
+    ) -> BorrowAssetAmount;
 
     /// This value is an *expected average over time*.
     /// Supply positions actually earn all of their yield the instant it is

--- a/common/src/number.rs
+++ b/common/src/number.rs
@@ -320,6 +320,10 @@ impl Decimal {
         U512([self.repr.0[0], self.repr.0[1], 0, 0, 0, 0, 0, 0])
     }
 
+    pub fn fractional_part_as_u128_dividend(&self) -> u128 {
+        u128::from(self.repr.0[0]) | (u128::from(self.repr.0[1]) << 64)
+    }
+
     fn epsilon_round(repr: U512) -> U512 {
         (repr + (Self::REPR_EPSILON >> 1)) & !(Self::REPR_EPSILON - 1)
     }
@@ -789,6 +793,14 @@ mod tests {
         assert!((Decimal::ONE_HALF.to_f64_lossy() - 0.5_f64).abs() < 1e-200);
         assert_eq!(Decimal::ONE.to_u128_floor().unwrap(), 1);
         assert_eq!(Decimal::TWO.to_u128_floor().unwrap(), 2);
+    }
+
+    #[rstest]
+    #[case(Decimal::ONE, 0)]
+    #[case(Decimal::ONE_HALF, 1u128 << 127)]
+    #[test]
+    fn get_fractional_dividend(#[case] value: Decimal, #[case] expected: u128) {
+        assert_eq!(value.fractional_part_as_u128_dividend(), expected);
     }
 
     #[rstest]

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -142,6 +142,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
             // never overflow underlying data type.
             #[allow(clippy::unwrap_used, reason = "Derived from real balances")]
             amount: accumulated.to_u128_floor().unwrap().into(),
+            fraction_as_u128_dividend: accumulated.fractional_part_as_u128_dividend(),
             next_snapshot_index,
         }
     }

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -32,14 +32,14 @@ async fn main() {
     c.collateralize(&borrow_user_2, 2000).await;
 
     c.borrow(&borrow_user_2, 1000).await;
-    let apply_interest_0 = c.apply_interest(&borrow_user_2, None).await;
+    let apply_interest_0 = c.apply_interest(&borrow_user_2, None, None).await;
 
     for _ in 0..ITERATIONS {
         c.borrow(&borrow_user, 1000).await;
         c.repay(&borrow_user, 1100).await;
     }
 
-    let apply_interest_max = c.apply_interest(&borrow_user_2, None).await;
+    let apply_interest_max = c.apply_interest(&borrow_user_2, None, None).await;
     let harvest_yield_max = c
         .harvest_yield_execution(&supply_user, Some(HarvestYieldMode::Compounding))
         .await;

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -254,7 +254,7 @@ impl MarketExternalInterface for Contract {
 
         require!(
             account_id == predecessor || !matches!(mode, HarvestYieldMode::Compounding),
-            "Only the account owner can compound yield",
+            "Only the position holder can compound yield",
         );
 
         let Some(mut supply_position) = self.supply_position_guard(account_id) else {

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -143,9 +143,9 @@ impl MarketExternalInterface for Contract {
         }
     }
 
-    fn apply_interest(&mut self, snapshot_limit: Option<u32>) {
-        let predecessor = env::predecessor_account_id();
-        if let Some(mut borrow_position) = self.borrow_position_guard(predecessor) {
+    fn apply_interest(&mut self, account_id: Option<AccountId>, snapshot_limit: Option<u32>) {
+        let account_id = account_id.unwrap_or_else(env::predecessor_account_id);
+        if let Some(mut borrow_position) = self.borrow_position_guard(account_id) {
             borrow_position.accumulate_interest_partial(snapshot_limit.unwrap_or(u32::MAX));
         }
     }
@@ -243,13 +243,25 @@ impl MarketExternalInterface for Contract {
         self.withdrawal_queue.get_status()
     }
 
-    fn harvest_yield(&mut self, mode: Option<HarvestYieldMode>) -> BorrowAssetAmount {
+    fn harvest_yield(
+        &mut self,
+        account_id: Option<AccountId>,
+        mode: Option<HarvestYieldMode>,
+    ) -> BorrowAssetAmount {
+        let mode = mode.unwrap_or_default();
         let predecessor = env::predecessor_account_id();
-        let Some(mut supply_position) = self.supply_position_guard(predecessor) else {
+        let account_id = account_id.unwrap_or_else(|| predecessor.clone());
+
+        require!(
+            account_id == predecessor || !matches!(mode, HarvestYieldMode::Compounding),
+            "Only the account owner can compound yield",
+        );
+
+        let Some(mut supply_position) = self.supply_position_guard(account_id) else {
             return BorrowAssetAmount::zero();
         };
 
-        match mode.unwrap_or_default() {
+        match mode {
             HarvestYieldMode::Compounding => {
                 let proof = supply_position.accumulate_yield();
                 // Compound yield by withdrawing it and recording it as an immediate deposit.

--- a/contract/market/tests/accumulations.rs
+++ b/contract/market/tests/accumulations.rs
@@ -1,0 +1,79 @@
+use templar_common::market::HarvestYieldMode;
+use test_utils::*;
+
+#[tokio::test]
+async fn third_party_accumulation_executor() {
+    setup_test!(extract(c) accounts(borrow_user, supply_user, third_party));
+
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 10_000),
+        c.collateralize(&borrow_user, 2000),
+    );
+
+    c.borrow(&borrow_user, 1000).await;
+
+    assert!(c
+        .apply_interest(&third_party, Some(borrow_user.id()), None)
+        .await
+        .failures()
+        .is_empty());
+    assert!(c
+        .apply_interest(&borrow_user, Some(borrow_user.id()), None)
+        .await
+        .failures()
+        .is_empty());
+
+    assert!(c.repay(&borrow_user, 1100).await.failures().is_empty());
+
+    c.harvest_yield(
+        &supply_user,
+        Some(supply_user.id()),
+        Some(HarvestYieldMode::Default),
+    )
+    .await;
+    c.harvest_yield(
+        &third_party,
+        Some(supply_user.id()),
+        Some(HarvestYieldMode::Default),
+    )
+    .await;
+    c.harvest_yield(
+        &supply_user,
+        Some(supply_user.id()),
+        Some(HarvestYieldMode::SnapshotLimit(100)),
+    )
+    .await;
+    c.harvest_yield(
+        &third_party,
+        Some(supply_user.id()),
+        Some(HarvestYieldMode::SnapshotLimit(100)),
+    )
+    .await;
+    c.harvest_yield(
+        &supply_user,
+        Some(supply_user.id()),
+        Some(HarvestYieldMode::Compounding),
+    )
+    .await;
+}
+
+#[tokio::test]
+#[should_panic = "Smart contract panicked: Only the position holder can compound yield"]
+async fn third_party_cannot_compound_yield() {
+    setup_test!(extract(c) accounts(borrow_user, supply_user, third_party));
+
+    tokio::join!(
+        c.supply_and_harvest_until_activation(&supply_user, 10_000),
+        c.collateralize(&borrow_user, 2000),
+    );
+
+    c.borrow(&borrow_user, 1000).await;
+    c.repay(&borrow_user, 1100).await;
+
+    c.harvest_yield(
+        &third_party,
+        Some(supply_user.id()),
+        Some(HarvestYieldMode::Compounding),
+    )
+    .await;
+}

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -46,7 +46,8 @@ async fn compounding_yield(
     tokio::join!(
         async {
             while !done.load(Ordering::Relaxed) {
-                c.harvest_yield(&supply_user_2, Some(compounding)).await;
+                c.harvest_yield(&supply_user_2, None, Some(compounding))
+                    .await;
                 iters += 1;
             }
         },
@@ -68,7 +69,7 @@ async fn compounding_yield(
     );
     eprintln!("Done sleeping!");
 
-    c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+    c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
         .await;
 
     let (supply_position_1_after, supply_position_2_after) = tokio::join!(

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -66,7 +66,7 @@ async fn test_happy() {
         .amount
         .is_zero()
     {
-        c.harvest_yield(&supply_user, None).await;
+        c.harvest_yield(&supply_user, None, None).await;
     }
 
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
@@ -140,7 +140,7 @@ async fn test_happy() {
         async {
             // Withdraw yield.
             {
-                c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+                c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
                     .await;
                 let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
                 assert_eq!(
@@ -149,7 +149,7 @@ async fn test_happy() {
                 );
                 // Move the yield to the principal so that it can be withdrawn
                 let amount_moved_to_principal = c
-                    .harvest_yield(&supply_user, Some(HarvestYieldMode::Compounding))
+                    .harvest_yield(&supply_user, None, Some(HarvestYieldMode::Compounding))
                     .await;
 
                 assert_eq!(

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -63,7 +63,7 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
                 // Technically it should be optimal to harvest (and
                 // compound) occasionally throughout the duration of
                 // the supply.
-                c.harvest_yield(&supply_user_2, Some(HarvestYieldMode::Default)),
+                c.harvest_yield(&supply_user_2, None, Some(HarvestYieldMode::Default)),
             );
             tokio::time::sleep(Duration::from_secs(1)).await;
             iters += 1;
@@ -167,12 +167,12 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
 
     let (supply_position_1, supply_position_2) = tokio::join!(
         async {
-            c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+            c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
                 .await;
             c.get_supply_position(supply_user.id()).await.unwrap()
         },
         async {
-            c.harvest_yield(&supply_user_2, Some(HarvestYieldMode::Default))
+            c.harvest_yield(&supply_user_2, None, Some(HarvestYieldMode::Default))
                 .await;
             c.get_supply_position(supply_user_2.id()).await.unwrap()
         },

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -58,7 +58,7 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
         // They should accumulate (very nearly) the same amount of interest regardless.
         while timer.elapsed() < Duration::from_secs(12) {
             tokio::join!(
-                c.apply_interest(&borrow_user_2, None),
+                c.apply_interest(&borrow_user_2, None, None),
                 // No compounding so we get apples-to-apples comparison.
                 // Technically it should be optimal to harvest (and
                 // compound) occasionally throughout the duration of

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -125,7 +125,7 @@ async fn successful_liquidation_good_debt_under_mcr(
 
     tokio::join!(
         async {
-            c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+            c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
                 .await;
             let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
             assert_eq!(
@@ -379,7 +379,7 @@ async fn successful_liquidation_only_from_interest() {
 
     let timer = Instant::now();
     while timer.elapsed() < Duration::from_secs(5) {
-        c.harvest_yield(&supply_user, None).await;
+        c.harvest_yield(&supply_user, None, None).await;
         tokio::time::sleep(Duration::from_millis(500)).await;
     }
 

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -52,7 +52,7 @@ async fn funds_activation() {
                 );
             },
             async {
-                c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+                c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
                     .await;
             },
         );
@@ -91,7 +91,7 @@ async fn funds_activation() {
                 );
             },
             async {
-                c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+                c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
                     .await;
             },
         );
@@ -130,7 +130,7 @@ async fn partial_snapshot_no_earnings() {
         .amount
         .is_zero()
     {
-        c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default))
+        c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
             .await;
     }
     let snapshot_supply_end = c.get_finalized_snapshots_len().await;
@@ -151,8 +151,8 @@ async fn partial_snapshot_no_earnings() {
         .is_zero()
     {
         tokio::join!(
-            c.harvest_yield(&supply_user, Some(HarvestYieldMode::Default)),
-            c.harvest_yield(&supply_user_2, Some(HarvestYieldMode::Default)),
+            c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default)),
+            c.harvest_yield(&supply_user_2, None, Some(HarvestYieldMode::Default)),
             async {
                 c.repay(&borrow_user, 10_000).await;
                 c.borrow(&borrow_user, 10_000).await;

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -79,7 +79,7 @@ impl MarketController {
         #[call(tgas(300))]
         pub fn borrow(amount: U128);
         #[call(tgas(300))]
-        pub fn apply_interest(snapshot_limit: Option<u32>);
+        pub fn apply_interest(account_id: Option<&AccountId>, snapshot_limit: Option<u32>);
         #[call(tgas(300))]
         pub fn harvest_yield(mode: Option<HarvestYieldMode>) -> BorrowAssetAmount;
         #[call(tgas(20))]

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -81,7 +81,7 @@ impl MarketController {
         #[call(tgas(300))]
         pub fn apply_interest(account_id: Option<&AccountId>, snapshot_limit: Option<u32>);
         #[call(tgas(300))]
-        pub fn harvest_yield(mode: Option<HarvestYieldMode>) -> BorrowAssetAmount;
+        pub fn harvest_yield(account_id: Option<&AccountId>, mode: Option<HarvestYieldMode>) -> BorrowAssetAmount;
         #[call(tgas(20))]
         pub fn withdraw_static_yield(borrow_asset_amount: Option<BorrowAssetAmount>, collateral_asset_amount: Option<CollateralAssetAmount>);
         #[call(tgas(25))]
@@ -315,7 +315,7 @@ impl UnifiedMarketController {
             .amount
             .is_zero()
         {
-            self.harvest_yield(supply_user, None).await;
+            self.harvest_yield(supply_user, None, None).await;
         }
         e
     }


### PR DESCRIPTION
In order to prevent abuse, we also need to account for fractional accumulation values, hence the introduction of the new field in the `Accumulator` and related structs.