### PR TITLE
chore: update to near-workspaces 0.21

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
- "gimli 0.31.1",
+ "gimli",
 ]
 
 [[package]]
@@ -312,7 +312,7 @@ dependencies = [
  "siphasher",
  "tar",
  "ureq",
- "zip 0.6.6",
+ "zip",
 ]
 
 [[package]]
@@ -386,9 +386,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "2.3.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97493a391b4b18ee918675fb8663e53646fd09321c58b46afa04e8ce2499c869"
+checksum = "ebeb9aaf9329dff6ceb65c689ca3db33dbf15f324909c60e4e5eef5701ce31b1"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -396,14 +396,16 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "2.3.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2af3eac944c12cdf4423eab70d310da0a8e5851a18ffb192c0a5e3f7ae1663"
+checksum = "77e9d642a7e3a318e37c2c9427b5a6a48aa1ad55dcd986f3034ab2239045a645"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "ident_case",
+ "prettyplease 0.2.25",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.93",
 ]
 
@@ -449,15 +451,6 @@ checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
-]
-
-[[package]]
-name = "brownstone"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "030ea61398f34f1395ccbeb046fb68c87b631d1f34567fed0f0f11fa35d18d8d"
-dependencies = [
- "arrayvec",
 ]
 
 [[package]]
@@ -562,32 +555,23 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.4.2"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e79fd27a64c34c965d14a81c28c93e512f77439fa4a8a501bb6c262e9e792fe"
+checksum = "aeeabf8f3443202828089b8b8e1561e54ad294978afcbc8a5e3095082903947a"
 dependencies = [
  "bon",
  "bs58 0.5.1",
  "camino",
  "cargo_metadata",
- "cc",
  "colored",
  "dunce",
  "eyre",
  "hex",
- "humantime",
  "indenter",
- "libloading",
- "near-abi",
+ "pathdiff",
  "rustc_version",
- "schemars",
- "serde_json",
  "sha2",
- "symbolic-debuginfo",
- "tempfile",
  "tracing",
- "wasm-opt",
- "zstd 0.13.2",
 ]
 
 [[package]]
@@ -708,16 +692,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
-
-[[package]]
 name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,7 +704,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -913,72 +887,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad7c7515609502d316ab9a24f67dc045132d93bfd3f00713389e90d9898bf30d"
-dependencies = [
- "cc",
- "cxxbridge-cmd",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "foldhash",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bfd16fca6fd420aebbd80d643c201ee4692114a0de208b790b9cd02ceae65fb"
-dependencies = [
- "cc",
- "codespan-reporting",
- "proc-macro2",
- "quote",
- "scratch",
- "syn 2.0.93",
-]
-
-[[package]]
-name = "cxxbridge-cmd"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c33fd49f5d956a1b7ee5f7a9768d58580c6752838d92e39d0d56439efdedc35"
-dependencies = [
- "clap",
- "codespan-reporting",
- "proc-macro2",
- "quote",
- "syn 2.0.93",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0f1077278fac36299cce8446effd19fe93a95eedb10d39265f3bf67b3036c9"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.136"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da7e4d6e74af6b79031d264b2f13c3ea70af1978083741c41ffce9308f1f24f"
-dependencies = [
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.93",
-]
-
-[[package]]
 name = "darling"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.10",
+ "darling_macro 0.20.10",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -996,23 +921,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.93",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.10",
  "quote",
  "syn 2.0.93",
 ]
 
 [[package]]
-name = "debugid"
-version = "0.7.3"
+name = "darling_macro"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6ee87af31d84ef885378aebca32be3d682b0e0dc119d5b4860a2c5bb5046730"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
- "uuid 0.8.2",
+ "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -1061,6 +1002,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1103,12 +1064,6 @@ dependencies = [
  "quote",
  "syn 2.0.93",
 ]
-
-[[package]]
-name = "dmsort"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0bc8fbe9441c17c9f46f75dfe27fa1ddb6c68a461ccaed0481419219d4f10d3"
 
 [[package]]
 name = "dotenvy"
@@ -1166,16 +1121,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "elementtree"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6319c9433cf1e95c60c8533978bccf0614f27f03bb4e514253468eeeaa7fe3"
-dependencies = [
- "string_cache",
- "xml-rs",
-]
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,7 +1162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1251,12 +1196,6 @@ dependencies = [
  "indenter",
  "once_cell",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
@@ -1523,16 +1462,6 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
-dependencies = [
- "fallible-iterator",
- "stable_deref_trait",
-]
-
-[[package]]
-name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
@@ -1542,17 +1471,6 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
-
-[[package]]
-name = "goblin"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7666983ed0dd8d21a6f6576ee00053ca0926fb281a5522577a4dbd0f1b54143"
-dependencies = [
- "log",
- "plain",
- "scroll 0.11.0",
-]
 
 [[package]]
 name = "h2"
@@ -1713,12 +1631,6 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1982,12 +1894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indent_write"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cfe9645a18782869361d9c8732246be7b410ad4e919d3609ebabdac00ba12c3"
-
-[[package]]
 name = "indenter"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2076,6 +1982,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2089,12 +2004,6 @@ checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "joinery"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
 name = "js-sys"
@@ -2154,26 +2063,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
-
-[[package]]
-name = "libloading"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
-dependencies = [
- "cfg-if 1.0.0",
- "windows-targets 0.52.6",
-]
 
 [[package]]
 name = "libm"
@@ -2203,19 +2096,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "link-cplusplus"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -2231,6 +2121,7 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -2280,15 +2171,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "memmap2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "memory_units"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2309,12 +2191,6 @@ dependencies = [
  "mime",
  "unicase",
 ]
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2403,7 +2279,7 @@ dependencies = [
  "convert_case 0.5.0",
  "near-abi-client-impl",
  "near-abi-client-macros",
- "prettyplease",
+ "prettyplease 0.1.25",
  "quote",
  "syn 1.0.109",
 ]
@@ -2435,9 +2311,9 @@ dependencies = [
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
+checksum = "975bb8e272af403d97656893f71e095e1b178ccee571b3ec4a193152be0248f5"
 dependencies = [
  "borsh",
  "serde",
@@ -2452,17 +2328,42 @@ dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
- "derive_more",
- "near-config-utils",
- "near-crypto",
- "near-parameters",
- "near-primitives",
- "near-time",
+ "derive_more 0.99.18",
+ "near-config-utils 0.28.0",
+ "near-crypto 0.28.0",
+ "near-parameters 0.28.0",
+ "near-primitives 0.28.0",
+ "near-time 0.28.0",
  "num-rational",
  "serde",
  "serde_json",
  "sha2",
- "smart-default",
+ "smart-default 0.6.0",
+ "time",
+ "tracing",
+]
+
+[[package]]
+name = "near-chain-configs"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "398bbc9829c66d1b52a213d3094f0ec5ab61d6fd4b3c05b98aabd1b6e70bcf44"
+dependencies = [
+ "anyhow",
+ "bytesize",
+ "chrono",
+ "derive_more 2.0.1",
+ "near-config-utils 0.31.1",
+ "near-crypto 0.31.1",
+ "near-parameters 0.31.1",
+ "near-primitives 0.31.1",
+ "near-time 0.31.1",
+ "num-rational",
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smart-default 0.7.1",
  "time",
  "tracing",
 ]
@@ -2472,6 +2373,18 @@ name = "near-config-utils"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bedc768765dd8229a1d960c94f517317f40771a003e78916124784c7d6ea9d74"
+dependencies = [
+ "anyhow",
+ "json_comments",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "near-config-utils"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4627060004177ea30e122644de51aaf2ea076fd1b6d22f6f3d19e7dfb86af949"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2498,13 +2411,39 @@ dependencies = [
  "borsh",
  "bs58 0.4.0",
  "curve25519-dalek",
- "derive_more",
+ "derive_more 0.99.18",
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils",
- "near-schema-checker-lib",
- "near-stdx",
+ "near-config-utils 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "near-stdx 0.28.0",
+ "primitive-types",
+ "rand",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "subtle",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "near-crypto"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40596a621b4cbf7c07189dac59ebf1239f8108ef4755620622db5b86743e0c3a"
+dependencies = [
+ "blake2",
+ "borsh",
+ "bs58 0.4.0",
+ "curve25519-dalek",
+ "derive_more 2.0.1",
+ "ed25519-dalek",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.31.1",
+ "near-schema-checker-lib 0.31.1",
+ "near-stdx 0.31.1",
  "primitive-types",
  "rand",
  "secp256k1",
@@ -2520,7 +2459,16 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f14f36eee2dcb0ecd8febb9f198e0e1fa768c834db9e1982ad2acfcd04b45acf"
 dependencies = [
- "near-primitives-core",
+ "near-primitives-core 0.28.0",
+]
+
+[[package]]
+name = "near-fmt"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e9fa3af54e4b13f4f0657e3ae640e63f7f8953a5fbedf836bc47b43f973dde"
+dependencies = [
+ "near-primitives-core 0.31.1",
 ]
 
 [[package]]
@@ -2543,10 +2491,29 @@ dependencies = [
  "borsh",
  "lazy_static",
  "log",
- "near-chain-configs",
- "near-crypto",
- "near-jsonrpc-primitives",
- "near-primitives",
+ "near-chain-configs 0.28.0",
+ "near-crypto 0.28.0",
+ "near-jsonrpc-primitives 0.28.0",
+ "near-primitives 0.28.0",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "near-jsonrpc-client"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d03f5dd8adf26ecf27f2a898bee6b7df80ea769ae6d7b4d6b9b49bf11d7838b"
+dependencies = [
+ "borsh",
+ "lazy_static",
+ "log",
+ "near-chain-configs 0.31.1",
+ "near-crypto 0.31.1",
+ "near-jsonrpc-primitives 0.31.1",
+ "near-primitives 0.31.1",
  "reqwest",
  "serde",
  "serde_json",
@@ -2560,10 +2527,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f445f809d1f227f0f61f38c14271635c0bc9a28a8f74a803a4fb25292d5ea7"
 dependencies = [
  "arbitrary",
- "near-chain-configs",
- "near-crypto",
- "near-primitives",
- "near-schema-checker-lib",
+ "near-chain-configs 0.28.0",
+ "near-crypto 0.28.0",
+ "near-primitives 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "time",
+]
+
+[[package]]
+name = "near-jsonrpc-primitives"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3feacba264550d045c5d5e26f1bdb4857a5122739590ddf6c4ed22d56d518301"
+dependencies = [
+ "arbitrary",
+ "near-chain-configs 0.31.1",
+ "near-crypto 0.31.1",
+ "near-primitives 0.31.1",
+ "near-schema-checker-lib 0.31.1",
+ "near-time 0.31.1",
  "serde",
  "serde_json",
  "thiserror 2.0.11",
@@ -2579,8 +2564,27 @@ dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core",
- "near-schema-checker-lib",
+ "near-primitives-core 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum 0.24.1",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "near-parameters"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a261341fca84a5322710f6f4eae45d809fce24a19b9913333e436da5d4de3574"
+dependencies = [
+ "borsh",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core 0.31.1",
+ "near-schema-checker-lib 0.31.1",
  "num-rational",
  "serde",
  "serde_repr",
@@ -2603,18 +2607,18 @@ dependencies = [
  "bytesize",
  "cfg-if 1.0.0",
  "chrono",
- "derive_more",
+ "derive_more 0.99.18",
  "easy-ext",
  "enum-map",
  "hex",
- "itertools",
- "near-crypto",
- "near-fmt",
- "near-parameters",
- "near-primitives-core",
- "near-schema-checker-lib",
- "near-stdx",
- "near-time",
+ "itertools 0.10.5",
+ "near-crypto 0.28.0",
+ "near-fmt 0.28.0",
+ "near-parameters 0.28.0",
+ "near-primitives-core 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "near-stdx 0.28.0",
+ "near-time 0.28.0",
  "num-rational",
  "ordered-float",
  "primitive-types",
@@ -2624,7 +2628,48 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha3",
- "smart-default",
+ "smart-default 0.6.0",
+ "strum 0.24.1",
+ "thiserror 2.0.11",
+ "tracing",
+ "zstd 0.13.2",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271dbac58be374c7dddbc511ade1f4eeeea7ae972ef368b358e3298facb2eec6"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "bitvec 1.0.1",
+ "borsh",
+ "bytes",
+ "bytesize",
+ "chrono",
+ "derive_more 2.0.1",
+ "easy-ext",
+ "enum-map",
+ "hex",
+ "itertools 0.12.1",
+ "near-crypto 0.31.1",
+ "near-fmt 0.31.1",
+ "near-parameters 0.31.1",
+ "near-primitives-core 0.31.1",
+ "near-schema-checker-lib 0.31.1",
+ "near-stdx 0.31.1",
+ "near-time 0.31.1",
+ "num-rational",
+ "ordered-float",
+ "primitive-types",
+ "rand",
+ "rand_chacha",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha3",
+ "smart-default 0.7.1",
  "strum 0.24.1",
  "thiserror 2.0.11",
  "tracing",
@@ -2641,10 +2686,31 @@ dependencies = [
  "base64 0.21.7",
  "borsh",
  "bs58 0.4.0",
- "derive_more",
+ "derive_more 0.99.18",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib",
+ "near-schema-checker-lib 0.28.0",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "sha2",
+ "thiserror 2.0.11",
+]
+
+[[package]]
+name = "near-primitives-core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621c20e3fd77ba5e1d4fd33f6b7383dadcaca3faf60e2a8fc71a6cc7e4463c31"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "borsh",
+ "bs58 0.4.0",
+ "derive_more 2.0.1",
+ "enum-map",
+ "near-account-id",
+ "near-schema-checker-lib 0.31.1",
  "num-rational",
  "serde",
  "serde_repr",
@@ -2654,9 +2720,9 @@ dependencies = [
 
 [[package]]
 name = "near-sandbox-utils"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51b918c05ec1ac6bf36f5f78e286befa987b17773b9fe4e80958d6350a494c98"
+checksum = "66ea2772bc3fb37be43b52c57c0a998b1add4675e609fd89113c600c7c016443"
 dependencies = [
  "anyhow",
  "binary-install",
@@ -2672,13 +2738,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a48405425eca34de98e680416310df33fdb75768a78481cc75b43172b2748613"
 
 [[package]]
+name = "near-schema-checker-core"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3515d1bd55d87bfb392f6889313dcfbcaaec4229bb4a4abb5640ab8dc5eda70c"
+
+[[package]]
 name = "near-schema-checker-lib"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfb720bf5cc256af687a9eb7a6e05baf3668dc75cfd43098e83ba1b3d3900f08"
 dependencies = [
- "near-schema-checker-core",
- "near-schema-checker-macro",
+ "near-schema-checker-core 0.28.0",
+ "near-schema-checker-macro 0.28.0",
+]
+
+[[package]]
+name = "near-schema-checker-lib"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93739f2bcb64be8bd04342beae187317836b9c2826b6cfba429c2001e4db73a8"
+dependencies = [
+ "near-schema-checker-core 0.31.1",
+ "near-schema-checker-macro 0.31.1",
 ]
 
 [[package]]
@@ -2686,6 +2768,12 @@ name = "near-schema-checker-macro"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41a159cbf732acc0279febdde046d9036330a32a951796bce42f9529bce799d"
+
+[[package]]
+name = "near-schema-checker-macro"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc45bb3760350de7f957c11827e1e20c5a4aff8d95d19fd2c0c492d795bfb02"
 
 [[package]]
 name = "near-sdk"
@@ -2697,11 +2785,11 @@ dependencies = [
  "borsh",
  "bs58 0.5.1",
  "near-account-id",
- "near-crypto",
+ "near-crypto 0.28.0",
  "near-gas",
- "near-parameters",
- "near-primitives",
- "near-primitives-core",
+ "near-parameters 0.28.0",
+ "near-primitives 0.28.0",
+ "near-primitives-core 0.28.0",
  "near-sdk-macros",
  "near-sys",
  "near-token",
@@ -2727,7 +2815,7 @@ name = "near-sdk-contract-tools-macros"
 version = "3.0.2"
 source = "git+https://github.com/near/near-sdk-contract-tools?branch=140-nep-245-multitoken-component#32431e86afe0cea055591fde3f5143a8cc260ac3"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "heck 0.5.0",
  "proc-macro2",
  "quote",
@@ -2743,7 +2831,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1268c4fc56bf53d70c200261fb8d57c6c1c6692243660f5f889c7fa4cf5771d2"
 dependencies = [
  "Inflector",
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "serde",
@@ -2760,6 +2848,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a91674768828a593f4bac4aeca9334c4b56fe19344a2ccf7bd795b2325f0b5e"
 
 [[package]]
+name = "near-stdx"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3c38fc0843ef7c5bca717cc4daaf2af05441c3cb9cf259824e226387b18740"
+
+[[package]]
 name = "near-sys"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2865,17 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c92bf9dffb11126e8db9a6a51bcb330c8584d0bab0d6d14c20cf2ff1f16d684d"
 dependencies = [
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "near-time"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697acb90b55637c075ce47be4e7834654c34157b88036b199d7189ced6d0f89c"
+dependencies = [
+ "parking_lot",
  "serde",
  "time",
 ]
@@ -2797,15 +2902,15 @@ dependencies = [
  "ed25519-dalek",
  "enum-map",
  "lru",
- "near-crypto",
- "near-parameters",
- "near-primitives-core",
- "near-schema-checker-lib",
- "near-stdx",
+ "near-crypto 0.28.0",
+ "near-parameters 0.28.0",
+ "near-primitives-core 0.28.0",
+ "near-schema-checker-lib 0.28.0",
+ "near-stdx 0.28.0",
  "num-rational",
  "rayon",
  "ripemd",
- "rustix",
+ "rustix 0.38.42",
  "serde",
  "serde_repr",
  "sha2",
@@ -2819,9 +2924,9 @@ dependencies = [
 
 [[package]]
 name = "near-workspaces"
-version = "0.16.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5804591268264c4e308cc84a54f4c7416da6ad34f8ea5c5a4b1842bc5462de"
+checksum = "1f02d7882561f4be4797b3483603f2ca48c9b4fde8c0487961cb70dad7c93267"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2833,11 +2938,11 @@ dependencies = [
  "libc",
  "near-abi-client",
  "near-account-id",
- "near-crypto",
+ "near-crypto 0.31.1",
  "near-gas",
- "near-jsonrpc-client",
- "near-jsonrpc-primitives",
- "near-primitives",
+ "near-jsonrpc-client 0.18.0",
+ "near-jsonrpc-primitives 0.31.1",
+ "near-primitives 0.31.1",
  "near-sandbox-utils",
  "near-token",
  "rand",
@@ -2878,35 +2983,6 @@ dependencies = [
  "serde_json",
  "syn 1.0.109",
  "uriparse",
-]
-
-[[package]]
-name = "new_debug_unreachable"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
-
-[[package]]
-name = "nom-supreme"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aadc66631948f6b65da03be4c4cd8bd104d481697ecbb9bbd65719b1ec60bc9f"
-dependencies = [
- "brownstone",
- "indent_write",
- "joinery",
- "memchr",
- "nom",
 ]
 
 [[package]]
@@ -3156,6 +3232,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+dependencies = [
+ "camino",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3165,17 +3250,6 @@ dependencies = [
  "hmac",
  "password-hash",
  "sha2",
-]
-
-[[package]]
-name = "pdb"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13f4d162ecaaa1467de5afbe62d597757b674b51da8bb4e587430c5fdb2af7aa"
-dependencies = [
- "fallible-iterator",
- "scroll 0.10.2",
- "uuid 0.8.2",
 ]
 
 [[package]]
@@ -3192,15 +3266,6 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
-
-[[package]]
-name = "phf_shared"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
-dependencies = [
- "siphasher",
-]
 
 [[package]]
 name = "pin-project"
@@ -3262,12 +3327,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3283,12 +3342,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "precomputed-hash"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
 name = "prettyplease"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3296,6 +3349,16 @@ checksum = "6c8646e95016a7a6c4adea95bafa8a16baab64b583356217f2c85db4a39d9a86"
 dependencies = [
  "proc-macro2",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.93",
 ]
 
 [[package]]
@@ -3598,7 +3661,7 @@ dependencies = [
  "rkyv_derive",
  "seahash",
  "tinyvec",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -3708,8 +3771,21 @@ dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.6.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3776,9 +3852,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -3788,9 +3864,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3803,38 +3879,6 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
-name = "scratch"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
-
-[[package]]
-name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-
-[[package]]
-name = "scroll"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04c565b551bafbef4157586fa379538366e4385d42082f255bfd96e4fe8519da"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db149f81d46d2deba7cd3c50772474707729550221e69588478ebf9ada425ae"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
-]
 
 [[package]]
 name = "seahash"
@@ -3993,7 +4037,7 @@ version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
- "darling",
+ "darling 0.20.10",
  "proc-macro2",
  "quote",
  "syn 2.0.93",
@@ -4120,6 +4164,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "smart-default"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.93",
+]
+
+[[package]]
 name = "socket2"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4195,7 +4250,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4276,7 +4331,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.11",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
  "whoami",
 ]
 
@@ -4315,7 +4370,7 @@ dependencies = [
  "stringprep",
  "thiserror 2.0.11",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
  "whoami",
 ]
 
@@ -4341,7 +4396,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tracing",
  "url",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -4355,20 +4410,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "string_cache"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
-dependencies = [
- "new_debug_unreachable",
- "once_cell",
- "parking_lot",
- "phf_shared",
- "precomputed-hash",
- "serde",
-]
 
 [[package]]
 name = "stringprep"
@@ -4433,48 +4474,6 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
-name = "symbolic-common"
-version = "8.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f551f902d5642e58039aee6a9021a61037926af96e071816361644983966f540"
-dependencies = [
- "debugid",
- "memmap2",
- "stable_deref_trait",
- "uuid 0.8.2",
-]
-
-[[package]]
-name = "symbolic-debuginfo"
-version = "8.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1165dabf9fc1d6bb6819c2c0e27c8dd0e3068d2c53cf186d319788e96517f0d6"
-dependencies = [
- "bitvec 1.0.1",
- "dmsort",
- "elementtree",
- "fallible-iterator",
- "flate2",
- "gimli 0.26.2",
- "goblin",
- "lazy_static",
- "lazycell",
- "nom",
- "nom-supreme",
- "parking_lot",
- "pdb",
- "regex",
- "scroll 0.11.0",
- "serde",
- "serde_json",
- "smallvec",
- "symbolic-common",
- "thiserror 1.0.69",
- "wasmparser",
- "zip 0.5.13",
-]
 
 [[package]]
 name = "syn"
@@ -4558,15 +4557,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
 dependencies = [
- "cfg-if 1.0.0",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
- "rustix",
- "windows-sys 0.59.0",
+ "rustix 1.0.8",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4578,10 +4577,10 @@ dependencies = [
  "base64 0.22.1",
  "clap",
  "futures",
- "near-crypto",
- "near-jsonrpc-client",
- "near-jsonrpc-primitives",
- "near-primitives",
+ "near-crypto 0.28.0",
+ "near-jsonrpc-client 0.15.1",
+ "near-jsonrpc-primitives 0.28.0",
+ "near-primitives 0.28.0",
  "near-sdk",
  "near-workspaces",
  "templar-common",
@@ -4599,7 +4598,7 @@ dependencies = [
  "borsh",
  "hex",
  "near-contract-standards",
- "near-primitives",
+ "near-primitives 0.28.0",
  "near-sdk",
  "primitive-types",
  "rand",
@@ -4661,10 +4660,10 @@ dependencies = [
  "axum",
  "clap",
  "dotenvy",
- "near-crypto",
- "near-jsonrpc-client",
- "near-jsonrpc-primitives",
- "near-primitives",
+ "near-crypto 0.28.0",
+ "near-jsonrpc-client 0.15.1",
+ "near-jsonrpc-primitives 0.28.0",
+ "near-primitives 0.28.0",
  "near-sdk",
  "near-sdk-contract-tools",
  "sqlx",
@@ -4678,15 +4677,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "test-utils"
 version = "0.1.0"
 dependencies = [
@@ -4694,6 +4684,7 @@ dependencies = [
  "near-sdk",
  "near-sdk-contract-tools",
  "near-workspaces",
+ "rstest",
  "templar-common",
  "tokio",
 ]
@@ -4981,7 +4972,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid 1.16.0",
+ "uuid",
 ]
 
 [[package]]
@@ -5116,12 +5107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
 name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5188,12 +5173,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 
 [[package]]
 name = "uuid"
@@ -5329,52 +5308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
 
 [[package]]
-name = "wasm-opt"
-version = "0.116.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd87a4c135535ffed86123b6fb0f0a5a0bc89e50416c942c5f0662c645f679c"
-dependencies = [
- "anyhow",
- "libc",
- "strum 0.24.1",
- "strum_macros 0.24.3",
- "tempfile",
- "thiserror 1.0.69",
- "wasm-opt-cxx-sys",
- "wasm-opt-sys",
-]
-
-[[package]]
-name = "wasm-opt-cxx-sys"
-version = "0.116.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c57b28207aa724318fcec6575fe74803c23f6f266fce10cbc9f3f116762f12e"
-dependencies = [
- "anyhow",
- "cxx",
- "cxx-build",
- "wasm-opt-sys",
-]
-
-[[package]]
-name = "wasm-opt-sys"
-version = "0.116.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1cce564dc768dacbdb718fc29df2dba80bd21cb47d8f77ae7e3d95ceb98cbe"
-dependencies = [
- "anyhow",
- "cc",
- "cxx",
- "cxx-build",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.83.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
-
-[[package]]
 name = "web-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5430,15 +5363,6 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -5691,15 +5615,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
 dependencies = [
  "libc",
- "linux-raw-sys",
- "rustix",
+ "linux-raw-sys 0.4.14",
+ "rustix 0.38.42",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8b391c9a790b496184c29f7f93b9ed5b16abb306c05415b68bcc16e4d06432"
 
 [[package]]
 name = "yoke"
@@ -5820,18 +5738,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.93",
-]
-
-[[package]]
-name = "zip"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
-dependencies = [
- "byteorder",
- "crc32fast",
- "flate2",
- "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ near-jsonrpc-primitives = "0.28.0"
 near-primitives = "0.28.0"
 near-sdk = { version = "5.7", features = ["unstable"] }
 near-sdk-contract-tools = { git = "https://github.com/near/near-sdk-contract-tools", branch = "140-nep-245-multitoken-component" }
-near-workspaces = { version = "0.16", features = ["unstable"] }
+near-workspaces = { version = "0.21", features = ["unstable"] }
 primitive-types = { version = "0.10.1" }
 rstest = { version = "0.24" }
 schemars = { version = "0.8" }

--- a/contract/lst-oracle/tests/lst_oracle.rs
+++ b/contract/lst-oracle/tests/lst_oracle.rs
@@ -1,5 +1,5 @@
 use controller::lst_oracle::LstOracleController;
-use near_workspaces::Account;
+use near_workspaces::{network::Sandbox, Account, Worker};
 use rstest::rstest;
 use templar_common::{
     dec,
@@ -79,10 +79,8 @@ async fn setup_lst_oracle(
 
 #[rstest]
 #[tokio::test]
-async fn lst_oracle() {
-    let worker = near_workspaces::sandbox().await.unwrap();
-
-    setup_test_w!(
+async fn lst_oracle(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(
         worker
         extract(c, protocol_yield_user)
         accounts(supply_user, borrow_user, lst_oracle, lst_market)

--- a/contract/market/examples/gas_report.rs
+++ b/contract/market/examples/gas_report.rs
@@ -18,7 +18,10 @@ use test_utils::*;
 async fn main() {
     const ITERATIONS: usize = 128;
 
+    let worker = worker().await;
+
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, borrow_user_2, supply_user)
         config(|c| {

--- a/contract/market/examples/receipt_gas.rs
+++ b/contract/market/examples/receipt_gas.rs
@@ -5,7 +5,9 @@ use test_utils::*;
 
 #[tokio::main]
 async fn main() {
+    let worker = worker().await;
     setup_test!(
+        worker
         extract(c, insurance_yield_user)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {

--- a/contract/market/tests/0_many_accounts.rs
+++ b/contract/market/tests/0_many_accounts.rs
@@ -4,6 +4,8 @@
 use std::{collections::HashSet, sync::Arc, time::Duration};
 
 use near_sdk::NearToken;
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use test_utils::*;
 use tokio::{
     sync::{mpsc, oneshot, Mutex},
@@ -13,10 +15,10 @@ use tokio::{
 const COUNT: usize = 100;
 
 #[allow(clippy::too_many_lines)]
+#[rstest]
 #[tokio::test]
-async fn many_accounts() {
-    let worker = near_workspaces::sandbox().await.unwrap();
-    setup_test_w!(worker extract(c) accounts(first_supply));
+async fn many_accounts(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(first_supply));
 
     c.supply_and_harvest_until_activation(&first_supply, 100_000)
         .await;

--- a/contract/market/tests/0_many_snapshots.rs
+++ b/contract/market/tests/0_many_snapshots.rs
@@ -1,6 +1,8 @@
 // This test is particularly long-running. Since tests are run in lexographical
 // order, this test is named 0_... to start it running sooner.
 
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use templar_common::time_chunk::TimeChunkConfiguration;
 use test_utils::*;
 
@@ -22,9 +24,11 @@ fn linear_regression_slope(data: &[(f64, f64)]) -> f64 {
     (n * sum_xy - sum_x * sum_y) / (n * sum_xx - sum_x * sum_x)
 }
 
+#[rstest]
 #[tokio::test]
-async fn many_snapshots() {
+async fn many_snapshots(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/accumulations.rs
+++ b/contract/market/tests/accumulations.rs
@@ -1,9 +1,12 @@
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use templar_common::market::HarvestYieldMode;
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn third_party_accumulation_executor() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user, third_party));
+async fn third_party_accumulation_executor(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user, third_party));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
@@ -57,10 +60,11 @@ async fn third_party_accumulation_executor() {
     .await;
 }
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Only the position holder can compound yield"]
-async fn third_party_cannot_compound_yield() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user, third_party));
+async fn third_party_cannot_compound_yield(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user, third_party));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),

--- a/contract/market/tests/borrow_limits.rs
+++ b/contract/market/tests/borrow_limits.rs
@@ -1,3 +1,4 @@
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
 use templar_common::{fee::Fee, interest_rate_strategy::InterestRateStrategy, number::Decimal};
 use test_utils::*;
@@ -10,11 +11,13 @@ use tokio::task::JoinSet;
 #[case(0, &[20, 20, 20, 20, 20], 100)]
 #[tokio::test]
 async fn borrow_within_bounds(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] minimum: u128,
     #[case] amounts: &[u128],
     #[case] maximum: u128,
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -45,8 +48,14 @@ async fn borrow_within_bounds(
 #[case(1000, 738, u128::MAX)]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: New borrow position is outside of allowable range"]
-async fn borrow_below_minimum(#[case] minimum: u128, #[case] amount: u128, #[case] maximum: u128) {
+async fn borrow_below_minimum(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] minimum: u128,
+    #[case] amount: u128,
+    #[case] maximum: u128,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -74,11 +83,13 @@ async fn borrow_below_minimum(#[case] minimum: u128, #[case] amount: u128, #[cas
 #[tokio::test]
 #[should_panic = "Smart contract panicked: New borrow position is outside of allowable range"]
 async fn borrow_above_maximum(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] minimum: u128,
     #[case] amounts: &[u128],
     #[case] maximum: u128,
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -103,8 +114,9 @@ async fn borrow_above_maximum(
 
 #[rstest]
 #[tokio::test]
-async fn withdraw_below_minimum() {
+async fn withdraw_below_minimum(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/collateral.rs
+++ b/contract/market/tests/collateral.rs
@@ -1,13 +1,16 @@
 use near_sdk::{serde_json::json, NearToken};
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use tokio::task::JoinSet;
 
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn collateral_withdrawal() {
+async fn collateral_withdrawal(#[future(awt)] worker: Worker<Sandbox>) {
     let amounts = [10u128; 30];
 
-    setup_test!(extract(c) accounts(borrow_user));
+    setup_test!(worker extract(c) accounts(borrow_user));
 
     let total = amounts.iter().copied().sum::<u128>();
 

--- a/contract/market/tests/compounding_yield.rs
+++ b/contract/market/tests/compounding_yield.rs
@@ -1,6 +1,8 @@
 use std::{sync::atomic::Ordering, time::Duration};
 
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
+
 use templar_common::{
     dec, fee::Fee, interest_rate_strategy::InterestRateStrategy, market::HarvestYieldMode,
 };
@@ -19,11 +21,13 @@ use test_utils::*;
 )]
 #[tokio::test]
 async fn compounding_yield(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] principal: u128,
     #[case] strategy: InterestRateStrategy,
     #[case] compounding: HarvestYieldMode,
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, supply_user_2)
         config(|c| {

--- a/contract/market/tests/disabled_when_liquidatable.rs
+++ b/contract/market/tests/disabled_when_liquidatable.rs
@@ -1,8 +1,12 @@
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
+
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn disable_collateralize_if_still_liquidatable() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user));
+async fn disable_collateralize_if_still_liquidatable(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 2_000_000),
@@ -29,9 +33,12 @@ async fn disable_collateralize_if_still_liquidatable() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn allow_sufficient_collateralization_during_liquidation() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user));
+async fn allow_sufficient_collateralization_during_liquidation(
+    #[future(awt)] worker: Worker<Sandbox>,
+) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 2_000_000),
@@ -59,9 +66,10 @@ async fn allow_sufficient_collateralization_during_liquidation() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn repayment() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user));
+async fn repayment(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 2_000_000),

--- a/contract/market/tests/empty_positions.rs
+++ b/contract/market/tests/empty_positions.rs
@@ -1,10 +1,13 @@
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
+
 use test_utils::*;
 
 #[rstest]
 #[tokio::test]
-async fn empty_positions_are_removed() {
+async fn empty_positions_are_removed(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
     );

--- a/contract/market/tests/fast_borrow.rs
+++ b/contract/market/tests/fast_borrow.rs
@@ -1,12 +1,16 @@
-use test_utils::*;
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 
 use templar_common::{
     dec, fee::Fee, interest_rate_strategy::InterestRateStrategy, time_chunk::TimeChunkConfiguration,
 };
+use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn fast_borrow_is_not_free() {
+async fn fast_borrow_is_not_free(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -1,3 +1,4 @@
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
 use tokio::join;
 
@@ -14,8 +15,13 @@ use test_utils::*;
 #[case(true, true)]
 #[allow(clippy::too_many_lines)]
 #[tokio::test]
-async fn test_happy(#[case] borrow_mt: bool, #[case] collateral_mt: bool) {
+async fn test_happy(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] borrow_mt: bool,
+    #[case] collateral_mt: bool,
+) {
     setup_test!(
+        worker
         extract(c, protocol_yield_user, insurance_yield_user)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -1,12 +1,14 @@
 use std::time::Duration;
 
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
+use tokio::time::Instant;
+
 use templar_common::{
     asset::BorrowAssetAmount, dec, fee::Fee, interest_rate_strategy::InterestRateStrategy,
     market::HarvestYieldMode, number::Decimal, YEAR_PER_MS,
 };
 use test_utils::*;
-use tokio::time::Instant;
 
 #[rstest]
 #[case(10_000_000, InterestRateStrategy::linear(dec!("1000"), dec!("1000")).unwrap())]
@@ -18,8 +20,13 @@ use tokio::time::Instant;
     InterestRateStrategy::exponential2(dec!("5"), dec!("800"), dec!("6")).unwrap()
 )]
 #[tokio::test]
-async fn interest_rate(#[case] principal: u128, #[case] strategy: InterestRateStrategy) {
+async fn interest_rate(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] principal: u128,
+    #[case] strategy: InterestRateStrategy,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(
             borrow_user,

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -1,5 +1,6 @@
 use std::time::Duration;
 
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
 
 use templar_common::{
@@ -14,9 +15,11 @@ use templar_common::{
 use test_utils::*;
 use tokio::time::Instant;
 
+#[rstest]
 #[tokio::test]
-async fn successful_liquidation_totally_underwater() {
+async fn successful_liquidation_totally_underwater(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
     );
@@ -69,6 +72,7 @@ async fn successful_liquidation_totally_underwater() {
 #[case(120, 1250, 1000, 88, dec!(".95"))]
 #[tokio::test]
 async fn successful_liquidation_good_debt_under_mcr(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] mcr: u16,
     #[case] collateral_amount: u128,
     #[case] borrow_amount: u128,
@@ -76,6 +80,7 @@ async fn successful_liquidation_good_debt_under_mcr(
     #[case] fmv_frac: Decimal,
 ) {
     setup_test!(
+        worker
         extract(c, protocol_yield_user, insurance_yield_user)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
@@ -167,6 +172,7 @@ async fn successful_liquidation_good_debt_under_mcr(
 #[case(150, 33, 32)]
 #[tokio::test]
 async fn successful_liquidation_with_spread(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] mcr: u16,
     #[case] maximum_spread_pct: u16,
     #[case] spread_pct: u16,
@@ -178,6 +184,7 @@ async fn successful_liquidation_with_spread(
     let mcr: Decimal = Decimal::from(mcr) / 100u32;
 
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
@@ -225,9 +232,11 @@ async fn successful_liquidation_with_spread(
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn fail_liquidation_too_little_attached() {
+async fn fail_liquidation_too_little_attached(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
     );
@@ -270,9 +279,11 @@ async fn fail_liquidation_too_little_attached() {
     assert!(status.is_liquidation());
 }
 
+#[rstest]
 #[tokio::test]
-async fn fail_liquidation_healthy_borrow() {
+async fn fail_liquidation_healthy_borrow(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
     );
@@ -314,10 +325,12 @@ async fn fail_liquidation_healthy_borrow() {
     assert!(status.is_healthy());
 }
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Attempt to liquidate more collateral than is currently eligible"]
-async fn liquidators_race() {
+async fn liquidators_race(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
     );
@@ -359,8 +372,9 @@ async fn liquidators_race() {
 
 #[rstest]
 #[tokio::test]
-async fn successful_liquidation_only_from_interest() {
+async fn successful_liquidation_only_from_interest(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
@@ -428,12 +442,14 @@ async fn successful_liquidation_only_from_interest() {
 #[case((10, 1000), (10, 1000), (10, -1000), (10, 1000))]
 #[tokio::test]
 async fn extreme_prices(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] (collateral_price, collateral_exponent): (i64, i32),
     #[case] (borrow_price, borrow_exponent): (i64, i32),
     #[case] (new_collateral_price, new_collateral_exponent): (i64, i32),
     #[case] (new_borrow_price, new_borrow_exponent): (i64, i32),
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
@@ -552,10 +568,12 @@ async fn extreme_prices(
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn partial_liquidation() {
+async fn partial_liquidation(#[future(awt)] worker: Worker<Sandbox>) {
     let spread = dec!("0.05");
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_alice, liquidator_bob)
         config(|c| {
@@ -664,10 +682,12 @@ async fn partial_liquidation() {
     );
 }
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Liquidation offer too low"]
-async fn partial_liquidation_fail_offer_too_little() {
+async fn partial_liquidation_fail_offer_too_little(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {
@@ -725,8 +745,12 @@ async fn partial_liquidation_fail_offer_too_little() {
 #[case(&[dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1"), dec!("0.1")])]
 #[case(&[dec!("0.5"), dec!("0.25"), dec!("0.125"), dec!("0.0625"), dec!("0.0625")])]
 #[tokio::test]
-async fn many_little_partial_liquidations(#[case] pattern: &[Decimal]) {
+async fn many_little_partial_liquidations(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] pattern: &[Decimal],
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, liquidator_user)
         config(|c| {

--- a/contract/market/tests/maximum_borrow_asset_usage_ratio.rs
+++ b/contract/market/tests/maximum_borrow_asset_usage_ratio.rs
@@ -1,7 +1,8 @@
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
-use test_utils::*;
 
 use templar_common::number::Decimal;
+use test_utils::*;
 
 #[rstest]
 #[case(1)]
@@ -9,8 +10,12 @@ use templar_common::number::Decimal;
 #[case(99)]
 #[case(100)]
 #[tokio::test]
-async fn borrow_within_maximum_usage_ratio(#[case] percent: u16) {
+async fn borrow_within_maximum_usage_ratio(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] percent: u16,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -47,8 +52,12 @@ async fn borrow_within_maximum_usage_ratio(#[case] percent: u16) {
 #[case(100)]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Insufficient borrow asset available"]
-async fn borrow_exceeds_maximum_usage_ratio(#[case] percent: u16) {
+async fn borrow_exceeds_maximum_usage_ratio(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] percent: u16,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/maximum_borrow_duration_ms.rs
+++ b/contract/market/tests/maximum_borrow_duration_ms.rs
@@ -1,12 +1,17 @@
 use std::time::Duration;
 
 use near_sdk::json_types::U64;
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
+
 use templar_common::borrow::{BorrowStatus, LiquidationReason};
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn liquidation_after_expiration() {
+async fn liquidation_after_expiration(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/mcr_maintenance.rs
+++ b/contract/market/tests/mcr_maintenance.rs
@@ -1,4 +1,6 @@
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
+
 use templar_common::{dec, fee::Fee, number::Decimal};
 use test_utils::*;
 
@@ -8,8 +10,13 @@ use test_utils::*;
 #[case(dec!("1.00000001"), dec!("1.1"))]
 #[case(dec!("1.00000000000000000000000000000000001"), dec!("5"))]
 #[tokio::test]
-async fn success_above_mcr_maintenance(#[case] liquidation: Decimal, #[case] maintenance: Decimal) {
+async fn success_above_mcr_maintenance(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] liquidation: Decimal,
+    #[case] maintenance: Decimal,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -57,8 +64,13 @@ async fn success_above_mcr_maintenance(#[case] liquidation: Decimal, #[case] mai
 #[case(dec!("1.001"), dec!("5"))]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Borrow position must be healthy after borrow"]
-async fn fail_below_mcr_maintenance(#[case] liquidation: Decimal, #[case] maintenance: Decimal) {
+async fn fail_below_mcr_maintenance(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] liquidation: Decimal,
+    #[case] maintenance: Decimal,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -86,10 +98,12 @@ async fn fail_below_mcr_maintenance(#[case] liquidation: Decimal, #[case] mainte
 #[case(dec!("1.5"), dec!("5"))]
 #[tokio::test]
 async fn not_in_liquidation_if_below_mcr_maintenance(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] liquidation: Decimal,
     #[case] maintenance: Decimal,
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -124,10 +138,12 @@ async fn not_in_liquidation_if_below_mcr_maintenance(
     assert!(!borrow_status.is_liquidation(), "Borrow should not be in liquidation when collateralization ratio is below minimum INITIAL if it is still above the minimum for liquidation.");
 }
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Borrow position must be healthy after collateral withdrawal"]
-async fn withdraw_collateral_below_mcr_maintenance() {
+async fn withdraw_collateral_below_mcr_maintenance(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {

--- a/contract/market/tests/snapshot.rs
+++ b/contract/market/tests/snapshot.rs
@@ -1,13 +1,17 @@
+use near_workspaces::{network::Sandbox, Worker};
 use partial::check;
+use rstest::rstest;
 use std::time::Duration;
 use templar_common::{
     dec, fee::Fee, interest_rate_strategy::InterestRateStrategy, time_chunk::TimeChunkConfiguration,
 };
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn snapshot_captures_borrow_and_collateral_state() {
+async fn snapshot_captures_borrow_and_collateral_state(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -60,9 +64,11 @@ async fn snapshot_captures_borrow_and_collateral_state() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn multiple_snapshots_show_progression() {
+async fn multiple_snapshots_show_progression(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(user, supply_user)
         config(|c| {
@@ -103,9 +109,11 @@ async fn multiple_snapshots_show_progression() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn snapshot_reflects_repayment_changes() {
+async fn snapshot_reflects_repayment_changes(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -158,9 +166,11 @@ async fn snapshot_reflects_repayment_changes() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn snapshot_handles_zero_operations() {
+async fn snapshot_handles_zero_operations(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user)
         config(|c| {
@@ -195,9 +205,11 @@ async fn snapshot_handles_zero_operations() {
     check(states!({ active = 1_000_000 }, { active += 1 }), snapshots);
 }
 
+#[rstest]
 #[tokio::test]
-async fn snapshot_with_full_repayment() {
+async fn snapshot_with_full_repayment(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -256,9 +268,11 @@ async fn snapshot_with_full_repayment() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn snapshot_field_validation() {
+async fn snapshot_field_validation(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user)
         config(|c| {
@@ -325,9 +339,11 @@ async fn snapshot_field_validation() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn many_users_different_snapshots() {
+async fn many_users_different_snapshots(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(user1, user2, user3, user4, user5, supply_user1, supply_user2)
         config(|c| {
@@ -381,14 +397,14 @@ async fn many_users_different_snapshots() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn many_users_same_snapshot() {
-    let w = near_workspaces::sandbox().await.unwrap();
+async fn many_users_same_snapshot(#[future(awt)] worker: Worker<Sandbox>) {
     eprintln!("Fast-forwarding...");
     // Need to fast forward right away because otherwise the contract will panic because it can't construct a previous time chunk
-    w.fast_forward(100).await.unwrap();
-    setup_test_w!(
-        w
+    worker.fast_forward(100).await.unwrap();
+    setup_test!(
+        worker
         extract(c)
         accounts(user1, user2, user3, user4, user5, supply_user1, supply_user2)
         config(|c| {
@@ -406,7 +422,7 @@ async fn many_users_same_snapshot() {
     );
 
     eprintln!("Fast-forwarding...");
-    w.fast_forward(100).await.unwrap();
+    worker.fast_forward(100).await.unwrap();
 
     eprintln!("Collateral operations");
     tokio::join!(
@@ -418,7 +434,7 @@ async fn many_users_same_snapshot() {
     );
 
     eprintln!("Fast-forwarding...");
-    w.fast_forward(100).await.unwrap();
+    worker.fast_forward(100).await.unwrap();
 
     eprintln!("Borrow operations");
     tokio::join!(
@@ -430,7 +446,7 @@ async fn many_users_same_snapshot() {
     );
 
     eprintln!("Fast-forwarding...");
-    w.fast_forward(100).await.unwrap();
+    worker.fast_forward(100).await.unwrap();
 
     eprintln!("Trigger snapshot");
     c.harvest_yield(&supply_user1, None, None).await;
@@ -447,12 +463,10 @@ async fn many_users_same_snapshot() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn incoming() {
-    setup_test!(
-        extract(c)
-        accounts(borrow_user, supply_user)
-    );
+async fn incoming(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     c.supply(&supply_user, 2_000_000).await;
 

--- a/contract/market/tests/storage_management.rs
+++ b/contract/market/tests/storage_management.rs
@@ -1,10 +1,12 @@
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "is not registered"]
-async fn registration_is_required() {
-    let worker = near_workspaces::sandbox().await.unwrap();
-    setup_test_w!(worker extract(c) accounts(supply_user));
+async fn registration_is_required(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(supply_user));
 
     let unregistered_account = worker.dev_create_account().await.unwrap();
     c.borrow_asset

--- a/contract/market/tests/supply_activation.rs
+++ b/contract/market/tests/supply_activation.rs
@@ -1,11 +1,16 @@
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
+
 use templar_common::{
     fee::Fee, interest_rate_strategy::InterestRateStrategy, time_chunk::TimeChunkConfiguration,
 };
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn activates_in_next_snapshot() {
+async fn activates_in_next_snapshot(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user, borrow_user)
         config(|c| {

--- a/contract/market/tests/supply_maximum_amount.rs
+++ b/contract/market/tests/supply_maximum_amount.rs
@@ -1,4 +1,6 @@
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
+
 use templar_common::{market::HarvestYieldMode, time_chunk::TimeChunkConfiguration};
 use test_utils::*;
 
@@ -8,10 +10,12 @@ use test_utils::*;
 #[case([1; 25], 10_000)]
 #[tokio::test]
 async fn supply_within_maximum(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] deposits: impl IntoIterator<Item = u128>,
     #[case] supply_maximum: u128,
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user)
         config(|c| {
@@ -38,10 +42,12 @@ async fn supply_within_maximum(
 #[tokio::test]
 #[should_panic = "Smart contract panicked: New supply position is outside of allowable range"]
 async fn supply_beyond_maximum(
+    #[future(awt)] worker: Worker<Sandbox>,
     #[case] deposits: impl IntoIterator<Item = u128>,
     #[case] supply_maximum: u128,
 ) {
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user)
         config(|c| {
@@ -57,11 +63,13 @@ async fn supply_beyond_maximum(
     }
 }
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: New supply position is outside of allowable range"]
-async fn harvest_yield_beyond_maximum() {
+async fn harvest_yield_beyond_maximum(#[future(awt)] worker: Worker<Sandbox>) {
     const LIMIT: u128 = 1_000_000;
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user, borrow_user)
         config(|c| {

--- a/contract/market/tests/supply_withdrawal_fee.rs
+++ b/contract/market/tests/supply_withdrawal_fee.rs
@@ -1,11 +1,15 @@
 use std::time::Duration;
 
 use near_sdk::json_types::U64;
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
+
 use templar_common::fee::{Fee, TimeBasedFee, TimeBasedFeeFunction};
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn supply_withdrawal_fee_flat() {
+async fn supply_withdrawal_fee_flat(#[future(awt)] worker: Worker<Sandbox>) {
     let fee = TimeBasedFee {
         fee: Fee::Flat(100.into()),
         duration: U64(1000 * 60 * 60 * 24 * 30),
@@ -13,6 +17,7 @@ async fn supply_withdrawal_fee_flat() {
     };
 
     setup_test!(
+        worker
         extract(c, protocol_yield_user)
         accounts(supply_user)
         config(|c| {
@@ -60,8 +65,9 @@ async fn supply_withdrawal_fee_flat() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn supply_withdrawal_fee_expired() {
+async fn supply_withdrawal_fee_expired(#[future(awt)] worker: Worker<Sandbox>) {
     let fee = TimeBasedFee {
         fee: Fee::Flat(100.into()),
         duration: U64(1000), // 1 second
@@ -69,6 +75,7 @@ async fn supply_withdrawal_fee_expired() {
     };
 
     setup_test!(
+        worker
         extract(c, protocol_yield_user)
         accounts(supply_user)
         config(|c| {

--- a/contract/market/tests/supply_withdrawal_queue.rs
+++ b/contract/market/tests/supply_withdrawal_queue.rs
@@ -1,6 +1,7 @@
 use std::time::Duration;
 
 use near_sdk::{serde_json::json, NearToken};
+use near_workspaces::{network::Sandbox, Worker};
 use rstest::rstest;
 
 use templar_common::withdrawal_queue::WithdrawalQueueStatus;
@@ -8,8 +9,8 @@ use test_utils::*;
 
 #[rstest]
 #[tokio::test]
-async fn successful_withdrawal() {
-    setup_test!(extract(c) accounts(supply_user));
+async fn successful_withdrawal(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(supply_user));
 
     c.supply_and_harvest_until_activation(&supply_user, 10_000)
         .await;
@@ -37,8 +38,8 @@ async fn successful_withdrawal() {
 #[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Insufficient liquidity to fulfill the request at this time"]
-async fn unsuccessful_withdrawal() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user));
+async fn unsuccessful_withdrawal(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
@@ -62,8 +63,8 @@ async fn unsuccessful_withdrawal() {
 #[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Attempt to withdraw more than current deposit"]
-async fn attempt_to_withdraw_more_than_deposit_incoming() {
-    setup_test!(extract(c) accounts(supply_user));
+async fn attempt_to_withdraw_more_than_deposit_incoming(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(supply_user));
 
     c.supply(&supply_user, 10_000).await;
     c.create_supply_withdrawal_request(&supply_user, 12_000)
@@ -73,8 +74,8 @@ async fn attempt_to_withdraw_more_than_deposit_incoming() {
 #[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Attempt to withdraw more than current deposit"]
-async fn attempt_to_withdraw_more_than_deposit() {
-    setup_test!(extract(c) accounts(supply_user));
+async fn attempt_to_withdraw_more_than_deposit(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(supply_user));
 
     c.supply_and_harvest_until_activation(&supply_user, 10_000)
         .await;
@@ -87,8 +88,12 @@ async fn attempt_to_withdraw_more_than_deposit() {
 #[case(2_500)]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Withdrawal amount is outside of allowable range"]
-async fn attempt_to_withdraw_outside_configured_range(#[case] amount: u128) {
+async fn attempt_to_withdraw_outside_configured_range(
+    #[future(awt)] worker: Worker<Sandbox>,
+    #[case] amount: u128,
+) {
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user)
         config(|c| {
@@ -103,9 +108,10 @@ async fn attempt_to_withdraw_outside_configured_range(#[case] amount: u128) {
         .await;
 }
 
+#[rstest]
 #[tokio::test]
-async fn supply_withdrawal_after_storage_unregister() {
-    setup_test!(extract(c) accounts(supply_user, supply_user_2));
+async fn supply_withdrawal_after_storage_unregister(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(supply_user, supply_user_2));
 
     tokio::join!(
         c.supply_and_harvest_until_activation(&supply_user, 10_000),
@@ -160,9 +166,10 @@ async fn supply_withdrawal_after_storage_unregister() {
     assert_eq!(status.length, 0);
 }
 
+#[rstest]
 #[tokio::test]
-async fn deposit_during_withdrawal() {
-    setup_test!(extract(c) accounts(supply_user, borrow_user));
+async fn deposit_during_withdrawal(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(supply_user, borrow_user));
 
     c.supply(&supply_user, 10_000).await;
     c.create_supply_withdrawal_request(&supply_user, 10_000)

--- a/contract/market/tests/supply_within_snapshot.rs
+++ b/contract/market/tests/supply_within_snapshot.rs
@@ -1,3 +1,5 @@
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use templar_common::{
     dec,
     fee::Fee,
@@ -8,9 +10,11 @@ use templar_common::{
 };
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
-async fn funds_activation() {
+async fn funds_activation(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(supply_user)
         config(|c| {
@@ -109,9 +113,11 @@ async fn funds_activation() {
     );
 }
 
+#[rstest]
 #[tokio::test]
-async fn partial_snapshot_no_earnings() {
+async fn partial_snapshot_no_earnings(#[future(awt)] worker: Worker<Sandbox>) {
     setup_test!(
+        worker
         extract(c)
         accounts(borrow_user, supply_user, supply_user_2)
         config(|c| {
@@ -159,7 +165,7 @@ async fn partial_snapshot_no_earnings() {
     let snapshot_supply_start = c.get_finalized_snapshots_len().await;
     while c.get_finalized_snapshots_len().await <= funds_activate_at {
         // Interest rate is high enough that this all goes to interest.
-        c.repay(&borrow_user, 10_000).await;
+        c.repay(&borrow_user, 10).await;
         c.harvest_yield(&supply_user, None, Some(HarvestYieldMode::Default))
             .await;
         c.harvest_yield(&supply_user_2, None, Some(HarvestYieldMode::Default))
@@ -207,6 +213,11 @@ async fn partial_snapshot_no_earnings() {
     let expected_both_active_interest_amount =
         10_000_000_u128 * interest_rate * both_active_duration_ms * YEAR_PER_MS / 2_u128;
 
+    eprintln!(
+        "Expected amount 1: {}",
+        expected_first_only_interest_amount + expected_both_active_interest_amount,
+    );
+    eprintln!("Expected amount 2: {expected_both_active_interest_amount}");
     eprintln!("Amount 1 end: {amount_1_end}");
     eprintln!("Amount 2 end: {amount_2_end}");
     assert!(

--- a/contract/market/tests/untracked_funds.rs
+++ b/contract/market/tests/untracked_funds.rs
@@ -1,9 +1,12 @@
+use near_workspaces::{network::Sandbox, Worker};
+use rstest::rstest;
 use test_utils::*;
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Insufficient borrow asset available"]
-async fn cannot_borrow_untracked_funds() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user));
+async fn cannot_borrow_untracked_funds(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     tokio::join!(
         async {
@@ -19,10 +22,11 @@ async fn cannot_borrow_untracked_funds() {
     c.borrow(&borrow_user, 12_000).await;
 }
 
+#[rstest]
 #[tokio::test]
 #[should_panic = "Smart contract panicked: Insufficient liquidity to fulfill the request at this time"]
-async fn cannot_withdraw_untracked_funds() {
-    setup_test!(extract(c) accounts(borrow_user, supply_user));
+async fn cannot_withdraw_untracked_funds(#[future(awt)] worker: Worker<Sandbox>) {
+    setup_test!(worker extract(c) accounts(borrow_user, supply_user));
 
     tokio::join!(
         async {

--- a/test-utils/Cargo.toml
+++ b/test-utils/Cargo.toml
@@ -10,6 +10,7 @@ hex-literal.workspace = true
 near-sdk.workspace = true
 near-sdk-contract-tools.workspace = true
 near-workspaces.workspace = true
+rstest.workspace = true
 templar-common.workspace = true
 tokio.workspace = true
 

--- a/test-utils/src/lib.rs
+++ b/test-utils/src/lib.rs
@@ -39,6 +39,13 @@ pub mod controller;
 pub mod partial;
 pub mod pyth_price_id;
 
+#[rstest::fixture]
+pub async fn worker() -> Worker<Sandbox> {
+    near_workspaces::sandbox_with_version("2.8.0")
+        .await
+        .unwrap()
+}
+
 pub fn to_price(price: f64) -> pyth::Price {
     pyth::Price {
         price: I64((price * 10000.0) as i64),
@@ -50,13 +57,17 @@ pub fn to_price(price: f64) -> pyth::Price {
 
 pub async fn create_prefixed_account(
     prefix: &str,
-    worker: &near_workspaces::Worker<impl DevNetwork + 'static>,
+    worker: &Worker<impl DevNetwork + 'static>,
 ) -> Account {
-    let (genid, sk) = worker.dev_generate().await;
+    let (genid, sk) = worker.generate_dev_account_credentials();
     let new_id: AccountId = format!("{prefix}{}", &genid.as_str()[prefix.len()..])
         .parse()
         .unwrap();
-    worker.create_tla(new_id, sk).await.unwrap().unwrap()
+    worker
+        .create_root_account_subaccount(new_id, sk)
+        .await
+        .unwrap()
+        .unwrap()
 }
 
 #[macro_export]
@@ -67,7 +78,7 @@ macro_rules! accounts {
 }
 
 #[macro_export]
-macro_rules! setup_test_w {
+macro_rules! setup_test {
     ($w:ident extract($($e:ident),*) accounts($($n:ident),*) config($f:expr)) => {
         $crate::accounts!($w, $($n),*);
         let s = $crate::setup_everything(&$w, $f).await;
@@ -77,23 +88,7 @@ macro_rules! setup_test_w {
         let $crate::SetupEverything { $($e,)* .. } = s;
     };
     ($w:ident extract($($e:ident),*) accounts($($n:ident),*)) => {
-        $crate::setup_test_w!($w extract($($e),*) accounts($($n),*) config(|_| {}))
-    };
-}
-
-#[macro_export]
-macro_rules! setup_test {
-    (extract($($e:ident),*) accounts($($n:ident),*) config($f:expr)) => {
-        let worker = near_workspaces::sandbox().await.unwrap();
-        $crate::accounts!(worker, $($n),*);
-        let s = $crate::setup_everything(&worker, $f).await;
-        ::tokio::join!(
-            $(s.c.init_account(&$n)),*
-        );
-        let $crate::SetupEverything { $($e,)* .. } = s;
-    };
-    (extract($($e:ident),*) accounts($($n:ident),*)) => {
-        $crate::setup_test!(extract($($e),*) accounts($($n),*) config(|_| {}))
+        $crate::setup_test!($w extract($($e),*) accounts($($n),*) config(|_| {}))
     };
 }
 


### PR DESCRIPTION
- Use rstest `#[fixture]`s for creating workers, since it is _ideally_ more efficient because it _should_ be reusing the workers instead of discarding and re-initializing them for every test. Though, I haven't seen too big of a difference.
- Update the neard version that tests use to 2.8.0 (latest mainnet)
- Update near-workspaces to 0.21, since the older version was not compatible with neard 2.8.0