### PR TITLE
feat: Fetch all deployments from registry

### DIFF
--- a/bots/README.md
+++ b/bots/README.md
@@ -26,7 +26,7 @@ Running the Bot:
 
 ```bash
 liquidator-service \
-    --markets market1.testnet \
+    --registries registry1.testnet --registries registry2.testnet \
     --signer-key ed25519:\<YOUR_PRIVATE_KEY_HERE> \
     --signer-account liquidator.testnet \
     --asset usdc.testnet \
@@ -34,12 +34,13 @@ liquidator-service \
     --network testnet \
     --timeout 60 \
     --concurrency 10 \
-    --interval 600
+    --interval 600 \
+    --registry-refresh-interval 3600
 ```
 
 Arguments:
 
-- `--markets`: A list of markets to monitor for liquidations (e.g., templar-market1.testnet).
+- `--registries`: A list of registries to query markets from which will be monitored for liquidations (e.g., templar-registry1.testnet).
 - `--signer-key`: The private key of the signer account used to sign transactions.
 - `--signer-account`: The NEAR account that will perform the liquidations (e.g., templar-liquidator.testnet).
 - `--asset`: The asset to liquidate NEP-141 token account used for repayments (e.g., usdc.testnet).
@@ -48,10 +49,12 @@ Arguments:
 - `--timeout`: The timeout for RPC calls in seconds (default is 60 seconds).
 - `--concurrency`: The number of concurrent liquidation attempts (default is 10).
 - `--interval`: The interval in seconds for the service to check for liquidatable positions (default is 600 seconds).
+- `--registry-refresh-interval`: The interval in seconds for the service to check for new markets on the registries (default is 3600 seconds - 1 hour).
 
 How it works:
 
-1. The bot initializes a Liquidator object for each market specified in the `--markets` argument.
+1. The bot fetches all deployments for each registry specified in the `--registryes` argument.
+1. The bot initializes a Liquidator object for each market fetched.
 1. It continuously checks the status of borrowers in each market.
 1. If a borrower is found to be liquidatable, it calculates the liquidation amount based on the borrower's collateral and debt.
 1. It sends an `ft_transfer_call` RPC call to the smart contract to trigger the liquidation process.
@@ -66,7 +69,7 @@ Liquidation Logic:
 The liquidation logic is encapsulated within the `Liquidator` object, which is responsible for:
 
 - Checking a borrower's status to determine if they are below the required collateralization ratio.
-- Calculating the liquidation amount based on the borrower's collateral and debt. (This calculation should be implemented by the liquidator according to their specific strategy or requirements.)
+- Calculating the liquidation amount based on the borrower's collateral and debt.
 
 ```rust
 #[instrument(skip(self), level = "debug")]
@@ -76,17 +79,7 @@ async fn liquidation_amount(
     oracle_response: &OracleResponse,
     configuration: MarketConfiguration,
 ) -> LiquidatorResult<(U128, U128)> {
-    // TODO: Calculate optimal liquidation amount
-    // For purposes of this example implementation we will just use the minimum acceptable
-    // liquidation amount.
-    // Costs to take into account here are:
-    //  - Gas fees
-    //  - Price impact
-    //  - Slippage
-    // All of this would be used in calculating both the optimal liquidation amount and wether to
-    // perform full or partial liquidation
     let borrow_asset = &configuration.borrow_asset;
-    let collateral_asset = &configuration.collateral_asset;
     let price_pair = configuration
         .price_oracle_configuration
         .create_price_pair(oracle_response)?;
@@ -111,17 +104,29 @@ async fn liquidation_amount(
         )
         .await
         .map_err(LiquidatorError::QuoteError)?;
-    let _quote_after_liquidate = self
-        .swap
-        .quote(
-            // TODO: Enable multitoken swaps
-            &collateral_asset.contract_id(),
-            &self.asset,
-            position.collateral_asset_deposit.into(),
-        )
-        .await
-        .map_err(LiquidatorError::QuoteError)?;
     Ok((quote_to_liquidate, min_liquidation_amount.into()))
+}
+```
+
+- Deciding on whether the liquidation should happen or not (This calculation should be implemented by the liquidator according to their specific strategy or requirements.)
+
+```rust
+#[instrument(skip(self), level = "debug")]
+pub async fn should_liquidate(
+    &self,
+    swap_amount: U128,
+    liquidation_amount: U128,
+) -> LiquidatorResult<bool> {
+    // TODO: Calculate optimal liquidation amount
+    // For purposes of this example implementation we will just use the minimum acceptable
+    // liquidation amount.
+    // Costs to take into account here are:
+    //  - Gas fees
+    //  - Price impact
+    //  - Slippage
+    // All of this would be used in calculating both the optimal liquidation amount and wether to
+    // perform full or partial liquidation
+    Ok(true)
 }
 ```
 
@@ -171,6 +176,67 @@ async fn get_oracle_prices(
 ```
 
 The liquidator will fetch the price data from the oracle contract in order to execute the liquidation and gauge whether the liquidation is profitable.
+
+### Fetching deployed markets
+
+```rust
+#[instrument(skip(client), level = "debug")]
+pub async fn list_deployments(
+    client: &JsonRpcClient,
+    registry: AccountId,
+    count: Option<u32>,
+    offset: Option<u32>,
+) -> RpcResult<Vec<AccountId>> {
+    let mut all_deployments = Vec::new();
+    let page_size = 500;
+    let mut current_offset = 0;
+
+    loop {
+        let params = json!({
+            "offset": current_offset,
+            "count": page_size,
+        });
+
+        let page =
+            view::<Vec<AccountId>>(client, registry.clone(), "list_deployments", params).await?;
+
+        let fetched = page.len();
+
+        if fetched == 0 {
+            break;
+        }
+
+        all_deployments.extend(page);
+        current_offset += fetched;
+
+        if fetched < page_size {
+            break;
+        }
+    }
+
+    Ok(all_deployments)
+}
+
+#[instrument(skip(client), level = "debug")]
+pub async fn list_all_deployments(
+    client: JsonRpcClient,
+    registries: Vec<AccountId>,
+    concurrency: usize,
+) -> RpcResult<Vec<AccountId>> {
+    let all_markets: Vec<AccountId> = futures::stream::iter(registries)
+        .map(|registry| {
+            let client = client.clone();
+            async move { list_deployments(&client, registry, None, None).await }
+        })
+        .buffer_unordered(concurrency)
+        .try_concat()
+        .await?;
+
+    Ok(all_markets)
+}
+```
+
+The liquidator will periodically fetch all registries for all of their deployments (markets).
 
 ### Getting the borrow positions for a market
 

--- a/bots/README.md
+++ b/bots/README.md
@@ -53,7 +53,7 @@ Arguments:
 
 How it works:
 
-1. The bot fetches all deployments for each registry specified in the `--registryes` argument.
+1. The bot fetches all deployments for each registry specified in the `--registries` argument.
 1. The bot initializes a Liquidator object for each market fetched.
 1. It continuously checks the status of borrowers in each market.
 1. If a borrower is found to be liquidatable, it calculates the liquidation amount based on the borrower's collateral and debt.

--- a/bots/src/bin/liquidator-bot.rs
+++ b/bots/src/bin/liquidator-bot.rs
@@ -1,10 +1,77 @@
-use std::time::Duration;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use clap::Parser;
-use templar_bots::liquidator::{setup_liquidators, Args, LiquidatorResult};
+use futures::{StreamExt, TryStreamExt};
+use near_crypto::InMemorySigner;
+use near_jsonrpc_client::JsonRpcClient;
+use near_sdk::{serde_json::json, AccountId};
+use templar_bots::{
+    liquidator::{Args, Liquidator, LiquidatorError, LiquidatorResult},
+    near::{view, RpcResult},
+    swap::{RheaSwap, SwapType},
+};
 use tokio::time::sleep;
-use tracing::info;
+use tracing::{info, instrument};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
+
+#[instrument(skip(client), level = "debug")]
+pub async fn list_deployments(
+    client: &JsonRpcClient,
+    registry: AccountId,
+    count: Option<u32>,
+    offset: Option<u32>,
+) -> RpcResult<Vec<AccountId>> {
+    let mut all_deployments = Vec::new();
+    let page_size = 500;
+    let mut current_offset = 0;
+
+    loop {
+        let params = json!({
+            "offset": current_offset,
+            "count": page_size,
+        });
+
+        let page =
+            view::<Vec<AccountId>>(client, registry.clone(), "list_deployments", params).await?;
+
+        let fetched = page.len();
+
+        if fetched == 0 {
+            break;
+        }
+
+        all_deployments.extend(page);
+        current_offset += fetched;
+
+        if fetched < page_size {
+            break;
+        }
+    }
+
+    Ok(all_deployments)
+}
+
+#[instrument(skip(client), level = "debug")]
+pub async fn list_all_deployments(
+    client: JsonRpcClient,
+    registries: Vec<AccountId>,
+    concurrency: usize,
+) -> RpcResult<Vec<AccountId>> {
+    let all_markets: Vec<AccountId> = futures::stream::iter(registries)
+        .map(|registry| {
+            let client = client.clone();
+            async move { list_deployments(&client, registry, None, None).await }
+        })
+        .buffer_unordered(concurrency)
+        .try_concat()
+        .await?;
+
+    Ok(all_markets)
+}
 
 #[tokio::main]
 async fn main() -> LiquidatorResult {
@@ -14,11 +81,53 @@ async fn main() -> LiquidatorResult {
         .init();
 
     let args = Args::parse();
+    let client = JsonRpcClient::connect(args.network.rpc_url());
+    let signer = Arc::new(InMemorySigner::from_secret_key(
+        args.signer_account.clone(),
+        args.signer_key.clone(),
+    ));
+    let swap = match args.swap {
+        SwapType::RheaSwap => Arc::new(RheaSwap::new(
+            args.swap.account_id(args.network),
+            client.clone(),
+            signer.clone(),
+        )),
+    };
+    let asset = Arc::new(args.asset);
 
-    let liquidators = setup_liquidators(&args)?;
+    let registry_refresh_interval = Duration::from_secs(args.registry_refresh_interval);
+    let mut next_refresh = Instant::now();
+    let mut markets = HashMap::<AccountId, Liquidator<_>>::new();
 
     loop {
-        for liquidator in &liquidators {
+        if Instant::now() >= next_refresh {
+            info!("Refreshing registry deployments");
+            let all_markets =
+                list_all_deployments(client.clone(), args.registries.clone(), args.concurrency)
+                    .await
+                    .map_err(LiquidatorError::ListDeploymentsError)?;
+            info!("Found {} deployments", all_markets.len());
+            markets = all_markets
+                .into_iter()
+                .map(|market| {
+                    let liquidator = Liquidator::new(
+                        // All clones are Arcs so this is cheap
+                        client.clone(),
+                        signer.clone(),
+                        asset.clone(),
+                        // This is the only true clone
+                        market.clone(),
+                        swap.clone(),
+                        args.timeout,
+                    );
+                    (market, liquidator)
+                })
+                .collect();
+            next_refresh = Instant::now() + registry_refresh_interval;
+        }
+
+        for (market, liquidator) in &markets {
+            info!("Running liquidations for market: {}", market);
             liquidator.run_liquidations(args.concurrency).await?;
         }
 

--- a/bots/src/liquidator.rs
+++ b/bots/src/liquidator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use clap::Parser;
 use futures::{StreamExt, TryStreamExt};
@@ -23,7 +23,7 @@ use tracing::{error, info, instrument};
 
 use crate::{
     near::{get_access_key_data, send_tx, serialize_and_encode, view, RpcError},
-    swap::{RheaSwap, Swap, SwapType},
+    swap::{Swap, SwapType},
     BorrowPositions, Network, DEFAULT_GAS,
 };
 
@@ -66,15 +66,21 @@ pub enum LiquidatorError {
     /// Error while fetching borrow positions.
     #[error("Failed to list borrow positions: {0}")]
     ListBorrowPositionsError(RpcError),
+    /// Error fetching registry deployments.
+    #[error("Failed to list deployments: {0}")]
+    ListDeploymentsError(RpcError),
+    /// Error fetching minimum acceptable liquidation amount.
+    #[error("Failed to fetch balance: {0}")]
+    FetchBalanceError(RpcError),
 }
 
 pub type LiquidatorResult<T = ()> = Result<T, LiquidatorError>;
 
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
-    /// Market to run liquidations for
-    #[arg(short, long, env = "MARKET_ACCOUNT_ID")]
-    pub markets: Vec<AccountId>,
+    /// Market registries to run liquidations for
+    #[arg(short, long, env = "REGISTRY_ACCOUNT_IDS")]
+    pub registries: Vec<AccountId>,
     /// Swap to use for liquidations
     #[arg(long, env = "SWAP_TYPE")]
     pub swap: SwapType,
@@ -96,6 +102,9 @@ pub struct Args {
     /// Interval between liquidation attempts
     #[arg(short, long, env = "INTERVAL", default_value_t = 600)]
     pub interval: u64,
+    /// Registry refresh interval in seconds
+    #[arg(short, long, env = "REGISTRY_REFRESH_INTERVAL", default_value_t = 3600)]
+    pub registry_refresh_interval: u64,
     /// Concurency for liquidations
     #[arg(short, long, env = "CONCURRENCY", default_value_t = 10)]
     pub concurrency: usize,
@@ -103,21 +112,21 @@ pub struct Args {
 
 pub struct Liquidator<S: Swap> {
     client: JsonRpcClient,
-    signer: InMemorySigner,
-    asset: AccountId,
+    signer: Arc<InMemorySigner>,
+    asset: Arc<AccountId>,
     pub market: AccountId,
     timeout: u64,
-    swap: S,
+    swap: Arc<S>,
 }
 
 impl<S: Swap> Liquidator<S> {
     #[must_use]
     pub fn new(
         client: JsonRpcClient,
-        signer: InMemorySigner,
-        asset: AccountId,
+        signer: Arc<InMemorySigner>,
+        asset: Arc<AccountId>,
         market: AccountId,
-        swap: S,
+        swap: Arc<S>,
         timeout: u64,
     ) -> Self {
         Self {
@@ -162,7 +171,7 @@ impl<S: Swap> Liquidator<S> {
 
         Ok(Transaction::V0(TransactionV0 {
             nonce,
-            receiver_id: self.asset.clone(),
+            receiver_id: self.asset.as_ref().clone(),
             block_hash,
             signer_id: self.signer.account_id.clone(),
             public_key: self.signer.public_key().clone(),
@@ -212,7 +221,23 @@ impl<S: Swap> Liquidator<S> {
             .liquidation_amount(&position, &oracle_response, configuration)
             .await?;
 
-        if self.asset != borrow_asset {
+        // Implement this function based on your liquidation strategy
+        if !self
+            .should_liquidate(swap_amount, liquidation_amount)
+            .await?
+        {
+            info!("Skipping liquidation due to insufficient conditions");
+            return Ok(());
+        }
+
+        let should_swap = if self.asset.as_ref() == &borrow_asset {
+            let asset_balance = self.get_asset_balance(self.asset.as_ref().clone()).await?;
+            asset_balance >= liquidation_amount
+        } else {
+            true
+        };
+
+        if should_swap {
             match self
                 .swap
                 .swap(&self.asset, &borrow_asset, swap_amount)
@@ -245,7 +270,7 @@ impl<S: Swap> Liquidator<S> {
             }
         }
 
-        if self.asset == collateral_asset {
+        if self.asset.as_ref() == &collateral_asset {
             match self
                 .swap
                 .swap(
@@ -274,17 +299,7 @@ impl<S: Swap> Liquidator<S> {
         oracle_response: &OracleResponse,
         configuration: MarketConfiguration,
     ) -> LiquidatorResult<(U128, U128)> {
-        // TODO: Calculate optimal liquidation amount
-        // For purposes of this example implementation we will just use the minimum acceptable
-        // liquidation amount.
-        // Costs to take into account here are:
-        //  - Gas fees
-        //  - Price impact
-        //  - Slippage
-        // All of this would be used in calculating both the optimal liquidation amount and wether to
-        // perform full or partial liquidation
         let borrow_asset = &configuration.borrow_asset;
-        let collateral_asset = &configuration.collateral_asset;
         let price_pair = configuration
             .price_oracle_configuration
             .create_price_pair(oracle_response)?;
@@ -306,16 +321,6 @@ impl<S: Swap> Liquidator<S> {
                     )
                 })?,
                 min_liquidation_amount.into(),
-            )
-            .await
-            .map_err(LiquidatorError::QuoteError)?;
-        let _quote_after_liquidate = self
-            .swap
-            .quote(
-                // TODO: Enable multitoken swaps
-                &collateral_asset.contract_id(),
-                &self.asset,
-                position.collateral_asset_deposit.into(),
             )
             .await
             .map_err(LiquidatorError::QuoteError)?;
@@ -349,6 +354,19 @@ impl<S: Swap> Liquidator<S> {
         )
         .await
         .map_err(LiquidatorError::PriceFetchError)
+    }
+
+    #[instrument(skip(self), level = "debug")]
+    async fn get_asset_balance(&self, asset: AccountId) -> LiquidatorResult<U128> {
+        let balance = view::<U128>(
+            &self.client,
+            asset,
+            "ft_balance_of",
+            json!({ "account_id": self.signer.account_id }),
+        )
+        .await
+        .map_err(LiquidatorError::FetchBalanceError)?;
+        Ok(balance)
     }
 
     #[instrument(skip(self), level = "debug")]
@@ -429,34 +447,22 @@ impl<S: Swap> Liquidator<S> {
 
         Ok(())
     }
-}
 
-#[instrument(level = "debug")]
-pub fn setup_liquidators(args: &Args) -> LiquidatorResult<Vec<Liquidator<impl Swap>>> {
-    let client = JsonRpcClient::connect(args.network.rpc_url());
-    let signer =
-        InMemorySigner::from_secret_key(args.signer_account.clone(), args.signer_key.clone());
-    let asset = args.asset.clone();
-    let swap = match args.swap {
-        SwapType::RheaSwap => RheaSwap::new(
-            args.swap.account_id(args.network),
-            client.clone(),
-            signer.clone(),
-        ),
-    };
-
-    Ok(args
-        .markets
-        .iter()
-        .map(|market| {
-            Liquidator::new(
-                client.clone(),
-                signer.clone(),
-                asset.clone(),
-                market.clone(),
-                swap.clone(),
-                args.timeout,
-            )
-        })
-        .collect())
+    #[instrument(skip(self), level = "debug")]
+    pub async fn should_liquidate(
+        &self,
+        swap_amount: U128,
+        liquidation_amount: U128,
+    ) -> LiquidatorResult<bool> {
+        // TODO: Calculate optimal liquidation amount
+        // For purposes of this example implementation we will just use the minimum acceptable
+        // liquidation amount.
+        // Costs to take into account here are:
+        //  - Gas fees
+        //  - Price impact
+        //  - Slippage
+        // All of this would be used in calculating both the optimal liquidation amount and wether to
+        // perform full or partial liquidation
+        Ok(true)
+    }
 }

--- a/bots/src/liquidator.rs
+++ b/bots/src/liquidator.rs
@@ -19,7 +19,7 @@ use templar_common::{
     market::{error::RetrievalError, DepositMsg, LiquidateMsg, MarketConfiguration},
     oracle::pyth::{OracleResponse, PriceIdentifier},
 };
-use tracing::{error, info, instrument};
+use tracing::{error, info, instrument, warn};
 
 use crate::{
     near::{get_access_key_data, send_tx, serialize_and_encode, view, RpcError},
@@ -217,9 +217,33 @@ impl<S: Swap> Liquidator<S> {
 
         let collateral_asset = configuration.collateral_asset.contract_id();
 
-        let (swap_amount, liquidation_amount) = self
+        let liquidation_amount = self
             .liquidation_amount(&position, &oracle_response, configuration)
             .await?;
+
+        let swap_output_amount = if self.asset.as_ref() == &borrow_asset {
+            let asset_balance = self.get_asset_balance(self.asset.as_ref().clone()).await?;
+            if asset_balance >= liquidation_amount {
+                0.into()
+            } else {
+                (liquidation_amount.0 - asset_balance.0).into()
+            }
+        } else {
+            liquidation_amount
+        };
+
+        let swap_amount = self
+            .swap
+            .quote(&self.asset, &borrow_asset, swap_output_amount)
+            .await
+            .map_err(LiquidatorError::QuoteError)?;
+
+        let available = self.get_asset_balance(self.asset.as_ref().clone()).await?;
+
+        if available < swap_amount {
+            warn!("Insufficient asset balance for liquidation: {available:?} < {swap_amount:?}");
+            return Ok(());
+        }
 
         // Implement this function based on your liquidation strategy
         if !self
@@ -230,14 +254,7 @@ impl<S: Swap> Liquidator<S> {
             return Ok(());
         }
 
-        let should_swap = if self.asset.as_ref() == &borrow_asset {
-            let asset_balance = self.get_asset_balance(self.asset.as_ref().clone()).await?;
-            asset_balance >= liquidation_amount
-        } else {
-            true
-        };
-
-        if should_swap {
+        if swap_amount > 0.into() {
             match self
                 .swap
                 .swap(&self.asset, &borrow_asset, swap_amount)
@@ -298,8 +315,7 @@ impl<S: Swap> Liquidator<S> {
         position: &BorrowPosition,
         oracle_response: &OracleResponse,
         configuration: MarketConfiguration,
-    ) -> LiquidatorResult<(U128, U128)> {
-        let borrow_asset = &configuration.borrow_asset;
+    ) -> LiquidatorResult<U128> {
         let price_pair = configuration
             .price_oracle_configuration
             .create_price_pair(oracle_response)?;
@@ -310,21 +326,7 @@ impl<S: Swap> Liquidator<S> {
                     "Failed to calculate minimum acceptable liquidation amount".to_owned(),
                 )
             })?;
-        // Here we would check a quote for the swap to ensure desired profit margin is met
-        let quote_to_liquidate = self
-            .swap
-            .quote(
-                &self.asset,
-                &borrow_asset.clone().into_nep141().ok_or_else(|| {
-                    LiquidatorError::StandardSupportError(
-                        "Only NEP-141 borrow assets supported".to_owned(),
-                    )
-                })?,
-                min_liquidation_amount.into(),
-            )
-            .await
-            .map_err(LiquidatorError::QuoteError)?;
-        Ok((quote_to_liquidate, min_liquidation_amount.into()))
+        Ok(min_liquidation_amount.into())
     }
 
     #[instrument(skip(self), level = "debug")]

--- a/bots/src/swap.rs
+++ b/bots/src/swap.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use clap::ValueEnum;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::JsonRpcClient;
@@ -52,11 +54,11 @@ impl SwapType {
 pub struct RheaSwap {
     pub contract: AccountId,
     pub client: JsonRpcClient,
-    pub signer: InMemorySigner,
+    pub signer: Arc<InMemorySigner>,
 }
 
 impl RheaSwap {
-    pub fn new(contract: AccountId, client: JsonRpcClient, signer: InMemorySigner) -> Self {
+    pub fn new(contract: AccountId, client: JsonRpcClient, signer: Arc<InMemorySigner>) -> Self {
         Self {
             contract,
             client,


### PR DESCRIPTION
This PR implements the logic to fetch from registries in order to get a list of deployments from them.
In addition to this it also improves swap logic by checking if the liquidator account already has enough funds for that asset and adds a new `should_liquidate` method to be implemented by each liquidator as an additional heuristic.