### PR TITLE
Use `U256` for underlying asset amounts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,26 +183,14 @@ checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "bitvec"
-version = "0.20.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
-dependencies = [
- "funty 1.1.0",
- "radium 0.6.2",
- "tap",
- "wyz 0.2.0",
-]
-
-[[package]]
-name = "bitvec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
- "funty 2.0.0",
- "radium 0.7.0",
+ "funty",
+ "radium",
  "tap",
- "wyz 0.5.1",
+ "wyz",
 ]
 
 [[package]]
@@ -275,7 +263,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2593a3b8b938bd68373196c9832f516be11fa487ef4ae745eb282e6a56a7244"
 dependencies = [
  "once_cell",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.93",
@@ -313,9 +301,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byte-slice-cast"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
+checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "byteorder"
@@ -519,6 +507,26 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -974,6 +982,15 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
+ "static_assertions",
+]
+
+[[package]]
+name = "fixed-hash"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
+dependencies = [
  "byteorder",
  "rand",
  "rustc-hex",
@@ -1044,12 +1061,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "funty"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "funty"
@@ -1544,11 +1555,20 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
+checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
 dependencies = [
  "parity-scale-codec",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a143eada6a1ec4aefa5049037a26a6d597bfd64f8c026d07b77133e02b7dd0b"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2008,7 +2028,7 @@ dependencies = [
  "near-config-utils",
  "near-schema-checker-lib",
  "near-stdx",
- "primitive-types",
+ "primitive-types 0.10.1",
  "rand",
  "secp256k1",
  "serde",
@@ -2100,7 +2120,7 @@ checksum = "6ab6ecc354e61c40b044c8b553c187383a587a1679d2e594f0b98ca58dbfb6e3"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "bitvec 1.0.1",
+ "bitvec",
  "borsh",
  "bytes",
  "bytesize",
@@ -2120,7 +2140,7 @@ dependencies = [
  "near-time",
  "num-rational",
  "ordered-float",
- "primitive-types",
+ "primitive-types 0.10.1",
  "rand",
  "rand_chacha",
  "serde",
@@ -2543,28 +2563,30 @@ dependencies = [
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.3.1"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
+checksum = "799781ae679d79a948e13d4824a40970bfa500058d245760dd857301059810fa"
 dependencies = [
  "arrayvec",
- "bitvec 0.20.4",
+ "bitvec",
  "byte-slice-cast",
+ "const_format",
  "impl-trait-for-tuples",
  "parity-scale-codec-derive",
+ "rustversion",
  "serde",
 ]
 
 [[package]]
 name = "parity-scale-codec-derive"
-version = "2.3.1"
+version = "3.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+checksum = "34b4653168b563151153c9e4c08ebed57fb8262bebfa79711552fa983c623e7a"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -2720,19 +2742,21 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
- "fixed-hash",
- "impl-codec",
- "uint",
+ "fixed-hash 0.7.0",
+ "uint 0.9.5",
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
+name = "primitive-types"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+checksum = "d15600a7d856470b7d278b3fe0e311fe28c2526348549f8ef2ff7db3299c87f5"
 dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
+ "fixed-hash 0.8.0",
+ "impl-codec",
+ "impl-serde",
+ "schemars",
+ "uint 0.10.0",
 ]
 
 [[package]]
@@ -2741,32 +2765,26 @@ version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.22.22",
+ "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "radium"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "radium"
@@ -2969,7 +2987,7 @@ checksum = "ef0053bbffce09062bee4bcc499b0fbe7a57b879f1efe088d6d8d4c7adcdef9b"
 dependencies = [
  "cfg-if 1.0.0",
  "glob",
- "proc-macro-crate 3.2.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "regex",
@@ -3190,18 +3208,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3495,7 +3513,7 @@ version = "8.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1165dabf9fc1d6bb6819c2c0e27c8dd0e3068d2c53cf186d319788e96517f0d6"
 dependencies = [
- "bitvec 1.0.1",
+ "bitvec",
  "dmsort",
  "elementtree",
  "fallible-iterator",
@@ -3620,7 +3638,7 @@ dependencies = [
  "hex",
  "near-contract-standards",
  "near-sdk",
- "primitive-types",
+ "primitive-types 0.13.1",
  "rand",
  "rstest",
  "schemars",
@@ -3636,6 +3654,7 @@ dependencies = [
  "near-sdk",
  "near-sdk-contract-tools",
  "near-workspaces",
+ "primitive-types 0.13.1",
  "rstest",
  "templar-common",
  "test-utils",
@@ -3673,6 +3692,7 @@ dependencies = [
  "near-sdk",
  "near-sdk-contract-tools",
  "near-workspaces",
+ "primitive-types 0.13.1",
  "templar-common",
  "tokio",
 ]
@@ -3863,24 +3883,13 @@ checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.7.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
  "indexmap 2.7.0",
  "toml_datetime",
- "winnow 0.6.21",
+ "winnow",
 ]
 
 [[package]]
@@ -3966,6 +3975,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "uint"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3976,6 +3997,12 @@ name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsafe-libyaml"
@@ -4370,15 +4397,6 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f5bb5257f2407a5425c6e749bfd9692192a73e70a6060516ac04f889087d68"
@@ -4397,12 +4415,6 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
-
-[[package]]
-name = "wyz"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ near-sdk = { version = "5.7", features = ["unstable"] }
 near-sdk-contract-tools = { git = "https://github.com/near/near-sdk-contract-tools", branch = "140-nep-245-multitoken-component" }
 near-contract-standards = "5.7"
 near-workspaces = { version = "0.16", features = ["unstable"] }
-primitive-types = { version = "0.10.1" }
+primitive-types = { version = "0.13.1", features = ["serde", "json-schema"] }
 rstest = { version = "0.24" }
 schemars = { version = "0.8" }
 templar-common = { path = "./common" }

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -2,14 +2,13 @@ use std::{fmt::Display, marker::PhantomData};
 
 use near_contract_standards::fungible_token::core::ext_ft_core;
 use near_sdk::{
-    env,
-    json_types::U128,
-    near,
+    env, near,
     serde_json::{self, json},
     AccountId, Gas, NearToken, Promise,
 };
+use primitive_types::U256;
 
-use crate::number::Decimal;
+use crate::number::{Decimal, U256SerializationWrapper};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[near(serializers = [json, borsh])]
@@ -44,7 +43,15 @@ impl<T: AssetClass> FungibleAsset<T> {
             FungibleAssetKind::Nep141(ref contract_id) => ext_ft_core::ext(contract_id.clone())
                 .with_static_gas(Self::GAS_FT_TRANSFER)
                 .with_attached_deposit(NearToken::from_yoctonear(1))
-                .ft_transfer(receiver_id, u128::from(amount).into(), None),
+                .ft_transfer(
+                    receiver_id,
+                    u128::try_from(amount)
+                        .unwrap_or_else(|_| {
+                            env::panic_str("NEP-141 transfer amount exceeds u128::MAX")
+                        })
+                        .into(),
+                    None,
+                ),
             FungibleAssetKind::Nep245 {
                 ref contract_id,
                 ref token_id,
@@ -169,9 +176,9 @@ impl AssetClass for BorrowAsset {}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
 #[near(serializers = [borsh, json])]
-#[serde(from = "U128", into = "U128")]
+#[serde(from = "U256SerializationWrapper", into = "U256SerializationWrapper")]
 pub struct FungibleAssetAmount<T: AssetClass> {
-    amount: U128,
+    amount: U256SerializationWrapper,
     #[borsh(skip)]
     discriminant: PhantomData<T>,
 }
@@ -182,8 +189,14 @@ impl<T: AssetClass> Default for FungibleAssetAmount<T> {
     }
 }
 
-impl<T: AssetClass> From<U128> for FungibleAssetAmount<T> {
-    fn from(amount: U128) -> Self {
+impl<T: AssetClass> From<FungibleAssetAmount<T>> for U256SerializationWrapper {
+    fn from(value: FungibleAssetAmount<T>) -> Self {
+        value.amount
+    }
+}
+
+impl<T: AssetClass> From<U256SerializationWrapper> for FungibleAssetAmount<T> {
+    fn from(amount: U256SerializationWrapper) -> Self {
         Self {
             amount,
             discriminant: PhantomData,
@@ -191,9 +204,18 @@ impl<T: AssetClass> From<U128> for FungibleAssetAmount<T> {
     }
 }
 
-impl<T: AssetClass> From<FungibleAssetAmount<T>> for U128 {
+impl<T: AssetClass> From<U256> for FungibleAssetAmount<T> {
+    fn from(amount: U256) -> Self {
+        Self {
+            amount: amount.into(),
+            discriminant: PhantomData,
+        }
+    }
+}
+
+impl<T: AssetClass> From<FungibleAssetAmount<T>> for U256 {
     fn from(value: FungibleAssetAmount<T>) -> Self {
-        value.amount
+        value.amount.0
     }
 }
 
@@ -204,22 +226,22 @@ impl<T: AssetClass> From<u128> for FungibleAssetAmount<T> {
 }
 
 impl<T: AssetClass> FungibleAssetAmount<T> {
-    pub fn new(amount: u128) -> Self {
+    pub fn new(amount: impl Into<U256>) -> Self {
         Self {
-            amount: amount.into(),
+            amount: amount.into().into(),
             discriminant: PhantomData,
         }
     }
 
     pub fn zero() -> Self {
         Self {
-            amount: 0.into(),
+            amount: U256::zero().into(),
             discriminant: PhantomData,
         }
     }
 
     pub fn is_zero(&self) -> bool {
-        self.amount.0 == 0
+        self.amount.0.is_zero()
     }
 
     pub fn split(&mut self, amount: impl Into<Self>) -> Option<Self> {
@@ -240,9 +262,11 @@ impl<T: AssetClass> From<FungibleAssetAmount<T>> for Decimal {
     }
 }
 
-impl<T: AssetClass> From<FungibleAssetAmount<T>> for u128 {
-    fn from(value: FungibleAssetAmount<T>) -> Self {
-        value.amount.0
+impl<T: AssetClass> TryFrom<FungibleAssetAmount<T>> for u128 {
+    type Error = primitive_types::Error;
+
+    fn try_from(value: FungibleAssetAmount<T>) -> Result<Self, Self::Error> {
+        primitive_types::U128::try_from(value.amount.0).map(|a| a.as_u128())
     }
 }
 

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use near_sdk::{env, json_types::U64, near, AccountId};
+use primitive_types::U256;
 
 use crate::{
     accumulator::{AccumulationRecord, Accumulator},
@@ -152,11 +153,11 @@ impl BorrowPosition {
         self.borrow_asset_fees.remove(amount_to_fees);
 
         let amount_to_principal = {
-            let minimum_amount = u128::from(minimum_amount);
+            let minimum_amount = U256::from(minimum_amount);
             let amount_remaining =
-                u128::from(self.borrow_asset_principal).saturating_sub(u128::from(amount));
-            if amount_remaining > 0 && amount_remaining < minimum_amount {
-                u128::from(self.borrow_asset_principal)
+                U256::from(self.borrow_asset_principal).saturating_sub(U256::from(amount));
+            if !amount_remaining.is_zero() && amount_remaining < minimum_amount {
+                U256::from(self.borrow_asset_principal)
                     .saturating_sub(minimum_amount)
                     .into()
             } else {
@@ -225,7 +226,7 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
             * Decimal::from(self.position.get_borrow_asset_principal())
             / *MS_IN_A_YEAR;
         #[allow(clippy::unwrap_used, reason = "Interest rate guaranteed <= APY_LIMIT")]
-        interest_in_current_snapshot.to_u128_ceil().unwrap().into()
+        interest_in_current_snapshot.to_u256_ceil().unwrap().into()
     }
 
     pub fn with_pending_interest(&mut self) {
@@ -285,9 +286,9 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
         AccumulationRecord {
             #[allow(
                 clippy::unwrap_used,
-                reason = "Assume accumulated interest will never exceed u128::MAX"
+                reason = "Assume accumulated interest will never exceed U256::MAX"
             )]
-            amount: accumulated.to_u128_floor().unwrap().into(),
+            amount: accumulated.to_u256_floor().unwrap().into(),
             fraction_as_u128_dividend: accumulated.fractional_part_as_u128_dividend(),
             next_snapshot_index,
         }

--- a/common/src/fee.rs
+++ b/common/src/fee.rs
@@ -1,4 +1,5 @@
 use near_sdk::{json_types::U64, near};
+use primitive_types::U256;
 
 use crate::{
     asset::{AssetClass, FungibleAssetAmount},
@@ -20,8 +21,8 @@ impl<T: AssetClass> Fee<T> {
     pub fn of(&self, amount: FungibleAssetAmount<T>) -> Option<FungibleAssetAmount<T>> {
         match self {
             Fee::Flat(f) => Some(*f),
-            Fee::Proportional(factor) => (factor * u128::from(amount))
-                .to_u128_ceil()
+            Fee::Proportional(factor) => (factor * U256::from(amount))
+                .to_u256_ceil()
                 .map(FungibleAssetAmount::new),
         }
     }
@@ -75,8 +76,8 @@ impl<T: AssetClass> TimeBasedFee<T> {
             TimeBasedFeeFunction::Linear => {
                 (Decimal::from(self.duration.0.saturating_sub(duration))
                     / Decimal::from(self.duration.0)
-                    * u128::from(base_fee))
-                .to_u128_ceil()
+                    * U256::from(base_fee))
+                .to_u256_ceil()
                 .map(FungibleAssetAmount::new)
             }
         }

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -281,7 +281,7 @@ impl MarketConfiguration {
             * Valuation::pessimistic(amount, &price_pair.collateral).ratio(
                 Valuation::optimistic(BorrowAssetAmount::new(1), &price_pair.borrow),
             )?)
-        .to_u128_ceil()
+        .to_u256_ceil()
         .map(BorrowAssetAmount::new)
     }
 }

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -4,6 +4,7 @@ use near_sdk::{
     collections::{LookupMap, UnorderedMap},
     env, near, AccountId, BorshStorageKey, IntoStorageKey,
 };
+use primitive_types::U256;
 
 use crate::{
     asset::BorrowAssetAmount,
@@ -176,12 +177,12 @@ impl Market {
         )]
         let must_retain = ((1u32 - self.configuration.borrow_asset_maximum_usage_ratio)
             * Decimal::from(self.borrow_asset_deposited_active))
-        .to_u128_ceil()
+        .to_u256_ceil()
         .unwrap();
 
-        u128::from(self.borrow_asset_deposited_active)
-            .saturating_sub(u128::from(self.borrow_asset_borrowed))
-            .saturating_sub(u128::from(self.borrow_asset_in_flight))
+        U256::from(self.borrow_asset_deposited_active)
+            .saturating_sub(U256::from(self.borrow_asset_borrowed))
+            .saturating_sub(U256::from(self.borrow_asset_in_flight))
             .saturating_sub(must_retain)
             .into()
     }
@@ -322,7 +323,7 @@ impl Market {
         for (account_id, share_weight) in &self.configuration.yield_weights.r#static {
             #[allow(clippy::unwrap_used, reason = "share_weight / total_weight <= 1")]
             let share = amount
-                .split((*share_weight * amount_per_weight).to_u128_floor().unwrap())
+                .split((*share_weight * amount_per_weight).to_u256_floor().unwrap())
                 // Safety:
                 // Guaranteed share_weight <= total_weight
                 // Guaranteed sum(share_weights) == total_weight

--- a/common/src/number.rs
+++ b/common/src/number.rs
@@ -6,10 +6,88 @@ use std::{
 
 use near_sdk::{
     borsh::{BorshDeserialize, BorshSchema, BorshSerialize},
+    near,
     serde::{self, Deserialize, Serialize},
 };
-use primitive_types::U512;
+use primitive_types::{U256, U512};
 use schemars::JsonSchema;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+#[near(serializers = [])]
+pub struct U256SerializationWrapper(pub U256);
+
+impl From<U256> for U256SerializationWrapper {
+    fn from(value: U256) -> Self {
+        Self(value)
+    }
+}
+
+impl From<U256SerializationWrapper> for U256 {
+    fn from(value: U256SerializationWrapper) -> Self {
+        value.0
+    }
+}
+
+impl JsonSchema for U256SerializationWrapper {
+    fn schema_name() -> String {
+        String::from("U256")
+    }
+
+    fn json_schema(gen: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        let mut schema = gen.subschema_for::<String>().into_object();
+        schema.metadata().description = Some("256-bit unsigned integer".to_string());
+        schema.string().pattern = Some("^(0|[1-9][0-9]{0,77})$".to_string());
+        schema.into()
+    }
+}
+
+impl BorshSchema for U256SerializationWrapper {
+    fn add_definitions_recursively(
+        definitions: &mut std::collections::BTreeMap<
+            near_sdk::borsh::schema::Declaration,
+            near_sdk::borsh::schema::Definition,
+        >,
+    ) {
+        <[u64; 4] as BorshSchema>::add_definitions_recursively(definitions);
+    }
+
+    fn declaration() -> near_sdk::borsh::schema::Declaration {
+        String::from("U256")
+    }
+}
+
+impl BorshSerialize for U256SerializationWrapper {
+    fn serialize<W: std::io::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        BorshSerialize::serialize(&self.0 .0, writer)
+    }
+}
+
+impl BorshDeserialize for U256SerializationWrapper {
+    fn deserialize_reader<R: std::io::Read>(reader: &mut R) -> std::io::Result<Self> {
+        Ok(Self(U256(BorshDeserialize::deserialize_reader(reader)?)))
+    }
+}
+
+impl Serialize for U256SerializationWrapper {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: near_sdk::serde::Serializer,
+    {
+        serializer.serialize_str(&self.0.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for U256SerializationWrapper {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = <String as serde::Deserialize>::deserialize(deserializer)?;
+        Ok(Self(
+            U256::from_dec_str(&s).map_err(serde::de::Error::custom)?,
+        ))
+    }
+}
 
 pub const FRACTIONAL_BITS: usize = 128;
 /// `floor(FRACTIONAL_BITS / log2(10))`
@@ -264,7 +342,7 @@ impl Decimal {
         }
     }
 
-    pub fn to_u128_floor(self) -> Option<u128> {
+    fn to_u128_floor(self) -> Option<u128> {
         let truncated = self.repr >> FRACTIONAL_BITS;
         if truncated.bits() <= 128 {
             Some(truncated.as_u128())
@@ -273,16 +351,26 @@ impl Decimal {
         }
     }
 
-    pub fn to_u128_ceil(self) -> Option<u128> {
+    pub fn to_u256_floor(self) -> Option<U256> {
         let truncated = self.repr >> FRACTIONAL_BITS;
-        if truncated.bits() <= 128 {
-            if self.fractional_part().is_zero() {
-                Some(truncated.as_u128())
-            } else {
-                truncated.as_u128().checked_add(1)
-            }
+        if truncated.bits() <= 256 {
+            Some(U256([
+                truncated.0[0],
+                truncated.0[1],
+                truncated.0[2],
+                truncated.0[3],
+            ]))
         } else {
             None
+        }
+    }
+
+    pub fn to_u256_ceil(self) -> Option<U256> {
+        let a = self.to_u256_floor()?;
+        if self.fractional_part().is_zero() {
+            Some(a)
+        } else {
+            a.checked_add(U256::one())
         }
     }
 

--- a/common/src/price.rs
+++ b/common/src/price.rs
@@ -87,16 +87,14 @@ pub struct Valuation {
 impl Valuation {
     pub fn optimistic<T: AssetClass>(amount: FungibleAssetAmount<T>, price: &Price<T>) -> Self {
         Self {
-            coefficient: U256::from(u128::from(amount))
-                * U256::from(price.price + price.confidence), // guaranteed not to overflow
+            coefficient: U256::from(amount) * U256::from(price.price + price.confidence), // guaranteed not to overflow
             exponent: price.exponent,
         }
     }
 
     pub fn pessimistic<T: AssetClass>(amount: FungibleAssetAmount<T>, price: &Price<T>) -> Self {
         Self {
-            coefficient: U256::from(u128::from(amount))
-                * U256::from(price.price - price.confidence), // guaranteed not to overflow
+            coefficient: U256::from(amount) * U256::from(price.price - price.confidence), // guaranteed not to overflow
             exponent: price.exponent,
         }
     }

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -1,6 +1,7 @@
 use std::ops::{Deref, DerefMut};
 
 use near_sdk::{env, json_types::U64, near, require, AccountId};
+use primitive_types::U256;
 
 use crate::{
     accumulator::{AccumulationRecord, Accumulator},
@@ -134,7 +135,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
     pub fn calculate_yield(&self, snapshot_limit: u32) -> AccumulationRecord<BorrowAsset> {
         let mut next_snapshot_index = self.position.borrow_asset_yield.get_next_snapshot_index();
 
-        let mut amount = u128::from(self.position.borrow_asset_deposit.active);
+        let mut amount = U256::from(self.position.borrow_asset_deposit.active);
         let mut accumulated = Decimal::ZERO;
         let mut next_incoming = 0;
 
@@ -158,7 +159,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
                 .filter(|incoming| incoming.activate_at_snapshot_index as usize == i)
             {
                 next_incoming += 1;
-                amount += u128::from(incoming.amount);
+                amount += U256::from(incoming.amount);
             }
 
             if !snapshot.deposited_active.is_zero() {
@@ -173,7 +174,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
             // Accumulated amount is derived from real balances, so it should
             // never overflow underlying data type.
             #[allow(clippy::unwrap_used, reason = "Derived from real balances")]
-            amount: accumulated.to_u128_floor().unwrap().into(),
+            amount: accumulated.to_u256_floor().unwrap().into(),
             fraction_as_u128_dividend: accumulated.fractional_part_as_u128_dividend(),
             next_snapshot_index,
         }

--- a/common/src/withdrawal_queue.rs
+++ b/common/src/withdrawal_queue.rs
@@ -1,6 +1,7 @@
 use std::num::NonZeroU32;
 
 use near_sdk::{collections::LookupMap, env, near, AccountId, BorshStorageKey, IntoStorageKey};
+use primitive_types::U256;
 
 use crate::asset::BorrowAssetAmount;
 
@@ -258,8 +259,8 @@ impl WithdrawalQueue {
         WithdrawalQueueStatus {
             depth: self
                 .iter()
-                .map(|(_, amount)| u128::from(amount))
-                .sum::<u128>()
+                .map(|(_, amount)| U256::from(amount))
+                .fold(U256::zero(), |a, b| a + b)
                 .into(),
             length: self.len(),
         }

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -33,6 +33,7 @@ getrandom.workspace = true
 near-sdk.workspace = true
 near-sdk-contract-tools.workspace = true
 near-contract-standards.workspace = true
+primitive-types.workspace = true
 templar-common.workspace = true
 
 [dev-dependencies]

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use near_sdk::{env, near, require, AccountId, Promise, PromiseOrValue};
+use primitive_types::U256;
 use templar_common::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
     borrow::{BorrowPosition, BorrowStatus},
@@ -220,10 +221,10 @@ impl MarketExternalInterface for Contract {
 
         // There may be loose/untracked funds that the contract controls but
         // does not account for in internal accounting.
-        let expect_success = u128::from(self.borrow_asset_deposited_active)
-            .saturating_add(u128::from(self.total_incoming()))
+        let expect_success = U256::from(self.borrow_asset_deposited_active)
+            .saturating_add(U256::from(self.total_incoming()))
             .checked_sub(
-                u128::from(self.borrow_asset_borrowed)
+                U256::from(self.borrow_asset_borrowed)
                     .saturating_add(self.borrow_asset_in_flight.into()),
             )
             .is_some();

--- a/contract/market/tests/borrow_limits.rs
+++ b/contract/market/tests/borrow_limits.rs
@@ -32,8 +32,8 @@ async fn borrow_within_bounds(
 
     let borrow_position = c.get_borrow_position(borrow_user.id()).await.unwrap();
     assert_eq!(
-        u128::from(borrow_position.get_borrow_asset_principal()),
-        amounts.iter().sum(),
+        borrow_position.get_borrow_asset_principal(),
+        amounts.iter().sum::<u128>().into(),
     );
 }
 

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -1,5 +1,6 @@
 use std::{sync::atomic::Ordering, time::Duration};
 
+use primitive_types::U256;
 use rstest::rstest;
 use templar_common::{
     dec, fee::Fee, interest_rate_strategy::InterestRateStrategy, market::HarvestYieldMode,
@@ -56,7 +57,8 @@ async fn compounding_yield(
                 let position = c.get_borrow_position(borrow_user.id()).await.unwrap();
                 c.repay(
                     &borrow_user,
-                    u128::from(position.get_total_borrow_asset_liability()) * 120 / 100,
+                    (U256::from(position.get_total_borrow_asset_liability()) * 120u64 / 100u64)
+                        .as_u128(),
                 )
                 .await;
                 c.borrow(&borrow_user, principal).await;
@@ -77,13 +79,13 @@ async fn compounding_yield(
         async { c.get_supply_position(supply_user_2.id()).await.unwrap() },
     );
 
-    let supply_yield_1 = u128::from(supply_position_1_after.get_deposit().total())
-        + u128::from(supply_position_1_after.borrow_asset_yield.get_total())
-        + u128::from(supply_position_1_after.borrow_asset_yield.pending_estimate)
+    let supply_yield_1 = U256::from(supply_position_1_after.get_deposit().total())
+        + U256::from(supply_position_1_after.borrow_asset_yield.get_total())
+        + U256::from(supply_position_1_after.borrow_asset_yield.pending_estimate)
         - principal * 5;
-    let supply_yield_2 = u128::from(supply_position_2_after.get_deposit().total())
-        + u128::from(supply_position_2_after.borrow_asset_yield.get_total())
-        + u128::from(supply_position_2_after.borrow_asset_yield.pending_estimate)
+    let supply_yield_2 = U256::from(supply_position_2_after.get_deposit().total())
+        + U256::from(supply_position_2_after.borrow_asset_yield.get_total())
+        + U256::from(supply_position_2_after.borrow_asset_yield.pending_estimate)
         - principal * 5;
 
     eprintln!("supply 1 yield: {supply_yield_1:#?}");

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -1,3 +1,4 @@
+use primitive_types::U256;
 use rstest::rstest;
 use tokio::join;
 
@@ -91,8 +92,8 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.total_incoming()),
-        1100,
+        supply_position.total_incoming(),
+        1100.into(),
         "Supply position should match amount of tokens supplied to contract",
     );
 
@@ -111,8 +112,8 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.get_deposit().active),
-        1100,
+        supply_position.get_deposit().active,
+        1100.into(),
         "Supply position should match amount of tokens supplied to contract",
     );
 
@@ -123,8 +124,8 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
     let borrow_position = c.get_borrow_position(borrow_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(borrow_position.collateral_asset_deposit),
-        2000,
+        borrow_position.collateral_asset_deposit,
+        2000.into(),
         "Collateral asset deposit should be equal to the number of collateral tokens sent",
     );
 
@@ -155,10 +156,10 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
 
     let borrow_position = c.get_borrow_position(borrow_user.id()).await.unwrap();
 
-    assert_eq!(u128::from(borrow_position.collateral_asset_deposit), 2000);
+    assert_eq!(borrow_position.collateral_asset_deposit, 2000.into());
     assert_eq!(
-        u128::from(borrow_position.get_total_borrow_asset_liability()),
-        1000 + 100, // origination fee
+        borrow_position.get_total_borrow_asset_liability(),
+        (1000 + 100).into(), // origination fee
     );
 
     // Step 4: Repay borrow
@@ -168,11 +169,11 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
     // Ensure borrow is paid off.
     let borrow_position = c.get_borrow_position(borrow_user.id()).await.unwrap();
 
-    assert_eq!(u128::from(borrow_position.collateral_asset_deposit), 2000);
     assert_eq!(
-        u128::from(borrow_position.get_total_borrow_asset_liability()),
-        0,
+        U256::from(borrow_position.collateral_asset_deposit),
+        2000.into(),
     );
+    assert!(borrow_position.get_total_borrow_asset_liability().is_zero());
 
     join!(
         // Supply withdrawals.
@@ -182,10 +183,7 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
                 c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
                     .await;
                 let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
-                assert_eq!(
-                    u128::from(supply_position.borrow_asset_yield.get_total()),
-                    80,
-                );
+                assert_eq!(supply_position.borrow_asset_yield.get_total(), 80.into());
                 // Move the yield to the principal so that it can be withdrawn
                 let amount_moved_to_principal = c
                     .harvest_yield(&supply_user, None, Some(HarvestYieldMode::Compounding))
@@ -203,8 +201,8 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
                 let balance_after = c.borrow_asset.balance_of(supply_user.id()).await;
 
                 assert_eq!(
-                    balance_after - balance_before,
-                    u128::from(supply_position.borrow_asset_yield.get_total()),
+                    supply_position.borrow_asset_yield.get_total(),
+                    (balance_after - balance_before).into(),
                 );
 
                 let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
@@ -236,11 +234,11 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
                     .get_supply_withdrawal_request_status(supply_user.id())
                     .await
                     .expect("Should be enqueued now");
-                assert_eq!(u128::from(request_status.amount), 1100);
-                assert_eq!(u128::from(request_status.depth), 0);
+                assert_eq!(request_status.amount, 1100.into());
+                assert_eq!(request_status.depth, 0.into());
                 assert_eq!(request_status.index, 0);
                 let queue_status = c.get_supply_withdrawal_queue_status().await;
-                assert_eq!(u128::from(queue_status.depth), 1100);
+                assert_eq!(queue_status.depth, 1100.into());
                 assert_eq!(queue_status.length, 1);
 
                 c.execute_next_supply_withdrawal_request(&supply_user).await;
@@ -272,7 +270,7 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
         async {
             let protocol_yield = c.get_static_yield(protocol_yield_user.id()).await.unwrap();
             assert!(protocol_yield.collateral_asset.is_zero());
-            assert_eq!(u128::from(protocol_yield.borrow_asset), 10);
+            assert_eq!(protocol_yield.borrow_asset, 10.into());
             let balance_before = c.borrow_asset.balance_of(protocol_yield_user.id()).await;
             let result = c
                 .withdraw_static_yield(&protocol_yield_user, None, None)
@@ -288,7 +286,7 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
         async {
             let insurance_yield = c.get_static_yield(insurance_yield_user.id()).await.unwrap();
             assert!(insurance_yield.collateral_asset.is_zero());
-            assert_eq!(u128::from(insurance_yield.borrow_asset), 10);
+            assert_eq!(insurance_yield.borrow_asset, 10.into());
             let balance_before = c.borrow_asset.balance_of(insurance_yield_user.id()).await;
             let result = c
                 .withdraw_static_yield(&insurance_yield_user, None, None)

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use primitive_types::U256;
 use rstest::rstest;
 use templar_common::{
     asset::BorrowAssetAmount, dec, fee::Fee, interest_rate_strategy::InterestRateStrategy,
@@ -79,32 +80,32 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
         );
         let duration_outer = time_outer.elapsed();
 
-        let supply_yield_1 = u128::from(supply_position_1.borrow_asset_yield.get_total())
-            + u128::from(supply_position_1.borrow_asset_yield.pending_estimate);
-        let supply_yield_2 = u128::from(supply_position_2.borrow_asset_yield.get_total())
-            + u128::from(supply_position_2.borrow_asset_yield.pending_estimate);
+        let supply_yield_1 = U256::from(supply_position_1.borrow_asset_yield.get_total())
+            + U256::from(supply_position_1.borrow_asset_yield.pending_estimate);
+        let supply_yield_2 = U256::from(supply_position_2.borrow_asset_yield.get_total())
+            + U256::from(supply_position_2.borrow_asset_yield.pending_estimate);
 
         // No yield yet.
-        assert_eq!(supply_yield_1, 0);
-        assert_eq!(supply_yield_2, 0);
+        assert!(supply_yield_1.is_zero());
+        assert!(supply_yield_2.is_zero());
 
         eprintln!("Borrow position 1: {borrow_position_1:#?}");
         eprintln!("Borrow position 2: {borrow_position_2:#?}");
 
         let f = principal * strategy.at(dec!("0.2")) / *MS_IN_A_YEAR;
 
-        let approximation_below = (f * duration_inner.as_millis()).to_u128_ceil().unwrap();
-        let approximation_above = (f * duration_outer.as_millis()).to_u128_ceil().unwrap();
+        let approximation_below = (f * duration_inner.as_millis()).to_u256_ceil().unwrap();
+        let approximation_above = (f * duration_outer.as_millis()).to_u256_ceil().unwrap();
 
-        let actual_1 = u128::from(borrow_position_1.borrow_asset_fees.get_total())
-            + u128::from(borrow_position_1.borrow_asset_fees.pending_estimate);
+        let actual_1 = U256::from(borrow_position_1.borrow_asset_fees.get_total())
+            + U256::from(borrow_position_1.borrow_asset_fees.pending_estimate);
         eprintln!("{approximation_below} <= {actual_1} <= {approximation_above}?");
 
         assert!(approximation_below <= actual_1);
         assert!(actual_1 <= approximation_above);
 
-        let actual_2 = u128::from(borrow_position_2.borrow_asset_fees.get_total())
-            + u128::from(borrow_position_2.borrow_asset_fees.pending_estimate);
+        let actual_2 = U256::from(borrow_position_2.borrow_asset_fees.get_total())
+            + U256::from(borrow_position_2.borrow_asset_fees.pending_estimate);
         eprintln!("{approximation_below} <= {actual_2} <= {approximation_above} + {iters}?");
 
         assert!(approximation_below <= actual_2);
@@ -126,8 +127,8 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
             let r = c
                 .repay(
                     &borrow_user,
-                    (u128::from(borrow_position_before.get_total_borrow_asset_liability())
-                        + u128::from(borrow_position_before.borrow_asset_fees.pending_estimate))
+                    (U256::from(borrow_position_before.get_total_borrow_asset_liability())
+                        + U256::from(borrow_position_before.borrow_asset_fees.pending_estimate))
                         * 110
                         / 100, /* overpayment */
                 )
@@ -149,9 +150,9 @@ async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateSt
             let borrow_position_before = c.get_borrow_position(borrow_user_2.id()).await.unwrap();
             c.repay(
                 &borrow_user_2,
-                (u128::from(borrow_position_before.get_total_borrow_asset_liability())
-                    + u128::from(borrow_position_before.borrow_asset_fees.pending_estimate))
-                    * 110
+                (U256::from(borrow_position_before.get_total_borrow_asset_liability())
+                    + U256::from(borrow_position_before.borrow_asset_fees.pending_estimate))
+                    * 110u64
                     / 100, /* overpayment */
             )
             .await;

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use primitive_types::U256;
 use rstest::rstest;
 
 use templar_common::{
@@ -115,17 +116,17 @@ async fn successful_liquidation_good_debt_under_mcr(
                 .await;
             let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
             assert_eq!(
-                u128::from(supply_position.borrow_asset_yield.get_total()),
-                yield_amount * 8 / 10,
+                supply_position.borrow_asset_yield.get_total(),
+                (yield_amount * 8 / 10).into(),
             );
         },
         async {
             let protocol_yield = c.get_static_yield(protocol_yield_user.id()).await.unwrap();
-            assert_eq!(u128::from(protocol_yield.borrow_asset), yield_amount / 10);
+            assert_eq!(protocol_yield.borrow_asset, (yield_amount / 10).into());
         },
         async {
             let insurance_yield = c.get_static_yield(insurance_yield_user.id()).await.unwrap();
-            assert_eq!(u128::from(insurance_yield.borrow_asset), yield_amount / 10);
+            assert_eq!(insurance_yield.borrow_asset, (yield_amount / 10).into());
         },
     );
 }
@@ -172,7 +173,7 @@ async fn successful_liquidation_with_spread(
         ;
 
     let liquidation_amount = (collateral_asset_price * (1u32 - target_spread) * 2000u32)
-        .to_u128_ceil()
+        .to_u256_ceil()
         .unwrap();
 
     c.set_collateral_asset_price(collateral_asset_price.to_f64_lossy())
@@ -189,7 +190,7 @@ async fn successful_liquidation_with_spread(
         "Liquidator should obtain all collateral after a successful liquidation",
     );
     assert_eq!(
-        borrow_balance_before - borrow_balance_after,
+        U256::from(borrow_balance_before - borrow_balance_after),
         liquidation_amount,
         "Liquidation should transfer correct amount of tokens",
     );
@@ -228,11 +229,8 @@ async fn fail_liquidation_too_little_attached() {
 
     // ensure borrow position remains unchanged
     let borrow_position = c.get_borrow_position(borrow_user.id()).await.unwrap();
-    assert_eq!(
-        u128::from(borrow_position.get_borrow_asset_principal()),
-        300,
-    );
-    assert_eq!(u128::from(borrow_position.collateral_asset_deposit), 500);
+    assert_eq!(borrow_position.get_borrow_asset_principal(), 300.into());
+    assert_eq!(borrow_position.collateral_asset_deposit, 500.into());
 }
 
 #[tokio::test]
@@ -267,11 +265,8 @@ async fn fail_liquidation_healthy_borrow() {
 
     // ensure borrow position remains unchanged
     let borrow_position = c.get_borrow_position(borrow_user.id()).await.unwrap();
-    assert_eq!(
-        u128::from(borrow_position.get_borrow_asset_principal()),
-        300,
-    );
-    assert_eq!(u128::from(borrow_position.collateral_asset_deposit), 500);
+    assert_eq!(borrow_position.get_borrow_asset_principal(), 300.into());
+    assert_eq!(borrow_position.collateral_asset_deposit, 500.into());
 }
 
 #[tokio::test]

--- a/contract/market/tests/maximum_borrow_asset_usage_ratio.rs
+++ b/contract/market/tests/maximum_borrow_asset_usage_ratio.rs
@@ -30,13 +30,11 @@ async fn borrow_within_maximum_usage_ratio(#[case] percent: u16) {
 
     assert_eq!(balance_before + amount, balance_after);
     assert_eq!(
-        u128::from(
-            c.get_borrow_position(borrow_user.id())
-                .await
-                .unwrap()
-                .get_borrow_asset_principal()
-        ),
-        amount,
+        c.get_borrow_position(borrow_user.id())
+            .await
+            .unwrap()
+            .get_borrow_asset_principal(),
+        amount.into(),
     );
 }
 

--- a/contract/market/tests/minimum_initial_collateral_ratio.rs
+++ b/contract/market/tests/minimum_initial_collateral_ratio.rs
@@ -27,7 +27,7 @@ async fn success_above_minimum_initial_collateral_ratio(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
         c.collateralize(
             &borrow_user,
-            (1000u32 * initial + Decimal::ONE).to_u128_ceil().unwrap(),
+            (1000u32 * initial + Decimal::ONE).to_u256_ceil().unwrap(),
         ),
     );
 
@@ -37,13 +37,11 @@ async fn success_above_minimum_initial_collateral_ratio(
 
     assert_eq!(balance_before + 1000, balance_after);
     assert_eq!(
-        u128::from(
-            c.get_borrow_position(borrow_user.id())
-                .await
-                .unwrap()
-                .get_borrow_asset_principal()
-        ),
-        1000
+        c.get_borrow_position(borrow_user.id())
+            .await
+            .unwrap()
+            .get_borrow_asset_principal(),
+        1000.into(),
     );
 }
 
@@ -73,7 +71,7 @@ async fn fail_below_minimum_initial_collateral_ratio(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
         c.collateralize(
             &borrow_user,
-            (1000u32 * initial).to_u128_floor().unwrap() - 1,
+            (1000u32 * initial).to_u256_floor().unwrap() - 1,
         ),
     );
 
@@ -104,7 +102,7 @@ async fn not_in_liquidation_if_below_minimum_initial_collateral_ratio(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
         c.collateralize(
             &borrow_user,
-            (1000u32 * initial + Decimal::ONE).to_u128_ceil().unwrap(),
+            (1000u32 * initial + Decimal::ONE).to_u256_ceil().unwrap(),
         ),
     );
 

--- a/contract/market/tests/supply_maximum_amount.rs
+++ b/contract/market/tests/supply_maximum_amount.rs
@@ -30,7 +30,7 @@ async fn supply_within_maximum(
     }
 
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
-    assert_eq!(u128::from(supply_position.get_deposit().total()), sum);
+    assert_eq!(supply_position.get_deposit().total(), sum.into());
 }
 
 #[rstest]

--- a/contract/market/tests/supply_withdrawal_fee.rs
+++ b/contract/market/tests/supply_withdrawal_fee.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use near_sdk::json_types::U64;
+use primitive_types::U256;
 use templar_common::fee::{Fee, TimeBasedFee, TimeBasedFeeFunction};
 use test_utils::*;
 
@@ -30,13 +31,13 @@ async fn supply_withdrawal_fee_flat() {
     let yield_before = c
         .get_static_yield(protocol_yield_user.id())
         .await
-        .map_or(0, |r| u128::from(r.borrow_asset));
+        .map_or(U256::zero(), |r| U256::from(r.borrow_asset));
 
     c.create_supply_withdrawal_request(&supply_user, 1000).await;
     c.execute_next_supply_withdrawal_request(&supply_user).await;
 
     let supply_user_balance_after = c.borrow_asset.balance_of(supply_user.id()).await;
-    let yield_after = u128::from(
+    let yield_after = U256::from(
         c.get_static_yield(protocol_yield_user.id())
             .await
             .unwrap()
@@ -82,13 +83,13 @@ async fn supply_withdrawal_fee_expired() {
     let yield_before = c
         .get_static_yield(protocol_yield_user.id())
         .await
-        .map_or(0, |r| u128::from(r.borrow_asset));
+        .map_or(U256::zero(), |r| U256::from(r.borrow_asset));
 
     c.create_supply_withdrawal_request(&supply_user, 1000).await;
     c.execute_next_supply_withdrawal_request(&supply_user).await;
 
     let supply_user_balance_after = c.borrow_asset.balance_of(supply_user.id()).await;
-    let yield_after = u128::from(
+    let yield_after = U256::from(
         c.get_static_yield(protocol_yield_user.id())
             .await
             .unwrap()

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -1,3 +1,4 @@
+use primitive_types::U256;
 use templar_common::{
     dec,
     fee::Fee,
@@ -144,7 +145,7 @@ async fn partial_snapshot_no_earnings() {
     c.supply(&supply_user_2, 100_000_000).await;
 
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
-    let mut earned_in_first_snapshot = 0u128;
+    let mut earned_in_first_snapshot = U256::zero();
     while !c
         .get_supply_position(supply_user_2.id())
         .await
@@ -167,7 +168,7 @@ async fn partial_snapshot_no_earnings() {
                 eprintln!("Older position total: {total}");
                 eprintln!("Older position pending: {pending}");
 
-                if !total.is_zero() && earned_in_first_snapshot == 0 {
+                if !total.is_zero() && earned_in_first_snapshot.is_zero() {
                     earned_in_first_snapshot = total.into();
                 }
             },
@@ -198,8 +199,8 @@ async fn partial_snapshot_no_earnings() {
     eprintln!("Amount 1 end: {amount_1_end}");
     eprintln!("Amount 2 end: {amount_2_end}");
     assert_eq!(
-        u128::from(amount_1_end),
-        u128::from(amount_2_end) + earned_in_first_snapshot,
+        U256::from(amount_1_end),
+        U256::from(amount_2_end) + earned_in_first_snapshot,
     );
     assert_eq!(
         position_1_end.borrow_asset_yield.pending_estimate,

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -10,6 +10,7 @@ hex-literal = "0.4"
 near-sdk.workspace = true
 near-sdk-contract-tools.workspace = true
 near-workspaces.workspace = true
+primitive-types.workspace = true
 templar-common.workspace = true
 tokio.workspace = true
 

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -8,6 +8,7 @@ use near_sdk::{
 use near_workspaces::{
     network::Sandbox, result::ExecutionSuccess, types::SecretKey, Account, Contract, Worker,
 };
+use primitive_types::U256;
 use templar_common::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
     borrow::{BorrowPosition, BorrowStatus},
@@ -79,7 +80,7 @@ impl MarketController {
         #[view] pub fn get_last_yield_rate() -> Decimal;
 
         #[call(tgas(300))]
-        pub fn borrow(amount: U128);
+        pub fn borrow(amount: BorrowAssetAmount);
         #[call(tgas(300))]
         pub fn apply_interest(account_id: Option<&AccountId>, snapshot_limit: Option<u32>);
         #[call(tgas(300))]
@@ -301,7 +302,12 @@ impl UnifiedMarketController {
             .await
     }
 
-    pub async fn supply(&self, supply_user: &Account, amount: u128) -> ExecutionSuccess {
+    pub async fn supply(
+        &self,
+        supply_user: &Account,
+        amount: impl Into<BorrowAssetAmount>,
+    ) -> ExecutionSuccess {
+        let amount = amount.into();
         eprintln!(
             "{} transferring {amount} tokens for supply...",
             supply_user.id()
@@ -310,7 +316,7 @@ impl UnifiedMarketController {
             .transfer_call(
                 supply_user,
                 self.market.contract().id(),
-                amount,
+                U256::from(amount).as_u128(),
                 serde_json::to_string(&DepositMsg::Supply).unwrap(),
             )
             .await
@@ -319,7 +325,7 @@ impl UnifiedMarketController {
     pub async fn supply_and_harvest_until_activation(
         &self,
         supply_user: &Account,
-        amount: u128,
+        amount: impl Into<BorrowAssetAmount>,
     ) -> ExecutionSuccess {
         let e = self.supply(supply_user, amount).await;
         while !self
@@ -335,7 +341,12 @@ impl UnifiedMarketController {
         e
     }
 
-    pub async fn collateralize(&self, borrow_user: &Account, amount: u128) -> ExecutionSuccess {
+    pub async fn collateralize(
+        &self,
+        borrow_user: &Account,
+        amount: impl Into<CollateralAssetAmount>,
+    ) -> ExecutionSuccess {
+        let amount = amount.into();
         eprintln!(
             "{} transferring {amount} tokens for collateral...",
             borrow_user.id(),
@@ -344,19 +355,24 @@ impl UnifiedMarketController {
             .transfer_call(
                 borrow_user,
                 self.market.contract().id(),
-                amount,
+                U256::from(amount).as_u128(),
                 serde_json::to_string(&DepositMsg::Collateralize).unwrap(),
             )
             .await
     }
 
-    pub async fn repay(&self, borrow_user: &Account, amount: u128) -> ExecutionSuccess {
+    pub async fn repay(
+        &self,
+        borrow_user: &Account,
+        amount: impl Into<BorrowAssetAmount>,
+    ) -> ExecutionSuccess {
+        let amount = amount.into();
         eprintln!("{} repaying {amount} tokens...", borrow_user.id());
         self.borrow_asset
             .transfer_call(
                 borrow_user,
                 self.market.contract().id(),
-                amount,
+                U256::from(amount).as_u128(),
                 serde_json::to_string(&DepositMsg::Repay).unwrap(),
             )
             .await
@@ -366,8 +382,9 @@ impl UnifiedMarketController {
         &self,
         liquidator_user: &Account,
         account_id: &AccountId,
-        borrow_asset_amount: u128,
+        borrow_asset_amount: impl Into<BorrowAssetAmount>,
     ) -> ExecutionSuccess {
+        let borrow_asset_amount = borrow_asset_amount.into();
         eprintln!(
             "{} executing liquidation against {} for {}...",
             liquidator_user.id(),
@@ -378,7 +395,7 @@ impl UnifiedMarketController {
             .transfer_call(
                 liquidator_user,
                 self.market.contract().id(),
-                borrow_asset_amount,
+                U256::from(borrow_asset_amount).as_u128(),
                 serde_json::to_string(&DepositMsg::Liquidate(LiquidateMsg {
                     account_id: account_id.clone(),
                 }))


### PR DESCRIPTION
I think this is a good idea, since we plan to add support for EVM assets, balances for which are 256 bits wide. However, as of yet, the NEAR Intents contract still uses 128 bit unsigned integers for balances. (I think. At least, that is [what the multi-token standard (which `intents.near` implements) specifies](https://nomicon.io/Standards/Tokens/MultiToken/Core#reference-level-explanation).)