### PR TITLE
fix: Fetch markets from registries and add service file

### DIFF
--- a/bots/accumulator.service
+++ b/bots/accumulator.service
@@ -1,0 +1,14 @@
+; vim: set filetype=dosini:
+[Unit]
+Description=Templar Accumulator Bot
+After=network.target
+
+[Service]
+EnvironmentFile=/etc/default/accumulator
+ExecStart="/usr/local/bin/accumulator"
+Restart=on-failure
+User=root
+WorkingDirectory=/usr/local/bin
+
+[Install]
+WantedBy=multi-user.target

--- a/bots/accumulator.service
+++ b/bots/accumulator.service
@@ -7,7 +7,7 @@ After=network.target
 EnvironmentFile=/etc/default/accumulator
 ExecStart="/usr/local/bin/accumulator"
 Restart=on-failure
-User=root
+User=accumulator
 WorkingDirectory=/usr/local/bin
 
 [Install]

--- a/bots/src/accumulator.rs
+++ b/bots/src/accumulator.rs
@@ -35,18 +35,18 @@ pub struct Args {
     #[arg(short, long, env = "TIMEOUT", default_value_t = 60)]
     pub timeout: u64,
     /// Interval between accumulations in seconds
-    #[arg(short, long, default_value = "600", env = "INTERVAL")]
+    #[arg(short, long, default_value_t = 600, env = "INTERVAL")]
     pub interval: u64,
     /// Registry refresh interval in seconds
     #[arg(
         short = 'r',
         long,
-        default_value = "3600",
+        default_value_t = 3600,
         env = "REGISTRY_REFRESH_INTERVAL"
     )]
     pub registry_refresh_interval: u64,
     /// Concurrency for accumulation tasks
-    #[arg(short, long, default_value = "4", env = "CONCURRENCY")]
+    #[arg(short, long, default_value_t = 4, env = "CONCURRENCY")]
     pub concurrency: usize,
 }
 

--- a/bots/src/accumulator.rs
+++ b/bots/src/accumulator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use clap::Parser;
 use futures::{StreamExt, TryStreamExt};
@@ -19,9 +19,9 @@ use crate::{
 
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
-    /// Market to run accumulator for
-    #[arg(short, long, env = "MARKET_ACCOUNT_ID")]
-    pub markets: Vec<AccountId>,
+    /// Registries to run accumulator for
+    #[arg(short, long, env = "REGISTRIES_ACCOUNT_IDS")]
+    pub registries: Vec<AccountId>,
     /// Signer key to use for signing transactions
     #[arg(short = 'k', long, env = "SIGNER_KEY")]
     pub signer_key: SecretKey,
@@ -35,16 +35,40 @@ pub struct Args {
     #[arg(short, long, env = "TIMEOUT", default_value_t = 60)]
     pub timeout: u64,
     /// Interval between accumulations in seconds
-    #[arg(short, long, default_value = "60", env = "INTERVAL")]
+    #[arg(short, long, default_value = "600", env = "INTERVAL")]
     pub interval: u64,
+    /// Registry refresh interval in seconds
+    #[arg(
+        short = 'r',
+        long,
+        default_value = "3600",
+        env = "REGISTRY_REFRESH_INTERVAL"
+    )]
+    pub registry_refresh_interval: u64,
     /// Concurrency for accumulation tasks
-    #[arg(short, long, default_value = "10", env = "CONCURRENCY")]
+    #[arg(short, long, default_value = "4", env = "CONCURRENCY")]
     pub concurrency: usize,
+}
+
+impl std::fmt::Display for Args {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "registries: {:?}\nsigner_account: {}\nnetwork: {}\ntimeout: {}\ninterval: {}\nregistry_refresh_interval: {}\nconcurrency: {}",
+            self.registries,
+            self.signer_account,
+            self.network,
+            self.timeout,
+            self.interval,
+            self.registry_refresh_interval,
+            self.concurrency
+        )
+    }
 }
 
 pub struct Accumulator {
     client: JsonRpcClient,
-    signer: InMemorySigner,
+    signer: Arc<InMemorySigner>,
     pub market: AccountId,
     timeout: u64,
 }
@@ -53,7 +77,7 @@ impl Accumulator {
     #[must_use]
     pub fn new(
         client: JsonRpcClient,
-        signer: InMemorySigner,
+        signer: Arc<InMemorySigner>,
         market: AccountId,
         timeout: u64,
     ) -> Self {
@@ -155,18 +179,5 @@ impl Accumulator {
             .await?;
 
         Ok(())
-    }
-
-    #[instrument(level = "debug")]
-    pub fn setup_accumulators(args: &Args) -> anyhow::Result<Vec<Self>> {
-        let client = JsonRpcClient::connect(args.network.rpc_url());
-        let signer =
-            InMemorySigner::from_secret_key(args.signer_account.clone(), args.signer_key.clone());
-
-        Ok(args
-            .markets
-            .iter()
-            .map(|market| Self::new(client.clone(), signer.clone(), market.clone(), args.timeout))
-            .collect())
     }
 }

--- a/bots/src/bin/accumulator-bot.rs
+++ b/bots/src/bin/accumulator-bot.rs
@@ -1,9 +1,13 @@
-use std::time::Duration;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use clap::Parser;
-use templar_bots::accumulator::{Accumulator, Args};
-use tokio::time::sleep;
-use tracing::info;
+use near_crypto::InMemorySigner;
+use near_jsonrpc_client::JsonRpcClient;
+use templar_bots::{
+    accumulator::{Accumulator, Args},
+    list_all_deployments,
+};
+use tracing::{error, info};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[tokio::main]
@@ -14,19 +18,53 @@ async fn main() -> anyhow::Result<()> {
         .init();
 
     let args = Args::parse();
+    info!("Starting accumulator bot with args: {args}");
+    let client = JsonRpcClient::connect(args.network.rpc_url());
+    let signer = Arc::new(InMemorySigner::from_secret_key(
+        args.signer_account.clone(),
+        args.signer_key.clone(),
+    ));
 
-    let accumulators = Accumulator::setup_accumulators(&args)?;
+    let mut refresh_ticker =
+        tokio::time::interval(Duration::from_secs(args.registry_refresh_interval));
+    let mut accumulate_ticker = tokio::time::interval(Duration::from_secs(args.interval));
+    let mut accumulators =
+        list_all_deployments(client.clone(), args.registries.clone(), args.concurrency)
+            .await?
+            .into_iter()
+            .map(|market| {
+                (
+                    market.clone(),
+                    Accumulator::new(client.clone(), signer.clone(), market, args.timeout),
+                )
+            })
+            .collect::<HashMap<_, _>>();
 
     loop {
-        for accumulator in &accumulators {
-            accumulator.run_accumulations(args.concurrency).await?;
-        }
+        tokio::select! {
+            _ = refresh_ticker.tick() => {
+                info!("Refreshing registry deployments");
+                let Ok(all_markets) =
+                    list_all_deployments(client.clone(), args.registries.clone(), args.concurrency)
+                        .await else {
+                    error!("Failed to list deployments, keeping existing ones");
+                    continue;
+                };
+                info!("Found {} deployments", all_markets.len());
+                for market in all_markets {
+                    accumulators.entry(market.clone()).or_insert_with(|| {
+                        Accumulator::new(client.clone(), signer.clone(), market, args.timeout)
+                    });
+                }
+            }
+            _ = accumulate_ticker.tick() => {
+                for (market, accumulator) in &accumulators {
+                    info!("Running accumulation for market: {market}");
+                    accumulator.run_accumulations(args.concurrency).await?;
+                }
 
-        info!(
-            "Accumulation job done, sleeping for {} seconds before next run",
-            args.interval
-        );
-        // Sleep for the specified interval before the next iteration
-        sleep(Duration::from_secs(args.interval)).await;
+                info!("Accumulation job done");
+            }
+        }
     }
 }

--- a/bots/src/bin/liquidator-bot.rs
+++ b/bots/src/bin/liquidator-bot.rs
@@ -5,73 +5,17 @@ use std::{
 };
 
 use clap::Parser;
-use futures::{StreamExt, TryStreamExt};
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::JsonRpcClient;
-use near_sdk::{serde_json::json, AccountId};
+use near_sdk::AccountId;
 use templar_bots::{
     liquidator::{Args, Liquidator, LiquidatorError, LiquidatorResult},
-    near::{view, RpcResult},
+    list_all_deployments,
     swap::{RheaSwap, SwapType},
 };
 use tokio::time::sleep;
-use tracing::{info, instrument};
+use tracing::info;
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
-
-#[instrument(skip(client), level = "debug")]
-pub async fn list_deployments(
-    client: &JsonRpcClient,
-    registry: AccountId,
-    count: Option<u32>,
-    offset: Option<u32>,
-) -> RpcResult<Vec<AccountId>> {
-    let mut all_deployments = Vec::new();
-    let page_size = 500;
-    let mut current_offset = 0;
-
-    loop {
-        let params = json!({
-            "offset": current_offset,
-            "count": page_size,
-        });
-
-        let page =
-            view::<Vec<AccountId>>(client, registry.clone(), "list_deployments", params).await?;
-
-        let fetched = page.len();
-
-        if fetched == 0 {
-            break;
-        }
-
-        all_deployments.extend(page);
-        current_offset += fetched;
-
-        if fetched < page_size {
-            break;
-        }
-    }
-
-    Ok(all_deployments)
-}
-
-#[instrument(skip(client), level = "debug")]
-pub async fn list_all_deployments(
-    client: JsonRpcClient,
-    registries: Vec<AccountId>,
-    concurrency: usize,
-) -> RpcResult<Vec<AccountId>> {
-    let all_markets: Vec<AccountId> = futures::stream::iter(registries)
-        .map(|registry| {
-            let client = client.clone();
-            async move { list_deployments(&client, registry, None, None).await }
-        })
-        .buffer_unordered(concurrency)
-        .try_concat()
-        .await?;
-
-    Ok(all_markets)
-}
 
 #[tokio::main]
 async fn main() -> LiquidatorResult {

--- a/bots/src/lib.rs
+++ b/bots/src/lib.rs
@@ -1,9 +1,12 @@
 use std::collections::HashMap;
 
 use clap::ValueEnum;
-use near_jsonrpc_client::{NEAR_MAINNET_RPC_URL, NEAR_TESTNET_RPC_URL};
-use near_sdk::{near, AccountId, Gas};
+use futures::{StreamExt, TryStreamExt};
+use near::{view, RpcResult};
+use near_jsonrpc_client::{JsonRpcClient, NEAR_MAINNET_RPC_URL, NEAR_TESTNET_RPC_URL};
+use near_sdk::{near, serde_json::json, AccountId, Gas};
 use templar_common::borrow::BorrowPosition;
+use tracing::instrument;
 
 pub mod accumulator;
 pub mod liquidator;
@@ -44,4 +47,59 @@ impl Network {
             Network::Testnet => NEAR_TESTNET_RPC_URL,
         }
     }
+}
+
+#[instrument(skip(client), level = "debug")]
+pub async fn list_deployments(
+    client: &JsonRpcClient,
+    registry: AccountId,
+    count: Option<u32>,
+    offset: Option<u32>,
+) -> RpcResult<Vec<AccountId>> {
+    let mut all_deployments = Vec::new();
+    let page_size = 500;
+    let mut current_offset = 0;
+
+    loop {
+        let params = json!({
+            "offset": current_offset,
+            "count": page_size,
+        });
+
+        let page =
+            view::<Vec<AccountId>>(client, registry.clone(), "list_deployments", params).await?;
+
+        let fetched = page.len();
+
+        if fetched == 0 {
+            break;
+        }
+
+        all_deployments.extend(page);
+        current_offset += fetched;
+
+        if fetched < page_size {
+            break;
+        }
+    }
+
+    Ok(all_deployments)
+}
+
+#[instrument(skip(client), level = "debug")]
+pub async fn list_all_deployments(
+    client: JsonRpcClient,
+    registries: Vec<AccountId>,
+    concurrency: usize,
+) -> RpcResult<Vec<AccountId>> {
+    let all_markets: Vec<AccountId> = futures::stream::iter(registries)
+        .map(|registry| {
+            let client = client.clone();
+            async move { list_deployments(&client, registry, None, None).await }
+        })
+        .buffer_unordered(concurrency)
+        .try_concat()
+        .await?;
+
+    Ok(all_markets)
 }

--- a/bots/src/near.rs
+++ b/bots/src/near.rs
@@ -1,6 +1,5 @@
 use std::time::Duration;
 
-use base64::Engine;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::{
     errors::JsonRpcError,
@@ -100,9 +99,7 @@ pub async fn get_access_key_data(
 
 #[allow(clippy::expect_used, reason = "We know the serialization will succeed")]
 pub fn serialize_and_encode(data: impl Serialize) -> Vec<u8> {
-    base64::engine::general_purpose::STANDARD
-        .encode(serde_json::to_string(&data).expect("Failed to serialize data"))
-        .into_bytes()
+    serde_json::to_vec(&data).expect("Failed to serialize data")
 }
 
 #[instrument(skip_all, level = "debug", fields(account_id = %account_id, method_name = %function_name, args = ?serde_json::to_string(&args)))]


### PR DESCRIPTION
Adds a service file for the accumulator bot. Updates the implementation to fetch markets from a list of registries and moves some code to be reused between the liquidator and accumulator bots.