### PR TITLE
chore: exclude integration tests from codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,23 +78,9 @@ jobs:
         run: |
           # Install cargo-llvm-cov for coverage
           curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
-          
+
           # Install cargo-nextest for faster testing
           curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ~/.cargo/bin
-          
-          # Install cargo-near for contract building
-          curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.16.1/cargo-near-installer.sh | sh
-
-      - name: Setup test environment
-        run: |
-          # Prebuild test contracts
-          ./script/prebuild-test-contracts.sh
-          
-          # Create empty .env file if it doesn't exist (for compose)
-          touch service/relayer/.env
-          
-          # Start database for relayer tests
-          docker compose --file service/relayer/compose.dev.yaml up postgres --detach
 
       - name: Run tests with coverage
         env:
@@ -102,8 +88,8 @@ jobs:
           CARGO_INCREMENTAL: 0
           RUSTFLAGS: "-Cinstrument-coverage"
         run: |
-          # Generate coverage report
-          cargo llvm-cov nextest --lcov --output-path coverage.lcov
+          # --lib: unit tests only (excludes slow WASM integration tests)
+          cargo llvm-cov nextest --lib --lcov --output-path coverage.lcov
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -114,7 +100,3 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Cleanup
-        if: always()
-        run: docker compose --file service/relayer/compose.dev.yaml down

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,14 +7,14 @@ coverage:
   status:
     project:
       default:
-        target: 25%  # Set low to not block PRs while building coverage
-        threshold: 5%  # Allow larger decreases while stabilizing
+        target: 15%  # Low threshold for unit tests only
+        threshold: 5%
         base: auto
 
     patch:
       default:
-        target: 50%  # Reduced from 85% - encourage coverage but don't block
-        threshold: 10%  # More lenient for new code
+        target: 15%  # Low threshold for new code
+        threshold: 5%
         only_pulls: true
 
 # PR comment configuration

--- a/script/coverage.sh
+++ b/script/coverage.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
-# Simple coverage script
+# Unit test coverage (excludes slow WASM integration tests)
+#
+# Usage: ./script/coverage.sh [html|lcov|text]
+
 set -e
 
 echo "🔧 Installing cargo-llvm-cov if needed..."
@@ -7,41 +10,28 @@ if ! command -v cargo-llvm-cov &> /dev/null; then
     cargo install cargo-llvm-cov
 fi
 
-echo "🏗️ Preparing test environment..."
-./script/prebuild-test-contracts.sh
+echo "🧪 Running unit tests with coverage..."
 
-# Start database for tests
-docker compose --file service/relayer/compose.dev.yaml up postgres --detach 2>/dev/null || {
-    echo "⚠️  Warning: Could not start postgres (may be missing .env file)"
-    echo "📝 Creating minimal .env file for testing..."
-    touch service/relayer/.env
-    docker compose --file service/relayer/compose.dev.yaml up postgres --detach
-}
-
-echo "🧪 Running tests with coverage..."
 export SQLX_OFFLINE=true
 export CARGO_INCREMENTAL=0
 export RUSTFLAGS="-Cinstrument-coverage"
 
-# Run with desired output format
+# --lib: run unit tests only (excludes tests/ integration tests)
 case "${1:-html}" in
     html)
-        cargo llvm-cov nextest --html --open
+        cargo llvm-cov nextest --lib --html --open
         ;;
     lcov)
-        cargo llvm-cov nextest --lcov --output-path coverage.lcov
-        echo "Coverage report saved to coverage.lcov"
+        cargo llvm-cov nextest --lib --lcov --output-path coverage.lcov
+        echo "📊 Coverage report saved to coverage.lcov"
         ;;
     text)
-        cargo llvm-cov nextest
+        cargo llvm-cov nextest --lib
         ;;
     *)
         echo "Usage: $0 [html|lcov|text]"
         exit 1
         ;;
 esac
-
-echo "🧹 Cleaning up..."
-docker compose --file service/relayer/compose.dev.yaml down postgres 2>/dev/null || true
 
 echo "✅ Coverage complete!"


### PR DESCRIPTION
- Exclude integration tests from codecov.
- Coverage fails under 20% which is expected, since previous implementations were added to coverage code from test-utils, universal-account etc, by running integration tests.  
-

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/268)
<!-- Reviewable:end -->
