### PR TITLE
Add glossary to documentation 

### DIFF
--- a/docs/src/README.md
+++ b/docs/src/README.md
@@ -2,4 +2,6 @@
 
 This is a high-level user guide for the Templar Protocol smart contracts.
 
+For definitions of key terms and concepts, refer to the [Glossary](./glossary.md).
+
 [The API documentation can be found here](../doc/templar_common/index.html).

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,4 +5,5 @@
   - [Supply](./market/supply.md)
   - [Borrow](./market/borrow.md)
   - [Liquidate](./market/liquidate.md)
+- [Glossary](./glossary.md)
 - [Notes](./notes.md)

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -1,0 +1,182 @@
+# Glossary
+
+This glossary provides definitions for key terms used throughout the Templar Protocol documentation and smart contracts.
+
+## A
+
+**APY (Annual Percentage Yield)**
+: The total return on an investment over one year, including compound interest. In Templar, this represents the effective yearly return for suppliers or the cost for borrowers.
+
+**Asset Pair**
+: The combination of collateral asset and borrow asset that defines a market (e.g., BTC/USDC means Bitcoin collateral, USDC borrowing).
+
+## B
+
+**Borrow Asset**
+: The token that users can borrow from the market. Typically a stablecoin like USDC, but can be any supported token.
+
+**Borrow Position** { #borrow-position }
+: A user's borrowing account containing collateral deposits, borrowed amounts, accumulated interest, and current status.
+
+**Borrower**
+: A user who deposits collateral and borrows assets from the market, paying interest on the borrowed amount.
+
+## C
+
+**Collateral Asset** { #collateral-asset }
+: The token deposited by borrowers to secure their loans. Must be worth more than the borrowed amount due to over-collateralization requirements.
+
+**Collateralization Ratio (CR)**
+: The ratio of collateral value to borrowed value. A 150% ratio means $150 of collateral backs $100 of debt.
+
+**Compounding**
+: The process of automatically reinvesting earned yield to generate additional returns over time.
+
+## D
+
+**Debt**
+: The total amount owed by a borrower, including principal plus accumulated interest and fees.
+
+## F
+
+**FMV (Fair Market Value)**
+: The current market price of an asset as determined by oracle price feeds.
+
+## G
+
+**Gas**
+: The computational cost for executing transactions on the NEAR blockchain.
+
+## H
+
+**Harvest Yield**
+: The action of claiming accumulated yield from a supply position. Can be withdrawn or compounded.
+
+## I
+
+**Interest Accumulation**
+: The process of calculating and adding accrued interest to a borrower's total liability.
+
+## L
+
+**Lending**
+: The general practice of providing assets to borrowers in exchange for interest payments. In Templar, suppliers lend to the market pool.
+
+**Liability**
+: The total debt owed by a borrower, including principal, accumulated interest, and fees.
+
+**Liquidation**
+: The forced sale of a borrower's collateral when their position becomes undercollateralized or expires.
+
+**Liquidator**
+: A third party who performs liquidations by repaying part of a borrower's debt in exchange for discounted collateral.
+
+**Liquidator Spread**
+: The discount liquidators receive when purchasing collateral, serving as incentive for providing the liquidation service.
+
+**Liquidity**
+: The availability of assets in the market for borrowing or withdrawal. When liquidity is low, withdrawal requests may need to wait in the queue.
+
+**Liquidity Pool**
+: The combined supply of assets deposited by all suppliers in a market, available for borrowers to access.
+
+## M
+
+**Market**
+: A smart contract managing lending and borrowing for a specific asset pair (e.g., BTC/USDC market).
+
+**Maximum Usage Ratio**
+: The maximum percentage of supplied assets that can be borrowed from a market, preventing over-utilization and maintaining liquidity reserves.
+
+**MCR (Minimum Collateralization Ratio)** { #mcr-minimum-collateralization-ratio }
+: The minimum ratio of collateral value to borrowed value required to maintain a position. Different MCR levels trigger maintenance requirements or liquidation.
+
+**MCR Liquidation**
+: The minimum collateralization ratio below which a position becomes eligible for liquidation.
+
+**MCR Maintenance**
+: The minimum collateralization ratio required for new borrows or collateral withdrawals.
+
+## N
+
+**NEP-141**
+: The NEAR Protocol standard for fungible tokens, similar to Ethereum's ERC-20. See the [official NEP-141 specification](https://nomicon.io/Standards/Tokens/FungibleToken/Core).
+
+**NEP-245**
+: The NEAR Protocol standard for multi-token contracts, similar to Ethereum's ERC-1155. See the [official NEP-245 specification](https://nomicon.io/Standards/Tokens/MultiToken/Core).
+
+## O
+
+**Oracle**
+: A service providing real-time price data for assets, essential for calculating collateralization ratios and liquidations.
+
+**Origination Fee**
+: A fee charged when creating a new borrow position, can be flat amount or percentage-based.
+
+**Over-collateralization**
+: The requirement for borrowers to deposit collateral worth more than the borrowed amount, providing a safety buffer against price volatility.
+
+## P
+
+**Partial Liquidation**
+: Liquidating only enough collateral to bring a position back to the minimum collateralization ratio, rather than liquidating the entire position.
+
+**Principal**
+: The original amount borrowed or supplied, excluding accumulated interest and fees.
+
+**Protocol Revenue**
+: Fees collected by the protocol from borrowers and suppliers, used for operations and governance.
+
+**Pyth Network**
+: A decentralized oracle network providing high-frequency price feeds for various assets.
+
+## R
+
+**Registry**
+: A smart contract that manages deployment and versioning of market contracts within the Templar Protocol.
+
+**Repay**
+: The action of returning borrowed assets plus interest to reduce or eliminate a borrower's debt.
+
+## S
+
+**Snapshot**
+: A point-in-time record of market state including interest rates, asset amounts, and yield distribution.
+
+**Stablecoin**
+: A cryptocurrency designed to maintain stable value, typically pegged to a fiat currency like USD. Commonly used as borrow assets in lending protocols.
+
+**Supply**
+: The total amount of assets deposited by suppliers that are available for borrowing in a market.
+
+**Supplier**
+: A user who deposits assets into the market to earn yield from borrower interest payments.
+
+**Supply Withdrawal Fee**
+: A fee charged when suppliers withdraw their assets from the market, configured per market to manage liquidity.
+
+## T
+
+**Time Chunk**
+: A configurable time period (based on blocks, epochs, or timestamps) that determines when new snapshots are created.
+
+**Transfer Call**
+: A token transfer that includes data, allowing the receiving contract to execute logic based on the transfer.
+
+## U
+
+**Undercollateralized**
+: A borrow position where the collateral value falls below the required minimum ratio, making it eligible for liquidation.
+
+**Utilization Rate**
+: The percentage of supplied assets currently borrowed. Calculated as: `borrowed_amount / total_supplied_amount`.
+
+## W
+
+**Withdrawal Queue**
+: A first-in-first-out system for processing supply withdrawals when market liquidity is insufficient.
+
+## Y
+
+**Yield**
+: The return earned by suppliers on their deposited assets, generated from borrower interest payments and fees.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -15,7 +15,7 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 **Borrow Asset**
 : The token that users can borrow from the market. Typically a stablecoin like USDC, but can be any supported token.
 
-**Borrow Position** { #borrow-position }
+**Borrow Position**
 : A user's borrowing account containing collateral deposits, borrowed amounts, accumulated interest, and current status.
 
 **Borrower**
@@ -23,7 +23,7 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 
 ## C
 
-**Collateral Asset** { #collateral-asset }
+**Collateral Asset**
 : The token deposited by borrowers to secure their loans. Must be worth more than the borrowed amount due to over-collateralization requirements.
 
 **Collateralization Ratio (CR)**
@@ -88,7 +88,7 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 **Maximum Usage Ratio**
 : The maximum percentage of supplied assets that can be borrowed from a market, preventing over-utilization and maintaining liquidity reserves.
 
-**MCR (Minimum Collateralization Ratio)** { #mcr-minimum-collateralization-ratio }
+**MCR (Minimum Collateralization Ratio)**
 : The minimum ratio of collateral value to borrowed value required to maintain a position. Different MCR levels trigger maintenance requirements or liquidation.
 
 **MCR Liquidation**
@@ -98,6 +98,9 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 : The minimum collateralization ratio required for new borrows or collateral withdrawals.
 
 ## N
+
+**NEAR Intents**
+: A NEAR Protocol feature that allows users to express desired outcomes (intents) that can be fulfilled by solvers, enabling more flexible and efficient transaction execution. See the [official NEAR Intents documentation](https://docs.near.org/chain-abstraction/intents/overview).
 
 **NEP-141**
 : The NEAR Protocol standard for fungible tokens, similar to Ethereum's ERC-20. See the [official NEP-141 specification](https://nomicon.io/Standards/Tokens/FungibleToken/Core).
@@ -119,13 +122,13 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 ## P
 
 **Partial Liquidation**
-: Liquidating only enough collateral to bring a position back to the minimum collateralization ratio, rather than liquidating the entire position.
+: Liquidating only enough collateral to bring a position back to the maintenance MCR, rather than liquidating the entire position.
 
 **Principal**
 : The original amount borrowed or supplied, excluding accumulated interest and fees.
 
 **Protocol Revenue**
-: Fees collected by the protocol from borrowers and suppliers, used for operations and governance.
+: Fees collected by the protocol from borrowers and suppliers, distributed to suppliers and other accounts according to configured yield weights.
 
 **Pyth Network**
 : A decentralized oracle network providing high-frequency price feeds for various assets.
@@ -145,6 +148,9 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 
 **Stablecoin**
 : A cryptocurrency designed to maintain stable value, typically pegged to a fiat currency like USD. Commonly used as borrow assets in lending protocols.
+
+**Static Yield**
+: A fixed yield rate mechanism that provides predictable returns independent of market utilization, often used for specific asset strategies or risk management.
 
 **Supply**
 : The total amount of assets deposited by suppliers that are available for borrowing in a market.

--- a/docs/src/glossary.md
+++ b/docs/src/glossary.md
@@ -150,7 +150,7 @@ This glossary provides definitions for key terms used throughout the Templar Pro
 : A cryptocurrency designed to maintain stable value, typically pegged to a fiat currency like USD. Commonly used as borrow assets in lending protocols.
 
 **Static Yield**
-: A fixed yield rate mechanism that provides predictable returns independent of market utilization, often used for specific asset strategies or risk management.
+: A fixed allocation of market revenue to specific accounts, independent of their supply activity. Defined in the market's yield_weights configuration, static yield is distributed proportionally to designated accounts and can be withdrawn using the withdraw_static_yield function.
 
 **Supply**
 : The total amount of assets deposited by suppliers that are available for borrowing in a market.


### PR DESCRIPTION
Added glossary.
https://github.com/Templar-Protocol/contracts/issues/223
I was trying to keep right balance: protocol-specific terms + useful general concepts.