### PR TITLE
chore: configs for cetes and ustry on templar-alpha.near

### DIFF
--- a/contract/market/examples/config/alpha/ixlmcetes-ixlmusdc.templar-alpha.near.json
+++ b/contract/market/examples/config/alpha/ixlmcetes-ixlmusdc.templar-alpha.near.json
@@ -1,0 +1,63 @@
+{
+  "time_chunk_configuration": {
+    "duration_ms": "600000"
+  },
+  "borrow_asset": {
+    "Nep245": {
+      "contract_id": "intents.near",
+      "token_id": "nep245:v2_1.omni.hot.tg:1100_111bzQBB65GxAPAVoxqmMcgYo5oS3txhqs1Uh1cgahKQUeTUq1TJu"
+    }
+  },
+  "collateral_asset": {
+    "Nep245": {
+      "contract_id": "intents.near",
+      "token_id": "nep245:v2_1.omni.hot.tg:1100_111bzQBB5uBD3Wrr7pthp8XhJsreEcwTVnmjQ1wpbzkvHLEQf3ygS"
+    }
+  },
+  "price_oracle_configuration": {
+    "account_id": "proxy-oracle-cetes-usdc.templar-alpha.near",
+    "collateral_asset_price_id": "4345544553000000000000000000000000000000000000000000000000000000",
+    "collateral_asset_decimals": 7,
+    "borrow_asset_price_id": "5553444300000000000000000000000000000000000000000000000000000000",
+    "borrow_asset_decimals": 7,
+    "price_maximum_age_s": 60
+  },
+  "borrow_mcr_maintenance": "1.5",
+  "borrow_mcr_liquidation": "1.4",
+  "borrow_asset_maximum_usage_ratio": "0.99",
+  "borrow_origination_fee": { "Flat": "0" },
+  "borrow_interest_rate_strategy": {
+    "Piecewise": {
+      "base": "0",
+      "optimal": "0.9",
+      "rate_1": "0.08888888888888888888888888888888888889",
+      "rate_2": "2.4"
+    }
+  },
+  "borrow_maximum_duration_ms": null,
+  "borrow_range": {
+    "minimum": "1",
+    "maximum": null
+  },
+  "supply_range": {
+    "minimum": "400000",
+    "maximum": null
+  },
+  "supply_withdrawal_range": {
+    "minimum": "400000",
+    "maximum": null
+  },
+  "supply_withdrawal_fee": {
+    "fee": {
+      "Flat": "0"
+    },
+    "duration": "0",
+    "behavior": "Fixed"
+  },
+  "yield_weights": {
+    "supply": 4,
+    "static": { "revenue.tmplr.near": 1 }
+  },
+  "protocol_account_id": "revenue.tmplr.near",
+  "liquidation_maximum_spread": "0.1"
+}

--- a/contract/market/examples/config/alpha/ixlmustry-ixlmusdc.templar-alpha.near.json
+++ b/contract/market/examples/config/alpha/ixlmustry-ixlmusdc.templar-alpha.near.json
@@ -1,0 +1,63 @@
+{
+  "time_chunk_configuration": {
+    "duration_ms": "600000"
+  },
+  "borrow_asset": {
+    "Nep245": {
+      "contract_id": "intents.near",
+      "token_id": "nep245:v2_1.omni.hot.tg:1100_111bzQBB65GxAPAVoxqmMcgYo5oS3txhqs1Uh1cgahKQUeTUq1TJu"
+    }
+  },
+  "collateral_asset": {
+    "Nep245": {
+      "contract_id": "intents.near",
+      "token_id": "nep245:v2_1.omni.hot.tg:1100_111bzQBB5yT2A5maKJqJQsuNg7BA6VG4S4ZATpqmKYLwYBsfEfh6e"
+    }
+  },
+  "price_oracle_configuration": {
+    "account_id": "proxy-oracle-ustry-usdc.templar-alpha.near",
+    "collateral_asset_price_id": "5553545259000000000000000000000000000000000000000000000000000000",
+    "collateral_asset_decimals": 7,
+    "borrow_asset_price_id": "5553444300000000000000000000000000000000000000000000000000000000",
+    "borrow_asset_decimals": 7,
+    "price_maximum_age_s": 60
+  },
+  "borrow_mcr_maintenance": "1.5",
+  "borrow_mcr_liquidation": "1.4",
+  "borrow_asset_maximum_usage_ratio": "0.99",
+  "borrow_origination_fee": { "Flat": "0" },
+  "borrow_interest_rate_strategy": {
+    "Piecewise": {
+      "base": "0",
+      "optimal": "0.9",
+      "rate_1": "0.08888888888888888888888888888888888889",
+      "rate_2": "2.4"
+    }
+  },
+  "borrow_maximum_duration_ms": null,
+  "borrow_range": {
+    "minimum": "1",
+    "maximum": null
+  },
+  "supply_range": {
+    "minimum": "400000",
+    "maximum": null
+  },
+  "supply_withdrawal_range": {
+    "minimum": "400000",
+    "maximum": null
+  },
+  "supply_withdrawal_fee": {
+    "fee": {
+      "Flat": "0"
+    },
+    "duration": "0",
+    "behavior": "Fixed"
+  },
+  "yield_weights": {
+    "supply": 4,
+    "static": { "revenue.tmplr.near": 1 }
+  },
+  "protocol_account_id": "revenue.tmplr.near",
+  "liquidation_maximum_spread": "0.1"
+}


### PR DESCRIPTION
This is the first mainnet (alpha) deployment batch that will utilize the new RedStone oracle adapter contract for prices.

The RedStone adapter contract is at [`redstone-adapter.templar-alpha.near`](https://nearblocks.io/address/redstone-adapter.templar-alpha.near), and the proxy oracles specified in the market configurations point to that for their prices.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/384)
<!-- Reviewable:end -->
