### PR TITLE
chore: rename mcr->mcr_liquidation,mcr_initial->mcr_maintenance

### DIFF
--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -314,16 +314,16 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
             .is_liquidation()
     }
 
-    pub fn satisfies_minimum_initial_collateral_ratio(&self, price_pair: &PricePair) -> bool {
+    pub fn satisfies_mcr_maintenance(&self, price_pair: &PricePair) -> bool {
         self.market
             .configuration
-            .satisfies_minimum_initial_collateral_ratio(&self.position, price_pair)
+            .satisfies_mcr_maintenance(&self.position, price_pair)
     }
 
-    pub fn satisfies_minimum_collateral_ratio(&self, price_pair: &PricePair) -> bool {
+    pub fn satisfies_mcr_liquidation(&self, price_pair: &PricePair) -> bool {
         self.market
             .configuration
-            .satisfies_minimum_collateral_ratio(&self.position, price_pair)
+            .satisfies_mcr_liquidation(&self.position, price_pair)
     }
 
     pub fn minimum_acceptable_liquidation_amount(

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -110,8 +110,8 @@ pub struct MarketConfiguration {
     pub borrow_asset: FungibleAsset<BorrowAsset>,
     pub collateral_asset: FungibleAsset<CollateralAsset>,
     pub price_oracle_configuration: PriceOracleConfiguration,
-    pub borrow_mcr_initial: Decimal,
-    pub borrow_mcr: Decimal,
+    pub borrow_mcr_maintenance: Decimal,
+    pub borrow_mcr_liquidation: Decimal,
     /// How much of the deposited principal may be lent out (up to 100%)?
     /// This is a matter of protection for supply providers.
     /// Set to 99% for starters.
@@ -192,12 +192,14 @@ impl MarketConfiguration {
             return Err(error::must_not_equal("borrow_asset", "collateral_asset"));
         }
 
-        if self.borrow_mcr_initial < 1u32 || self.borrow_mcr_initial < self.borrow_mcr {
-            return Err(error::out_of_bounds("borrow_mcr_initial"));
+        if self.borrow_mcr_maintenance < 1u32
+            || self.borrow_mcr_maintenance < self.borrow_mcr_liquidation
+        {
+            return Err(error::out_of_bounds("borrow_mcr_maintenance"));
         }
 
-        if self.borrow_mcr < 1u32 {
-            return Err(error::out_of_bounds("borrow_mcr"));
+        if self.borrow_mcr_liquidation < 1u32 {
+            return Err(error::out_of_bounds("borrow_mcr_liquidation"));
         }
 
         if self.borrow_asset_maximum_usage_ratio.is_zero()
@@ -227,7 +229,7 @@ impl MarketConfiguration {
         price_pair: &PricePair,
         block_timestamp_ms: u64,
     ) -> BorrowStatus {
-        if !self.satisfies_minimum_collateral_ratio(borrow_position, price_pair) {
+        if !self.satisfies_mcr_liquidation(borrow_position, price_pair) {
             return BorrowStatus::Liquidation(LiquidationReason::Undercollateralization);
         }
 
@@ -252,24 +254,28 @@ impl MarketConfiguration {
             .is_none_or(|duration_ms| duration_ms <= maximum_duration_ms)
     }
 
-    pub fn satisfies_minimum_initial_collateral_ratio(
+    pub fn satisfies_mcr_maintenance(
         &self,
         borrow_position: &BorrowPosition,
         oracle_price_proof: &PricePair,
     ) -> bool {
         satisfies_minimum_collateral_ratio(
-            self.borrow_mcr_initial,
+            self.borrow_mcr_maintenance,
             borrow_position,
             oracle_price_proof,
         )
     }
 
-    pub fn satisfies_minimum_collateral_ratio(
+    pub fn satisfies_mcr_liquidation(
         &self,
         borrow_position: &BorrowPosition,
         oracle_price_proof: &PricePair,
     ) -> bool {
-        satisfies_minimum_collateral_ratio(self.borrow_mcr, borrow_position, oracle_price_proof)
+        satisfies_minimum_collateral_ratio(
+            self.borrow_mcr_liquidation,
+            borrow_position,
+            oracle_price_proof,
+        )
     }
 
     pub fn minimum_acceptable_liquidation_amount(

--- a/contract/lst-oracle/tests/lst_oracle.rs
+++ b/contract/lst-oracle/tests/lst_oracle.rs
@@ -100,8 +100,8 @@ async fn lst_oracle() {
         lst_market,
         [&supply_user, &borrow_user],
         |configuration| {
-            configuration.borrow_mcr = dec!("2");
-            configuration.borrow_mcr_initial = dec!("2");
+            configuration.borrow_mcr_liquidation = dec!("2");
+            configuration.borrow_mcr_maintenance = dec!("2");
 
             configuration.borrow_origination_fee = Fee::zero();
             configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -194,8 +194,8 @@ impl Contract {
         borrow_position.record_borrow_asset_in_flight_start(proof, amount, fees);
 
         require!(
-            borrow_position.satisfies_minimum_initial_collateral_ratio(&price_pair),
-            "New position must exceed initial minimum collateral ratio",
+            borrow_position.satisfies_mcr_maintenance(&price_pair),
+            "Borrow position must satisfy maintenance minimum collateral ratio after borrow.",
         );
 
         require!(
@@ -445,13 +445,13 @@ impl Contract {
         borrow_position.record_collateral_asset_withdrawal(proof, amount);
 
         require!(
-            borrow_position.satisfies_minimum_collateral_ratio(&price_pair),
-            "Borrow position must satisfy MCR after collateral withdrawal.",
+            borrow_position.satisfies_mcr_liquidation(&price_pair),
+            "Borrow position must satisfy liquidation minimum collateral ratio after collateral withdrawal.",
         );
 
         require!(
-            borrow_position.satisfies_minimum_initial_collateral_ratio(&price_pair),
-            "Borrow position must satisfy initial MCR after collateral withdrawal.",
+            borrow_position.satisfies_mcr_maintenance(&price_pair),
+            "Borrow position must satisfy maintenance minimum collateral ratio after collateral withdrawal.",
         );
 
         drop(borrow_position);

--- a/contract/market/tests/configuration_validation.rs
+++ b/contract/market/tests/configuration_validation.rs
@@ -24,32 +24,32 @@ async fn borrow_interest_rate_strategy_exceed_apy_limit() {
 }
 
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_mcr_initial`: out of bounds"]
-async fn borrow_mcr_initial_less_than_1() {
+#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_mcr_maintenance`: out of bounds"]
+async fn borrow_mcr_maintenance_less_than_1() {
     let worker = near_workspaces::sandbox().await.unwrap();
     setup_everything(&worker, |c| {
-        c.borrow_mcr_initial = dec!(".99");
+        c.borrow_mcr_maintenance = dec!(".99");
     })
     .await;
 }
 
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_mcr_initial`: out of bounds"]
-async fn borrow_mcr_initial_less_than_borrow_mcr() {
+#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_mcr_maintenance`: out of bounds"]
+async fn borrow_mcr_maintenance_less_than_borrow_mcr_liquidation() {
     let worker = near_workspaces::sandbox().await.unwrap();
     setup_everything(&worker, |c| {
-        c.borrow_mcr_initial = dec!("1.2");
-        c.borrow_mcr = dec!("1.200000001");
+        c.borrow_mcr_maintenance = dec!("1.2");
+        c.borrow_mcr_liquidation = dec!("1.200000001");
     })
     .await;
 }
 
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_mcr`: out of bounds"]
-async fn borrow_mcr_less_than_1() {
+#[should_panic = "Smart contract panicked: Invalid configuration field `borrow_mcr_liquidation`: out of bounds"]
+async fn borrow_mcr_liquidation_less_than_1() {
     let worker = near_workspaces::sandbox().await.unwrap();
     setup_everything(&worker, |c| {
-        c.borrow_mcr = dec!(".99");
+        c.borrow_mcr_liquidation = dec!(".99");
     })
     .await;
 }

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -70,7 +70,7 @@ async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
         );
     }
 
-    assert!(configuration.borrow_mcr.near_equal(dec!("1.2")));
+    assert!(configuration.borrow_mcr_liquidation.near_equal(dec!("1.2")));
 
     let bounds = c.storage_balance_bounds().await;
 

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -72,8 +72,8 @@ async fn successful_liquidation_good_debt_under_mcr(
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
             c.borrow_origination_fee = Fee::zero();
-            c.borrow_mcr = Decimal::from(mcr) / 100u32;
-            c.borrow_mcr_initial = Decimal::from(mcr) / 100u32;
+            c.borrow_mcr_liquidation = Decimal::from(mcr) / 100u32;
+            c.borrow_mcr_maintenance = Decimal::from(mcr) / 100u32;
         })
     );
 
@@ -152,8 +152,8 @@ async fn successful_liquidation_with_spread(
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
-            c.borrow_mcr = mcr;
-            c.borrow_mcr_initial = mcr;
+            c.borrow_mcr_liquidation = mcr;
+            c.borrow_mcr_maintenance = mcr;
             c.liquidation_maximum_spread = liquidation_maximum_spread;
         })
     );
@@ -320,8 +320,8 @@ async fn successful_liquidation_only_from_interest() {
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
-            c.borrow_mcr = dec!("2");
-            c.borrow_mcr_initial = dec!("2");
+            c.borrow_mcr_liquidation = dec!("2");
+            c.borrow_mcr_maintenance = dec!("2");
             c.borrow_origination_fee = Fee::zero();
             c.borrow_interest_rate_strategy =
                 InterestRateStrategy::linear(dec!("1000"), dec!("1000")).unwrap();
@@ -385,8 +385,8 @@ async fn extreme_prices(
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
-            c.borrow_mcr = dec!("2");
-            c.borrow_mcr_initial = dec!("2");
+            c.borrow_mcr_liquidation = dec!("2");
+            c.borrow_mcr_maintenance = dec!("2");
             c.borrow_origination_fee = Fee::zero();
             c.borrow_interest_rate_strategy =
                 InterestRateStrategy::linear(Decimal::ZERO, Decimal::ZERO).unwrap();

--- a/contract/market/tests/mcr_maintenance.rs
+++ b/contract/market/tests/mcr_maintenance.rs
@@ -9,17 +9,14 @@ use test_utils::*;
 #[case(dec!("1"), dec!("2"))]
 #[case(dec!("1"), dec!("5"))]
 #[tokio::test]
-async fn success_above_minimum_initial_collateral_ratio(
-    #[case] minimum: Decimal,
-    #[case] initial: Decimal,
-) {
+async fn success_above_mcr_maintenance(#[case] liquidation: Decimal, #[case] maintenance: Decimal) {
     setup_test!(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
             c.borrow_origination_fee = Fee::zero();
-            c.borrow_mcr = minimum;
-            c.borrow_mcr_initial = initial;
+            c.borrow_mcr_liquidation = liquidation;
+            c.borrow_mcr_maintenance = maintenance;
         })
     );
 
@@ -27,7 +24,9 @@ async fn success_above_minimum_initial_collateral_ratio(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
         c.collateralize(
             &borrow_user,
-            (1000u32 * initial + Decimal::ONE).to_u128_ceil().unwrap(),
+            (1000u32 * maintenance + Decimal::ONE)
+                .to_u128_ceil()
+                .unwrap(),
         ),
     );
 
@@ -54,18 +53,15 @@ async fn success_above_minimum_initial_collateral_ratio(
 #[case(dec!("1"), dec!("2"))]
 #[case(dec!("1"), dec!("5"))]
 #[tokio::test]
-#[should_panic = "Smart contract panicked: New position must exceed initial minimum collateral ratio"]
-async fn fail_below_minimum_initial_collateral_ratio(
-    #[case] minimum: Decimal,
-    #[case] initial: Decimal,
-) {
+#[should_panic = "Smart contract panicked: Borrow position must satisfy maintenance minimum collateral ratio"]
+async fn fail_below_mcr_maintenance(#[case] liquidation: Decimal, #[case] maintenance: Decimal) {
     setup_test!(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
             c.borrow_origination_fee = Fee::zero();
-            c.borrow_mcr = minimum;
-            c.borrow_mcr_initial = initial;
+            c.borrow_mcr_liquidation = liquidation;
+            c.borrow_mcr_maintenance = maintenance;
         })
     );
 
@@ -73,7 +69,7 @@ async fn fail_below_minimum_initial_collateral_ratio(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
         c.collateralize(
             &borrow_user,
-            (1000u32 * initial).to_u128_floor().unwrap() - 1,
+            (1000u32 * maintenance).to_u128_floor().unwrap() - 1,
         ),
     );
 
@@ -86,17 +82,17 @@ async fn fail_below_minimum_initial_collateral_ratio(
 #[case(dec!("1.5"), dec!("2"))]
 #[case(dec!("1.5"), dec!("5"))]
 #[tokio::test]
-async fn not_in_liquidation_if_below_minimum_initial_collateral_ratio(
-    #[case] minimum: Decimal,
-    #[case] initial: Decimal,
+async fn not_in_liquidation_if_below_mcr_maintenance(
+    #[case] liquidation: Decimal,
+    #[case] maintenance: Decimal,
 ) {
     setup_test!(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
             c.borrow_origination_fee = Fee::zero();
-            c.borrow_mcr = minimum;
-            c.borrow_mcr_initial = initial;
+            c.borrow_mcr_liquidation = liquidation;
+            c.borrow_mcr_maintenance = maintenance;
         })
     );
 
@@ -104,7 +100,9 @@ async fn not_in_liquidation_if_below_minimum_initial_collateral_ratio(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
         c.collateralize(
             &borrow_user,
-            (1000u32 * initial + Decimal::ONE).to_u128_ceil().unwrap(),
+            (1000u32 * maintenance + Decimal::ONE)
+                .to_u128_ceil()
+                .unwrap(),
         ),
     );
 
@@ -121,15 +119,15 @@ async fn not_in_liquidation_if_below_minimum_initial_collateral_ratio(
 }
 
 #[tokio::test]
-#[should_panic = "Smart contract panicked: Borrow position must satisfy initial MCR after collateral withdrawal."]
-async fn withdraw_collateral_below_initial_mcr() {
+#[should_panic = "Smart contract panicked: Borrow position must satisfy maintenance minimum collateral ratio after collateral withdrawal."]
+async fn withdraw_collateral_below_mcr_maintenance() {
     setup_test!(
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
             c.borrow_origination_fee = Fee::zero();
-            c.borrow_mcr = dec!("1.2");
-            c.borrow_mcr_initial = dec!("1.5");
+            c.borrow_mcr_liquidation = dec!("1.2");
+            c.borrow_mcr_maintenance = dec!("1.5");
         })
     );
 

--- a/test-utils/examples/generate_testnet_configuration.rs
+++ b/test-utils/examples/generate_testnet_configuration.rs
@@ -36,8 +36,8 @@ pub fn main() {
                 collateral_asset_decimals: 24,
                 price_maximum_age_s: 60,
             },
-            borrow_mcr_initial: Decimal::from_str("1.25").unwrap(),
-            borrow_mcr: Decimal::from_str("1.2").unwrap(),
+            borrow_mcr_maintenance: Decimal::from_str("1.25").unwrap(),
+            borrow_mcr_liquidation: Decimal::from_str("1.2").unwrap(),
             borrow_asset_maximum_usage_ratio: Decimal::from_str("0.99").unwrap(),
             borrow_origination_fee: Fee::zero(),
             borrow_interest_rate_strategy: InterestRateStrategy::piecewise(

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -116,8 +116,8 @@ pub fn market_configuration(
             borrow_asset_decimals: 24,
             price_maximum_age_s: 60,
         },
-        borrow_mcr_initial: Decimal::from_str("1.25").unwrap(),
-        borrow_mcr: Decimal::from_str("1.2").unwrap(),
+        borrow_mcr_maintenance: Decimal::from_str("1.25").unwrap(),
+        borrow_mcr_liquidation: Decimal::from_str("1.2").unwrap(),
         borrow_asset_maximum_usage_ratio: Decimal::from_str("0.99").unwrap(),
         borrow_origination_fee: Fee::Proportional(Decimal::from_str("0.1").unwrap()),
         borrow_interest_rate_strategy: InterestRateStrategy::piecewise(


### PR DESCRIPTION
For consistency in naming. Makes it more clear when and how each field is used.