### PR TITLE
Update GH comment with the correct contract links

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -146,8 +146,8 @@ jobs:
 
           echo "| Name            | Deployment |" >> comment.md
           echo "| ----            | ---------- |" >> comment.md
-          echo "| Registry        | ["'`'"${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}"'`'"](https://explorer.${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}.near.org/accounts/${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}) |" >> comment.md
-          echo "| Default market  | ["'`'"${MARKET_ACCOUNT_ID}"'`'"](https://explorer.${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}.near.org/accounts/${MARKET_ACCOUNT_ID}) |" >> comment.md
+          echo "| Registry        | ["'`'"${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}"'`'"](https://$([[ \"${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}\" == \"testnet\" ]] && echo 'testnet.' || echo '')nearblocks.io/address/${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}) |" >> comment.md
+          echo "| Default market  | ["'`'"${MARKET_ACCOUNT_ID}"'`'"](https://$([[ \"${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}\" == \"testnet\" ]] && echo 'testnet.' || echo '')nearblocks.io/address/${MARKET_ACCOUNT_ID}) |" >> comment.md
           echo '' >> comment.md
           echo "---" >> comment.md
           echo '' >> comment.md


### PR DESCRIPTION
The current links lead to https://explorer.testnet.near.org, but it is not showing the actual address

https://explorer.testnet.near.org/accounts/gh-196.templar-in-training.testnet

will be updated to be https://testnet.nearblocks.io/address/gh-196.templar-in-training.testnet