### PR TITLE
chore: remove liquidator refunding

### DIFF
--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -722,7 +722,7 @@ impl<'a> BorrowPositionGuard<'a> {
         InterestAccumulationProof(())
     }
 
-    pub fn liquidation_lock(&mut self, amount: CollateralAssetAmount) {
+    pub(crate) fn liquidation_lock(&mut self, amount: CollateralAssetAmount) {
         asset_op!(
             @msg("Attempt to liquidate more collateral than position has deposited")
             self.position.collateral_asset_deposit -= amount;
@@ -730,7 +730,7 @@ impl<'a> BorrowPositionGuard<'a> {
         );
     }
 
-    pub fn liquidation_unlock(&mut self, amount: CollateralAssetAmount) {
+    pub(crate) fn liquidation_unlock(&mut self, amount: CollateralAssetAmount) {
         asset_op!(
             @msg("Invariant violation: Liquidation unlock of more collateral that was locked")
             self.position.liquidation_lock -= amount;

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -332,7 +332,18 @@ impl Contract {
         initial_liquidation: InitialLiquidation,
         return_style: ReturnStyle,
     ) -> serde_json::Value {
-        let success = matches!(env::promise_result(0), PromiseResult::Successful(_));
+        // let success = matches!(env::promise_result(0), PromiseResult::Successful(_));
+        // If the transfer of collateral failed, it could mean:
+        //
+        // 1. The liquidator has opted-out of storage management for the
+        //  collateral token. This can be due to negligence or malice, but
+        //  we cannot be sure, so we cannot refund the tokens, because
+        //  that would allow a borrow position in liquidation to
+        //  indefinitely lock their collateral from being liquidated.
+        //
+        // 2. Somehow the contract does not have enough collateral
+        //  available. This would be indicative of a *fundamental flaw*
+        //  in the contract (i.e. this should never happen).
 
         let snapshot = self.snapshot();
         let mut borrow_position = self
@@ -341,26 +352,9 @@ impl Contract {
                 env::panic_str("Invariant violation: Liquidation of nonexistent position.")
             });
 
-        if success {
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_liquidation_final(proof, liquidator_id, &initial_liquidation);
-            return_style.serialize(initial_liquidation.refund)
-        } else {
-            // Somehow transfer of collateral failed. This could mean:
-            //
-            // 1. Somehow the contract does not have enough collateral
-            //  available. This would be indicative of a *fundamental flaw*
-            //  in the contract (i.e. this should never happen).
-            //
-            // 2. More likely, in a multichain context, communication
-            //  broke down somewhere between the signer and the remote RPC.
-            //  Could be as simple as a nonce sync issue. Should just wait
-            //  and try again later.
-            borrow_position.liquidation_unlock(initial_liquidation.liquidated);
-            let mut return_amount = initial_liquidation.recovered;
-            asset_op!(return_amount += initial_liquidation.refund);
-            return_style.serialize(return_amount)
-        }
+        let proof = borrow_position.accumulate_interest();
+        borrow_position.record_liquidation_final(proof, liquidator_id, &initial_liquidation);
+        return_style.serialize(initial_liquidation.refund)
     }
 
     // ~5.0 Tgas

--- a/docs/src/market/liquidate.md
+++ b/docs/src/market/liquidate.md
@@ -4,6 +4,13 @@ Liquidation is the process by which the asset collateralizing certain positions 
 
 A liquidator is a third party willing to send a quantity of a market's borrow asset (usually a stablecoin) to the market in exchange for the amount of collateral asset supporting a specific account's position. As compensation for this service, the liquidator receives an exchange rate that is slightly better than the current rate. This difference in rates is called the "liquidator spread," and the maximum liquidator spread is configurable on a per-market basis.
 
+<div class="warning">
+
+- The liquidator _**MUST**_ ensure that its account is able to receive the collateral tokens. Usually this means opting-in to [storage management](https://github.com/near/NEPs/blob/master/neps/nep-0145.md) (if the collateral token in question implements that standard). If the collateral transfer fails, the liquidator _will not be refunded!_
+- It is the responsibility of the liquidator to calculate the optimal amount of tokens to attach to a liquidation call. The market will either completely accept or completely reject the liquidation attempt&mdash;no refunds!
+
+</div>
+
 A liquidator will follow this high-level workflow:
 
 1. The liquidator obtains a list of accounts borrowing from the market by calling [`list_borrow_positions`](../../doc/templar_common/market/trait.MarketExternalInterface.html#tymethod.list_borrow_positions).
@@ -24,12 +31,6 @@ Thus, the arguments to a liquidation call might look something like this:
   "receiver_id": "<market-id>"
 }
 ```
-
-<div class="warning">
-
-It is the responsibility of the liquidator to calculate the optimal amount of tokens to attach to a liquidation call. The market will either completely accept or completely reject the liquidation attempt&mdash;no refunds!
-
-</div>
 
 ## Example
 


### PR DESCRIPTION
We ignore collateral transfer failures to liquidators, since it could be used to artificially lock the collateral of a liquidatable position.