### PR TITLE
chore: every package versioned independently + bump market to 1.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12208,7 +12208,7 @@ dependencies = [
 
 [[package]]
 name = "templar-common"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "borsh 1.5.7",
  "clap",
@@ -12274,7 +12274,7 @@ dependencies = [
 
 [[package]]
 name = "templar-fuzz"
-version = "1.2.1"
+version = "0.0.0"
 dependencies = [
  "arbitrary",
  "hex-literal",
@@ -12326,7 +12326,7 @@ dependencies = [
 
 [[package]]
 name = "templar-market-contract"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
  "getrandom 0.2.15",
  "near-contract-standards",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12451,7 +12451,7 @@ dependencies = [
 
 [[package]]
 name = "templar-vault-contract"
-version = "1.2.1"
+version = "1.0.0"
 dependencies = [
  "futures",
  "getrandom 0.2.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ members = [
 license = "MIT"
 repository = "https://github.com/Templar-Protocol/contracts"
 edition = "2021"
-version = "1.2.1"
 
 [workspace.dependencies]
 alloy = { version = "1", default-features = false }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-common"
 repository.workspace = true
-version.workspace = true
+version = "1.3.0"
 
 [dependencies]
 borsh.workspace = true

--- a/contract/lst-oracle/Cargo.toml
+++ b/contract/lst-oracle/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-lst-oracle-contract"
 repository.workspace = true
-version.workspace = true
+version = "1.2.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-market-contract"
 repository.workspace = true
-version.workspace = true
+version = "1.3.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/registry/Cargo.toml
+++ b/contract/registry/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-registry-contract"
 repository.workspace = true
-version.workspace = true
+version = "1.2.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/vault/Cargo.toml
+++ b/contract/vault/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-vault-contract"
 repository.workspace = true
-version = "1.2.1"
+version = "1.0.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/vault/Cargo.toml
+++ b/contract/vault/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-vault-contract"
 repository.workspace = true
-version.workspace = true
+version = "1.2.1"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
-name = "templar-fuzz"
-license.workspace = true
-repository.workspace = true
 edition.workspace = true
-version.workspace = true
+license.workspace = true
+name = "templar-fuzz"
+publish = false
+repository.workspace = true
+version = "0.0.0"
 
 [dependencies]
 arbitrary.workspace = true

--- a/universal-account/Cargo.toml
+++ b/universal-account/Cargo.toml
@@ -3,7 +3,7 @@ name = "templar-universal-account"
 license.workspace = true
 repository.workspace = true
 edition.workspace = true
-version.workspace = true
+version = "1.2.1"
 
 [dependencies]
 alloy = { workspace = true, default-features = false, features = ["eip712", "signers", "sol-types"] }


### PR DESCRIPTION
@carrion256 Just making sure that you're aware of this -- the vault previously was using the workspace version, but I don't think that it is correct for everything to be using the same version anymore, since the repository contains a lot of different packages now. Please update the vault version to whatever you think is appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/370)
<!-- Reviewable:end -->
