### PR TITLE
Allow unknown fields in `clientDataJSON`

### DIFF
--- a/universal-account/src/authentication/passkey/data.rs
+++ b/universal-account/src/authentication/passkey/data.rs
@@ -77,7 +77,7 @@ impl schemars::JsonSchema for Challenge {
 
 #[derive(Clone, Debug)]
 #[near(serializers = [json, borsh])]
-#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
 pub struct ClientDataJson {
     pub r#type: String,
     pub challenge: Challenge,


### PR DESCRIPTION
Chrome is being annoying. https://goo.gl/yabPex\

They only insert this field infrequently, so we only discovered this bug/necessary workaround now. Unfortunately this makes our payloads slightly more malleable. Probably not a security issue, but it is an additional surface.