### PR TITLE
fix: Make registry IDs delimited by spaces

### DIFF
--- a/service/accumulator/src/lib.rs
+++ b/service/accumulator/src/lib.rs
@@ -22,7 +22,7 @@ use crate::rpc::{
 #[derive(Debug, Clone, Parser)]
 pub struct Args {
     /// Registries to run accumulator for
-    #[arg(short, long, env = "REGISTRIES_ACCOUNT_IDS")]
+    #[arg(short, long, env = "REGISTRIES_ACCOUNT_IDS", value_delimiter = ' ')]
     pub registries: Vec<AccountId>,
     /// Signer key to use for signing transactions
     #[arg(short = 'k', long, env = "SIGNER_KEY")]
@@ -46,7 +46,12 @@ pub struct Args {
     #[arg(long, default_value_t = 86_400, env = "STATIC_INTERVAL")]
     pub static_interval: u64,
     /// Registry refresh interval in seconds
-    #[arg(short, long, default_value_t = 3600, env = "REGISTRY_REFRESH_INTERVAL")]
+    #[arg(
+        short = 'R',
+        long,
+        default_value_t = 3600,
+        env = "REGISTRY_REFRESH_INTERVAL"
+    )]
     pub registry_refresh_interval: u64,
     /// Concurrency for accumulation tasks
     #[arg(short, long, default_value_t = 4, env = "CONCURRENCY")]

--- a/service/accumulator/src/main.rs
+++ b/service/accumulator/src/main.rs
@@ -113,7 +113,9 @@ mod tests {
     use near_crypto::{InMemorySigner, KeyType, SecretKey};
     use near_jsonrpc_primitives::types::query::{QueryResponseKind, RpcQueryResponse};
     use near_primitives::hash::CryptoHash;
+    use near_sdk::AccountId;
     use std::collections::HashMap;
+    use std::env;
     use std::str::FromStr;
     use tokio::time::{self, Duration};
     use wiremock::{
@@ -301,5 +303,41 @@ mod tests {
                 + static_calls.load(std::sync::atomic::Ordering::SeqCst)
                 >= 1
         );
+    }
+
+    #[test]
+    fn registries_env_is_space_delimited() {
+        let sk = SecretKey::from_random(KeyType::ED25519);
+        let original_regs = env::var("REGISTRIES_ACCOUNT_IDS").ok();
+        let original_signer = env::var("SIGNER_ACCOUNT_ID").ok();
+        let original_key = env::var("SIGNER_KEY").ok();
+
+        env::set_var("REGISTRIES_ACCOUNT_IDS", "one.testnet two.testnet");
+        env::set_var("SIGNER_ACCOUNT_ID", "signer.testnet");
+        env::set_var("SIGNER_KEY", sk.to_string());
+
+        let args = Args::parse_from(["accumulator"]);
+        let expected: Vec<AccountId> = vec![
+            "one.testnet".parse().unwrap(),
+            "two.testnet".parse().unwrap(),
+        ];
+
+        assert_eq!(args.registries, expected);
+
+        if let Some(val) = original_regs {
+            env::set_var("REGISTRIES_ACCOUNT_IDS", val);
+        } else {
+            env::remove_var("REGISTRIES_ACCOUNT_IDS");
+        }
+        if let Some(val) = original_signer {
+            env::set_var("SIGNER_ACCOUNT_ID", val);
+        } else {
+            env::remove_var("SIGNER_ACCOUNT_ID");
+        }
+        if let Some(val) = original_key {
+            env::set_var("SIGNER_KEY", val);
+        } else {
+            env::remove_var("SIGNER_KEY");
+        }
     }
 }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/330)
<!-- Reviewable:end -->
