### PR TITLE
feat: balance tracking + dedicated yield compounding function

### DIFF
--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -575,6 +575,7 @@ impl<'a> BorrowPositionGuard<'a> {
         }
 
         self.market.record_borrow_asset_yield_distribution(fees);
+        self.market.borrow_asset_balance -= amount;
 
         Ok(InitialBorrow { amount, fees })
     }
@@ -632,6 +633,8 @@ impl<'a> BorrowPositionGuard<'a> {
             //
             // TODO: Implement case 2 mitigation.
             // NOTE: Not needed for chain-local (NEP-141-only) tokens.
+
+            self.market.borrow_asset_balance += borrow.amount;
         }
     }
 
@@ -643,6 +646,7 @@ impl<'a> BorrowPositionGuard<'a> {
         proof: InterestAccumulationProof,
         amount: BorrowAssetAmount,
     ) -> BorrowAssetAmount {
+        self.market.borrow_asset_balance += amount;
         let liability_reduction = self.reduce_borrow_asset_liability(proof, amount);
 
         MarketEvent::BorrowRepaid {
@@ -761,6 +765,7 @@ impl<'a> BorrowPositionGuard<'a> {
             self.reduce_borrow_asset_liability(proof, initial_liquidation.recovered);
         self.market
             .record_borrow_asset_yield_distribution(liability_reduction.remaining);
+        self.market.borrow_asset_balance += initial_liquidation.recovered;
 
         MarketEvent::Liquidation {
             liquidator_id,
@@ -832,6 +837,7 @@ mod tests {
 
         let mut market = Market::new(b"m", configuration.clone());
         market.borrow_asset_deposited_active += BorrowAssetAmount::new(100_000_000_000);
+        market.borrow_asset_balance += BorrowAssetAmount::new(100_000_000_000);
         let snapshot_proof = market.snapshot();
 
         let mut position = BorrowPositionGuard(BorrowPositionRef {

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -36,6 +36,12 @@ enum StorageKey {
 pub struct Market {
     prefix: Vec<u8>,
     pub configuration: MarketConfiguration,
+    /// Total amount of borrow asset that the market knows it currently holds.
+    ///
+    /// This is different from `active - borrowed` because some of the active
+    /// amount might be compounded yield (deposited into the protocol without
+    /// actually being transferred in).
+    pub borrow_asset_balance: BorrowAssetAmount,
     /// Total amount of borrow asset earning interest in the market.
     pub borrow_asset_deposited_active: BorrowAssetAmount,
     /// Upcoming snapshot indices with amounts of borrow asset that will be activated.
@@ -87,6 +93,7 @@ impl Market {
         let mut self_ = Self {
             prefix: prefix.clone(),
             configuration,
+            borrow_asset_balance: 0.into(),
             borrow_asset_deposited_active: 0.into(),
             borrow_asset_deposited_incoming: Vec::new(),
             borrow_asset_withdrawal_in_flight: 0.into(),
@@ -219,15 +226,16 @@ impl Market {
             clippy::unwrap_used,
             reason = "Factor is guaranteed to be <=1, so value must still fit in u128"
         )]
-        let must_retain = ((1u32 - self.configuration.borrow_asset_maximum_usage_ratio)
+        let must_retain: BorrowAssetAmount = ((1u32
+            - self.configuration.borrow_asset_maximum_usage_ratio)
             * Decimal::from(self.borrow_asset_deposited_active))
         .to_u128_ceil()
-        .unwrap();
+        .unwrap()
+        .into();
 
-        u128::from(self.borrow_asset_deposited_active)
-            .saturating_sub(u128::from(self.borrowed()))
+        self.borrow_asset_balance
+            .saturating_sub(self.total_incoming())
             .saturating_sub(must_retain)
-            .into()
     }
 
     pub fn iter_supply_positions(&self) -> impl Iterator<Item = (AccountId, SupplyPosition)> + '_ {
@@ -418,5 +426,327 @@ fn usage_ratio(active: BorrowAssetAmount, borrowed: BorrowAssetAmount) -> Decima
         Decimal::ONE
     } else {
         Decimal::from(borrowed) / Decimal::from(active)
+    }
+}
+
+#[allow(clippy::too_many_lines)]
+#[cfg(test)]
+mod tests {
+    use near_sdk::{test_utils::*, testing_env};
+
+    use crate::{
+        asset::FungibleAsset,
+        dec,
+        fee::{Fee, TimeBasedFee},
+        interest_rate_strategy::InterestRateStrategy,
+        market::{PriceOracleConfiguration, YieldWeights},
+        oracle::pyth::PriceIdentifier,
+        price::PricePair,
+        supply::WithdrawalAttempt,
+        time_chunk::TimeChunkConfiguration,
+    };
+
+    use super::*;
+
+    fn configuration() -> MarketConfiguration {
+        MarketConfiguration {
+            time_chunk_configuration: TimeChunkConfiguration::new(1),
+            borrow_asset: FungibleAsset::nep141("borrow.near".parse().unwrap()),
+            collateral_asset: FungibleAsset::nep141("collateral.near".parse().unwrap()),
+            price_oracle_configuration: PriceOracleConfiguration {
+                account_id: "pyth-oracle.near".parse().unwrap(),
+                collateral_asset_price_id: PriceIdentifier([0xcc; 32]),
+                collateral_asset_decimals: 24,
+                borrow_asset_price_id: PriceIdentifier([0xbb; 32]),
+                borrow_asset_decimals: 24,
+                price_maximum_age_s: 60,
+            },
+            borrow_mcr_maintenance: dec!("1.25"),
+            borrow_mcr_liquidation: dec!("1.2"),
+            borrow_asset_maximum_usage_ratio: dec!("0.9"),
+            borrow_origination_fee: Fee::Proportional(dec!("0.25")),
+            borrow_interest_rate_strategy: InterestRateStrategy::zero(),
+            borrow_maximum_duration_ms: None,
+            borrow_range: (1, None).try_into().unwrap(),
+            supply_range: (1, None).try_into().unwrap(),
+            supply_withdrawal_range: (1, None).try_into().unwrap(),
+            supply_withdrawal_fee: TimeBasedFee::zero(),
+            yield_weights: YieldWeights::new_with_supply_weight(9)
+                .with_static("revenue.tmplr.near".parse().unwrap(), 1),
+            protocol_account_id: "revenue.tmplr.near".parse().unwrap(),
+            liquidation_maximum_spread: dec!("0.05"),
+        }
+    }
+
+    fn price_pair(collateral: i64, borrow: i64) -> PricePair {
+        PricePair::new(
+            &crate::oracle::pyth::Price {
+                price: collateral.into(),
+                conf: 0.into(),
+                expo: 24,
+                publish_time: 10,
+            },
+            24,
+            &crate::oracle::pyth::Price {
+                price: borrow.into(),
+                conf: 0.into(),
+                expo: 24,
+                publish_time: 10,
+            },
+            24,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn balance() {
+        let mut c = VMContextBuilder::new()
+            .block_timestamp(1_000_000_000_000)
+            .build();
+        testing_env!(c.clone());
+
+        let configuration = configuration();
+
+        let supply_id: AccountId = "supply.near".parse().unwrap();
+        let borrow_id: AccountId = "borrow.near".parse().unwrap();
+
+        let mut market = Market::new(b"m", configuration.clone());
+
+        let mut tick = |market: &mut Market| {
+            c.block_timestamp += 1_000_000;
+            testing_env!(c.clone());
+            market.snapshot()
+        };
+
+        // Supply
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position =
+                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
+            let yield_proof = supply_position.accumulate_yield();
+            supply_position.record_deposit(
+                yield_proof,
+                10_000_000.into(),
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            0.into(),
+            "still incoming, not yet active",
+        );
+
+        // Collateralize
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position =
+                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(interest_proof, 4_000_000.into());
+        }
+        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            9_000_000.into()
+        );
+
+        // Borrow: initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_borrow_initial(
+                    snapshot,
+                    interest_proof,
+                    2_000_000.into(),
+                    &price_pair(1, 1),
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        assert_eq!(market.borrow_asset_balance, 8_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            7_000_000.into()
+        );
+
+        // Borrow: final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_borrow_final(
+                snapshot,
+                interest_proof,
+                &initial,
+                true,
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 8_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            7_000_000.into()
+        );
+
+        // Repay half
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_repay(interest_proof, 1_000_000.into());
+        }
+        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Withdraw half of collateral: initial
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_collateral_asset_withdrawal_initial(interest_proof, 2_000_000.into());
+        }
+        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Withdraw half of collateral: final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_withdrawal_final(
+                interest_proof,
+                2_000_000.into(),
+                true,
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Liquidate the position: initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_liquidation_initial(
+                    interest_proof,
+                    1_000_000.into(),
+                    None,
+                    &price_pair(1, 2), // should cause 100% of the position to be liquidated
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Liquidate the position: final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_liquidation_final(
+                interest_proof,
+                "liquidator.near".parse().unwrap(),
+                &initial,
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            9_000_000.into()
+        );
+
+        // Supply yield compounding
+        let expected_yield_amount: BorrowAssetAmount = (500_000 * 9 / 10).into();
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            let proof = supply_position.accumulate_yield();
+            let yield_amount = supply_position.total_yield();
+            assert_eq!(yield_amount, expected_yield_amount);
+            supply_position.record_yield_compound(proof, yield_amount);
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            10_000_000.into(),
+            "Yield compounding does not affect the market's recorded balance",
+        );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(9_000_000) - expected_yield_amount, // compounded yield is still incoming
+        );
+
+        tick(&mut market);
+        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            (10_000_000 - (10_000_000 + u128::from(expected_yield_amount)) / 10).into(),
+        );
+
+        // Withdraw supply: initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            let proof = supply_position.accumulate_yield();
+            supply_position.record_withdrawal_initial(
+                proof,
+                10_000_000.into(),
+                env::block_timestamp_ms(),
+            )
+        };
+        let initial = match initial {
+            WithdrawalAttempt::Full(initial) => initial,
+            a => {
+                panic!("Should be full withdrawal: {a:?}");
+            }
+        };
+        assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+
+        // Withdraw supply: final
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            supply_position.record_withdrawal_final(&initial, true);
+        }
+        assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
     }
 }

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -27,11 +27,10 @@ pub struct Deposit {
 
 impl Deposit {
     pub fn total(&self) -> BorrowAssetAmount {
-        let mut total = self.active;
+        let mut total = self.active + self.outgoing;
         for incoming in &self.incoming {
             total += incoming.amount;
         }
-        total += self.outgoing;
         total
     }
 }
@@ -348,20 +347,17 @@ impl<'a> SupplyPositionGuard<'a> {
         // Check liquidity & eligibility
         //
 
-        let incoming = self.position.total_incoming();
-        let active = self.position.get_deposit().active;
-        let entitled_to_withdraw = incoming + active;
+        let my_incoming = self.position.total_incoming();
+        let my_active = self.position.get_deposit().active;
+        let entitled_to_withdraw = my_incoming + my_active;
 
         if entitled_to_withdraw.is_zero() {
             return WithdrawalAttempt::EmptyPosition;
         }
 
         let requested_amount = requested_amount.min(entitled_to_withdraw);
-        let generally_available = self
-            .market
-            .borrow_asset_deposited_active
-            .saturating_sub(self.market.borrowed());
-        let available_to_me = generally_available + incoming;
+        let market_incoming = self.market.total_incoming();
+        let available_to_me = self.market.borrow_asset_balance - market_incoming + my_incoming;
         let can_withdraw_now = entitled_to_withdraw.min(available_to_me);
 
         if can_withdraw_now.is_zero() {
@@ -408,6 +404,7 @@ impl<'a> SupplyPositionGuard<'a> {
 
         let amount_to_account = withdrawal_amount.saturating_sub(amount_to_fees);
 
+        self.market.borrow_asset_balance -= amount_to_account;
         self.market.borrow_asset_withdrawal_in_flight += amount_to_account;
 
         let withdrawal = Withdrawal {
@@ -443,6 +440,7 @@ impl<'a> SupplyPositionGuard<'a> {
             }
             .emit();
         } else {
+            self.market.borrow_asset_balance += withdrawal.amount_to_account;
             self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
         }
     }
@@ -459,6 +457,7 @@ impl<'a> SupplyPositionGuard<'a> {
             self.position.started_at_block_timestamp_ms = Some(block_timestamp_ms.into());
         }
 
+        self.market.borrow_asset_balance += amount;
         self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
 
         if !amount.is_zero() {
@@ -473,8 +472,27 @@ impl<'a> SupplyPositionGuard<'a> {
     pub fn record_yield_withdrawal(&mut self, amount: BorrowAssetAmount) {
         self.0.position.borrow_asset_yield.remove(amount);
     }
+
+    /// Converts an amount of borrow asset from the yield record to the
+    /// deposit record, allowing the account to earn compound interest on
+    /// their yield without withdrawing it.
+    ///
+    /// # Panics
+    ///
+    /// If `amount` is greater the amount in the yield record. The caller
+    /// should probably use the return value of
+    /// [`SupplyPositionRef::total_yield`] as an upper bound for this argument.
+    pub fn record_yield_compound(
+        &mut self,
+        _proof: YieldAccumulationProof,
+        amount: BorrowAssetAmount,
+    ) {
+        self.0.position.borrow_asset_yield.remove(amount);
+        self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
+    }
 }
 
+#[derive(Debug)]
 pub enum WithdrawalAttempt {
     Full(Withdrawal),
     Partial {

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -422,6 +422,7 @@ impl Contract {
             });
             yield_record.add_once(amount);
             self.static_yield.insert(&account_id, &yield_record);
+            self.borrow_asset_balance += amount;
         }
     }
 }

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -312,10 +312,8 @@ impl MarketExternalInterface for Contract {
         match mode {
             HarvestYieldMode::Compounding => {
                 let proof = supply_position.accumulate_yield();
-                // Compound yield by withdrawing it and recording it as an immediate deposit.
                 let total_yield = supply_position.total_yield();
-                supply_position.record_yield_withdrawal(total_yield);
-                supply_position.record_deposit(proof, total_yield, env::block_timestamp_ms());
+                supply_position.record_yield_compound(proof, total_yield);
                 require!(
                     supply_position.is_within_allowable_range(),
                     "New supply position is outside of allowable range",
@@ -368,6 +366,7 @@ impl MarketExternalInterface for Contract {
         yield_record.remove(amount);
 
         self.static_yield.insert(&predecessor, &yield_record);
+        self.borrow_asset_balance -= amount;
 
         self.configuration
             .borrow_asset


### PR DESCRIPTION
Originally I had planned to add virtual supply tracking fields to avoid some edge cases with compounding yield. However, I went with what (I believe) is a much simpler solution: tracking the current balance of the market separately from the active supply. This makes it easier to narrow down the cases for when the field needs to be updated, and also makes its meaning/purpose easier to understand.

When reviewing this PR, please focus on:
1. Ensuring that there are no cases when the new `borrow_asset_balance` field should be updated but isn't (or is updated when it should not be updated).
2. Ensuring that semantics are correctly preserved/updated, particularly with regards to: active supply, incoming supply.

The main reason for the introduction of this PR is to eliminate an edge case in which compounding yield would skew the result of the `get_borrow_asset_available_to_borrow` function, so I have added a (rather long) test to check for that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/339)
<!-- Reviewable:end -->
