### PR TITLE
chore: versioning; contracts 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "mock-ft"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "mock-mt"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "mock-oracle"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "getrandom",
  "near-contract-standards",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "templar-bots"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3816,7 +3816,7 @@ dependencies = [
 
 [[package]]
 name = "templar-common"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "borsh",
  "hex",
@@ -3831,7 +3831,7 @@ dependencies = [
 
 [[package]]
 name = "templar-lst-oracle-contract"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "getrandom",
  "hex-literal",
@@ -3847,7 +3847,7 @@ dependencies = [
 
 [[package]]
 name = "templar-market-contract"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "getrandom",
  "near-contract-standards",
@@ -3862,7 +3862,7 @@ dependencies = [
 
 [[package]]
 name = "templar-registry-contract"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "getrandom",
  "near-sdk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1957,7 +1957,7 @@ dependencies = [
 
 [[package]]
 name = "mock-ft"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",
@@ -1966,7 +1966,7 @@ dependencies = [
 
 [[package]]
 name = "mock-mt"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "near-contract-standards",
  "near-sdk",
@@ -1975,7 +1975,7 @@ dependencies = [
 
 [[package]]
 name = "mock-oracle"
-version = "1.0.0"
+version = "0.0.0"
 dependencies = [
  "getrandom",
  "near-contract-standards",
@@ -3795,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "templar-bots"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,12 @@
 [workspace]
 resolver = "2"
 members = ["bots", "common", "contract/*", "mock/*", "test-utils"]
-package.license = "MIT"
+
+[workspace.package]
+license = "MIT"
+repository = "https://github.com/Templar-Protocol/contracts"
+edition = "2021"
+version = "1.0.0"
 
 [workspace.dependencies]
 anyhow = "1.0.95"

--- a/bots/Cargo.toml
+++ b/bots/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-name = "templar-bots"
-version = "0.1.0"
-edition = "2024"
+edition.workspace = true
 license.workspace = true
+name = "templar-bots"
+repository.workspace = true
+version = "0.1.0"
 
 [[bin]]
 name = "liquidator"

--- a/bots/src/accumulator.rs
+++ b/bots/src/accumulator.rs
@@ -9,12 +9,12 @@ use near_primitives::{
     hash::CryptoHash,
     transaction::{Transaction, TransactionV0},
 };
-use near_sdk::{AccountId, serde_json::json};
+use near_sdk::{serde_json::json, AccountId};
 use tracing::{error, info, instrument};
 
 use crate::{
-    BorrowPositions, DEFAULT_GAS, Network,
     near::{get_access_key_data, send_tx, serialize_and_encode, view},
+    BorrowPositions, Network, DEFAULT_GAS,
 };
 
 #[derive(Debug, Clone, Parser)]

--- a/bots/src/bin/accumulator-bot.rs
+++ b/bots/src/bin/accumulator-bot.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use templar_bots::accumulator::{Accumulator, Args};
 use tokio::time::sleep;
 use tracing::info;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {

--- a/bots/src/bin/liquidator-bot.rs
+++ b/bots/src/bin/liquidator-bot.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
 use clap::Parser;
-use templar_bots::liquidator::{Args, LiquidatorResult, setup_liquidators};
+use templar_bots::liquidator::{setup_liquidators, Args, LiquidatorResult};
 use tokio::time::sleep;
 use tracing::info;
-use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[tokio::main]
 async fn main() -> LiquidatorResult {

--- a/bots/src/lib.rs
+++ b/bots/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use clap::ValueEnum;
 use near_jsonrpc_client::{NEAR_MAINNET_RPC_URL, NEAR_TESTNET_RPC_URL};
-use near_sdk::{AccountId, Gas, near};
+use near_sdk::{near, AccountId, Gas};
 use templar_common::borrow::BorrowPosition;
 
 pub mod accumulator;

--- a/bots/src/liquidator.rs
+++ b/bots/src/liquidator.rs
@@ -10,21 +10,21 @@ use near_primitives::{
     transaction::{Transaction, TransactionV0},
 };
 use near_sdk::{
-    AccountId, NearToken,
     json_types::U128,
     serde_json::{self, json},
+    AccountId, NearToken,
 };
 use templar_common::{
     borrow::{BorrowPosition, BorrowStatus},
-    market::{DepositMsg, LiquidateMsg, MarketConfiguration, error::RetrievalError},
+    market::{error::RetrievalError, DepositMsg, LiquidateMsg, MarketConfiguration},
     oracle::pyth::{OracleResponse, PriceIdentifier},
 };
 use tracing::{error, info, instrument};
 
 use crate::{
-    BorrowPositions, DEFAULT_GAS, Network,
-    near::{RpcError, get_access_key_data, send_tx, serialize_and_encode, view},
+    near::{get_access_key_data, send_tx, serialize_and_encode, view, RpcError},
     swap::{RheaSwap, Swap, SwapType},
+    BorrowPositions, Network, DEFAULT_GAS,
 };
 
 /// Errors that can occur during liquidation operations.

--- a/bots/src/near.rs
+++ b/bots/src/near.rs
@@ -3,13 +3,13 @@ use std::time::Duration;
 use base64::Engine;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::{
-    JsonRpcClient,
     errors::JsonRpcError,
     methods::{
         query::{RpcQueryError, RpcQueryRequest},
         send_tx::RpcSendTransactionRequest,
         tx::{RpcTransactionError, RpcTransactionStatusRequest, TransactionInfo},
     },
+    JsonRpcClient,
 };
 use near_jsonrpc_primitives::types::query::QueryResponseKind;
 use near_primitives::{
@@ -19,7 +19,7 @@ use near_primitives::{
     views::{FinalExecutionStatus, QueryRequest, TxExecutionStatus},
 };
 use near_sdk::{
-    serde::{Serialize, de::DeserializeOwned},
+    serde::{de::DeserializeOwned, Serialize},
     serde_json,
 };
 use tokio::time::Instant;

--- a/bots/src/swap.rs
+++ b/bots/src/swap.rs
@@ -6,11 +6,11 @@ use near_primitives::{
     transaction::{Transaction, TransactionV0},
     views::FinalExecutionStatus,
 };
-use near_sdk::{AccountId, NearToken, json_types::U128, near, serde_json::json};
+use near_sdk::{json_types::U128, near, serde_json::json, AccountId, NearToken};
 
 use crate::{
-    DEFAULT_GAS, Network,
-    near::{RpcResult, get_access_key_data, send_tx, serialize_and_encode, view},
+    near::{get_access_key_data, send_tx, serialize_and_encode, view, RpcResult},
+    Network, DEFAULT_GAS,
 };
 
 #[async_trait::async_trait]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-name = "templar-common"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license.workspace = true
+name = "templar-common"
+repository.workspace = true
+version.workspace = true
 
 [dependencies]
 borsh.workspace = true

--- a/contract/lst-oracle/Cargo.toml
+++ b/contract/lst-oracle/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
-name = "templar-lst-oracle-contract"
-version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 license.workspace = true
-repository = "https://github.com/Templar-Protocol/contracts"
+name = "templar-lst-oracle-contract"
+repository.workspace = true
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "templar-market-contract"
-description = "cargo-near-new-project-description"
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/Templar-Protocol/contract-mvp"
+edition.workspace = true
 license.workspace = true
+name = "templar-market-contract"
+repository.workspace = true
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/registry/Cargo.toml
+++ b/contract/registry/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "templar-registry-contract"
-description = ""
-version = "0.1.0"
-edition = "2021"
-repository = "https://github.com/Templar-Protocol/contract-mvp"
+edition.workspace = true
 license.workspace = true
+name = "templar-registry-contract"
+repository.workspace = true
+version.workspace = true
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/mock/ft/Cargo.toml
+++ b/mock/ft/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "mock-ft"
-version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
 license.workspace = true
+name = "mock-ft"
+publish = false
+repository.workspace = true
+version = "0.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/mock/mt/Cargo.toml
+++ b/mock/mt/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "mock-mt"
-version = "0.1.0"
-edition = "2021"
-publish = false
+edition.workspace = true
 license.workspace = true
+name = "mock-mt"
+publish = false
+repository.workspace = true
+version = "0.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/mock/oracle/Cargo.toml
+++ b/mock/oracle/Cargo.toml
@@ -1,8 +1,10 @@
 [package]
+edition.workspace = true
+license.workspace = true
 name = "mock-oracle"
-version = "0.1.0"
-edition = "2021"
 publish = false
+repository.workspace = true
+version = "0.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
Versioning...

- ...services (bots) separately from contracts.
- ...mock contracts as permanently `0.0.0`.
- ...main contracts identically.

Forces all code in the repo to use the same Rust edition (2021).