### PR TITLE
chore: upgrade near-cli to v0.22.0

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -21,7 +21,5 @@ jobs:
           cargo near deploy build-reproducible-wasm "${{ vars.NEAR_CONTRACT_PRODUCTION_ACCOUNT_ID }}" \
             without-init-call \
             network-config "${{ vars.NEAR_CONTRACT_PRODUCTION_NETWORK }}" \
-            sign-with-plaintext-private-key \
-              --signer-public-key "${{ vars.NEAR_CONTRACT_PRODUCTION_ACCOUNT_PUBLIC_KEY }}" \
-              --signer-private-key "${{ secrets.NEAR_CONTRACT_PRODUCTION_ACCOUNT_PRIVATE_KEY }}" \
+            sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_PRODUCTION_ACCOUNT_PRIVATE_KEY }}" \
             send

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.13.3/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.16.1/cargo-near-installer.sh | sh
       - name: Deploy to production
         run: |
           cargo near deploy build-reproducible-wasm "${{ vars.NEAR_CONTRACT_PRODUCTION_ACCOUNT_ID }}" \

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -43,7 +43,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.13.3/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.16.1/cargo-near-installer.sh | sh
 
       - name: Initialize staging account
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -30,7 +30,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.19.0/near-cli-rs-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.22.0/near-cli-rs-installer.sh | sh
 
       - uses: actions/cache@v4
         with:
@@ -58,9 +58,7 @@ jobs:
               use-manually-provided-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
               sign-as "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
               network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-              sign-with-plaintext-private-key \
-                --signer-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
-                --signer-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+              sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
               send
 
             echo "NEWLY_CREATED=1" >> $GITHUB_ENV
@@ -70,17 +68,14 @@ jobs:
             near tokens "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
               send-near "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" '5 NEAR' \
               network-config "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-              sign-with-plaintext-private-key \
-                --signer-public-key "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
-                --signer-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
+              sign-with-plaintext-private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
               send
 
             ./script/ci/remove-all-versions-from-registry.sh \
               --account     "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
               --registry    "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
               --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-              --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-              --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+              --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"
           fi
 
       - name: Deploy registry to staging account
@@ -89,7 +84,6 @@ jobs:
             --account     "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
             --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
             --init        $([[ -n "$NEWLY_CREATED" ]] && echo true || echo false)
 
       - name: Add market version to registry
@@ -99,8 +93,7 @@ jobs:
             --registry    "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             --version-key "${{ env.MARKET_VERSION_ID }}" \
             --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+            --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"
 
       - name: Generate init args
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -111,8 +111,7 @@ jobs:
             --name                  "${{ env.MARKET_NAME }}" \
             --with-full-access-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}" \
             --network               "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            --private-key           "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            --public-key            "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+            --private-key           "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"
 
       - name: Generate market ID
         run: |
@@ -126,8 +125,7 @@ jobs:
               --account     "${MARKET_ACCOUNT_ID}" \
               --contract    "${BORROW_ID}" \
               --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-              --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-              --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+              --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"
           fi
 
           COLLATERAL_ID=$(echo "$INIT_ARGS" | jq -r '.configuration.collateral_asset.Nep141')
@@ -136,8 +134,7 @@ jobs:
               --account     "${MARKET_ACCOUNT_ID}" \
               --contract    "${COLLATERAL_ID}" \
               --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-              --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-              --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+              --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"
           fi
 
       - name: Comment on pull request

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.85.0
       - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.13.3/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.16.1/cargo-near-installer.sh | sh
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
         # https://nexte.st/docs/installation/pre-built-binaries/#linux-x86_64
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
       - name: Install cargo-near
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.13.3/cargo-near-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.16.1/cargo-near-installer.sh | sh
       - uses: actions/cache@v4
         with:
           path: |

--- a/.github/workflows/undeploy-staging.yml
+++ b/.github/workflows/undeploy-staging.yml
@@ -32,8 +32,7 @@ jobs:
             --account     "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             --registry    "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+            --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"
 
       - name: Remove registry account
         run: |
@@ -41,5 +40,4 @@ jobs:
             --account     "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
             --beneficiary "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}" \
             --network     "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" \
-            --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}" \
-            --public-key  "${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_PUBLIC_KEY }}"
+            --private-key "${{ secrets.NEAR_CONTRACT_STAGING_ACCOUNT_PRIVATE_KEY }}"

--- a/.github/workflows/undeploy-staging.yml
+++ b/.github/workflows/undeploy-staging.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Install near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.19.0/near-cli-rs-installer.sh | sh
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.22.0/near-cli-rs-installer.sh | sh
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@1.85.0
       - uses: actions/cache@v4

--- a/script/ci/add-version-to-registry.sh
+++ b/script/ci/add-version-to-registry.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--version-key:VERSION_KEY,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--version-key:VERSION_KEY,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -35,9 +35,7 @@ near contract call-function as-transaction "${REGISTRY_ID}" \
         attached-deposit '1 yoctoNEAR' \
     sign-as "${ACCOUNT_ID}" \
     network-config "${NETWORK}" \
-    sign-with-plaintext-private-key \
-        --signer-public-key "${PUBLIC_KEY}" \
-        --signer-private-key "${PRIVATE_KEY}" \
+    sign-with-plaintext-private-key "${PRIVATE_KEY}" \
     send
 
 

--- a/script/ci/deploy-market-from-registry.sh
+++ b/script/ci/deploy-market-from-registry.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--version-key:VERSION_KEY,--init-args:INIT_ARGS,--name:NAME,--with-full-access-key:WITH_FULL_ACCESS_KEY,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--version-key:VERSION_KEY,--init-args:INIT_ARGS,--name:NAME,--with-full-access-key:WITH_FULL_ACCESS_KEY,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -39,9 +39,7 @@ near contract call-function as-transaction "${REGISTRY_ID}" \
         attached-deposit '5 NEAR' \
     sign-as "${ACCOUNT_ID}" \
     network-config "${NETWORK}" \
-    sign-with-plaintext-private-key \
-      --signer-public-key "${PUBLIC_KEY}" \
-      --signer-private-key "${PRIVATE_KEY}" \
+    sign-with-plaintext-private-key "${PRIVATE_KEY}" \
     send
 
 

--- a/script/ci/deploy-registry.sh
+++ b/script/ci/deploy-registry.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--init:INIT,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--init:INIT,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
   NETWORK="testnet"
@@ -24,18 +24,14 @@ if $INIT; then
             prepaid-gas '100.0 Tgas' \
             attached-deposit '0 NEAR' \
         network-config "${NETWORK}" \
-        sign-with-plaintext-private-key \
-            --signer-public-key "${PUBLIC_KEY}" \
-            --signer-private-key "${PRIVATE_KEY}" \
+        sign-with-plaintext-private-key "${PRIVATE_KEY}" \
         send
 else
     echo "Deploying registry contract to ${ACCOUNT_ID} on ${NETWORK} without initialization call"
     cargo near deploy build-reproducible-wasm --skip-git-remote-check "${ACCOUNT_ID}" \
         without-init-call \
         network-config "${NETWORK}" \
-        sign-with-plaintext-private-key \
-            --signer-public-key "${PUBLIC_KEY}" \
-            --signer-private-key "${PRIVATE_KEY}" \
+        sign-with-plaintext-private-key "${PRIVATE_KEY}" \
         send
 fi
 

--- a/script/ci/recover-nep141.sh
+++ b/script/ci/recover-nep141.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--token:TOKEN_ID,--beneficiary:BENEFICIARY_ID,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--token:TOKEN_ID,--beneficiary:BENEFICIARY_ID,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
   NETWORK="testnet"
@@ -17,9 +17,7 @@ echo "Transferring balance to $BENEFICIARY_ID"
 set +e # send all errors if balance is zero
 near tokens "$ACCOUNT_ID" send-ft "$TOKEN_ID" "$BENEFICIARY_ID" all memo "" \
   network-config "$NETWORK" \
-  sign-with-plaintext-private-key \
-    --signer-public-key "$PUBLIC_KEY" \
-    --signer-private-key "$PRIVATE_KEY" \
+  sign-with-plaintext-private-key "$PRIVATE_KEY" \
   send
 set -e
 
@@ -31,9 +29,7 @@ near contract call-function as-transaction "$TOKEN_ID" storage_unregister \
   attached-deposit '1 yoctoNEAR' \
   sign-as "$ACCOUNT_ID" \
   network-config "$NETWORK" \
-  sign-with-plaintext-private-key \
-    --signer-public-key "$PUBLIC_KEY" \
-    --signer-private-key "$PRIVATE_KEY" \
+  sign-with-plaintext-private-key "$PRIVATE_KEY" \
   send
 
 echo "Done"

--- a/script/ci/remove-all-markets-from-registry.sh
+++ b/script/ci/remove-all-markets-from-registry.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -25,8 +25,7 @@ echo "${DEPLOYMENTS}" | jq -r '.[]' | while read MARKET_ID; do
         --account "${MARKET_ID}" \
         --beneficiary "${REGISTRY_ID}" \
         --network "${NETWORK}" \
-        --private-key "${PRIVATE_KEY}" \
-        --public-key "${PUBLIC_KEY}"
+        --private-key "${PRIVATE_KEY}"
 done
 
 echo "Done"

--- a/script/ci/remove-all-versions-from-registry.sh
+++ b/script/ci/remove-all-versions-from-registry.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -26,7 +26,6 @@ echo "${VERSIONS}" | jq -r '.[]' | while read VERSION_KEY; do
         --registry      "${ACCOUNT_ID}" \
         --version-key   "${VERSION_KEY}" \
         --network       "${NETWORK}" \
-        --public-key    "${PUBLIC_KEY}" \
         --private-key   "${PRIVATE_KEY}"
 done
 

--- a/script/ci/remove-market.sh
+++ b/script/ci/remove-market.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--beneficiary:BENEFICIARY_ID,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--beneficiary:BENEFICIARY_ID,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -36,7 +36,6 @@ if [ -n "$BORROW_ID" ]; then
         --token         "${BORROW_ID}" \
         --beneficiary   "${BENEFICIARY_ID}" \
         --network       "${NETWORK}" \
-        --public-key    "${PUBLIC_KEY}" \
         --private-key   "${PRIVATE_KEY}"
 fi
 
@@ -49,7 +48,6 @@ if [ -n "$COLLATERAL_ID" ]; then
         --token         "${COLLATERAL_ID}" \
         --beneficiary   "${BENEFICIARY_ID}" \
         --network       "${NETWORK}" \
-        --public-key    "${PUBLIC_KEY}" \
         --private-key   "${PRIVATE_KEY}"
 fi
 
@@ -58,9 +56,7 @@ echo "Deleting account ${ACCOUNT_ID}"
 near account delete-account "${ACCOUNT_ID}" \
   beneficiary "${BENEFICIARY_ID}" \
   network-config "${NETWORK}" \
-  sign-with-plaintext-private-key \
-    --signer-public-key "${PUBLIC_KEY}" \
-    --signer-private-key "${PRIVATE_KEY}" \
+  sign-with-plaintext-private-key "${PRIVATE_KEY}" \
   send
 
 echo "Done"

--- a/script/ci/remove-registry.sh
+++ b/script/ci/remove-registry.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--beneficiary:BENEFICIARY_ID,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--beneficiary:BENEFICIARY_ID,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -23,15 +23,12 @@ $SCRIPT_DIR/remove-all-versions-from-registry.sh \
     --account       "${ACCOUNT_ID}" \
     --registry      "${ACCOUNT_ID}" \
     --network       "${NETWORK}" \
-    --public-key    "${PUBLIC_KEY}" \
     --private-key   "${PRIVATE_KEY}"
 
 near account delete-account "${ACCOUNT_ID}" \
     beneficiary "${BENEFICIARY_ID}" \
     network-config "${NETWORK}" \
-    sign-with-plaintext-private-key \
-        --signer-public-key "${PUBLIC_KEY}" \
-        --signer-private-key "${PRIVATE_KEY}" \
+    sign-with-plaintext-private-key "${PRIVATE_KEY}" \
     send
 
 echo "Done"

--- a/script/ci/remove-version-from-registry.sh
+++ b/script/ci/remove-version-from-registry.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--version-key:VERSION_KEY,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--registry:REGISTRY_ID,--version-key:VERSION_KEY,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -16,9 +16,7 @@ near contract call-function as-transaction "${REGISTRY_ID}" remove_version \
     attached-deposit '1 yoctoNEAR' \
     sign-as "${ACCOUNT_ID}" \
     network-config testnet \
-    sign-with-plaintext-private-key \
-        --signer-public-key "${PUBLIC_KEY}" \
-        --signer-private-key "${PRIVATE_KEY}" \
+    sign-with-plaintext-private-key "${PRIVATE_KEY}" \
     send
 
 echo "Done"

--- a/script/ci/storage-deposit.sh
+++ b/script/ci/storage-deposit.sh
@@ -4,7 +4,7 @@ set -e
 SCRIPT_DIR=$(dirname "$(readlink -f ${BASH_SOURCE[0]})")
 source "$SCRIPT_DIR/utils.sh"
 
-parse_args "--account:ACCOUNT_ID,--contract:CONTRACT_ID,--network:NETWORK,--private-key:PRIVATE_KEY,--public-key:PUBLIC_KEY" "$@"
+parse_args "--account:ACCOUNT_ID,--contract:CONTRACT_ID,--network:NETWORK,--private-key:PRIVATE_KEY" "$@"
 
 if [ -z "$NETWORK" ]; then
     NETWORK="testnet"
@@ -15,9 +15,7 @@ near account \
   deposit "${ACCOUNT_ID}" '0.00125 NEAR' \
   sign-as "${ACCOUNT_ID}" \
   network-config "${NETWORK}" \
-  sign-with-plaintext-private-key \
-    --signer-public-key "${PUBLIC_KEY}" \
-    --signer-private-key "${PRIVATE_KEY}" \
+  sign-with-plaintext-private-key "${PRIVATE_KEY}" \
   send
 
 echo "Done"


### PR DESCRIPTION
It appears that there is a bug in nearcore that earlier versions of `near-cli-rs` were not able to handle, and it was breaking the GH Actions workflows. Fixed as of v0.22.0: https://github.com/near/near-cli-rs/pull/510