### PR TITLE
ci: improve workflows to only run on PR when contract logic is changed

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -23,8 +23,9 @@ jobs:
             contracts:
               - 'common/**'
               - 'contract/**'
+              - 'mock/**'
+              - 'script/**'
               - '**/Cargo.toml'
-              - '**/Cargo.lock'
 
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -25,7 +25,6 @@ jobs:
               - 'contract/**'
               - 'mock/**'
               - 'script/**'
-              - '**/Cargo.toml'
 
   test:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -3,17 +3,44 @@ on:
   pull_request:
 
 jobs:
+  # Check if we need to run contract-related jobs
+  check-changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should-run-contracts: ${{ steps.changes.outputs.contracts }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            contracts:
+              - 'common/**'
+              - 'contract/**'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+
   test:
     uses: ./.github/workflows/test.yml
 
   gas-report:
+    needs: check-changes
+    if: needs.check-changes.outputs.should-run-contracts == 'true'
     uses: ./.github/workflows/gas-report.yml
 
   deploy-staging:
     name: Deploy to staging subaccount
     permissions:
       pull-requests: write
-    needs: [test, gas-report]
+    needs: [test, gas-report, check-changes]
+    # Run if contracts changed OR if gas-report was skipped
+    if: always() && needs.test.result == 'success' && (needs.gas-report.result == 'success' || needs.gas-report.result == 'skipped')
     runs-on: ubuntu-latest
     env:
       NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID: gh-${{ github.event.number }}.${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -7,9 +7,35 @@ on:
         value: ${{ jobs.gas-report.outputs.comment }}
 
 jobs:
+  # Add a job to check if relevant files changed
+  check-changes:
+    name: Check for relevant changes
+    runs-on: ubuntu-latest
+    outputs:
+      should-run: ${{ steps.changes.outputs.contracts }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Needed for change detection
+
+      - name: Check for changes
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            contracts:
+              - 'common/**'
+              - 'contract/**'
+              - '**/Cargo.toml'
+              - '**/Cargo.lock'
+
   gas-report:
     name: Gas report
     runs-on: ubuntu-latest
+    needs: check-changes
+    # Only run if there are relevant changes
+    if: needs.check-changes.outputs.should-run == 'true'
     outputs:
       comment: ${{ steps.generate.outputs.comment }}
     steps:

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -27,8 +27,9 @@ jobs:
             contracts:
               - 'common/**'
               - 'contract/**'
+              - 'mock/**'
+              - 'script/**'
               - '**/Cargo.toml'
-              - '**/Cargo.lock'
 
   gas-report:
     name: Gas report

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -29,7 +29,6 @@ jobs:
               - 'contract/**'
               - 'mock/**'
               - 'script/**'
-              - '**/Cargo.toml'
 
   gas-report:
     name: Gas report

--- a/.github/workflows/undeploy-staging.yml
+++ b/.github/workflows/undeploy-staging.yml
@@ -4,9 +4,41 @@ on:
     types: [closed]
 
 jobs:
+  # Check if a staging environment was actually created (contract changes existed)
+  check-staging-exists:
+    name: Check if staging environment exists
+    runs-on: ubuntu-latest
+    outputs:
+      should-cleanup: ${{ steps.check.outputs.exists }}
+    env:
+      NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID: gh-${{ github.event.number }}.${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Check if staging account exists
+        id: check
+        run: |
+          # Install near CLI for account checking
+          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/near-cli-rs/releases/download/v0.22.0/near-cli-rs-installer.sh | sh
+          
+          EXISTS=$(./script/ci/account-exists.sh \
+            --account "${{ env.NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID }}" \
+            --network "${{ vars.NEAR_CONTRACT_STAGING_NETWORK }}" || echo "")
+          
+          if [[ -n "$EXISTS" ]]; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+            echo "Staging account exists, will proceed with cleanup"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "Staging account does not exist, skipping cleanup"
+          fi
+
   cleanup-staging:
     name: Cleanup staging account
     runs-on: ubuntu-latest
+    needs: check-staging-exists
+    if: needs.check-staging-exists.outputs.should-cleanup == 'true'
     env:
       NEAR_CONTRACT_PR_STAGING_ACCOUNT_ID: gh-${{ github.event.number }}.${{ vars.NEAR_CONTRACT_STAGING_ACCOUNT_ID }}
     steps:


### PR DESCRIPTION
Its a bit excessive when we keep on needing to run the contract flows when working on code unrelated to the contract like the bots. I propose a change to improve this by adjusting the Github workflows relating to deployments to only run when any of those files had changed in the PR.

This fixes those issues by checking contract changes, or previous stages if they had run.

Related: #206 