### PR TITLE
feat: improved FungibleAssetAmount API

### DIFF
--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -36,13 +36,12 @@ impl<T: AssetClass> Accumulator<T> {
         self.next_snapshot_index = next_snapshot_index;
     }
 
-    pub fn remove(&mut self, amount: FungibleAssetAmount<T>) -> Option<FungibleAssetAmount<T>> {
-        self.total.split(amount)
+    pub fn remove(&mut self, amount: FungibleAssetAmount<T>) {
+        self.total -= amount;
     }
 
-    pub fn add_once(&mut self, amount: FungibleAssetAmount<T>) -> Option<()> {
-        self.total.join(amount)?;
-        Some(())
+    pub fn add_once(&mut self, amount: FungibleAssetAmount<T>) {
+        self.total += amount;
     }
 
     pub fn accumulate(
@@ -52,19 +51,18 @@ impl<T: AssetClass> Accumulator<T> {
             fraction_as_u128_dividend: fraction,
             next_snapshot_index,
         }: AccumulationRecord<T>,
-    ) -> Option<()> {
+    ) {
         require!(
             next_snapshot_index >= self.next_snapshot_index,
             "Invariant violation: Asset accumulations cannot occur retroactively.",
         );
         let (fraction, carry) = self.fraction_as_u128_dividend.0.overflowing_add(fraction);
         if carry {
-            amount.join(1u128)?;
+            amount += 1;
         }
-        self.add_once(amount)?;
+        self.add_once(amount);
         self.fraction_as_u128_dividend.0 = fraction;
         self.next_snapshot_index = next_snapshot_index;
-        Some(())
     }
 }
 

--- a/common/src/asset.rs
+++ b/common/src/asset.rs
@@ -380,65 +380,62 @@ impl<T: AssetClass> FungibleAssetAmount<T> {
     }
 
     #[must_use]
-    pub fn split(&mut self, amount: impl Into<Self>) -> Option<Self> {
-        let a = amount.into();
-        self.amount.0 = self.amount.0.checked_sub(a.amount.0)?;
-        Some(a)
+    pub fn unwrap_add(self, other: impl Into<Self>, message: &str) -> Self {
+        Self {
+            amount: self
+                .amount
+                .0
+                .checked_add(other.into().amount.0)
+                .unwrap_or_else(|| env::panic_str(&format!("Arithmetic overflow: {message}")))
+                .into(),
+            ..self
+        }
     }
 
     #[must_use]
-    pub fn join(&mut self, amount: impl Into<Self>) -> Option<()> {
-        let a = amount.into();
-        self.amount.0 = self.amount.0.checked_add(a.amount.0)?;
-        Some(())
+    pub fn saturating_add(self, other: impl Into<Self>) -> Self {
+        Self {
+            amount: self.amount.0.saturating_add(other.into().amount.0).into(),
+            ..self
+        }
     }
-}
 
-#[macro_export]
-macro_rules! asset_op {
-    (@msg($($msg:literal)?) $a_head:ident $(. $a_tail:ident)* += $b:expr $(;)*) => {
-        $crate::asset::FungibleAssetAmount::join(&mut $a_head $(.$a_tail)*, $b).unwrap_or_else(|| {
-            ::near_sdk::env::panic_str(concat!($($msg, ": ",)? stringify!($a_head $(.$a_tail)*), " + ", stringify!($b), " overflow"));
-        });
-    };
-    ($a_head:ident $(. $a_tail:ident)* += $b:expr $(;)*) => {
-        $crate::asset_op!(@msg() $a_head $(.$a_tail)* += $b);
-    };
-    (@msg($($msg:literal)?) $a_head:ident $(. $a_tail:ident)* += $b:expr ; $($tail:tt)*) => {
-        $crate::asset_op!(@msg($($msg)?) $a_head $(.$a_tail)* += $b);
-        $crate::asset_op!($($tail)*);
-    };
-    ($a_head:ident $(. $a_tail:ident)* += $b:expr ; $($tail:tt)*) => {
-        $crate::asset_op!($a_head $(.$a_tail)* += $b);
-        $crate::asset_op!($($tail)*);
-    };
+    #[must_use]
+    pub fn checked_add(self, other: impl Into<Self>) -> Option<Self> {
+        Some(Self {
+            amount: self.amount.0.checked_add(other.into().amount.0)?.into(),
+            ..self
+        })
+    }
 
-    (@msg($($msg:literal)?) $a_head:ident $(. $a_tail:ident)* -= $b:expr $(;)*) => {
-        $crate::asset::FungibleAssetAmount::split(&mut $a_head $(.$a_tail)*, $b).unwrap_or_else(|| {
-            ::near_sdk::env::panic_str(concat!($($msg, ": ",)? stringify!($a_head $(.$a_tail)*), " - ", stringify!($b), " underflow"));
-        });
-    };
-    ($a_head:ident $(. $a_tail:ident)* -= $b:expr $(;)*) => {
-        $crate::asset_op!(@msg() $a_head $(.$a_tail)* -= $b);
-    };
-    (@msg($($msg:literal)?) $a_head:ident $(. $a_tail:ident)* -= $b:expr ; $($tail:tt)*) => {
-        $crate::asset_op!(@msg($($msg)?) $a_head $(.$a_tail)* -= $b);
-        $crate::asset_op!($($tail)*);
-    };
-    ($a_head:ident $(. $a_tail:ident)* -= $b:expr ; $($tail:tt)*) => {
-        $crate::asset_op!($a_head $(.$a_tail)* -= $b);
-        $crate::asset_op!($($tail)*);
-    };
+    #[must_use]
+    pub fn unwrap_sub(self, other: impl Into<Self>, message: &str) -> Self {
+        Self {
+            amount: self
+                .amount
+                .0
+                .checked_sub(other.into().amount.0)
+                .unwrap_or_else(|| env::panic_str(&format!("Arithmetic underflow: {message}")))
+                .into(),
+            ..self
+        }
+    }
 
-    ($s:stmt $(;)*) => {
-        $s;
-    };
-    ($s:stmt ; $($tail:tt)*) => {
-        $s;
-        $crate::asset_op!($($tail)*);
-    };
+    #[must_use]
+    pub fn saturating_sub(self, other: impl Into<Self>) -> Self {
+        Self {
+            amount: self.amount.0.saturating_sub(other.into().amount.0).into(),
+            ..self
+        }
+    }
 
-    () => {};
+    #[must_use]
+    pub fn checked_sub(self, other: impl Into<Self>) -> Option<Self> {
+        Some(Self {
+            amount: self.amount.0.checked_sub(other.into().amount.0)?.into(),
+            ..self
+        })
+    }
 }
 
 impl<T: AssetClass> From<FungibleAssetAmount<T>> for Decimal {
@@ -459,6 +456,40 @@ impl<T: AssetClass> std::fmt::Display for FungibleAssetAmount<T> {
     }
 }
 
+impl<T: AssetClass, R: Into<Self>> std::ops::Add<R> for FungibleAssetAmount<T> {
+    type Output = Self;
+
+    fn add(self, rhs: R) -> Self::Output {
+        Self {
+            amount: U128(self.amount.0 + rhs.into().amount.0),
+            ..self
+        }
+    }
+}
+
+impl<T: AssetClass, R: Into<Self>> std::ops::AddAssign<R> for FungibleAssetAmount<T> {
+    fn add_assign(&mut self, rhs: R) {
+        self.amount.0 += rhs.into().amount.0;
+    }
+}
+
+impl<T: AssetClass, R: Into<Self>> std::ops::Sub<R> for FungibleAssetAmount<T> {
+    type Output = Self;
+
+    fn sub(self, rhs: R) -> Self::Output {
+        Self {
+            amount: U128(self.amount.0 - rhs.into().amount.0),
+            ..self
+        }
+    }
+}
+
+impl<T: AssetClass, R: Into<Self>> std::ops::SubAssign<R> for FungibleAssetAmount<T> {
+    fn sub_assign(&mut self, rhs: R) {
+        self.amount.0 -= rhs.into().amount.0;
+    }
+}
+
 pub type BorrowAssetAmount = FungibleAssetAmount<BorrowAsset>;
 pub type CollateralAssetAmount = FungibleAssetAmount<CollateralAsset>;
 
@@ -474,25 +505,5 @@ mod tests {
         assert_eq!(serialized, "\"100\"");
         let deserialized: BorrowAssetAmount = serde_json::from_str(&serialized).unwrap();
         assert_eq!(deserialized, amount);
-    }
-
-    #[test]
-    #[should_panic = "a + u128::MAX overflow"]
-    fn asset_op_macro_overflow() {
-        let mut a = BorrowAssetAmount::new(100);
-
-        asset_op! {
-            a += u128::MAX;
-        };
-    }
-
-    #[test]
-    #[should_panic = "a - 101u128 underflow"]
-    fn asset_op_macro_underflow() {
-        let mut a = BorrowAssetAmount::new(100);
-
-        asset_op! {
-            a -= 101u128;
-        };
     }
 }

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -5,7 +5,6 @@ use near_sdk::{env, json_types::U64, near, AccountId};
 use crate::{
     accumulator::{AccumulationRecord, Accumulator},
     asset::{BorrowAsset, BorrowAssetAmount, CollateralAssetAmount},
-    asset_op,
     event::MarketEvent,
     market::{Market, SnapshotProof},
     number::Decimal,
@@ -88,32 +87,18 @@ impl BorrowPosition {
     }
 
     pub fn get_borrow_asset_principal(&self) -> BorrowAssetAmount {
-        let mut total = BorrowAssetAmount::zero();
-        asset_op! {
-            total += self.borrow_asset_principal;
-            total += self.borrow_asset_in_flight;
-        };
-        total
+        self.borrow_asset_principal + self.borrow_asset_in_flight
     }
 
     pub fn get_total_borrow_asset_liability(&self) -> BorrowAssetAmount {
-        let mut total = BorrowAssetAmount::zero();
-        asset_op! {
-            total += self.borrow_asset_principal;
-            total += self.borrow_asset_in_flight;
-            total += self.interest.get_total();
-            total += self.fees;
-        };
-        total
+        self.borrow_asset_principal
+            + (self.borrow_asset_in_flight)
+            + (self.interest.get_total())
+            + (self.fees)
     }
 
     pub fn get_total_collateral_amount(&self) -> CollateralAssetAmount {
-        let mut total = CollateralAssetAmount::zero();
-        asset_op! {
-            total += self.collateral_asset_deposit;
-            total += self.liquidation_lock;
-        };
-        total
+        self.collateral_asset_deposit + (self.liquidation_lock)
     }
 
     pub fn exists(&self) -> bool {
@@ -142,13 +127,13 @@ impl BorrowPosition {
         _proof: InterestAccumulationProof,
         amount: BorrowAssetAmount,
         block_timestamp_ms: u64,
-    ) -> Option<()> {
+    ) {
         if self.started_at_block_timestamp_ms.is_none()
             || self.get_total_borrow_asset_liability().is_zero()
         {
             self.started_at_block_timestamp_ms = Some(block_timestamp_ms.into());
         }
-        self.borrow_asset_principal.join(amount)
+        self.borrow_asset_principal += amount;
     }
 
     pub fn liquidatable_collateral(
@@ -195,7 +180,7 @@ impl BorrowPosition {
             let unscaled_amount =
                 (scaled_liability - scaled_collateral_amount) / (mcr - Decimal::ONE);
 
-            let mut available = if unscaled_amount >= collateral_amount_dec / mcr {
+            let available = if unscaled_amount >= collateral_amount_dec / mcr {
                 collateral_amount
             } else {
                 let amount = mcr * unscaled_amount;
@@ -203,11 +188,7 @@ impl BorrowPosition {
                     .to_u128_ceil()
                     .map_or(collateral_amount, CollateralAssetAmount::new)
             };
-            asset_op! {
-                @msg("Invariant violation: get_total_collateral_amount() >= liquidation_lock should hold")
-                available -= self.liquidation_lock;
-            };
-            available
+            available.unwrap_sub(self.liquidation_lock, "Invariant violation: get_total_collateral_amount() >= liquidation_lock should hold")
         }
     }
 }
@@ -314,8 +295,8 @@ impl<M: Deref<Target = Market>> BorrowPositionRef<M> {
     }
 
     pub fn with_pending_interest(&mut self) {
-        let mut pending_estimate = self.calculate_interest(u32::MAX).get_amount();
-        asset_op!(pending_estimate += self.estimate_current_snapshot_interest());
+        let pending_estimate = self.calculate_interest(u32::MAX).get_amount()
+            + self.estimate_current_snapshot_interest();
 
         self.position.interest.pending_estimate = pending_estimate;
     }
@@ -440,17 +421,17 @@ impl<'a> BorrowPositionGuard<'a> {
     ) -> LiabilityReduction {
         // No bounds checks necessary here: the min() call prevents underflow.
         let to_fees = self.position.fees.min(amount);
-        asset_op! {
-            @msg("Invariant violation: min() precludes underflow")
-            amount -= to_fees;
-            self.position.fees -= to_fees;
-        };
+        amount = amount.unwrap_sub(to_fees, "Invariant violation: min() precludes underflow");
+        self.position.fees = self
+            .position
+            .fees
+            .unwrap_sub(to_fees, "Invariant violation: min() precludes underflow");
 
         let to_interest = self.position.interest.get_total().min(amount);
-        asset_op! {
-            @msg("Invariant violation: min() precludes underflow")
-            amount -= to_interest;
-        };
+        amount = amount.unwrap_sub(
+            to_interest,
+            "Invariant violation: min() precludes underflow",
+        );
         self.position.interest.remove(to_interest);
 
         let to_principal = {
@@ -465,14 +446,18 @@ impl<'a> BorrowPositionGuard<'a> {
                 self.position.borrow_asset_principal.min(amount)
             }
         };
-        asset_op! {
-            @msg("Invariant violation: amount_to_principal > amount")
-            amount -= to_principal;
-            @msg("Invariant violation: amount_to_principal > borrow_asset_principal")
-            self.position.borrow_asset_principal -= to_principal;
-            @msg("Invariant violation: amount_to_principal > market.borrow_asset_borrowed")
-            self.market.borrow_asset_borrowed -= to_principal;
-        };
+        amount = amount.unwrap_sub(
+            to_principal,
+            "Invariant violation: amount_to_principal > amount",
+        );
+        self.position.borrow_asset_principal = self.position.borrow_asset_principal.unwrap_sub(
+            to_principal,
+            "Invariant violation: amount_to_principal > borrow_asset_principal",
+        );
+        self.market.borrow_asset_borrowed = self.market.borrow_asset_borrowed.unwrap_sub(
+            to_principal,
+            "Invariant violation: amount_to_principal > market.borrow_asset_borrowed",
+        );
 
         if self.position.borrow_asset_principal.is_zero() {
             // fully paid off
@@ -492,10 +477,8 @@ impl<'a> BorrowPositionGuard<'a> {
         _proof: InterestAccumulationProof,
         amount: CollateralAssetAmount,
     ) {
-        asset_op! {
-            self.position.collateral_asset_deposit += amount;
-            self.market.collateral_asset_deposited += amount;
-        };
+        self.position.collateral_asset_deposit += amount;
+        self.market.collateral_asset_deposited += amount;
 
         MarketEvent::CollateralDeposited {
             account_id: self.account_id.clone(),
@@ -509,11 +492,9 @@ impl<'a> BorrowPositionGuard<'a> {
         _proof: InterestAccumulationProof,
         amount: CollateralAssetAmount,
     ) {
-        asset_op! {
-            self.position.collateral_asset_in_flight += amount;
-            self.position.collateral_asset_deposit -= amount;
-            self.market.collateral_asset_deposited -= amount;
-        };
+        self.position.collateral_asset_in_flight += amount;
+        self.position.collateral_asset_deposit -= amount;
+        self.market.collateral_asset_deposited -= amount;
     }
 
     pub fn record_collateral_asset_withdrawal_final(
@@ -522,10 +503,11 @@ impl<'a> BorrowPositionGuard<'a> {
         amount: CollateralAssetAmount,
         success: bool,
     ) {
-        asset_op! {
-            @msg("Invariant violation: attempt to unlock more than locked as in-flight")
-            self.position.collateral_asset_in_flight -= amount;
-        };
+        self.position.collateral_asset_in_flight =
+            self.position.collateral_asset_in_flight.unwrap_sub(
+                amount,
+                "Invariant violation: attempt to unlock more than locked as in-flight",
+            );
 
         if success {
             MarketEvent::CollateralWithdrawn {
@@ -534,10 +516,8 @@ impl<'a> BorrowPositionGuard<'a> {
             }
             .emit();
         } else {
-            asset_op! {
-                self.position.collateral_asset_deposit += amount;
-                self.market.collateral_asset_deposited += amount;
-            };
+            self.position.collateral_asset_deposit += amount;
+            self.market.collateral_asset_deposited += amount;
         }
     }
 
@@ -546,10 +526,8 @@ impl<'a> BorrowPositionGuard<'a> {
         _proof: InterestAccumulationProof,
         amount: CollateralAssetAmount,
     ) {
-        asset_op! {
-            self.position.collateral_asset_deposit -= amount;
-            self.market.collateral_asset_deposited -= amount;
-        };
+        self.position.collateral_asset_deposit -= amount;
+        self.market.collateral_asset_deposited -= amount;
     }
 
     /// # Errors
@@ -586,30 +564,25 @@ impl<'a> BorrowPositionGuard<'a> {
             .ok_or(error::InitialBorrowError::FeeCalculationFailure)?;
 
         let mut fees = origination_fee;
-        fees.join(single_snapshot_fee)
+        fees = fees
+            .checked_add(single_snapshot_fee)
             .ok_or(error::InitialBorrowError::FeeCalculationFailure)?;
 
-        asset_op! {
-            self.market.borrow_asset_borrowed_in_flight += amount;
-            self.position.borrow_asset_in_flight += amount;
-            self.position.fees += fees;
-        };
+        self.market.borrow_asset_borrowed_in_flight += amount;
+        self.position.borrow_asset_in_flight += amount;
+        self.position.fees += fees;
 
         if !self.status(price_pair, block_timestamp_ms).is_healthy() {
-            asset_op! {
-                self.market.borrow_asset_borrowed_in_flight -= amount;
-                self.position.borrow_asset_in_flight -= amount;
-                self.position.fees -= fees;
-            };
+            self.market.borrow_asset_borrowed_in_flight -= amount;
+            self.position.borrow_asset_in_flight -= amount;
+            self.position.fees -= fees;
             return Err(error::InitialBorrowError::Undercollateralization);
         }
 
         if !self.within_allowable_borrow_range() {
-            asset_op! {
-                self.market.borrow_asset_borrowed_in_flight -= amount;
-                self.position.borrow_asset_in_flight -= amount;
-                self.position.fees -= fees;
-            };
+            self.market.borrow_asset_borrowed_in_flight -= amount;
+            self.position.borrow_asset_in_flight -= amount;
+            self.position.fees -= fees;
             return Err(error::InitialBorrowError::OutsideAllowableRange);
         }
 
@@ -628,21 +601,21 @@ impl<'a> BorrowPositionGuard<'a> {
     ) {
         // This should never panic, because a given amount of in-flight borrow
         // asset should always be added before it is removed.
-        asset_op! {
-            self.market.borrow_asset_borrowed_in_flight -= borrow.amount;
-            self.position.borrow_asset_in_flight -= borrow.amount;
-        };
+        self.market.borrow_asset_borrowed_in_flight -= borrow.amount;
+        self.position.borrow_asset_in_flight -= borrow.amount;
 
         if success {
             // GREAT SUCCESS
             //
             // Borrow position has already been created: finalize
             // withdrawal record.
-            self.position
-                .increase_borrow_asset_principal(interest, borrow.amount, block_timestamp_ms)
-                .unwrap_or_else(|| env::panic_str("Increase borrow asset principal overflow"));
+            self.position.increase_borrow_asset_principal(
+                interest,
+                borrow.amount,
+                block_timestamp_ms,
+            );
 
-            asset_op!(self.market.borrow_asset_borrowed += borrow.amount);
+            self.market.borrow_asset_borrowed += borrow.amount;
 
             MarketEvent::BorrowWithdrawn {
                 account_id: self.account_id.clone(),
@@ -723,19 +696,19 @@ impl<'a> BorrowPositionGuard<'a> {
     }
 
     pub(crate) fn liquidation_lock(&mut self, amount: CollateralAssetAmount) {
-        asset_op!(
-            @msg("Attempt to liquidate more collateral than position has deposited")
-            self.position.collateral_asset_deposit -= amount;
-            self.position.liquidation_lock += amount;
+        self.position.collateral_asset_deposit = self.position.collateral_asset_deposit.unwrap_sub(
+            amount,
+            "Attempt to liquidate more collateral than position has deposited",
         );
+        self.position.liquidation_lock += amount;
     }
 
     pub(crate) fn liquidation_unlock(&mut self, amount: CollateralAssetAmount) {
-        asset_op!(
-            @msg("Invariant violation: Liquidation unlock of more collateral that was locked")
-            self.position.liquidation_lock -= amount;
-            self.position.collateral_asset_deposit += amount;
+        self.position.liquidation_lock = self.position.liquidation_lock.unwrap_sub(
+            amount,
+            "Invariant violation: Liquidation unlock of more collateral that was locked",
         );
+        self.position.collateral_asset_deposit += amount;
     }
 
     /// # Errors
@@ -801,13 +774,11 @@ impl<'a> BorrowPositionGuard<'a> {
 
         self.liquidation_lock(liquidator_request);
 
-        let mut refund = BorrowAssetAmount::zero();
-        let mut recovered = liquidator_sent;
-        if liquidator_sent > maximum_acceptable {
-            recovered = maximum_acceptable;
-            refund = liquidator_sent;
-            asset_op!(refund -= recovered);
-        }
+        let (refund, recovered) = if liquidator_sent > maximum_acceptable {
+            (liquidator_sent - maximum_acceptable, maximum_acceptable)
+        } else {
+            (BorrowAssetAmount::zero(), liquidator_sent)
+        };
 
         Ok(InitialLiquidation {
             liquidated: liquidator_request,

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -6,7 +6,6 @@ use near_sdk::{
 use crate::{
     accumulator::{AccumulationRecord, Accumulator},
     asset::{BorrowAsset, BorrowAssetAmount, CollateralAssetAmount},
-    asset_op,
     borrow::{BorrowPosition, BorrowPositionGuard, BorrowPositionRef},
     chunked_append_only_list::ChunkedAppendOnlyList,
     event::MarketEvent,
@@ -110,19 +109,15 @@ impl Market {
     }
 
     pub fn borrowed(&self) -> BorrowAssetAmount {
-        let mut total = self.borrow_asset_borrowed;
-        asset_op!(total += self.borrow_asset_borrowed_in_flight);
-        total
+        self.borrow_asset_borrowed + self.borrow_asset_borrowed_in_flight
     }
 
     pub fn total_incoming(&self) -> BorrowAssetAmount {
-        self.borrow_asset_deposited_incoming.iter().fold(
-            BorrowAssetAmount::zero(),
-            |mut total_incoming, incoming| {
-                asset_op!(total_incoming += incoming.amount);
-                total_incoming
-            },
-        )
+        self.borrow_asset_deposited_incoming
+            .iter()
+            .fold(BorrowAssetAmount::zero(), |total_incoming, incoming| {
+                total_incoming + incoming.amount
+            })
     }
 
     pub fn incoming_at(&self, snapshot_index: u32) -> BorrowAssetAmount {
@@ -145,8 +140,7 @@ impl Market {
         let current_snapshot_index = self.finalized_snapshots.len();
         let incoming = self.incoming_at(current_snapshot_index);
 
-        let mut active = self.borrow_asset_deposited_active;
-        asset_op!(active += incoming);
+        let active = self.borrow_asset_deposited_active + incoming;
 
         let borrowed = self.borrowed();
 
@@ -192,7 +186,7 @@ impl Market {
         for i in 0..self.borrow_asset_deposited_incoming.len() {
             let incoming = &self.borrow_asset_deposited_incoming[i];
             if incoming.activate_at_snapshot_index == current_snapshot_index {
-                asset_op!(self.borrow_asset_deposited_active += incoming.amount);
+                self.borrow_asset_deposited_active += incoming.amount;
                 self.borrow_asset_deposited_incoming.remove(i);
                 break;
             }
@@ -368,7 +362,7 @@ impl Market {
             return;
         }
 
-        asset_op!(self.current_yield_distribution += amount);
+        self.current_yield_distribution += amount;
     }
 
     /// Accumulate static yield for an account.

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -4,8 +4,7 @@ use near_sdk::{env, json_types::U64, near, require, AccountId};
 
 use crate::{
     accumulator::{AccumulationRecord, Accumulator},
-    asset::{BorrowAsset, BorrowAssetAmount, FungibleAssetAmount},
-    asset_op,
+    asset::{BorrowAsset, BorrowAssetAmount},
     event::MarketEvent,
     incoming_deposit::IncomingDeposit,
     market::{Market, WithdrawalResolution},
@@ -30,9 +29,9 @@ impl Deposit {
     pub fn total(&self) -> BorrowAssetAmount {
         let mut total = self.active;
         for incoming in &self.incoming {
-            asset_op!(total += incoming.amount);
+            total += incoming.amount;
         }
-        asset_op!(total += self.outgoing);
+        total += self.outgoing;
         total
     }
 }
@@ -59,13 +58,12 @@ impl SupplyPosition {
     }
 
     pub fn total_incoming(&self) -> BorrowAssetAmount {
-        self.borrow_asset_deposit.incoming.iter().fold(
-            BorrowAssetAmount::zero(),
-            |mut total_incoming, incoming| {
-                asset_op!(total_incoming += incoming.amount);
-                total_incoming
-            },
-        )
+        self.borrow_asset_deposit
+            .incoming
+            .iter()
+            .fold(BorrowAssetAmount::zero(), |total_incoming, incoming| {
+                total_incoming + incoming.amount
+            })
     }
 
     pub fn get_started_at_block_timestamp_ms(&self) -> Option<u64> {
@@ -238,7 +236,7 @@ impl<'a> SupplyPositionGuard<'a> {
         while let Some(deposit) =
             incoming.next_if(|d| d.activate_at_snapshot_index <= through_snapshot_index)
         {
-            asset_op!(self.position.borrow_asset_deposit.active += deposit.amount);
+            self.position.borrow_asset_deposit.active += deposit.amount;
         }
         self.position.borrow_asset_deposit.incoming = incoming.collect();
 
@@ -246,10 +244,8 @@ impl<'a> SupplyPositionGuard<'a> {
     }
 
     fn remove_active(&mut self, amount: BorrowAssetAmount) {
-        asset_op! {
-            self.position.borrow_asset_deposit.active -= amount;
-            self.market.borrow_asset_deposited_active -= amount;
-        };
+        self.position.borrow_asset_deposit.active -= amount;
+        self.market.borrow_asset_deposited_active -= amount;
     }
 
     fn add_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
@@ -258,7 +254,7 @@ impl<'a> SupplyPositionGuard<'a> {
             .last_mut()
             .filter(|i| i.activate_at_snapshot_index == activate_at_snapshot_index)
         {
-            asset_op!(deposit.amount += amount);
+            deposit.amount += amount;
         } else {
             const MAX_INCOMING: usize = 4;
             require!(
@@ -277,7 +273,7 @@ impl<'a> SupplyPositionGuard<'a> {
             .iter_mut()
             .find(|incoming| incoming.activate_at_snapshot_index == activate_at_snapshot_index)
         {
-            asset_op!(incoming.amount += amount);
+            incoming.amount += amount;
         } else {
             self.market
                 .borrow_asset_deposited_incoming
@@ -292,7 +288,7 @@ impl<'a> SupplyPositionGuard<'a> {
     fn remove_incoming(&mut self, amount: BorrowAssetAmount) -> BorrowAssetAmount {
         let mut total = BorrowAssetAmount::zero();
         while let Some(newest) = self.position.borrow_asset_deposit.incoming.pop() {
-            asset_op!(total += newest.amount);
+            total += newest.amount;
 
             let Some(market_incoming) = self
                 .market
@@ -304,19 +300,13 @@ impl<'a> SupplyPositionGuard<'a> {
             else {
                 env::panic_str("Invariant violation: Market incoming entry should exist if position incoming entry exists");
             };
-            asset_op!(
-                @msg("Invariant violation: Market incoming >= position incoming should hold for all snapshot indices")
-                market_incoming.amount -= newest.amount;
-            );
+            market_incoming.amount = market_incoming.amount.unwrap_sub(newest.amount, "Invariant violation: Market incoming >= position incoming should hold for all snapshot indices");
 
             #[allow(clippy::comparison_chain)]
             if total == amount {
                 return amount;
             } else if total > amount {
-                let mut remainder = total;
-                // Infallible
-                let _ = remainder.split(amount);
-                self.add_incoming(remainder, newest.activate_at_snapshot_index);
+                self.add_incoming(total - amount, newest.activate_at_snapshot_index);
                 return amount;
             }
         }
@@ -356,12 +346,12 @@ impl<'a> SupplyPositionGuard<'a> {
     ) -> WithdrawalResolution {
         let mut amount_to_remove = amount;
 
-        asset_op! {
-            self.position.borrow_asset_deposit.outgoing += amount;
+        self.position.borrow_asset_deposit.outgoing += amount;
 
-            @msg("Invariant violation: remove_incoming(amount) > amount")
-            amount_to_remove -= self.remove_incoming(amount);
-        };
+        amount_to_remove = amount_to_remove.unwrap_sub(
+            self.remove_incoming(amount),
+            "Invariant violation: remove_incoming(amount) > amount",
+        );
 
         if !amount_to_remove.is_zero() {
             self.remove_active(amount_to_remove);
@@ -381,9 +371,7 @@ impl<'a> SupplyPositionGuard<'a> {
             .of(amount, supply_duration)
             .unwrap_or_else(|| env::panic_str("Fee calculation overflow"));
 
-        if amount.split(amount_to_fees).is_none() {
-            amount = FungibleAssetAmount::zero();
-        }
+        amount = amount.saturating_sub(amount_to_fees);
 
         WithdrawalResolution {
             account_id: self.account_id.clone(),
@@ -397,12 +385,9 @@ impl<'a> SupplyPositionGuard<'a> {
         withdrawal_resolution: &WithdrawalResolution,
         success: bool,
     ) {
-        let mut amount = withdrawal_resolution.amount_to_account;
+        let amount = withdrawal_resolution.amount_to_account + withdrawal_resolution.amount_to_fees;
 
-        asset_op! {
-            amount += withdrawal_resolution.amount_to_fees;
-            self.position.borrow_asset_deposit.outgoing -= amount;
-        };
+        self.position.borrow_asset_deposit.outgoing -= amount;
 
         if success {
             MarketEvent::SupplyWithdrawn {
@@ -439,10 +424,7 @@ impl<'a> SupplyPositionGuard<'a> {
         }
     }
 
-    pub fn record_yield_withdrawal(
-        &mut self,
-        amount: BorrowAssetAmount,
-    ) -> Option<BorrowAssetAmount> {
-        self.0.position.borrow_asset_yield.remove(amount)
+    pub fn record_yield_withdrawal(&mut self, amount: BorrowAssetAmount) {
+        self.0.position.borrow_asset_yield.remove(amount);
     }
 }

--- a/common/src/withdrawal_queue.rs
+++ b/common/src/withdrawal_queue.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroU32;
 
 use near_sdk::{collections::LookupMap, env, near, AccountId, BorshStorageKey, IntoStorageKey};
 
-use crate::{asset::BorrowAssetAmount, asset_op};
+use crate::asset::BorrowAssetAmount;
 
 #[derive(Debug)]
 #[near(serializers = [borsh])]
@@ -284,7 +284,7 @@ impl WithdrawalQueue {
                 });
             }
 
-            asset_op!(depth += amount);
+            depth += amount;
         }
 
         unreachable!()

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -3,7 +3,6 @@ use templar_common::{
     asset::{
         BorrowAsset, BorrowAssetAmount, CollateralAsset, CollateralAssetAmount, FungibleAsset,
     },
-    asset_op,
     borrow::{InitialBorrow, InitialLiquidation},
     market::{LiquidateMsg, WithdrawalResolution},
     oracle::pyth::OracleResponse,
@@ -176,9 +175,7 @@ impl Contract {
         &mut self,
         withdrawal_resolution: WithdrawalResolution,
     ) {
-        asset_op!(
-            self.borrow_asset_withdrawal_in_flight -= withdrawal_resolution.amount_to_account
-        );
+        self.borrow_asset_withdrawal_in_flight -= withdrawal_resolution.amount_to_account;
 
         // Withdrawal succeeded: remove the withdrawal request from the queue.
         // Withdrawal failed but should have succeeded: remove request but still refund.

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -4,7 +4,6 @@ use near_sdk::{env, near, require, AccountId, Promise, PromiseOrValue};
 use templar_common::{
     accumulator::Accumulator,
     asset::{BorrowAsset, BorrowAssetAmount, CollateralAssetAmount},
-    asset_op,
     borrow::{BorrowPosition, BorrowStatus},
     contract::list,
     market::{BorrowAssetMetrics, HarvestYieldMode, MarketConfiguration, MarketExternalInterface},
@@ -213,9 +212,7 @@ impl MarketExternalInterface for Contract {
             "Insufficient liquidity to fulfill the request at this time",
         );
 
-        asset_op!(
-            self.borrow_asset_withdrawal_in_flight += withdrawal_resolution.amount_to_account
-        );
+        self.borrow_asset_withdrawal_in_flight += withdrawal_resolution.amount_to_account;
 
         PromiseOrValue::Promise(
             self.configuration
@@ -315,9 +312,7 @@ impl MarketExternalInterface for Contract {
 
         let amount = amount.unwrap_or_else(|| yield_record.get_total());
 
-        yield_record
-            .remove(amount)
-            .unwrap_or_else(|| env::panic_str("Attempt to overdraw"));
+        yield_record.remove(amount);
 
         self.static_yield.insert(&predecessor, &yield_record);
 

--- a/contract/market/tests/disabled_when_liquidatable.rs
+++ b/contract/market/tests/disabled_when_liquidatable.rs
@@ -60,8 +60,8 @@ async fn allow_sufficient_collateralization_during_liquidation(
         .collateral_asset_deposit;
 
     assert_eq!(
-        u128::from(collateral_before) + 2_000_000,
-        collateral_after.into(),
+        collateral_before + 2_000_000,
+        collateral_after,
         "Collateralization should be allowed if it brings the position out of liquidation",
     );
 }

--- a/contract/market/tests/interest_rate.rs
+++ b/contract/market/tests/interest_rate.rs
@@ -95,10 +95,10 @@ async fn interest_rate(
         );
         let duration_outer = time_outer.elapsed();
 
-        let supply_yield_1 = u128::from(supply_position_1.borrow_asset_yield.get_total())
-            + u128::from(supply_position_1.borrow_asset_yield.pending_estimate);
-        let supply_yield_2 = u128::from(supply_position_2.borrow_asset_yield.get_total())
-            + u128::from(supply_position_2.borrow_asset_yield.pending_estimate);
+        let supply_yield_1 = supply_position_1.borrow_asset_yield.get_total()
+            + supply_position_1.borrow_asset_yield.pending_estimate;
+        let supply_yield_2 = supply_position_2.borrow_asset_yield.get_total()
+            + supply_position_2.borrow_asset_yield.pending_estimate;
 
         let yield_rate = c
             .configuration
@@ -127,19 +127,19 @@ async fn interest_rate(
         let approximation_below = (f * duration_inner.as_millis()).to_u128_ceil().unwrap();
         let approximation_above = (f * duration_outer.as_millis()).to_u128_ceil().unwrap();
 
-        let actual_1 = u128::from(borrow_position_1.interest.get_total())
-            + u128::from(borrow_position_1.interest.pending_estimate);
+        let actual_1 =
+            borrow_position_1.interest.get_total() + borrow_position_1.interest.pending_estimate;
         eprintln!("{approximation_below} <= {actual_1} <= {approximation_above}?");
 
-        assert!(approximation_below <= actual_1);
-        assert!(actual_1 <= approximation_above);
+        assert!(approximation_below <= actual_1.into());
+        assert!(u128::from(actual_1) <= approximation_above);
 
-        let actual_2 = u128::from(borrow_position_2.interest.get_total())
-            + u128::from(borrow_position_2.interest.pending_estimate);
+        let actual_2 =
+            borrow_position_2.interest.get_total() + borrow_position_2.interest.pending_estimate;
         eprintln!("{approximation_below} <= {actual_2} <= {approximation_above} + {iters}?");
 
-        assert!(approximation_below <= actual_2);
-        assert!(actual_2 <= approximation_above + iters);
+        assert!(approximation_below <= actual_2.into());
+        assert!(u128::from(actual_2) <= approximation_above + iters);
 
         assert!(
             actual_2 >= actual_1,
@@ -157,9 +157,10 @@ async fn interest_rate(
             let r = c
                 .repay(
                     &borrow_user,
-                    (u128::from(borrow_position_before.get_total_borrow_asset_liability())
-                        + u128::from(borrow_position_before.interest.pending_estimate))
-                        * 110
+                    u128::from(
+                        borrow_position_before.get_total_borrow_asset_liability()
+                            + borrow_position_before.interest.pending_estimate,
+                    ) * 110
                         / 100, /* overpayment */
                 )
                 .await;
@@ -180,9 +181,10 @@ async fn interest_rate(
             let borrow_position_before = c.get_borrow_position(borrow_user_2.id()).await.unwrap();
             c.repay(
                 &borrow_user_2,
-                (u128::from(borrow_position_before.get_total_borrow_asset_liability())
-                    + u128::from(borrow_position_before.interest.pending_estimate))
-                    * 110
+                u128::from(
+                    borrow_position_before.get_total_borrow_asset_liability()
+                        + borrow_position_before.interest.pending_estimate,
+                ) * 110
                     / 100, /* overpayment */
             )
             .await;

--- a/contract/market/tests/liquidation.rs
+++ b/contract/market/tests/liquidation.rs
@@ -129,7 +129,7 @@ async fn successful_liquidation_good_debt_under_mcr(
         "Liquidation should transfer correct amount of tokens",
     );
 
-    let yield_amount = u128::from(price).saturating_sub(borrow_amount).max(10);
+    let yield_amount: u128 = price.saturating_sub(borrow_amount).max(10.into()).into();
 
     // finalize a snapshot
     c.apply_interest(&borrow_user, None, None).await;
@@ -514,7 +514,7 @@ async fn extreme_prices(
         &liquidator_user,
         borrow_user.id(),
         liquidate,
-        (u128::from(price) - 1).into(), // offer too low at first
+        price - 1, // offer too low at first
     )
     .await;
 
@@ -555,15 +555,15 @@ async fn extreme_prices(
     let borrow_position_after = c.get_borrow_position(borrow_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(borrow_position_before.get_total_collateral_amount())
-            - u128::from(borrow_position_after.get_total_collateral_amount()),
-        u128::from(liquidate),
+        borrow_position_before.get_total_collateral_amount()
+            - borrow_position_after.get_total_collateral_amount(),
+        liquidate,
         "Position collateral should decrease by the amount purchased by the liquidator"
     );
     assert_eq!(
-        u128::from(borrow_position_before.get_total_borrow_asset_liability())
-            - u128::from(borrow_position_after.get_total_borrow_asset_liability()),
-        u128::from(price),
+        borrow_position_before.get_total_borrow_asset_liability()
+            - borrow_position_after.get_total_borrow_asset_liability(),
+        price,
         "Position liability should decrease by the amount paid by the liquidator, sans fees"
     );
 }
@@ -619,10 +619,8 @@ async fn partial_liquidation(#[future(awt)] worker: Worker<Sandbox>) {
     eprintln!("Pay for collateral: {pay_for_collateral}");
     eprintln!("Collateral to liquidate: {liquidate_collateral}");
 
-    let mut liability = borrow_position.get_total_borrow_asset_liability();
-    liability.split(pay_for_collateral).unwrap();
-    let mut collateral = borrow_position.get_total_collateral_amount();
-    collateral.split(liquidate_collateral).unwrap();
+    let liability = borrow_position.get_total_borrow_asset_liability() - pay_for_collateral;
+    let collateral = borrow_position.get_total_collateral_amount() - liquidate_collateral;
     let new_cr = price_pair
         .valuation(collateral)
         .ratio(price_pair.valuation(liability))

--- a/contract/market/tests/maximum_borrow_asset_usage_ratio.rs
+++ b/contract/market/tests/maximum_borrow_asset_usage_ratio.rs
@@ -35,13 +35,11 @@ async fn borrow_within_maximum_usage_ratio(
 
     assert_eq!(balance_before + amount, balance_after);
     assert_eq!(
-        u128::from(
-            c.get_borrow_position(borrow_user.id())
-                .await
-                .unwrap()
-                .get_borrow_asset_principal()
-        ),
-        amount,
+        c.get_borrow_position(borrow_user.id())
+            .await
+            .unwrap()
+            .get_borrow_asset_principal(),
+        amount.into(),
     );
 }
 


### PR DESCRIPTION
- Removes the horrendous `asset_op!()` macro
- Replaces `split` and `join` with `[checked|saturating|unwrap]_[add|sub]` on `FungibleAssetAmount`
- Implements `+`, `+=`, `-`, and `-=` operators for `FungibleAssetAmount`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/270)
<!-- Reviewable:end -->
