### PR TITLE
feat: virtual supply tracking

### DIFF
--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -52,7 +52,6 @@ impl<T: AssetClass> Accumulator<T> {
             next_snapshot_index,
         }: AccumulationRecord<T>,
     ) {
-        near_sdk::log!("accumulate({amount}, {fraction}, {next_snapshot_index})");
         require!(
             next_snapshot_index >= self.next_snapshot_index,
             "Invariant violation: Asset accumulations cannot occur retroactively.",

--- a/common/src/accumulator.rs
+++ b/common/src/accumulator.rs
@@ -52,6 +52,7 @@ impl<T: AssetClass> Accumulator<T> {
             next_snapshot_index,
         }: AccumulationRecord<T>,
     ) {
+        near_sdk::log!("accumulate({amount}, {fraction}, {next_snapshot_index})");
         require!(
             next_snapshot_index >= self.next_snapshot_index,
             "Invariant violation: Asset accumulations cannot occur retroactively.",

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -417,6 +417,8 @@ impl<'a> BorrowPositionGuard<'a> {
         );
         self.position.interest.remove(to_interest);
 
+        self.market.borrow_asset_virtual_credit += to_fees + to_interest;
+
         let to_principal = {
             let minimum_amount = u128::from(self.market.configuration.borrow_range.minimum);
             let amount_remaining =

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -417,7 +417,16 @@ impl<'a> BorrowPositionGuard<'a> {
         );
         self.position.interest.remove(to_interest);
 
-        self.market.borrow_asset_virtual_credit += to_fees + to_interest;
+        let weight_numerator = self.market.configuration.yield_weights.supply.get();
+        let weight_denominator = self.market.configuration.yield_weights.total_weight().get();
+        self.market.borrow_asset_virtual_credit +=
+            (Decimal::from(to_fees + to_interest) * weight_numerator / weight_denominator)
+                .to_u128_floor()
+                .unwrap_or_else(|| {
+                    crate::panic_with_message(
+                        "Invariant violation: guaranteed supply weight <= total weight",
+                    )
+                });
 
         let to_principal = {
             let minimum_amount = u128::from(self.market.configuration.borrow_range.minimum);

--- a/common/src/borrow.rs
+++ b/common/src/borrow.rs
@@ -824,7 +824,7 @@ mod tests {
         };
 
         let mut market = Market::new(b"m", configuration.clone());
-        market.borrow_asset_deposited_active += BorrowAssetAmount::new(100_000_000_000);
+        market.borrow_asset_deposited_active_real += BorrowAssetAmount::new(100_000_000_000);
         market.borrow_asset_balance += BorrowAssetAmount::new(100_000_000_000);
         let snapshot_proof = market.snapshot();
 

--- a/common/src/incoming_deposit.rs
+++ b/common/src/incoming_deposit.rs
@@ -6,5 +6,6 @@ use crate::asset::BorrowAssetAmount;
 #[near(serializers = [json, borsh])]
 pub struct IncomingDeposit {
     pub activate_at_snapshot_index: u32,
-    pub amount: BorrowAssetAmount,
+    pub amount_real: BorrowAssetAmount,
+    pub amount_virtual: BorrowAssetAmount,
 }

--- a/common/src/market/configuration.rs
+++ b/common/src/market/configuration.rs
@@ -326,15 +326,15 @@ impl MarketConfiguration {
     }
 
     pub fn supply_yield_rate_from_interest(&self, snapshot: &Snapshot) -> Decimal {
-        if snapshot.borrow_asset_deposited_active.is_zero() {
+        let supply = snapshot.active_supply();
+        if supply.is_zero() {
             return Decimal::ZERO;
         }
-        let deposited: Decimal = snapshot.borrow_asset_deposited_active.into();
         let borrowed: Decimal = snapshot.borrow_asset_borrowed.into();
         let supply_weight: Decimal = self.yield_weights.supply.get().into();
         let total_weight: Decimal = self.yield_weights.total_weight().get().into();
 
-        snapshot.interest_rate * borrowed * supply_weight / deposited / total_weight
+        snapshot.interest_rate * borrowed * supply_weight / Decimal::from(supply) / total_weight
     }
 }
 

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -235,6 +235,7 @@ impl Market {
 
         self.borrow_asset_balance
             .saturating_sub(self.total_incoming())
+            .min(self.borrow_asset_deposited_active)
             .saturating_sub(must_retain)
     }
 
@@ -496,6 +497,229 @@ mod tests {
             24,
         )
         .unwrap()
+    }
+
+    #[rstest::rstest]
+    #[should_panic = "InsufficientBorrowAssetAvailable"]
+    #[case(65_000_000)]
+    #[case(63_500_000)]
+    fn balance2(#[case] second_borrow_amount: u128) {
+        let second_borrow_amount = BorrowAssetAmount::new(second_borrow_amount);
+
+        let mut c = VMContextBuilder::new()
+            .block_timestamp(1_000_000_000_000)
+            .build();
+        testing_env!(c.clone());
+
+        let mut configuration = configuration();
+
+        configuration.borrow_origination_fee = Fee::Flat(15_000_000.into());
+        configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();
+        configuration.borrow_asset_maximum_usage_ratio = Decimal::ONE;
+
+        let supply_id: AccountId = "supply.near".parse().unwrap();
+        let borrow_id: AccountId = "borrow.near".parse().unwrap();
+        let borrow_2_id: AccountId = "borrow2.near".parse().unwrap();
+
+        let mut market = Market::new(b"m", configuration.clone());
+
+        let mut tick = |market: &mut Market| {
+            c.block_timestamp += 1_000_000;
+            testing_env!(c.clone());
+            market.snapshot()
+        };
+
+        // Supply 100
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position =
+                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
+            let yield_proof = supply_position.accumulate_yield();
+            supply_position.record_deposit(
+                yield_proof,
+                100_000_000.into(),
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+
+        // Collateralize 200
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position =
+                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
+        }
+        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+
+        // Borrow 100 initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_borrow_initial(
+                    snapshot,
+                    proof,
+                    100_000_000.into(),
+                    &price_pair(1, 1),
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        assert_eq!(market.borrow_asset_balance, 0.into());
+
+        // Borrow final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_borrow_final(
+                snapshot,
+                proof,
+                &initial,
+                true,
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 0.into());
+
+        // Borrow repay 100% + fees
+        let amount_repaid = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            let liability = borrow_position.inner().get_total_borrow_asset_liability();
+            let remaining = borrow_position.record_repay(proof, liability);
+            assert_eq!(remaining, 0.into());
+            liability
+        };
+        assert_eq!(market.borrow_asset_balance, amount_repaid);
+
+        // Supplier withdraws 50: initial
+        let withdrawal = {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            let yield_proof = supply_position.accumulate_yield();
+            let yield_amount = supply_position.total_yield();
+            supply_position.record_yield_compound(yield_proof, yield_amount);
+            let yield_proof = supply_position.accumulate_yield();
+            supply_position.record_withdrawal_initial(
+                yield_proof,
+                50_000_000.into(),
+                env::block_timestamp_ms(),
+            )
+        };
+        let WithdrawalAttempt::Full(withdrawal) = withdrawal else {
+            panic!("Expected full withdrawal");
+        };
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+
+        // Supply withdrawal final
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            supply_position.record_withdrawal_final(&withdrawal, true);
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+
+        // Collateralize2 200
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position =
+                market.get_or_create_borrow_position_guard(snapshot, borrow_2_id.clone());
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+
+        eprintln!(
+            "Available: {}",
+            market.get_borrow_asset_available_to_borrow()
+        );
+        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
+        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
+        eprintln!(
+            "Borrow asset deposited active: {}",
+            market.borrow_asset_deposited_active
+        );
+
+        // Borrow2 100 initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_2_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_borrow_initial(
+                    snapshot,
+                    proof,
+                    second_borrow_amount,
+                    &price_pair(1, 1),
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
+        );
+
+        eprintln!("Borrow2 final");
+        eprintln!("{initial:?}");
+        eprintln!("{}", market.borrow_asset_borrowed_in_flight);
+
+        // Borrow2 final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_2_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_borrow_final(
+                snapshot,
+                proof,
+                &initial,
+                true,
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
+        );
+
+        eprintln!(
+            "Available: {}",
+            market.get_borrow_asset_available_to_borrow()
+        );
+        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
+        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
+        eprintln!(
+            "Borrow asset deposited active: {}",
+            market.borrow_asset_deposited_active
+        );
     }
 
     #[test]

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -233,9 +233,9 @@ impl Market {
         .unwrap()
         .into();
 
-        self.borrow_asset_balance
-            .saturating_sub(self.total_incoming())
-            .min(self.borrow_asset_deposited_active)
+        self.borrow_asset_deposited_active
+            .saturating_sub(self.borrow_asset_borrowed)
+            .saturating_sub(self.borrow_asset_borrowed_in_flight)
             .saturating_sub(must_retain)
     }
 
@@ -542,6 +542,10 @@ mod tests {
             );
         }
         assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            0.into() // still in incoming
+        );
 
         // Collateralize 200
         {
@@ -552,6 +556,10 @@ mod tests {
             borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
         }
         assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            100_000_000.into()
+        );
 
         // Borrow 100 initial
         let initial = {
@@ -571,6 +579,7 @@ mod tests {
                 .unwrap()
         };
         assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
 
         // Borrow final
         {
@@ -588,6 +597,7 @@ mod tests {
             );
         }
         assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
 
         // Borrow repay 100% + fees
         let amount_repaid = {
@@ -597,14 +607,19 @@ mod tests {
                 .unwrap();
             let proof = borrow_position.accumulate_interest();
             let liability = borrow_position.inner().get_total_borrow_asset_liability();
+            assert_eq!(liability, 115_000_000.into());
             let remaining = borrow_position.record_repay(proof, liability);
             assert_eq!(remaining, 0.into());
             liability
         };
         assert_eq!(market.borrow_asset_balance, amount_repaid);
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            100_000_000.into()
+        );
 
         // Supplier withdraws 50: initial
-        let withdrawal = {
+        let (withdrawal, yield_amount) = {
             let snapshot = tick(&mut market);
             let mut supply_position = market
                 .supply_position_guard(snapshot, supply_id.clone())
@@ -613,10 +628,13 @@ mod tests {
             let yield_amount = supply_position.total_yield();
             supply_position.record_yield_compound(yield_proof, yield_amount);
             let yield_proof = supply_position.accumulate_yield();
-            supply_position.record_withdrawal_initial(
-                yield_proof,
-                50_000_000.into(),
-                env::block_timestamp_ms(),
+            (
+                supply_position.record_withdrawal_initial(
+                    yield_proof,
+                    50_000_000.into(),
+                    env::block_timestamp_ms(),
+                ),
+                yield_amount,
             )
         };
         let WithdrawalAttempt::Full(withdrawal) = withdrawal else {
@@ -625,6 +643,10 @@ mod tests {
         assert_eq!(
             market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount
         );
 
         // Supply withdrawal final
@@ -639,6 +661,10 @@ mod tests {
             market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000),
         );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount
+        );
 
         // Collateralize2 200
         {
@@ -652,6 +678,10 @@ mod tests {
             market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000),
         );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount
+        );
 
         eprintln!(
             "Available: {}",
@@ -664,7 +694,7 @@ mod tests {
             market.borrow_asset_deposited_active
         );
 
-        // Borrow2 100 initial
+        // Borrow2 initial
         let initial = {
             let snapshot = tick(&mut market);
             let mut borrow_position = market
@@ -684,6 +714,10 @@ mod tests {
         assert_eq!(
             market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
+        );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount - second_borrow_amount,
         );
 
         eprintln!("Borrow2 final");
@@ -792,6 +826,7 @@ mod tests {
                 )
                 .unwrap()
         };
+        eprintln!("Borrowed: {}", market.borrow_asset_borrowed);
         assert_eq!(market.borrow_asset_balance, 8_000_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
@@ -813,6 +848,7 @@ mod tests {
                 env::block_timestamp_ms(),
             );
         }
+        assert_eq!(market.borrow_asset_borrowed, 2_000_000.into());
         assert_eq!(market.borrow_asset_balance, 8_000_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
@@ -826,9 +862,11 @@ mod tests {
                 .borrow_position_guard(snapshot, borrow_id.clone())
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
-            borrow_position.record_repay(interest_proof, 1_000_000.into());
+            borrow_position.record_repay(interest_proof, 1_500_000.into());
         }
-        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(market.borrow_asset_borrowed, 1_000_000.into());
+        eprintln!("Borrowed: {}", market.borrow_asset_borrowed);
+        assert_eq!(market.borrow_asset_balance, 9_500_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
             8_000_000.into()
@@ -844,7 +882,7 @@ mod tests {
             borrow_position
                 .record_collateral_asset_withdrawal_initial(interest_proof, 2_000_000.into());
         }
-        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(market.borrow_asset_balance, 9_500_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
             8_000_000.into()
@@ -863,7 +901,7 @@ mod tests {
                 true,
             );
         }
-        assert_eq!(market.borrow_asset_balance, 9_000_000.into());
+        assert_eq!(market.borrow_asset_balance, 9_500_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
             8_000_000.into()
@@ -888,7 +926,7 @@ mod tests {
                 .unwrap();
             assert_eq!(u128::from(liquidation.liquidated), 2_000_000);
         }
-        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
+        assert_eq!(market.borrow_asset_balance, 10_500_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
             9_000_000.into()
@@ -908,19 +946,20 @@ mod tests {
         }
         assert_eq!(
             market.borrow_asset_balance,
-            10_000_000.into(),
+            10_500_000.into(),
             "Yield compounding does not affect the market's recorded balance",
         );
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(9_000_000) - expected_yield_amount, // compounded yield is still incoming
+            BorrowAssetAmount::new(9_000_000), // should still be in incoming
         );
 
-        tick(&mut market);
-        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
+        tick(&mut market); // move incoming to active
+        assert_eq!(market.borrow_asset_balance, 10_500_000.into());
+        assert_eq!(market.borrow_asset_deposited_active, 10_450_000.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
-            (10_000_000 - (10_000_000 + u128::from(expected_yield_amount)) / 10).into(),
+            BorrowAssetAmount::new(10_450_000 * 9 / 10),
         );
 
         // Withdraw supply: initial
@@ -932,7 +971,7 @@ mod tests {
             let proof = supply_position.accumulate_yield();
             supply_position.record_withdrawal_initial(
                 proof,
-                10_000_000.into(),
+                10_450_000.into(),
                 env::block_timestamp_ms(),
             )
         };
@@ -942,7 +981,7 @@ mod tests {
                 panic!("Should be full withdrawal: {a:?}");
             }
         };
-        assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.borrow_asset_balance, 50_000.into());
         assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
 
         // Withdraw supply: final
@@ -953,7 +992,7 @@ mod tests {
                 .unwrap();
             supply_position.record_withdrawal_final(&initial, true);
         }
-        assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.borrow_asset_balance, 50_000.into());
         assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
     }
 }

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -428,6 +428,47 @@ impl Market {
 
         Ok(())
     }
+
+    /// # Errors
+    ///
+    /// - If the account does not earn static yield.
+    pub fn withdraw_static_yield_initial(
+        &mut self,
+        account_id: &AccountId,
+        amount: Option<BorrowAssetAmount>,
+    ) -> Result<BorrowAssetAmount, UnknownAccount> {
+        let mut yield_record = self.static_yield.get(account_id).ok_or(UnknownAccount)?;
+
+        let yield_total = yield_record.get_total();
+        let amount = amount.map_or(yield_total, |a| a.min(yield_total));
+
+        yield_record.remove(amount);
+
+        self.static_yield.insert(account_id, &yield_record);
+        self.borrow_asset_balance -= amount;
+
+        Ok(amount)
+    }
+
+    pub fn withdraw_static_yield_final(
+        &mut self,
+        account_id: &AccountId,
+        amount: BorrowAssetAmount,
+        succeeded: bool,
+    ) {
+        if succeeded {
+            return;
+        }
+
+        let mut yield_record = self.static_yield.get(account_id).unwrap_or_else(|| {
+            crate::panic_with_message(
+                "Invariant violation: static yield entry must exist during callback",
+            )
+        });
+        yield_record.add_once(amount);
+        self.static_yield.insert(account_id, &yield_record);
+        self.borrow_asset_balance += amount;
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -447,14 +447,15 @@ fn usage_ratio(active: BorrowAssetAmount, borrowed: BorrowAssetAmount) -> Decima
 #[allow(clippy::too_many_lines)]
 #[cfg(test)]
 mod tests {
-    use near_sdk::{test_utils::*, testing_env};
+    use near_sdk::{test_utils::*, testing_env, VMContext};
 
     use crate::{
         asset::FungibleAsset,
+        borrow::InitialBorrow,
         dec,
         fee::{Fee, TimeBasedFee},
         interest_rate_strategy::InterestRateStrategy,
-        market::{PriceOracleConfiguration, YieldWeights},
+        market::{PriceOracleConfiguration, Withdrawal, YieldWeights},
         oracle::pyth::PriceIdentifier,
         price::PricePair,
         supply::WithdrawalAttempt,
@@ -513,245 +514,336 @@ mod tests {
         .unwrap()
     }
 
-    #[test]
-    fn balance_1() {
-        let mut c = VMContextBuilder::new()
-            .block_timestamp(1_000_000_000_000)
-            .build();
-        testing_env!(c.clone());
+    struct TestMarketController {
+        pub context: VMContext,
+        pub market: Market,
+    }
 
-        let configuration = configuration();
+    impl TestMarketController {
+        pub fn new(configuration: MarketConfiguration) -> Self {
+            let context = VMContextBuilder::new()
+                .block_timestamp(1_000_000_000_000)
+                .build();
+            testing_env!(context.clone());
 
-        let supply_id: AccountId = "supply.near".parse().unwrap();
-        let borrow_id: AccountId = "borrow.near".parse().unwrap();
+            let market = Market::new(b"m", configuration);
 
-        let mut market = Market::new(b"m", configuration.clone());
+            Self { context, market }
+        }
 
-        let mut tick = |market: &mut Market| {
-            c.block_timestamp += 1_000_000;
-            testing_env!(c.clone());
-            market.snapshot()
-        };
+        pub fn tick(&mut self) -> SnapshotProof {
+            self.context.block_timestamp += 1_000_000;
+            testing_env!(self.context.clone());
+            self.market.snapshot()
+        }
 
-        // Supply
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position =
-                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
+        pub fn supply(&mut self, account: AccountId, amount: u128) {
+            let snapshot = self.tick();
+            let mut supply_position = self
+                .market
+                .get_or_create_supply_position_guard(snapshot, account);
             let yield_proof = supply_position.accumulate_yield();
-            supply_position.record_deposit(
-                yield_proof,
-                10_000_000.into(),
-                env::block_timestamp_ms(),
-            );
+            supply_position.record_deposit(yield_proof, amount.into(), env::block_timestamp_ms());
         }
-        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            0.into(),
-            "still incoming, not yet active",
-        );
 
-        // Collateralize
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position =
-                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
+        pub fn collateralize(&mut self, account: AccountId, amount: u128) {
+            let snapshot_proof = self.tick();
+            let mut borrow_position = self
+                .market
+                .get_or_create_borrow_position_guard(snapshot_proof, account);
             let interest_proof = borrow_position.accumulate_interest();
-            borrow_position.record_collateral_asset_deposit(interest_proof, 4_000_000.into());
+            borrow_position.record_collateral_asset_deposit(interest_proof, amount.into());
         }
-        assert_eq!(market.borrow_asset_balance, 10_000_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            9_000_000.into()
-        );
 
-        // Borrow: initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
+        pub fn borrow_initial(&mut self, account_id: AccountId, amount: u128) -> InitialBorrow {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, account_id)
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
             borrow_position
                 .record_borrow_initial(
                     snapshot,
                     interest_proof,
-                    2_000_000.into(),
+                    amount.into(),
                     &price_pair(1, 1),
                     env::block_timestamp_ms(),
                 )
                 .unwrap()
-        };
-        eprintln!("Borrowed: {}", market.borrow_asset_borrowed);
-        assert_eq!(market.borrow_asset_balance, 8_000_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            7_000_000.into()
-        );
+        }
 
-        // Borrow: final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
+        pub fn borrow_final(&mut self, account_id: AccountId, initial: &InitialBorrow) {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, account_id)
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
             borrow_position.record_borrow_final(
                 snapshot,
                 interest_proof,
-                &initial,
+                initial,
                 true,
                 env::block_timestamp_ms(),
             );
         }
-        assert_eq!(market.borrow_asset_borrowed, 2_000_000.into());
-        assert_eq!(market.borrow_asset_balance, 8_000_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            7_000_000.into()
-        );
 
-        // Repay half
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
+        pub fn accumulate_interest(&mut self, account_id: AccountId) -> BorrowPosition {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, account_id)
+                .unwrap();
+            let _ = borrow_position.accumulate_interest();
+            borrow_position.inner().clone()
+        }
+
+        pub fn repay(
+            &mut self,
+            account_id: AccountId,
+            amount: impl Into<BorrowAssetAmount>,
+        ) -> BorrowAssetAmount {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, account_id)
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
-            borrow_position.record_repay(interest_proof, 1_500_000.into());
+            borrow_position.record_repay(interest_proof, amount.into())
         }
-        assert_eq!(market.borrow_asset_borrowed, 1_000_000.into());
-        eprintln!("Borrowed: {}", market.borrow_asset_borrowed);
-        assert_eq!(market.borrow_asset_balance, 9_500_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            8_000_000.into()
-        );
 
-        // Withdraw half of collateral: initial
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
+        pub fn withdraw_collateral_initial(&mut self, account_id: AccountId, amount: u128) {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, account_id)
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
             borrow_position
-                .record_collateral_asset_withdrawal_initial(interest_proof, 2_000_000.into());
+                .record_collateral_asset_withdrawal_initial(interest_proof, amount.into());
         }
-        assert_eq!(market.borrow_asset_balance, 9_500_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            8_000_000.into()
-        );
 
-        // Withdraw half of collateral: final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
+        pub fn withdraw_collateral_final(&mut self, account_id: AccountId, amount: u128) {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, account_id)
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
             borrow_position.record_collateral_asset_withdrawal_final(
                 interest_proof,
-                2_000_000.into(),
+                amount.into(),
                 true,
             );
         }
-        assert_eq!(market.borrow_asset_balance, 9_500_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            8_000_000.into()
-        );
 
-        // Liquidate the position
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
+        pub fn liquidate(
+            &mut self,
+            liquidator_id: AccountId,
+            position_id: AccountId,
+            send: u128,
+            request: u128,
+            price_pair: &PricePair,
+        ) {
+            let snapshot = self.tick();
+            let mut borrow_position = self
+                .market
+                .borrow_position_guard(snapshot, position_id)
                 .unwrap();
             let interest_proof = borrow_position.accumulate_interest();
             let liquidation = borrow_position
                 .record_liquidation(
                     interest_proof,
-                    "liquidator.near".parse().unwrap(),
-                    1_000_000.into(),
-                    None,
-                    &price_pair(1, 2), // should cause 100% of the position to be liquidated
+                    liquidator_id,
+                    send.into(),
+                    Some(request.into()),
+                    price_pair,
                     env::block_timestamp_ms(),
                 )
                 .unwrap();
-            assert_eq!(u128::from(liquidation.liquidated), 2_000_000);
+            assert_eq!(u128::from(liquidation.liquidated), request);
         }
-        assert_eq!(market.borrow_asset_balance, 10_500_000.into());
+
+        pub fn accumulate_yield(&mut self, account_id: AccountId) -> SupplyPosition {
+            let snapshot = self.tick();
+            let mut supply_position = self
+                .market
+                .supply_position_guard(snapshot, account_id)
+                .unwrap();
+            let _ = supply_position.accumulate_yield();
+            supply_position.inner().clone()
+        }
+
+        pub fn compound_yield(
+            &mut self,
+            account_id: AccountId,
+            amount: impl Into<BorrowAssetAmount>,
+        ) {
+            let snapshot = self.tick();
+            let mut supply_position = self
+                .market
+                .supply_position_guard(snapshot, account_id)
+                .unwrap();
+            let proof = supply_position.accumulate_yield();
+            supply_position.record_yield_compound(proof, amount.into());
+        }
+
+        pub fn withdraw_supply_initial(
+            &mut self,
+            account_id: AccountId,
+            amount: u128,
+        ) -> WithdrawalAttempt {
+            let snapshot = self.tick();
+            let mut supply_position = self
+                .market
+                .supply_position_guard(snapshot, account_id)
+                .unwrap();
+            let proof = supply_position.accumulate_yield();
+            supply_position.record_withdrawal_initial(
+                proof,
+                amount.into(),
+                env::block_timestamp_ms(),
+            )
+        }
+
+        pub fn withdraw_supply_final(&mut self, account_id: AccountId, initial: &Withdrawal) {
+            let snapshot = self.tick();
+            let mut supply_position = self
+                .market
+                .supply_position_guard(snapshot, account_id)
+                .unwrap();
+            supply_position.record_withdrawal_final(initial, true);
+        }
+    }
+
+    #[test]
+    fn balance_1() {
+        let supplier: AccountId = "supply.near".parse().unwrap();
+        let borrower: AccountId = "borrow.near".parse().unwrap();
+
+        let mut c = TestMarketController::new(configuration());
+
+        // Supply
+        c.supply(supplier.clone(), 10_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 10_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
+            0.into(),
+            "still incoming, not yet active",
+        );
+
+        c.collateralize(borrower.clone(), 4_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 10_000_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            9_000_000.into()
+        );
+
+        let initial = c.borrow_initial(borrower.clone(), 2_000_000);
+        eprintln!("Borrowed: {}", c.market.borrow_asset_borrowed);
+        assert_eq!(c.market.borrow_asset_balance, 8_000_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            7_000_000.into()
+        );
+
+        c.borrow_final(borrower.clone(), &initial);
+        assert_eq!(c.market.borrow_asset_borrowed, 2_000_000.into());
+        assert_eq!(c.market.borrow_asset_balance, 8_000_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            7_000_000.into()
+        );
+
+        // Repay half
+        c.repay(borrower.clone(), 1_500_000);
+        assert_eq!(c.market.borrow_asset_borrowed, 1_000_000.into());
+        assert_eq!(c.market.borrow_asset_balance, 9_500_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Withdraw half of collateral: initial
+        c.withdraw_collateral_initial(borrower.clone(), 2_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 9_500_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Withdraw half of collateral: final
+        c.withdraw_collateral_final(borrower.clone(), 2_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 9_500_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            8_000_000.into()
+        );
+
+        // Liquidate the position
+        let liquidator: AccountId = "liquidator.near".parse().unwrap();
+        c.liquidate(
+            liquidator.clone(),
+            borrower.clone(),
+            1_000_000,
+            2_000_000,
+            &price_pair(1, 2),
+        );
+        assert_eq!(c.market.borrow_asset_balance, 10_500_000.into());
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
             9_000_000.into()
         );
 
         // Supply yield compounding
         let expected_yield_amount: BorrowAssetAmount = (500_000 * 9 / 10).into();
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            let proof = supply_position.accumulate_yield();
-            let yield_amount = supply_position.total_yield();
-            assert_eq!(yield_amount, expected_yield_amount);
-            supply_position.record_yield_compound(proof, yield_amount);
-        }
+        let yield_amount = c
+            .accumulate_yield(supplier.clone())
+            .borrow_asset_yield
+            .get_total();
+        c.compound_yield(supplier.clone(), yield_amount);
+        assert_eq!(yield_amount, expected_yield_amount);
         assert_eq!(
-            market.borrow_asset_balance,
+            c.market.borrow_asset_balance,
             10_500_000.into(),
             "Yield compounding does not affect the market's recorded balance",
         );
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             BorrowAssetAmount::new(9_000_000), // should still be in incoming
         );
 
-        tick(&mut market); // move incoming to active
-        assert_eq!(market.borrow_asset_balance, 10_500_000.into());
-        assert_eq!(market.borrow_asset_deposited_active_real, 10_450_000.into());
-        assert_eq!(market.borrow_asset_deposited_active_virtual, 0.into());
+        c.tick(); // move incoming to active
+        assert_eq!(c.market.borrow_asset_balance, 10_500_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(10_450_000 * 9 / 10),
+            c.market.borrow_asset_deposited_active_real,
+            10_000_000.into()
+        );
+        assert_eq!(
+            c.market.borrow_asset_deposited_active_virtual,
+            450_000.into()
+        );
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(10_000_000 * 9 / 10),
         );
 
         // Withdraw supply: initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            let proof = supply_position.accumulate_yield();
-            supply_position.record_withdrawal_initial(
-                proof,
-                10_450_000.into(),
-                env::block_timestamp_ms(),
-            )
-        };
+        let initial = c.withdraw_supply_initial(supplier.clone(), 10_450_000);
         let initial = match initial {
             WithdrawalAttempt::Full(initial) => initial,
             a => {
                 panic!("Should be full withdrawal: {a:?}");
             }
         };
-        assert_eq!(market.borrow_asset_balance, 50_000.into());
-        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+        assert_eq!(c.market.borrow_asset_balance, 50_000.into());
+        assert_eq!(c.market.get_borrow_asset_available_to_borrow(), 0.into());
 
         // Withdraw supply: final
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            supply_position.record_withdrawal_final(&initial, true);
-        }
-        assert_eq!(market.borrow_asset_balance, 50_000.into());
-        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+        c.withdraw_supply_final(supplier.clone(), &initial);
+        assert_eq!(c.market.borrow_asset_balance, 50_000.into());
+        assert_eq!(c.market.get_borrow_asset_available_to_borrow(), 0.into());
     }
 
     #[rstest::rstest]
@@ -759,282 +851,167 @@ mod tests {
     #[case(65_000_000)]
     #[case(63_500_000)]
     fn balance_2(#[case] second_borrow_amount: u128) {
-        let second_borrow_amount = BorrowAssetAmount::new(second_borrow_amount);
-
-        let mut c = VMContextBuilder::new()
-            .block_timestamp(1_000_000_000_000)
-            .build();
-        testing_env!(c.clone());
-
         let mut configuration = configuration();
 
         configuration.borrow_origination_fee = Fee::Flat(15_000_000.into());
         configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();
         configuration.borrow_asset_maximum_usage_ratio = Decimal::ONE;
 
+        let mut c = TestMarketController::new(configuration);
+
         let supply_id: AccountId = "supply.near".parse().unwrap();
         let borrow_id: AccountId = "borrow.near".parse().unwrap();
         let borrow_2_id: AccountId = "borrow2.near".parse().unwrap();
 
-        let mut market = Market::new(b"m", configuration.clone());
-
-        let mut tick = |market: &mut Market| {
-            c.block_timestamp += 1_000_000;
-            testing_env!(c.clone());
-            market.snapshot()
-        };
-
         // Supply 100
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position =
-                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
-            let yield_proof = supply_position.accumulate_yield();
-            supply_position.record_deposit(
-                yield_proof,
-                100_000_000.into(),
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        c.supply(supply_id.clone(), 100_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 100_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             0.into() // still in incoming
         );
 
         // Collateralize 200
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position =
-                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
-        }
-        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        c.collateralize(borrow_id.clone(), 200_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 100_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             100_000_000.into()
         );
 
         // Borrow 100 initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position
-                .record_borrow_initial(
-                    snapshot,
-                    proof,
-                    100_000_000.into(),
-                    &price_pair(1, 1),
-                    env::block_timestamp_ms(),
-                )
-                .unwrap()
-        };
-        assert_eq!(market.borrow_asset_balance, 0.into());
-        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+        let initial = c.borrow_initial(borrow_id.clone(), 100_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 0.into());
+        assert_eq!(c.market.get_borrow_asset_available_to_borrow(), 0.into());
 
         // Borrow final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_borrow_final(
-                snapshot,
-                proof,
-                &initial,
-                true,
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(market.borrow_asset_balance, 0.into());
-        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+        c.borrow_final(borrow_id.clone(), &initial);
+        assert_eq!(c.market.borrow_asset_balance, 0.into());
+        assert_eq!(c.market.get_borrow_asset_available_to_borrow(), 0.into());
 
         // Borrow repay 100% + fees
-        let amount_repaid = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            let liability = borrow_position.inner().get_total_borrow_asset_liability();
-            assert_eq!(liability, 115_000_000.into());
-            let remaining = borrow_position.record_repay(proof, liability);
-            assert_eq!(remaining, 0.into());
-            liability
-        };
-        assert_eq!(market.borrow_asset_balance, amount_repaid);
+        let amount_repaid = c
+            .accumulate_interest(borrow_id.clone())
+            .get_total_borrow_asset_liability();
+        let amount_remaining = c.repay(borrow_id.clone(), amount_repaid);
+        assert_eq!(amount_remaining, 0.into());
+        assert_eq!(c.market.borrow_asset_balance, amount_repaid);
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             100_000_000.into()
         );
 
         // Supplier withdraws 50: initial
-        let (withdrawal, yield_amount) = {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            let yield_proof = supply_position.accumulate_yield();
-            let yield_amount = supply_position.total_yield();
-            supply_position.record_yield_compound(yield_proof, yield_amount);
-            let yield_proof = supply_position.accumulate_yield();
-            let withdrawal = supply_position.record_withdrawal_initial(
-                yield_proof,
-                50_000_000.into(),
-                env::block_timestamp_ms(),
-            );
-            (withdrawal, yield_amount)
-        };
+        let yield_amount = c
+            .accumulate_yield(supply_id.clone())
+            .borrow_asset_yield
+            .get_total();
+        c.compound_yield(supply_id.clone(), yield_amount);
+        assert_eq!(c.market.borrow_asset_deposited_incoming.len(), 1);
+        assert_eq!(
+            c.market.borrow_asset_deposited_incoming[0].amount_real,
+            0.into()
+        );
+        assert_eq!(
+            c.market.borrow_asset_deposited_incoming[0].amount_virtual,
+            yield_amount
+        );
+        assert_eq!(
+            c.market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(100_000_000)
+        );
+        let withdrawal = c.withdraw_supply_initial(supply_id.clone(), 50_000_000);
         let WithdrawalAttempt::Full(withdrawal) = withdrawal else {
             panic!("Expected full withdrawal");
         };
         assert_eq!(
-            market.borrow_asset_balance,
+            c.market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000),
         );
-        assert_eq!(market.borrow_asset_deposited_incoming.len(), 1);
         assert_eq!(
-            market.borrow_asset_deposited_incoming[0].amount_real,
-            0.into()
-        );
-        assert_eq!(
-            market.borrow_asset_deposited_incoming[0].amount_virtual,
-            yield_amount
-        );
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(50_000_000)
+            c.market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount
         );
 
         // Supply withdrawal final
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            let _ = supply_position.accumulate_yield();
-            supply_position.record_withdrawal_final(&withdrawal, true);
-        }
+        c.withdraw_supply_final(supply_id.clone(), &withdrawal);
+        // TODO: might need to accumulate yield
         assert_eq!(
-            market.borrow_asset_balance,
+            c.market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000),
         );
-        assert_eq!(market.borrow_asset_deposited_incoming.len(), 0);
+        assert_eq!(c.market.borrow_asset_deposited_incoming.len(), 0);
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             BorrowAssetAmount::new(50_000_000) + yield_amount
         );
 
         // Collateralize2 200
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position =
-                market.get_or_create_borrow_position_guard(snapshot, borrow_2_id.clone());
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
-        }
+        c.collateralize(borrow_2_id.clone(), 200_000_000);
         assert_eq!(
-            market.borrow_asset_balance,
+            c.market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000),
         );
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             BorrowAssetAmount::new(50_000_000) + yield_amount
         );
 
         eprintln!(
             "Available: {}",
-            market.get_borrow_asset_available_to_borrow()
+            c.market.get_borrow_asset_available_to_borrow()
         );
-        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
-        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
+        eprintln!("Borrow asset balance: {}", c.market.borrow_asset_balance);
+        eprintln!("Borrow asset borrowed: {}", c.market.borrow_asset_borrowed);
         eprintln!(
             "Borrow asset deposited active real: {}",
-            market.borrow_asset_deposited_active_real,
+            c.market.borrow_asset_deposited_active_real,
         );
         eprintln!(
             "Borrow asset deposited active virtual: {}",
-            market.borrow_asset_deposited_active_virtual,
+            c.market.borrow_asset_deposited_active_virtual,
         );
 
         // Borrow2 initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_2_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position
-                .record_borrow_initial(
-                    snapshot,
-                    proof,
-                    second_borrow_amount,
-                    &price_pair(1, 1),
-                    env::block_timestamp_ms(),
-                )
-                .unwrap()
-        };
+        let initial = c.borrow_initial(borrow_2_id.clone(), second_borrow_amount);
         assert_eq!(
-            market.borrow_asset_balance,
+            c.market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
         );
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             BorrowAssetAmount::new(50_000_000) + yield_amount - second_borrow_amount,
         );
 
         eprintln!("Borrow2 final");
         eprintln!("{initial:?}");
-        eprintln!("{}", market.borrow_asset_borrowed_in_flight);
+        eprintln!("{}", c.market.borrow_asset_borrowed_in_flight);
 
         // Borrow2 final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_2_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_borrow_final(
-                snapshot,
-                proof,
-                &initial,
-                true,
-                env::block_timestamp_ms(),
-            );
-        }
+        c.borrow_final(borrow_2_id.clone(), &initial);
         assert_eq!(
-            market.borrow_asset_balance,
+            c.market.borrow_asset_balance,
             amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
         );
 
         eprintln!(
             "Available: {}",
-            market.get_borrow_asset_available_to_borrow()
+            c.market.get_borrow_asset_available_to_borrow()
         );
-        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
-        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
+        eprintln!("Borrow asset balance: {}", c.market.borrow_asset_balance);
+        eprintln!("Borrow asset borrowed: {}", c.market.borrow_asset_borrowed);
         eprintln!(
             "Borrow asset deposited active real: {}",
-            market.borrow_asset_deposited_active_real,
+            c.market.borrow_asset_deposited_active_real,
         );
         eprintln!(
             "Borrow asset deposited active virtual: {}",
-            market.borrow_asset_deposited_active_virtual,
+            c.market.borrow_asset_deposited_active_virtual,
         );
     }
 
     #[test]
     fn balance_3() {
-        let mut c = VMContextBuilder::new()
-            .block_timestamp(1_000_000_000_000)
-            .build();
-        testing_env!(c.clone());
-
         let mut configuration = configuration();
         configuration.borrow_origination_fee = Fee::Flat(10_000_000.into());
         configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();
@@ -1044,117 +1021,63 @@ mod tests {
         let supply_id: AccountId = "supply.near".parse().unwrap();
         let borrow_id: AccountId = "borrow.near".parse().unwrap();
 
-        let mut market = Market::new(b"m", configuration.clone());
-
-        let mut tick = |market: &mut Market| {
-            c.block_timestamp += 1_000_000;
-            testing_env!(c.clone());
-            market.snapshot()
-        };
+        let mut c = TestMarketController::new(configuration);
 
         // Supply
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position =
-                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
-            let yield_proof = supply_position.accumulate_yield();
-            supply_position.record_deposit(
-                yield_proof,
-                100_000_000.into(),
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        c.supply(supply_id.clone(), 100_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 100_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             0.into(),
             "still incoming, not yet active",
         );
 
         // Collateralize
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position =
-                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
-            let interest_proof = borrow_position.accumulate_interest();
-            borrow_position.record_collateral_asset_deposit(interest_proof, 100_000_000.into());
-        }
-        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        c.collateralize(borrow_id.clone(), 100_000_000);
+        assert_eq!(c.market.borrow_asset_balance, 100_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             100_000_000.into()
         );
 
         // Borrow: initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let interest_proof = borrow_position.accumulate_interest();
-            borrow_position
-                .record_borrow_initial(
-                    snapshot,
-                    interest_proof,
-                    60_000_000.into(),
-                    &price_pair(1, 1),
-                    env::block_timestamp_ms(),
-                )
-                .unwrap()
-        };
-        eprintln!("Borrowed: {}", market.borrow_asset_borrowed);
-        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        let initial = c.borrow_initial(borrow_id.clone(), 60_000_000);
+        eprintln!("Borrowed: {}", c.market.borrow_asset_borrowed);
+        assert_eq!(c.market.borrow_asset_balance, 40_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             40_000_000.into()
         );
 
         // Borrow: final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let interest_proof = borrow_position.accumulate_interest();
-            borrow_position.record_borrow_final(
-                snapshot,
-                interest_proof,
-                &initial,
-                true,
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(market.borrow_asset_borrowed, 60_000_000.into());
-        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        c.borrow_final(borrow_id.clone(), &initial);
+        assert_eq!(c.market.borrow_asset_borrowed, 60_000_000.into());
+        assert_eq!(c.market.borrow_asset_balance, 40_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             40_000_000.into()
         );
 
         // Harvest in compound mode
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            let yield_proof = supply_position.accumulate_yield();
-            let yield_amount = supply_position.total_yield();
-            supply_position.record_yield_compound(yield_proof, yield_amount);
-        }
-        assert_eq!(market.borrow_asset_borrowed, 60_000_000.into());
-        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        let yield_amount = c
+            .accumulate_yield(supply_id.clone())
+            .borrow_asset_yield
+            .get_total();
+        c.compound_yield(supply_id.clone(), yield_amount);
+        assert_eq!(c.market.borrow_asset_borrowed, 60_000_000.into());
+        assert_eq!(c.market.borrow_asset_balance, 40_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             40_000_000.into()
         );
 
-        tick(&mut market);
-        tick(&mut market);
+        c.tick();
+        c.tick();
 
-        assert_eq!(market.borrow_asset_borrowed, 60_000_000.into());
-        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        assert_eq!(c.market.borrow_asset_borrowed, 60_000_000.into());
+        assert_eq!(c.market.borrow_asset_balance, 40_000_000.into());
         assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
+            c.market.get_borrow_asset_available_to_borrow(),
             40_000_000.into()
         );
     }

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -46,6 +46,8 @@ pub struct Market {
     pub borrow_asset_deposited_active_real: BorrowAssetAmount,
     /// How much of `borrow_asset_deposited_active` is actually virtual (compounded)?
     pub borrow_asset_deposited_active_virtual: BorrowAssetAmount,
+    /// Amount paid by borrowers for fees that has not yet been claimed/activated by supply positions during accumulation.
+    pub borrow_asset_virtual_credit: BorrowAssetAmount,
     /// Upcoming snapshot indices with amounts of borrow asset that will be activated.
     pub borrow_asset_deposited_incoming: Vec<IncomingDeposit>,
     pub borrow_asset_withdrawal_in_flight: BorrowAssetAmount,
@@ -98,6 +100,7 @@ impl Market {
             borrow_asset_balance: 0.into(),
             borrow_asset_deposited_active_real: 0.into(),
             borrow_asset_deposited_active_virtual: 0.into(),
+            borrow_asset_virtual_credit: 0.into(),
             borrow_asset_deposited_incoming: Vec::new(),
             borrow_asset_withdrawal_in_flight: 0.into(),
             borrow_asset_borrowed_in_flight: 0.into(),
@@ -245,15 +248,9 @@ impl Market {
         .unwrap()
         .into();
 
-        // What we really want to say here is:
-        // available = active - virtually_compounded - borrowed - must_retain
-
         self.borrow_asset_deposited_active_real
             .saturating_sub(self.borrowed())
             .saturating_sub(must_retain)
-        // self.borrow_asset_balance
-        //     .saturating_sub(self.total_incoming())
-        //     .saturating_sub(must_retain)
     }
 
     pub fn iter_supply_positions(&self) -> impl Iterator<Item = (AccountId, SupplyPosition)> + '_ {
@@ -516,273 +513,8 @@ mod tests {
         .unwrap()
     }
 
-    #[rstest::rstest]
-    #[should_panic = "InsufficientBorrowAssetAvailable"]
-    #[case(65_000_000)]
-    #[case(63_500_000)]
-    fn balance2(#[case] second_borrow_amount: u128) {
-        let second_borrow_amount = BorrowAssetAmount::new(second_borrow_amount);
-
-        let mut c = VMContextBuilder::new()
-            .block_timestamp(1_000_000_000_000)
-            .build();
-        testing_env!(c.clone());
-
-        let mut configuration = configuration();
-
-        configuration.borrow_origination_fee = Fee::Flat(15_000_000.into());
-        configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();
-        configuration.borrow_asset_maximum_usage_ratio = Decimal::ONE;
-
-        let supply_id: AccountId = "supply.near".parse().unwrap();
-        let borrow_id: AccountId = "borrow.near".parse().unwrap();
-        let borrow_2_id: AccountId = "borrow2.near".parse().unwrap();
-
-        let mut market = Market::new(b"m", configuration.clone());
-
-        let mut tick = |market: &mut Market| {
-            c.block_timestamp += 1_000_000;
-            testing_env!(c.clone());
-            market.snapshot()
-        };
-
-        // Supply 100
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position =
-                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
-            let yield_proof = supply_position.accumulate_yield();
-            supply_position.record_deposit(
-                yield_proof,
-                100_000_000.into(),
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            0.into() // still in incoming
-        );
-
-        // Collateralize 200
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position =
-                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
-        }
-        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            100_000_000.into()
-        );
-
-        // Borrow 100 initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position
-                .record_borrow_initial(
-                    snapshot,
-                    proof,
-                    100_000_000.into(),
-                    &price_pair(1, 1),
-                    env::block_timestamp_ms(),
-                )
-                .unwrap()
-        };
-        assert_eq!(market.borrow_asset_balance, 0.into());
-        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
-
-        // Borrow final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_borrow_final(
-                snapshot,
-                proof,
-                &initial,
-                true,
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(market.borrow_asset_balance, 0.into());
-        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
-
-        // Borrow repay 100% + fees
-        let amount_repaid = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            let liability = borrow_position.inner().get_total_borrow_asset_liability();
-            assert_eq!(liability, 115_000_000.into());
-            let remaining = borrow_position.record_repay(proof, liability);
-            assert_eq!(remaining, 0.into());
-            liability
-        };
-        assert_eq!(market.borrow_asset_balance, amount_repaid);
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            100_000_000.into()
-        );
-
-        // Supplier withdraws 50: initial
-        let (withdrawal, yield_amount) = {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            let yield_proof = supply_position.accumulate_yield();
-            let yield_amount = supply_position.total_yield();
-            supply_position.record_yield_compound(yield_proof, yield_amount);
-            let yield_proof = supply_position.accumulate_yield();
-            (
-                supply_position.record_withdrawal_initial(
-                    yield_proof,
-                    50_000_000.into(),
-                    env::block_timestamp_ms(),
-                ),
-                yield_amount,
-            )
-        };
-        let WithdrawalAttempt::Full(withdrawal) = withdrawal else {
-            panic!("Expected full withdrawal");
-        };
-        assert_eq!(
-            market.borrow_asset_balance,
-            amount_repaid - BorrowAssetAmount::new(50_000_000),
-        );
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(50_000_000) + yield_amount
-        );
-
-        // Supply withdrawal final
-        {
-            let snapshot = tick(&mut market);
-            let mut supply_position = market
-                .supply_position_guard(snapshot, supply_id.clone())
-                .unwrap();
-            supply_position.record_withdrawal_final(&withdrawal, true);
-        }
-        assert_eq!(
-            market.borrow_asset_balance,
-            amount_repaid - BorrowAssetAmount::new(50_000_000),
-        );
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(50_000_000) + yield_amount
-        );
-
-        // Collateralize2 200
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position =
-                market.get_or_create_borrow_position_guard(snapshot, borrow_2_id.clone());
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
-        }
-        assert_eq!(
-            market.borrow_asset_balance,
-            amount_repaid - BorrowAssetAmount::new(50_000_000),
-        );
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(50_000_000) + yield_amount
-        );
-
-        eprintln!(
-            "Available: {}",
-            market.get_borrow_asset_available_to_borrow()
-        );
-        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
-        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
-        eprintln!(
-            "Borrow asset deposited active real: {}",
-            market.borrow_asset_deposited_active_real,
-        );
-        eprintln!(
-            "Borrow asset deposited active virtual: {}",
-            market.borrow_asset_deposited_active_virtual,
-        );
-
-        // Borrow2 initial
-        let initial = {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_2_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position
-                .record_borrow_initial(
-                    snapshot,
-                    proof,
-                    second_borrow_amount,
-                    &price_pair(1, 1),
-                    env::block_timestamp_ms(),
-                )
-                .unwrap()
-        };
-        assert_eq!(
-            market.borrow_asset_balance,
-            amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
-        );
-        assert_eq!(
-            market.get_borrow_asset_available_to_borrow(),
-            BorrowAssetAmount::new(50_000_000) + yield_amount - second_borrow_amount,
-        );
-
-        eprintln!("Borrow2 final");
-        eprintln!("{initial:?}");
-        eprintln!("{}", market.borrow_asset_borrowed_in_flight);
-
-        // Borrow2 final
-        {
-            let snapshot = tick(&mut market);
-            let mut borrow_position = market
-                .borrow_position_guard(snapshot, borrow_2_id.clone())
-                .unwrap();
-            let proof = borrow_position.accumulate_interest();
-            borrow_position.record_borrow_final(
-                snapshot,
-                proof,
-                &initial,
-                true,
-                env::block_timestamp_ms(),
-            );
-        }
-        assert_eq!(
-            market.borrow_asset_balance,
-            amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
-        );
-
-        eprintln!(
-            "Available: {}",
-            market.get_borrow_asset_available_to_borrow()
-        );
-        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
-        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
-        eprintln!(
-            "Borrow asset deposited active real: {}",
-            market.borrow_asset_deposited_active_real,
-        );
-        eprintln!(
-            "Borrow asset deposited active virtual: {}",
-            market.borrow_asset_deposited_active_virtual,
-        );
-    }
-
     #[test]
-    fn balance() {
+    fn balance_1() {
         let mut c = VMContextBuilder::new()
             .block_timestamp(1_000_000_000_000)
             .build();
@@ -1020,6 +752,280 @@ mod tests {
         }
         assert_eq!(market.borrow_asset_balance, 50_000.into());
         assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+    }
+
+    #[rstest::rstest]
+    #[should_panic = "InsufficientBorrowAssetAvailable"]
+    #[case(65_000_000)]
+    #[case(63_500_000)]
+    fn balance_2(#[case] second_borrow_amount: u128) {
+        let second_borrow_amount = BorrowAssetAmount::new(second_borrow_amount);
+
+        let mut c = VMContextBuilder::new()
+            .block_timestamp(1_000_000_000_000)
+            .build();
+        testing_env!(c.clone());
+
+        let mut configuration = configuration();
+
+        configuration.borrow_origination_fee = Fee::Flat(15_000_000.into());
+        configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();
+        configuration.borrow_asset_maximum_usage_ratio = Decimal::ONE;
+
+        let supply_id: AccountId = "supply.near".parse().unwrap();
+        let borrow_id: AccountId = "borrow.near".parse().unwrap();
+        let borrow_2_id: AccountId = "borrow2.near".parse().unwrap();
+
+        let mut market = Market::new(b"m", configuration.clone());
+
+        let mut tick = |market: &mut Market| {
+            c.block_timestamp += 1_000_000;
+            testing_env!(c.clone());
+            market.snapshot()
+        };
+
+        // Supply 100
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position =
+                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
+            let yield_proof = supply_position.accumulate_yield();
+            supply_position.record_deposit(
+                yield_proof,
+                100_000_000.into(),
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            0.into() // still in incoming
+        );
+
+        // Collateralize 200
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position =
+                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
+        }
+        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            100_000_000.into()
+        );
+
+        // Borrow 100 initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_borrow_initial(
+                    snapshot,
+                    proof,
+                    100_000_000.into(),
+                    &price_pair(1, 1),
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+
+        // Borrow final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_borrow_final(
+                snapshot,
+                proof,
+                &initial,
+                true,
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 0.into());
+        assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+
+        // Borrow repay 100% + fees
+        let amount_repaid = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            let liability = borrow_position.inner().get_total_borrow_asset_liability();
+            assert_eq!(liability, 115_000_000.into());
+            let remaining = borrow_position.record_repay(proof, liability);
+            assert_eq!(remaining, 0.into());
+            liability
+        };
+        assert_eq!(market.borrow_asset_balance, amount_repaid);
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            100_000_000.into()
+        );
+
+        // Supplier withdraws 50: initial
+        let (withdrawal, yield_amount) = {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            let yield_proof = supply_position.accumulate_yield();
+            let yield_amount = supply_position.total_yield();
+            supply_position.record_yield_compound(yield_proof, yield_amount);
+            let yield_proof = supply_position.accumulate_yield();
+            let withdrawal = supply_position.record_withdrawal_initial(
+                yield_proof,
+                50_000_000.into(),
+                env::block_timestamp_ms(),
+            );
+            (withdrawal, yield_amount)
+        };
+        let WithdrawalAttempt::Full(withdrawal) = withdrawal else {
+            panic!("Expected full withdrawal");
+        };
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+        assert_eq!(market.borrow_asset_deposited_incoming.len(), 1);
+        assert_eq!(
+            market.borrow_asset_deposited_incoming[0].amount_real,
+            0.into()
+        );
+        assert_eq!(
+            market.borrow_asset_deposited_incoming[0].amount_virtual,
+            yield_amount
+        );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000)
+        );
+
+        // Supply withdrawal final
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            let _ = supply_position.accumulate_yield();
+            supply_position.record_withdrawal_final(&withdrawal, true);
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+        assert_eq!(market.borrow_asset_deposited_incoming.len(), 0);
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount
+        );
+
+        // Collateralize2 200
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position =
+                market.get_or_create_borrow_position_guard(snapshot, borrow_2_id.clone());
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(proof, 200_000_000.into());
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000),
+        );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount
+        );
+
+        eprintln!(
+            "Available: {}",
+            market.get_borrow_asset_available_to_borrow()
+        );
+        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
+        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
+        eprintln!(
+            "Borrow asset deposited active real: {}",
+            market.borrow_asset_deposited_active_real,
+        );
+        eprintln!(
+            "Borrow asset deposited active virtual: {}",
+            market.borrow_asset_deposited_active_virtual,
+        );
+
+        // Borrow2 initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_2_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_borrow_initial(
+                    snapshot,
+                    proof,
+                    second_borrow_amount,
+                    &price_pair(1, 1),
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
+        );
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            BorrowAssetAmount::new(50_000_000) + yield_amount - second_borrow_amount,
+        );
+
+        eprintln!("Borrow2 final");
+        eprintln!("{initial:?}");
+        eprintln!("{}", market.borrow_asset_borrowed_in_flight);
+
+        // Borrow2 final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_2_id.clone())
+                .unwrap();
+            let proof = borrow_position.accumulate_interest();
+            borrow_position.record_borrow_final(
+                snapshot,
+                proof,
+                &initial,
+                true,
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(
+            market.borrow_asset_balance,
+            amount_repaid - BorrowAssetAmount::new(50_000_000) - second_borrow_amount,
+        );
+
+        eprintln!(
+            "Available: {}",
+            market.get_borrow_asset_available_to_borrow()
+        );
+        eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
+        eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
+        eprintln!(
+            "Borrow asset deposited active real: {}",
+            market.borrow_asset_deposited_active_real,
+        );
+        eprintln!(
+            "Borrow asset deposited active virtual: {}",
+            market.borrow_asset_deposited_active_virtual,
+        );
     }
 
     #[test]

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -43,7 +43,9 @@ pub struct Market {
     /// actually being transferred in).
     pub borrow_asset_balance: BorrowAssetAmount,
     /// Total amount of borrow asset earning interest in the market.
-    pub borrow_asset_deposited_active: BorrowAssetAmount,
+    pub borrow_asset_deposited_active_real: BorrowAssetAmount,
+    /// How much of `borrow_asset_deposited_active` is actually virtual (compounded)?
+    pub borrow_asset_deposited_active_virtual: BorrowAssetAmount,
     /// Upcoming snapshot indices with amounts of borrow asset that will be activated.
     pub borrow_asset_deposited_incoming: Vec<IncomingDeposit>,
     pub borrow_asset_withdrawal_in_flight: BorrowAssetAmount,
@@ -94,7 +96,8 @@ impl Market {
             prefix: prefix.clone(),
             configuration,
             borrow_asset_balance: 0.into(),
-            borrow_asset_deposited_active: 0.into(),
+            borrow_asset_deposited_active_real: 0.into(),
+            borrow_asset_deposited_active_virtual: 0.into(),
             borrow_asset_deposited_incoming: Vec::new(),
             borrow_asset_withdrawal_in_flight: 0.into(),
             borrow_asset_borrowed_in_flight: 0.into(),
@@ -115,25 +118,32 @@ impl Market {
         self_
     }
 
+    pub fn active_supply(&self) -> BorrowAssetAmount {
+        self.borrow_asset_deposited_active_real + self.borrow_asset_deposited_active_virtual
+    }
+
     pub fn borrowed(&self) -> BorrowAssetAmount {
         self.borrow_asset_borrowed + self.borrow_asset_borrowed_in_flight
     }
 
-    pub fn total_incoming(&self) -> BorrowAssetAmount {
+    pub fn total_incoming_real(&self) -> BorrowAssetAmount {
         self.borrow_asset_deposited_incoming
             .iter()
             .fold(BorrowAssetAmount::zero(), |total_incoming, incoming| {
-                total_incoming + incoming.amount
+                total_incoming + incoming.amount_real
             })
     }
 
-    pub fn incoming_at(&self, snapshot_index: u32) -> BorrowAssetAmount {
+    pub fn incoming_at(&self, snapshot_index: u32) -> Option<&IncomingDeposit> {
         self.borrow_asset_deposited_incoming
             .iter()
-            .find_map(|incoming| {
-                (incoming.activate_at_snapshot_index == snapshot_index).then_some(incoming.amount)
-            })
-            .unwrap_or(0.into())
+            .find(|incoming| incoming.activate_at_snapshot_index == snapshot_index)
+    }
+
+    pub fn incoming_at_mut(&mut self, snapshot_index: u32) -> Option<&mut IncomingDeposit> {
+        self.borrow_asset_deposited_incoming
+            .iter_mut()
+            .find(|incoming| incoming.activate_at_snapshot_index == snapshot_index)
     }
 
     pub fn get_last_finalized_snapshot(&self) -> &Snapshot {
@@ -147,19 +157,23 @@ impl Market {
         let current_snapshot_index = self.finalized_snapshots.len();
         let incoming = self.incoming_at(current_snapshot_index);
 
-        let active = self.borrow_asset_deposited_active + incoming;
+        let active_real =
+            self.borrow_asset_deposited_active_real + incoming.map_or(0.into(), |i| i.amount_real);
+        let active_virtual = self.borrow_asset_deposited_active_virtual
+            + incoming.map_or(0.into(), |i| i.amount_virtual);
 
         let borrowed = self.borrowed();
 
         let interest_rate = self
             .configuration
             .borrow_interest_rate_strategy
-            .at(usage_ratio(active, borrowed));
+            .at(usage_ratio(active_real + active_virtual, borrowed));
 
         Snapshot {
             time_chunk: self.current_time_chunk,
             end_timestamp_ms: env::block_timestamp_ms().into(),
-            borrow_asset_deposited_active: active,
+            borrow_asset_deposited_active_real: active_real,
+            borrow_asset_deposited_active_virtual: active_virtual,
             borrow_asset_borrowed: borrowed,
             collateral_asset_deposited: self.collateral_asset_deposited,
             yield_distribution: self.current_yield_distribution,
@@ -193,7 +207,8 @@ impl Market {
         for i in 0..self.borrow_asset_deposited_incoming.len() {
             let incoming = &self.borrow_asset_deposited_incoming[i];
             if incoming.activate_at_snapshot_index == current_snapshot_index {
-                self.borrow_asset_deposited_active += incoming.amount;
+                self.borrow_asset_deposited_active_real += incoming.amount_real;
+                self.borrow_asset_deposited_active_virtual += incoming.amount_virtual;
                 self.borrow_asset_deposited_incoming.remove(i);
                 break;
             }
@@ -215,10 +230,7 @@ impl Market {
     pub fn interest_rate(&self) -> Decimal {
         self.configuration
             .borrow_interest_rate_strategy
-            .at(usage_ratio(
-                self.borrow_asset_deposited_active,
-                self.borrowed(),
-            ))
+            .at(usage_ratio(self.active_supply(), self.borrowed()))
     }
 
     pub fn get_borrow_asset_available_to_borrow(&self) -> BorrowAssetAmount {
@@ -228,15 +240,20 @@ impl Market {
         )]
         let must_retain: BorrowAssetAmount = ((1u32
             - self.configuration.borrow_asset_maximum_usage_ratio)
-            * Decimal::from(self.borrow_asset_deposited_active))
+            * Decimal::from(self.borrow_asset_deposited_active_real))
         .to_u128_ceil()
         .unwrap()
         .into();
 
-        self.borrow_asset_deposited_active
-            .saturating_sub(self.borrow_asset_borrowed)
-            .saturating_sub(self.borrow_asset_borrowed_in_flight)
+        // What we really want to say here is:
+        // available = active - virtually_compounded - borrowed - must_retain
+
+        self.borrow_asset_deposited_active_real
+            .saturating_sub(self.borrowed())
             .saturating_sub(must_retain)
+        // self.borrow_asset_balance
+        //     .saturating_sub(self.total_incoming())
+        //     .saturating_sub(must_retain)
     }
 
     pub fn iter_supply_positions(&self) -> impl Iterator<Item = (AccountId, SupplyPosition)> + '_ {
@@ -690,8 +707,12 @@ mod tests {
         eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
         eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
         eprintln!(
-            "Borrow asset deposited active: {}",
-            market.borrow_asset_deposited_active
+            "Borrow asset deposited active real: {}",
+            market.borrow_asset_deposited_active_real,
+        );
+        eprintln!(
+            "Borrow asset deposited active virtual: {}",
+            market.borrow_asset_deposited_active_virtual,
         );
 
         // Borrow2 initial
@@ -751,8 +772,12 @@ mod tests {
         eprintln!("Borrow asset balance: {}", market.borrow_asset_balance);
         eprintln!("Borrow asset borrowed: {}", market.borrow_asset_borrowed);
         eprintln!(
-            "Borrow asset deposited active: {}",
-            market.borrow_asset_deposited_active
+            "Borrow asset deposited active real: {}",
+            market.borrow_asset_deposited_active_real,
+        );
+        eprintln!(
+            "Borrow asset deposited active virtual: {}",
+            market.borrow_asset_deposited_active_virtual,
         );
     }
 
@@ -956,7 +981,8 @@ mod tests {
 
         tick(&mut market); // move incoming to active
         assert_eq!(market.borrow_asset_balance, 10_500_000.into());
-        assert_eq!(market.borrow_asset_deposited_active, 10_450_000.into());
+        assert_eq!(market.borrow_asset_deposited_active_real, 10_450_000.into());
+        assert_eq!(market.borrow_asset_deposited_active_virtual, 0.into());
         assert_eq!(
             market.get_borrow_asset_available_to_borrow(),
             BorrowAssetAmount::new(10_450_000 * 9 / 10),
@@ -994,5 +1020,136 @@ mod tests {
         }
         assert_eq!(market.borrow_asset_balance, 50_000.into());
         assert_eq!(market.get_borrow_asset_available_to_borrow(), 0.into());
+    }
+
+    #[test]
+    fn balance_3() {
+        let mut c = VMContextBuilder::new()
+            .block_timestamp(1_000_000_000_000)
+            .build();
+        testing_env!(c.clone());
+
+        let mut configuration = configuration();
+        configuration.borrow_origination_fee = Fee::Flat(10_000_000.into());
+        configuration.borrow_interest_rate_strategy = InterestRateStrategy::zero();
+        configuration.yield_weights = YieldWeights::new_with_supply_weight(1);
+        configuration.borrow_asset_maximum_usage_ratio = Decimal::ONE;
+
+        let supply_id: AccountId = "supply.near".parse().unwrap();
+        let borrow_id: AccountId = "borrow.near".parse().unwrap();
+
+        let mut market = Market::new(b"m", configuration.clone());
+
+        let mut tick = |market: &mut Market| {
+            c.block_timestamp += 1_000_000;
+            testing_env!(c.clone());
+            market.snapshot()
+        };
+
+        // Supply
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position =
+                market.get_or_create_supply_position_guard(snapshot, supply_id.clone());
+            let yield_proof = supply_position.accumulate_yield();
+            supply_position.record_deposit(
+                yield_proof,
+                100_000_000.into(),
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            0.into(),
+            "still incoming, not yet active",
+        );
+
+        // Collateralize
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position =
+                market.get_or_create_borrow_position_guard(snapshot, borrow_id.clone());
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_collateral_asset_deposit(interest_proof, 100_000_000.into());
+        }
+        assert_eq!(market.borrow_asset_balance, 100_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            100_000_000.into()
+        );
+
+        // Borrow: initial
+        let initial = {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position
+                .record_borrow_initial(
+                    snapshot,
+                    interest_proof,
+                    60_000_000.into(),
+                    &price_pair(1, 1),
+                    env::block_timestamp_ms(),
+                )
+                .unwrap()
+        };
+        eprintln!("Borrowed: {}", market.borrow_asset_borrowed);
+        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            40_000_000.into()
+        );
+
+        // Borrow: final
+        {
+            let snapshot = tick(&mut market);
+            let mut borrow_position = market
+                .borrow_position_guard(snapshot, borrow_id.clone())
+                .unwrap();
+            let interest_proof = borrow_position.accumulate_interest();
+            borrow_position.record_borrow_final(
+                snapshot,
+                interest_proof,
+                &initial,
+                true,
+                env::block_timestamp_ms(),
+            );
+        }
+        assert_eq!(market.borrow_asset_borrowed, 60_000_000.into());
+        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            40_000_000.into()
+        );
+
+        // Harvest in compound mode
+        {
+            let snapshot = tick(&mut market);
+            let mut supply_position = market
+                .supply_position_guard(snapshot, supply_id.clone())
+                .unwrap();
+            let yield_proof = supply_position.accumulate_yield();
+            let yield_amount = supply_position.total_yield();
+            supply_position.record_yield_compound(yield_proof, yield_amount);
+        }
+        assert_eq!(market.borrow_asset_borrowed, 60_000_000.into());
+        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            40_000_000.into()
+        );
+
+        tick(&mut market);
+        tick(&mut market);
+
+        assert_eq!(market.borrow_asset_borrowed, 60_000_000.into());
+        assert_eq!(market.borrow_asset_balance, 40_000_000.into());
+        assert_eq!(
+            market.get_borrow_asset_available_to_borrow(),
+            40_000_000.into()
+        );
     }
 }

--- a/common/src/market/impl.rs
+++ b/common/src/market/impl.rs
@@ -42,11 +42,14 @@ pub struct Market {
     /// amount might be compounded yield (deposited into the protocol without
     /// actually being transferred in).
     pub borrow_asset_balance: BorrowAssetAmount,
-    /// Total amount of borrow asset earning interest in the market.
+    /// Amount of borrow asset earning interest in the market that has real
+    /// deposits backing it.
     pub borrow_asset_deposited_active_real: BorrowAssetAmount,
-    /// How much of `borrow_asset_deposited_active` is actually virtual (compounded)?
+    /// Amount of borrow asset earning interest in the market that does not
+    /// have real deposits backing it (i.e. compounded yield).
     pub borrow_asset_deposited_active_virtual: BorrowAssetAmount,
-    /// Amount paid by borrowers for fees that has not yet been claimed/activated by supply positions during accumulation.
+    /// Amount paid by borrowers for fees that has not yet been "real"-ized
+    /// (converting virtual to real) by supply positions during accumulation.
     pub borrow_asset_virtual_credit: BorrowAssetAmount,
     /// Upcoming snapshot indices with amounts of borrow asset that will be activated.
     pub borrow_asset_deposited_incoming: Vec<IncomingDeposit>,

--- a/common/src/market/mod.rs
+++ b/common/src/market/mod.rs
@@ -5,6 +5,7 @@ use near_sdk::{near, AccountId};
 
 use crate::{
     asset::{BorrowAssetAmount, CollateralAssetAmount},
+    incoming_deposit::IncomingDeposit,
     number::Decimal,
 };
 mod configuration;
@@ -25,8 +26,9 @@ pub mod error {
 #[near(serializers = [borsh, json])]
 pub struct BorrowAssetMetrics {
     pub available: BorrowAssetAmount,
-    pub deposited_active: BorrowAssetAmount,
-    pub deposited_incoming: HashMap<u32, BorrowAssetAmount>,
+    pub deposited_active_real: BorrowAssetAmount,
+    pub deposited_active_virtual: BorrowAssetAmount,
+    pub deposited_incoming: Vec<IncomingDeposit>,
     pub borrowed: BorrowAssetAmount,
 }
 

--- a/common/src/snapshot.rs
+++ b/common/src/snapshot.rs
@@ -11,7 +11,8 @@ use crate::{
 pub struct Snapshot {
     pub time_chunk: TimeChunk,
     pub end_timestamp_ms: U64,
-    pub borrow_asset_deposited_active: BorrowAssetAmount,
+    pub borrow_asset_deposited_active_real: BorrowAssetAmount,
+    pub borrow_asset_deposited_active_virtual: BorrowAssetAmount,
     pub borrow_asset_borrowed: BorrowAssetAmount,
     pub collateral_asset_deposited: CollateralAssetAmount,
     pub yield_distribution: BorrowAssetAmount,
@@ -23,11 +24,16 @@ impl Snapshot {
         Self {
             time_chunk,
             end_timestamp_ms: env::block_timestamp_ms().into(),
-            borrow_asset_deposited_active: 0.into(),
+            borrow_asset_deposited_active_real: 0.into(),
+            borrow_asset_deposited_active_virtual: 0.into(),
             borrow_asset_borrowed: 0.into(),
             collateral_asset_deposited: 0.into(),
             yield_distribution: BorrowAssetAmount::zero(),
             interest_rate: Decimal::ZERO,
         }
+    }
+
+    pub fn active_supply(&self) -> BorrowAssetAmount {
+        self.borrow_asset_deposited_active_real + self.borrow_asset_deposited_active_virtual
     }
 }

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -20,14 +20,19 @@ pub struct YieldAccumulationProof(());
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 #[near(serializers = [json, borsh])]
 pub struct Deposit {
-    pub active: BorrowAssetAmount,
+    pub active_real: BorrowAssetAmount,
+    pub active_virtual: BorrowAssetAmount,
     pub incoming: Vec<IncomingDeposit>,
     pub outgoing: BorrowAssetAmount,
 }
 
 impl Deposit {
+    pub fn active(&self) -> BorrowAssetAmount {
+        self.active_real + self.active_virtual
+    }
+
     pub fn total(&self) -> BorrowAssetAmount {
-        let mut total = self.active + self.outgoing;
+        let mut total = self.active_real + self.active_virtual + self.outgoing;
         for incoming in &self.incoming {
             total += incoming.amount_real + incoming.amount_virtual;
         }
@@ -127,7 +132,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
     pub fn calculate_yield(&self, snapshot_limit: u32) -> AccumulationRecord<BorrowAsset> {
         let mut next_snapshot_index = self.position.borrow_asset_yield.get_next_snapshot_index();
 
-        let mut amount = u128::from(self.position.borrow_asset_deposit.active);
+        let mut amount = u128::from(self.position.borrow_asset_deposit.active());
         let mut accumulated = Decimal::ZERO;
         let mut next_incoming = 0;
 
@@ -236,18 +241,27 @@ impl<'a> SupplyPositionGuard<'a> {
         while let Some(deposit) =
             incoming.next_if(|d| d.activate_at_snapshot_index <= through_snapshot_index)
         {
-            self.position.borrow_asset_deposit.active +=
-                deposit.amount_real + deposit.amount_virtual;
+            self.position.borrow_asset_deposit.active_real += deposit.amount_real;
+            self.position.borrow_asset_deposit.active_virtual += deposit.amount_virtual;
         }
         self.position.borrow_asset_deposit.incoming = incoming.collect();
 
         // Calling market.snapshot() performs the market accounting
     }
 
-    // fn remove_active(&mut self, amount: BorrowAssetAmount) {
-    //     self.position.borrow_asset_deposit.active -= amount;
-    //     self.market.borrow_asset_deposited_active -= amount;
-    // }
+    fn remove_active(&mut self, amount: BorrowAssetAmount) {
+        let amount_virtual = if amount >= self.position.borrow_asset_deposit.active_virtual {
+            self.position.borrow_asset_deposit.active_virtual
+        } else {
+            amount
+        };
+        let amount_real = amount - amount_virtual;
+
+        self.position.borrow_asset_deposit.active_virtual -= amount_virtual;
+        self.market.borrow_asset_deposited_active_virtual -= amount_virtual;
+        self.position.borrow_asset_deposit.active_real -= amount_real;
+        self.market.borrow_asset_deposited_active_real -= amount_real;
+    }
 
     fn add_incoming(
         &mut self,
@@ -297,20 +311,26 @@ impl<'a> SupplyPositionGuard<'a> {
     /// Returns the amount successfully removed from incoming.
     fn remove_incoming_real(&mut self, amount: BorrowAssetAmount) -> BorrowAssetAmount {
         let mut total = BorrowAssetAmount::zero();
+        let mut removals = vec![];
         for newest in self.position.borrow_asset_deposit.incoming.iter_mut().rev() {
-            let Some(market_incoming) = self
-                .market
-                .incoming_at_mut(newest.activate_at_snapshot_index)
-            else {
-                crate::panic_with_message("Invariant violation: Market incoming entry should exist if position incoming entry exists");
-            };
             if total + newest.amount_real >= amount {
+                let delta = amount - total;
                 total = amount;
-                newest.amount_real = total + newest.amount_real - amount;
+                newest.amount_real -= delta;
+                removals.push((newest.activate_at_snapshot_index, delta));
                 break;
             }
             total += newest.amount_real;
+            removals.push((newest.activate_at_snapshot_index, newest.amount_real));
             newest.amount_real = 0.into();
+        }
+
+        for (snapshot_index, amount_removed) in removals {
+            let Some(market_incoming) = self.market.incoming_at_mut(snapshot_index) else {
+                crate::panic_with_message("Invariant violation: Market incoming entry should exist if position incoming entry exists");
+            };
+
+            market_incoming.amount_real -= amount_removed;
         }
 
         self.position
@@ -318,29 +338,9 @@ impl<'a> SupplyPositionGuard<'a> {
             .incoming
             .retain(|i| !i.amount_real.is_zero() || !i.amount_virtual.is_zero());
 
-        while let Some(newest) = self.position.borrow_asset_deposit.incoming.pop() {
-            total += newest.amount_real;
-
-            let Some(market_incoming) = self
-                .market
-                .borrow_asset_deposited_incoming
-                .iter_mut()
-                .find(|incoming| {
-                    incoming.activate_at_snapshot_index == newest.activate_at_snapshot_index
-                })
-            else {
-                crate::panic_with_message("Invariant violation: Market incoming entry should exist if position incoming entry exists");
-            };
-            market_incoming.amount_real = market_incoming.amount_real.unwrap_sub(newest.amount_real, "Invariant violation: Market incoming >= position incoming should hold for all snapshot indices");
-
-            #[allow(clippy::comparison_chain)]
-            if total == amount {
-                return amount;
-            } else if total > amount {
-                self.add_incoming(total - amount, newest.activate_at_snapshot_index);
-                return amount;
-            }
-        }
+        self.market
+            .borrow_asset_deposited_incoming
+            .retain(|i| !i.amount_real.is_zero() || !i.amount_virtual.is_zero());
 
         total
     }
@@ -366,6 +366,22 @@ impl<'a> SupplyPositionGuard<'a> {
 
     pub fn accumulate_yield(&mut self) -> YieldAccumulationProof {
         self.accumulate_yield_partial(u32::MAX);
+
+        // Claim virtual to real
+        let claimable = Ord::min(
+            self.position.borrow_asset_deposit.active_virtual,
+            self.market.borrow_asset_virtual_credit,
+        );
+        if !claimable.is_zero() {
+            self.market.borrow_asset_virtual_credit -= claimable;
+
+            self.position.borrow_asset_deposit.active_virtual -= claimable;
+            self.market.borrow_asset_deposited_active_virtual -= claimable;
+
+            self.position.borrow_asset_deposit.active_real += claimable;
+            self.market.borrow_asset_deposited_active_real += claimable;
+        }
+
         YieldAccumulationProof(())
     }
 
@@ -380,7 +396,7 @@ impl<'a> SupplyPositionGuard<'a> {
         //
 
         let my_incoming = self.position.total_incoming_real();
-        let my_active = self.position.get_deposit().active;
+        let my_active = self.position.get_deposit().active();
         let entitled_to_withdraw = my_incoming + my_active;
 
         if entitled_to_withdraw.is_zero() {
@@ -388,8 +404,7 @@ impl<'a> SupplyPositionGuard<'a> {
         }
 
         let requested_amount = requested_amount.min(entitled_to_withdraw);
-        let market_incoming = self.market.total_incoming_real();
-        let available_to_me = self.market.active_supply() - market_incoming + my_incoming;
+        let available_to_me = self.market.active_supply() + my_incoming;
         let can_withdraw_now = entitled_to_withdraw.min(available_to_me);
 
         if can_withdraw_now.is_zero() {
@@ -407,8 +422,8 @@ impl<'a> SupplyPositionGuard<'a> {
         self.position.borrow_asset_deposit.outgoing += withdrawal_amount;
 
         amount_to_remove = amount_to_remove.unwrap_sub(
-            self.remove_incoming(withdrawal_amount),
-            "Invariant violation: remove_incoming(amount) > amount",
+            self.remove_incoming_real(withdrawal_amount),
+            "Invariant violation: remove_incoming_real(amount) > amount",
         );
 
         if !amount_to_remove.is_zero() {
@@ -473,7 +488,8 @@ impl<'a> SupplyPositionGuard<'a> {
             .emit();
         } else {
             self.market.borrow_asset_balance += withdrawal.amount_to_account;
-            self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
+            // TODO: Is this correct? Do we need to separate real & virtual for failed withdrawals too?
+            self.add_incoming(amount, 0.into(), self.market.finalized_snapshots.len() + 1);
         }
     }
 
@@ -484,13 +500,13 @@ impl<'a> SupplyPositionGuard<'a> {
         block_timestamp_ms: u64,
     ) {
         if self.position.started_at_block_timestamp_ms.is_none()
-            || self.position.borrow_asset_deposit.active.is_zero()
+            || self.position.borrow_asset_deposit.total().is_zero()
         {
             self.position.started_at_block_timestamp_ms = Some(block_timestamp_ms.into());
         }
 
         self.market.borrow_asset_balance += amount;
-        self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
+        self.add_incoming(amount, 0.into(), self.market.finalized_snapshots.len() + 1);
 
         if !amount.is_zero() {
             MarketEvent::SupplyDeposited {
@@ -516,7 +532,7 @@ impl<'a> SupplyPositionGuard<'a> {
         amount: BorrowAssetAmount,
     ) {
         self.0.position.borrow_asset_yield.remove(amount);
-        self.add_incoming(amount, self.market.finalized_snapshots.len() + 1);
+        self.add_incoming(0.into(), amount, self.market.finalized_snapshots.len() + 1);
     }
 }
 

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -249,11 +249,6 @@ impl<'a> SupplyPositionGuard<'a> {
         // Calling market.snapshot() performs the market accounting
     }
 
-    fn remove_active_real(&mut self, amount: BorrowAssetAmount) {
-        self.position.borrow_asset_deposit.active_real -= amount;
-        self.market.borrow_asset_deposited_active_real -= amount;
-    }
-
     fn add_incoming(
         &mut self,
         amount_real: BorrowAssetAmount,
@@ -358,12 +353,24 @@ impl<'a> SupplyPositionGuard<'a> {
     pub fn accumulate_yield(&mut self) -> YieldAccumulationProof {
         self.accumulate_yield_partial(u32::MAX);
 
+        let market_credit = self.market.borrow_asset_virtual_credit;
+        let my_virtual = self.position.borrow_asset_deposit.active_virtual;
+        let market_virtual = self.market.borrow_asset_deposited_active_virtual;
+
         // Claim virtual to real
-        let claimable = Ord::min(
-            self.position.borrow_asset_deposit.active_virtual,
-            self.market.borrow_asset_virtual_credit,
-        );
-        if !claimable.is_zero() {
+        if !market_credit.is_zero() && !my_virtual.is_zero() && !market_virtual.is_zero() {
+            near_sdk::log!("credit: {market_credit}, my_virtual: {my_virtual}, market_virtual: {market_virtual}");
+
+            // let claimable = if market_credit >= market_virtual {
+            //     my_virtual
+            // } else if
+
+            let claimable = (Decimal::from(market_credit) * u128::from(my_virtual) / u128::from(market_virtual) )
+            .to_u128_floor()
+            .map_or_else(|| {
+                crate::panic_with_message("Invariant violation: guaranteed position.active_virtual <= market.active_virtual");
+            }, BorrowAssetAmount::new).min(my_virtual);
+
             self.market.borrow_asset_virtual_credit -= claimable;
 
             self.position.borrow_asset_deposit.active_virtual -= claimable;
@@ -398,7 +405,8 @@ impl<'a> SupplyPositionGuard<'a> {
         }
 
         let requested_amount = requested_amount.min(entitled_to_withdraw);
-        let available_to_me = self.market.borrow_asset_deposited_active_real + my_incoming;
+        let available_to_me =
+            self.market.borrow_asset_deposited_active_real - self.market.borrowed() + my_incoming;
         let can_withdraw_now = entitled_to_withdraw.min(available_to_me);
 
         if can_withdraw_now.is_zero() {
@@ -421,7 +429,8 @@ impl<'a> SupplyPositionGuard<'a> {
         );
 
         if !amount_to_remove.is_zero() {
-            self.remove_active_real(amount_to_remove);
+            self.position.borrow_asset_deposit.active_real -= amount_to_remove;
+            self.market.borrow_asset_deposited_active_real -= amount_to_remove;
         }
 
         // The only way to withdraw from a position is if it already has a deposit.

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -249,18 +249,9 @@ impl<'a> SupplyPositionGuard<'a> {
         // Calling market.snapshot() performs the market accounting
     }
 
-    fn remove_active(&mut self, amount: BorrowAssetAmount) {
-        let amount_virtual = if amount >= self.position.borrow_asset_deposit.active_virtual {
-            self.position.borrow_asset_deposit.active_virtual
-        } else {
-            amount
-        };
-        let amount_real = amount - amount_virtual;
-
-        self.position.borrow_asset_deposit.active_virtual -= amount_virtual;
-        self.market.borrow_asset_deposited_active_virtual -= amount_virtual;
-        self.position.borrow_asset_deposit.active_real -= amount_real;
-        self.market.borrow_asset_deposited_active_real -= amount_real;
+    fn remove_active_real(&mut self, amount: BorrowAssetAmount) {
+        self.position.borrow_asset_deposit.active_real -= amount;
+        self.market.borrow_asset_deposited_active_real -= amount;
     }
 
     fn add_incoming(
@@ -385,6 +376,9 @@ impl<'a> SupplyPositionGuard<'a> {
         YieldAccumulationProof(())
     }
 
+    /// This will only withdraw from the "real" balance; "virtual" balances
+    /// must be converted to "real" by running accumulations (after sufficient
+    /// fees have been paid by borrowers).
     pub fn record_withdrawal_initial(
         &mut self,
         _proof: YieldAccumulationProof,
@@ -396,7 +390,7 @@ impl<'a> SupplyPositionGuard<'a> {
         //
 
         let my_incoming = self.position.total_incoming_real();
-        let my_active = self.position.get_deposit().active();
+        let my_active = self.position.get_deposit().active_real;
         let entitled_to_withdraw = my_incoming + my_active;
 
         if entitled_to_withdraw.is_zero() {
@@ -404,7 +398,7 @@ impl<'a> SupplyPositionGuard<'a> {
         }
 
         let requested_amount = requested_amount.min(entitled_to_withdraw);
-        let available_to_me = self.market.active_supply() + my_incoming;
+        let available_to_me = self.market.borrow_asset_deposited_active_real + my_incoming;
         let can_withdraw_now = entitled_to_withdraw.min(available_to_me);
 
         if can_withdraw_now.is_zero() {
@@ -427,7 +421,7 @@ impl<'a> SupplyPositionGuard<'a> {
         );
 
         if !amount_to_remove.is_zero() {
-            self.remove_active(amount_to_remove);
+            self.remove_active_real(amount_to_remove);
         }
 
         // The only way to withdraw from a position is if it already has a deposit.
@@ -488,7 +482,6 @@ impl<'a> SupplyPositionGuard<'a> {
             .emit();
         } else {
             self.market.borrow_asset_balance += withdrawal.amount_to_account;
-            // TODO: Is this correct? Do we need to separate real & virtual for failed withdrawals too?
             self.add_incoming(amount, 0.into(), self.market.finalized_snapshots.len() + 1);
         }
     }

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -355,29 +355,17 @@ impl<'a> SupplyPositionGuard<'a> {
 
         let market_credit = self.market.borrow_asset_virtual_credit;
         let my_virtual = self.position.borrow_asset_deposit.active_virtual;
-        let market_virtual = self.market.borrow_asset_deposited_active_virtual;
 
         // Claim virtual to real
-        if !market_credit.is_zero() && !my_virtual.is_zero() && !market_virtual.is_zero() {
-            near_sdk::log!("credit: {market_credit}, my_virtual: {my_virtual}, market_virtual: {market_virtual}");
+        let convertible = my_virtual.min(market_credit);
+        if !convertible.is_zero() {
+            self.market.borrow_asset_virtual_credit -= convertible;
 
-            // let claimable = if market_credit >= market_virtual {
-            //     my_virtual
-            // } else if
+            self.position.borrow_asset_deposit.active_virtual -= convertible;
+            self.market.borrow_asset_deposited_active_virtual -= convertible;
 
-            let claimable = (Decimal::from(market_credit) * u128::from(my_virtual) / u128::from(market_virtual) )
-            .to_u128_floor()
-            .map_or_else(|| {
-                crate::panic_with_message("Invariant violation: guaranteed position.active_virtual <= market.active_virtual");
-            }, BorrowAssetAmount::new).min(my_virtual);
-
-            self.market.borrow_asset_virtual_credit -= claimable;
-
-            self.position.borrow_asset_deposit.active_virtual -= claimable;
-            self.market.borrow_asset_deposited_active_virtual -= claimable;
-
-            self.position.borrow_asset_deposit.active_real += claimable;
-            self.market.borrow_asset_deposited_active_real += claimable;
+            self.position.borrow_asset_deposit.active_real += convertible;
+            self.market.borrow_asset_deposited_active_real += convertible;
         }
 
         YieldAccumulationProof(())

--- a/common/src/supply.rs
+++ b/common/src/supply.rs
@@ -29,7 +29,7 @@ impl Deposit {
     pub fn total(&self) -> BorrowAssetAmount {
         let mut total = self.active + self.outgoing;
         for incoming in &self.incoming {
-            total += incoming.amount;
+            total += incoming.amount_real + incoming.amount_virtual;
         }
         total
     }
@@ -56,12 +56,12 @@ impl SupplyPosition {
         &self.borrow_asset_deposit
     }
 
-    pub fn total_incoming(&self) -> BorrowAssetAmount {
+    pub fn total_incoming_real(&self) -> BorrowAssetAmount {
         self.borrow_asset_deposit
             .incoming
             .iter()
             .fold(BorrowAssetAmount::zero(), |total_incoming, incoming| {
-                total_incoming + incoming.amount
+                total_incoming + incoming.amount_real
             })
     }
 
@@ -163,10 +163,11 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
                 .filter(|incoming| incoming.activate_at_snapshot_index as usize == i)
             {
                 next_incoming += 1;
-                amount += u128::from(incoming.amount);
+                amount += u128::from(incoming.amount_real + incoming.amount_virtual);
             }
 
-            if !snapshot.borrow_asset_deposited_active.is_zero() {
+            let snapshot_active_supply = snapshot.active_supply();
+            if !snapshot_active_supply.is_zero() {
                 let snapshot_duration_ms = snapshot.end_timestamp_ms.0 - prev_end_timestamp_ms;
                 let interest_paid_by_borrowers = Decimal::from(snapshot.borrow_asset_borrowed)
                     * snapshot.interest_rate
@@ -175,7 +176,7 @@ impl<M: Deref<Target = Market>> SupplyPositionRef<M> {
                 let other_yield = Decimal::from(snapshot.yield_distribution);
                 accumulated +=
                     (interest_paid_by_borrowers + other_yield) * amount * weight_numerator
-                        / u128::from(snapshot.borrow_asset_deposited_active)
+                        / u128::from(snapshot_active_supply)
                         / weight_denominator;
             }
 
@@ -235,25 +236,32 @@ impl<'a> SupplyPositionGuard<'a> {
         while let Some(deposit) =
             incoming.next_if(|d| d.activate_at_snapshot_index <= through_snapshot_index)
         {
-            self.position.borrow_asset_deposit.active += deposit.amount;
+            self.position.borrow_asset_deposit.active +=
+                deposit.amount_real + deposit.amount_virtual;
         }
         self.position.borrow_asset_deposit.incoming = incoming.collect();
 
         // Calling market.snapshot() performs the market accounting
     }
 
-    fn remove_active(&mut self, amount: BorrowAssetAmount) {
-        self.position.borrow_asset_deposit.active -= amount;
-        self.market.borrow_asset_deposited_active -= amount;
-    }
+    // fn remove_active(&mut self, amount: BorrowAssetAmount) {
+    //     self.position.borrow_asset_deposit.active -= amount;
+    //     self.market.borrow_asset_deposited_active -= amount;
+    // }
 
-    fn add_incoming(&mut self, amount: BorrowAssetAmount, activate_at_snapshot_index: u32) {
+    fn add_incoming(
+        &mut self,
+        amount_real: BorrowAssetAmount,
+        amount_virtual: BorrowAssetAmount,
+        activate_at_snapshot_index: u32,
+    ) {
         let incoming = &mut self.position.borrow_asset_deposit.incoming;
         if let Some(deposit) = incoming
             .last_mut()
             .filter(|i| i.activate_at_snapshot_index == activate_at_snapshot_index)
         {
-            deposit.amount += amount;
+            deposit.amount_real += amount_real;
+            deposit.amount_virtual += amount_virtual;
         } else {
             const MAX_INCOMING: usize = 4;
             require!(
@@ -262,7 +270,8 @@ impl<'a> SupplyPositionGuard<'a> {
             );
             incoming.push(IncomingDeposit {
                 activate_at_snapshot_index,
-                amount,
+                amount_real,
+                amount_virtual,
             });
         }
 
@@ -272,22 +281,45 @@ impl<'a> SupplyPositionGuard<'a> {
             .iter_mut()
             .find(|incoming| incoming.activate_at_snapshot_index == activate_at_snapshot_index)
         {
-            incoming.amount += amount;
+            incoming.amount_real += amount_real;
+            incoming.amount_virtual += amount_virtual;
         } else {
             self.market
                 .borrow_asset_deposited_incoming
                 .push(IncomingDeposit {
                     activate_at_snapshot_index,
-                    amount,
+                    amount_real,
+                    amount_virtual,
                 });
         }
     }
 
     /// Returns the amount successfully removed from incoming.
-    fn remove_incoming(&mut self, amount: BorrowAssetAmount) -> BorrowAssetAmount {
+    fn remove_incoming_real(&mut self, amount: BorrowAssetAmount) -> BorrowAssetAmount {
         let mut total = BorrowAssetAmount::zero();
+        for newest in self.position.borrow_asset_deposit.incoming.iter_mut().rev() {
+            let Some(market_incoming) = self
+                .market
+                .incoming_at_mut(newest.activate_at_snapshot_index)
+            else {
+                crate::panic_with_message("Invariant violation: Market incoming entry should exist if position incoming entry exists");
+            };
+            if total + newest.amount_real >= amount {
+                total = amount;
+                newest.amount_real = total + newest.amount_real - amount;
+                break;
+            }
+            total += newest.amount_real;
+            newest.amount_real = 0.into();
+        }
+
+        self.position
+            .borrow_asset_deposit
+            .incoming
+            .retain(|i| !i.amount_real.is_zero() || !i.amount_virtual.is_zero());
+
         while let Some(newest) = self.position.borrow_asset_deposit.incoming.pop() {
-            total += newest.amount;
+            total += newest.amount_real;
 
             let Some(market_incoming) = self
                 .market
@@ -299,7 +331,7 @@ impl<'a> SupplyPositionGuard<'a> {
             else {
                 crate::panic_with_message("Invariant violation: Market incoming entry should exist if position incoming entry exists");
             };
-            market_incoming.amount = market_incoming.amount.unwrap_sub(newest.amount, "Invariant violation: Market incoming >= position incoming should hold for all snapshot indices");
+            market_incoming.amount_real = market_incoming.amount_real.unwrap_sub(newest.amount_real, "Invariant violation: Market incoming >= position incoming should hold for all snapshot indices");
 
             #[allow(clippy::comparison_chain)]
             if total == amount {
@@ -347,7 +379,7 @@ impl<'a> SupplyPositionGuard<'a> {
         // Check liquidity & eligibility
         //
 
-        let my_incoming = self.position.total_incoming();
+        let my_incoming = self.position.total_incoming_real();
         let my_active = self.position.get_deposit().active;
         let entitled_to_withdraw = my_incoming + my_active;
 
@@ -356,8 +388,8 @@ impl<'a> SupplyPositionGuard<'a> {
         }
 
         let requested_amount = requested_amount.min(entitled_to_withdraw);
-        let market_incoming = self.market.total_incoming();
-        let available_to_me = self.market.borrow_asset_balance - market_incoming + my_incoming;
+        let market_incoming = self.market.total_incoming_real();
+        let available_to_me = self.market.active_supply() - market_incoming + my_incoming;
         let can_withdraw_now = entitled_to_withdraw.min(available_to_me);
 
         if can_withdraw_now.is_zero() {
@@ -467,10 +499,6 @@ impl<'a> SupplyPositionGuard<'a> {
             }
             .emit();
         }
-    }
-
-    pub fn record_yield_withdrawal(&mut self, amount: BorrowAssetAmount) {
-        self.0.position.borrow_asset_yield.remove(amount);
     }
 
     /// Converts an amount of borrow asset from the yield record to the

--- a/contract/market/src/impl_helper.rs
+++ b/contract/market/src/impl_helper.rs
@@ -401,15 +401,8 @@ impl Contract {
         account_id: AccountId,
         amount: BorrowAssetAmount,
     ) {
-        if matches!(env::promise_result(0), PromiseResult::Failed) {
-            let mut yield_record = self.static_yield.get(&account_id).unwrap_or_else(|| {
-                templar_common::panic_with_message(
-                    "Invariant violation: static yield entry must exist during callback",
-                )
-            });
-            yield_record.add_once(amount);
-            self.static_yield.insert(&account_id, &yield_record);
-            self.borrow_asset_balance += amount;
-        }
+        let succeeded = matches!(env::promise_result(0), PromiseResult::Successful(_));
+        self.market
+            .withdraw_static_yield_final(&account_id, amount, succeeded);
     }
 }

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -354,16 +354,10 @@ impl MarketExternalInterface for Contract {
 
     fn withdraw_static_yield(&mut self, amount: Option<BorrowAssetAmount>) -> Promise {
         let predecessor = env::predecessor_account_id();
-        let Some(mut yield_record) = self.static_yield.get(&predecessor) else {
-            templar_common::panic_with_message("Yield record does not exist");
-        };
-
-        let amount = amount.unwrap_or_else(|| yield_record.get_total());
-
-        yield_record.remove(amount);
-
-        self.static_yield.insert(&predecessor, &yield_record);
-        self.borrow_asset_balance -= amount;
+        let amount = self
+            .market
+            .withdraw_static_yield_initial(&predecessor, amount)
+            .unwrap_or_else(|e| templar_common::panic_with_message(&e.to_string()));
 
         self.configuration
             .borrow_asset

--- a/contract/market/src/impl_market_external.rs
+++ b/contract/market/src/impl_market_external.rs
@@ -36,12 +36,9 @@ impl MarketExternalInterface for Contract {
     fn get_borrow_asset_metrics(&self) -> BorrowAssetMetrics {
         BorrowAssetMetrics {
             available: self.get_borrow_asset_available_to_borrow(),
-            deposited_active: self.borrow_asset_deposited_active,
-            deposited_incoming: self
-                .borrow_asset_deposited_incoming
-                .iter()
-                .map(|incoming| (incoming.activate_at_snapshot_index, incoming.amount))
-                .collect(),
+            deposited_active_real: self.borrow_asset_deposited_active_real,
+            deposited_active_virtual: self.borrow_asset_deposited_active_virtual,
+            deposited_incoming: self.borrow_asset_deposited_incoming.clone(),
             borrowed: self.borrowed(),
         }
     }

--- a/contract/market/tests/0_many_accounts.rs
+++ b/contract/market/tests/0_many_accounts.rs
@@ -89,7 +89,7 @@ async fn many_accounts(#[future(awt)] worker: Worker<Sandbox>) {
                             .await
                             .unwrap()
                             .get_deposit()
-                            .active,
+                            .active_real,
                         100_000.into(),
                     );
                     tokio::time::sleep(Duration::from_secs(5)).await;

--- a/contract/market/tests/happy_path.rs
+++ b/contract/market/tests/happy_path.rs
@@ -88,7 +88,8 @@ async fn test_happy(
     let snapshots = c.list_finalized_snapshots(None, None).await;
     assert_eq!(snapshots.len(), 1);
     assert!(snapshots[0].yield_distribution.is_zero());
-    assert!(snapshots[0].borrow_asset_deposited_active.is_zero());
+    assert!(snapshots[0].borrow_asset_deposited_active_real.is_zero());
+    assert!(snapshots[0].borrow_asset_deposited_active_virtual.is_zero());
     assert!(snapshots[0].borrow_asset_borrowed.is_zero());
 
     // Step 1: Supply user sends tokens to contract to use for borrows.
@@ -97,7 +98,7 @@ async fn test_happy(
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.total_incoming()),
+        u128::from(supply_position.total_incoming_real()),
         1100,
         "Supply position should match amount of tokens supplied to contract",
     );
@@ -117,7 +118,7 @@ async fn test_happy(
     let supply_position = c.get_supply_position(supply_user.id()).await.unwrap();
 
     assert_eq!(
-        u128::from(supply_position.get_deposit().active),
+        u128::from(supply_position.get_deposit().active()),
         1100,
         "Supply position should match amount of tokens supplied to contract",
     );

--- a/contract/market/tests/snapshot.rs
+++ b/contract/market/tests/snapshot.rs
@@ -55,7 +55,7 @@ async fn snapshot_captures_borrow_and_collateral_state(#[future(awt)] worker: Wo
 
     check(
         states!(
-            { active += 2_000_000 },
+            { active_real += 2_000_000 },
             { collateral += 1_000_000 },
             { borrowed += 500_000 },
             { collateral += 1 },
@@ -101,7 +101,7 @@ async fn multiple_snapshots_show_progression(#[future(awt)] worker: Worker<Sandb
 
     check(
         states!(
-            { active = 3_000_000 },
+            { active_real = 3_000_000 },
             { collateral += 1_000_000 },
             { borrowed += 400_000 },
             { borrowed += 200_000 },
@@ -203,7 +203,10 @@ async fn snapshot_handles_zero_operations(#[future(awt)] worker: Worker<Sandbox>
 
     let snapshots = c.list_finalized_snapshots(None, None).await;
 
-    check(states!({ active = 1_000_000 }, { active += 1 }), snapshots);
+    check(
+        states!({ active_real = 1_000_000 }, { active_real += 1 }),
+        snapshots,
+    );
 }
 
 #[rstest]
@@ -311,7 +314,7 @@ async fn snapshot_field_validation(#[future(awt)] worker: Worker<Sandbox>) {
 
     check(
         states!(
-            { active = 1_500_000 },
+            { active_real = 1_500_000 },
             { collateral += 1 },
             { collateral += 800_000 },
             { collateral += 1 },
@@ -381,8 +384,8 @@ async fn many_users_different_snapshots(#[future(awt)] worker: Worker<Sandbox>) 
 
     check(
         states!(
-            { active += 2_000_000 },
-            { active += 1_500_000 },
+            { active_real += 2_000_000 },
+            { active_real += 1_500_000 },
             { collateral += 400_000 },
             { collateral += 350_000 },
             { collateral += 300_000 },
@@ -456,7 +459,7 @@ async fn many_users_same_snapshot(#[future(awt)] worker: Worker<Sandbox>) {
 
     check(
         states!(
-            { active += 2_000_000 + 1_500_000 },
+            { active_real += 2_000_000 + 1_500_000 },
             { collateral += 400_000 + 350_000 + 300_000 + 250_000 + 200_000 },
             { borrowed += 150_000 + 120_000 + 100_000 + 80_000 + 60_000 },
         ),
@@ -507,16 +510,19 @@ async fn incoming(#[future(awt)] worker: Worker<Sandbox>) {
     let snapshot_after_after = &snapshots[incoming_activates_at as usize + 2];
 
     assert!(snapshot_before_before
-        .borrow_asset_deposited_active
+        .borrow_asset_deposited_active_real
         .is_zero());
-    assert!(snapshot_before.borrow_asset_deposited_active.is_zero());
-    assert_eq!(snapshot_at.borrow_asset_deposited_active, 2_000_000.into());
+    assert!(snapshot_before.borrow_asset_deposited_active_real.is_zero());
     assert_eq!(
-        snapshot_after.borrow_asset_deposited_active,
+        snapshot_at.borrow_asset_deposited_active_real,
+        2_000_000.into()
+    );
+    assert_eq!(
+        snapshot_after.borrow_asset_deposited_active_real,
         2_000_000.into(),
     );
     assert_eq!(
-        snapshot_after_after.borrow_asset_deposited_active,
+        snapshot_after_after.borrow_asset_deposited_active_real,
         2_000_000.into(),
     );
 }

--- a/contract/vault/tests/happy_path.rs
+++ b/contract/vault/tests/happy_path.rs
@@ -125,7 +125,13 @@ async fn happy(#[future(awt)] worker: Worker<Sandbox>) {
     harvest(&c, &vault).await;
 
     assert_eq!(
-        u128::from(c.get_supply_position(v).await.unwrap().get_deposit().active),
+        u128::from(
+            c.get_supply_position(v)
+                .await
+                .unwrap()
+                .get_deposit()
+                .active(),
+        ),
         amount.0,
         "Supply position should match amount of tokens supplied to contract",
     );

--- a/fuzz/fuzz_targets/fuzz_supply.rs
+++ b/fuzz/fuzz_targets/fuzz_supply.rs
@@ -27,7 +27,8 @@ fuzz_target!(|data: (u32, u128, u128, u128, u32, u32, u128)| {
     let _ = position.can_be_removed();
     // Fuzz deposit structure
     let mut deposit = Deposit {
-        active: BorrowAssetAmount::new(active_amount),
+        active_real: BorrowAssetAmount::new(active_amount),
+        active_virtual: 0.into(),
         incoming: vec![],
         outgoing: BorrowAssetAmount::zero(),
     };
@@ -36,14 +37,16 @@ fuzz_target!(|data: (u32, u128, u128, u128, u32, u32, u128)| {
     if incoming_amount_1 > 0 && activate_at_1 > snapshot_index {
         deposit.incoming.push(IncomingDeposit {
             activate_at_snapshot_index: activate_at_1,
-            amount: BorrowAssetAmount::new(incoming_amount_1),
+            amount_real: BorrowAssetAmount::new(incoming_amount_1),
+            amount_virtual: 0.into(),
         });
     }
 
     if incoming_amount_2 > 0 && activate_at_2 > snapshot_index && activate_at_2 != activate_at_1 {
         deposit.incoming.push(IncomingDeposit {
             activate_at_snapshot_index: activate_at_2,
-            amount: BorrowAssetAmount::new(incoming_amount_2),
+            amount_real: BorrowAssetAmount::new(incoming_amount_2),
+            amount_virtual: 0.into(),
         });
     }
 
@@ -61,7 +64,7 @@ fuzz_target!(|data: (u32, u128, u128, u128, u32, u32, u128)| {
     position.borrow_asset_yield = yield_acc;
 
     // Test total_incoming
-    let _ = position.total_incoming();
+    let _ = position.total_incoming_real();
 
     // Test exists and can_be_removed after modifications
     let _ = position.exists();
@@ -81,10 +84,12 @@ fuzz_target!(|data: (u32, u128, u128, u128, u32, u32, u128)| {
 
     // Test deposit with max values
     let max_deposit = Deposit {
-        active: BorrowAssetAmount::new(u128::MAX / 3),
+        active_real: BorrowAssetAmount::new(u128::MAX / 3),
+        active_virtual: 0.into(),
         incoming: vec![IncomingDeposit {
             activate_at_snapshot_index: u32::MAX - 1,
-            amount: BorrowAssetAmount::new(u128::MAX / 3),
+            amount_real: BorrowAssetAmount::new(u128::MAX / 3),
+            amount_virtual: 0.into(),
         }],
         outgoing: BorrowAssetAmount::new(u128::MAX / 3),
     };

--- a/test-utils/src/controller/market.rs
+++ b/test-utils/src/controller/market.rs
@@ -114,8 +114,12 @@ impl MarketController {
             eprintln!("\t{i}: {}", snapshot.time_chunk.0 .0);
             eprintln!("\t\tTimestamp:\t{}", snapshot.end_timestamp_ms.0);
             eprintln!(
-                "\t\tDeposited (active):\t{}",
-                snapshot.borrow_asset_deposited_active,
+                "\t\tActive supply (real):\t{}",
+                snapshot.borrow_asset_deposited_active_real,
+            );
+            eprintln!(
+                "\t\tActive supply (virtual):\t{}",
+                snapshot.borrow_asset_deposited_active_virtual,
             );
             eprintln!("\t\tBorrowed:\t{}", snapshot.borrow_asset_borrowed);
             eprintln!("\t\tDistribution:\t{}", snapshot.yield_distribution);

--- a/test-utils/src/partial.rs
+++ b/test-utils/src/partial.rs
@@ -4,7 +4,8 @@ use templar_common::snapshot::Snapshot;
 
 #[derive(Debug, Clone, Default)]
 pub struct PartialSnapshot {
-    pub active: u128,
+    pub active_real: u128,
+    pub active_virtual: u128,
     pub collateral: u128,
     pub borrowed: u128,
 }
@@ -22,9 +23,14 @@ impl PartialSnapshot {
         }
 
         test(
-            "borrow_asset_deposited_active",
-            self.active,
-            u128::from(snapshot.borrow_asset_deposited_active),
+            "borrow_asset_deposited_active_real",
+            self.active_real,
+            u128::from(snapshot.borrow_asset_deposited_active_real),
+        )?;
+        test(
+            "borrow_asset_deposited_active_virtual",
+            self.active_virtual,
+            u128::from(snapshot.borrow_asset_deposited_active_virtual),
         )?;
         test(
             "collateral_asset_deposited",


### PR DESCRIPTION
This PR introduces virtual supply tracking.

Active supply is split into two categories: **real** and **virtual**. Supply that is deposited directly by suppliers (this is the normal workflow) is considered **real**. Supply that is added to a supplier's record via yield compounding is **virtual** supply. The sum of active + virtual is still used to calculate information such as usage ratio, interest rates, yield, etc.

Supply must be considered **real** in order for it to be withdrawn. The mechanism to convert virtual supply to real supply is as follows:
1. Supplier Susie deposits $100 in supply. Susie's record now contains: **real**: $100, **virtual**: $0.
2. Some time passes, and a compounding yield accumulation is run on Susie's account. Now Susie's record contains: **real**: $100, **virtual**: $10.
3. Susie is earning yield on $110, but can only withdraw $100.
4. Borrower Bob repays a loan, paying $5 in fees/interest. This adds $5 to the market's virtual credit record.
5. Susie runs a normal (non-compounding) accumulation. Because there is $5 in the market's virtual credit record, $5 from Susie's record are converted from virtual to real. Susie's record is now: **real**: $105, **virtual**: $5, and the market's virtual credit record is $0.
6. Susie is earning yield on $110 and can withdraw $105.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/360)
<!-- Reviewable:end -->
