### PR TITLE
Liquidator: filter non-market deployments, HTTP oracle prices, swap eligibility check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ _site/
 client/vault/dist/
 
 .aider*
+.claude/

--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -161,7 +161,7 @@ DRY_RUN=true
 RUST_LOG=info
 
 # ============================================
-# ORACLE PRICE UPDATES
+# ORACLE PRICE SOURCES
 # ============================================
 
 # Pyth Hermes API URL for fetching latest price data
@@ -170,9 +170,7 @@ RUST_LOG=info
 # Default: https://hermes.pyth.network
 PYTH_HERMES_URL=https://hermes.pyth.network
 
-# Auto-update stale Pyth prices before liquidations
-# When enabled, the liquidator will fetch latest prices from Hermes and push to oracle if needed
-# Requires SIGNER_ACCOUNT_ID and SIGNER_KEY to be configured
-# Cost: ~0.001-0.002 NEAR per update transaction (unused deposit is refunded)
-# Default: false
-AUTO_UPDATE_PRICES=false
+# RedStone gateway URL for fetching fresh prices
+# Gateways: https://oracle-gateway-1.a.redstone.vip, https://oracle-gateway-2.a.redstone.finance
+# Default: https://oracle-gateway-1.a.redstone.vip
+REDSTONE_GATEWAY_URL=https://oracle-gateway-1.a.redstone.vip

--- a/service/liquidator/docker-compose.yml
+++ b/service/liquidator/docker-compose.yml
@@ -21,7 +21,6 @@ services:
       "--signer-account", "${SIGNER_ACCOUNT_ID}",
       "--signer-key", "${SIGNER_KEY}",
       "--registries", "${REGISTRY_ACCOUNT_IDS:-v1.tmplr.near}",
-      "--liquidation-strategy", "${LIQUIDATION_STRATEGY:-partial}",
       "--partial-percentage", "${PARTIAL_LIQUIDATION_PERCENTAGE:-50}",
       "--min-profit-bps", "${MIN_PROFIT_BPS:-50}",
       "--liquidation-scan-interval", "${LIQUIDATION_SCAN_INTERVAL:-600}",
@@ -31,6 +30,7 @@ services:
       "--collateral-strategy", "${COLLATERAL_STRATEGY:-hold}",
       "--max-loop-iterations", "${MAX_LOOP_ITERATIONS:-10}",
       "--hermes-url", "${PYTH_HERMES_URL:-https://hermes.pyth.network}",
+      "--redstone-gateway-url", "${REDSTONE_GATEWAY_URL:-https://oracle-gateway-1.a.redstone.vip}",
       # Uncomment to enable loop liquidation (repeatedly liquidate until healthy):
       # "--loop-liquidation",
       # "--fixed-liquidation-amount-usd", "${FIXED_LIQUIDATION_AMOUNT_USD}",

--- a/service/liquidator/scripts/run-mainnet.sh
+++ b/service/liquidator/scripts/run-mainnet.sh
@@ -64,7 +64,7 @@ IGNORED_COLLATERAL_ASSETS="${IGNORED_COLLATERAL_ASSETS}"
 
 # Oracle price update configuration
 PYTH_HERMES_URL="${PYTH_HERMES_URL:-https://hermes.pyth.network}"
-AUTO_UPDATE_PRICES="${AUTO_UPDATE_PRICES:-false}"
+REDSTONE_GATEWAY_URL="${REDSTONE_GATEWAY_URL:-https://oracle-gateway-1.a.redstone.vip}"
 
 # Build binary
 PROJECT_ROOT="$SCRIPT_DIR/../../.."
@@ -175,7 +175,7 @@ fi
 
 # Add oracle price update arguments
 CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
-[ "$AUTO_UPDATE_PRICES" = "true" ] && CMD_ARGS+=("--auto-update-prices")
+CMD_ARGS+=("--redstone-gateway-url" "$REDSTONE_GATEWAY_URL")
 
 info "Starting liquidator..."
 echo ""

--- a/service/liquidator/scripts/run-testnet.sh
+++ b/service/liquidator/scripts/run-testnet.sh
@@ -64,7 +64,7 @@ IGNORED_COLLATERAL_ASSETS="${IGNORED_COLLATERAL_ASSETS}"
 
 # Oracle price update configuration
 PYTH_HERMES_URL="${PYTH_HERMES_URL:-https://hermes-beta.pyth.network}"
-AUTO_UPDATE_PRICES="${AUTO_UPDATE_PRICES:-false}"
+REDSTONE_GATEWAY_URL="${REDSTONE_GATEWAY_URL:-https://oracle-gateway-1.a.redstone.vip}"
 
 # Build binary
 PROJECT_ROOT="$SCRIPT_DIR/../../.."
@@ -176,7 +176,7 @@ fi
 
 # Add oracle price update arguments
 CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
-[ "$AUTO_UPDATE_PRICES" = "true" ] && CMD_ARGS+=("--auto-update-prices")
+CMD_ARGS+=("--redstone-gateway-url" "$REDSTONE_GATEWAY_URL")
 
 info "Starting liquidator..."
 echo ""

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -118,7 +118,7 @@ pub struct Args {
     #[arg(long, env = "MAX_LOOP_ITERATIONS", default_value_t = 10)]
     pub max_loop_iterations: u32,
 
-    /// Pyth Hermes API URL for price updates
+    /// Pyth Hermes API URL for fetching price data
     #[arg(
         long,
         env = "PYTH_HERMES_URL",
@@ -126,9 +126,13 @@ pub struct Args {
     )]
     pub hermes_url: String,
 
-    /// Enable automatic Pyth price updates before liquidations
-    #[arg(long, env = "AUTO_UPDATE_PRICES", default_value_t = false)]
-    pub auto_update_prices: bool,
+    /// RedStone gateway URL for fetching fresh prices
+    #[arg(
+        long,
+        env = "REDSTONE_GATEWAY_URL",
+        default_value = "https://oracle-gateway-1.a.redstone.vip"
+    )]
+    pub redstone_gateway_url: String,
 
     /// Minimum USD value to attempt a swap (JIT or batch).
     /// Amounts below this threshold are skipped and left for batch swap.
@@ -290,7 +294,7 @@ impl Args {
             loop_liquidation: self.loop_liquidation,
             max_loop_iterations: self.max_loop_iterations,
             hermes_url: self.hermes_url.clone(),
-            auto_update_prices: self.auto_update_prices,
+            redstone_gateway_url: self.redstone_gateway_url.clone(),
             min_swap_value_usd: self.min_swap_value_usd,
             batch_swap_on_cycle_start: self.batch_swap_on_cycle_start,
             swap_retry_config: SwapRetryConfig {
@@ -346,7 +350,7 @@ mod tests {
             loop_liquidation: false,
             max_loop_iterations: 10,
             hermes_url: "https://hermes.pyth.network".to_string(),
-            auto_update_prices: false,
+            redstone_gateway_url: "https://oracle-gateway-1.a.redstone.vip".to_string(),
             min_swap_value_usd: 10.0,
             batch_swap_on_cycle_start: true,
             swap_retry_attempts: 3,

--- a/service/liquidator/src/executor.rs
+++ b/service/liquidator/src/executor.rs
@@ -217,6 +217,12 @@ impl LiquidationExecutor {
                             "Liquidation executed successfully (all receipts succeeded)"
                         );
 
+                        // Release the reservation — tokens have left our account
+                        self.inventory
+                            .write()
+                            .await
+                            .release(borrow_asset, liquidation_amount);
+
                         // Handle collateral based on strategy
                         let swap_succeeded = match &self.collateral_strategy {
                             CollateralStrategy::Hold => false, // No swap performed

--- a/service/liquidator/src/executor.rs
+++ b/service/liquidator/src/executor.rs
@@ -22,6 +22,7 @@ use templar_common::{
 use crate::{
     inventory,
     rpc::{check_transaction_success, get_access_key_data, send_tx},
+    swap::SwapProvider,
     CollateralStrategy, LiquidationOutcome, LiquidatorError, LiquidatorResult,
 };
 
@@ -297,6 +298,7 @@ impl LiquidationExecutor {
     /// Swap collateral immediately after liquidation.
     ///
     /// Returns `Ok(true)` if swap succeeded, `Ok(false)` if skipped or failed (non-fatal).
+    #[allow(clippy::too_many_lines)]
     async fn swap_collateral_to_borrow(
         &self,
         collateral_asset: &FungibleAsset<CollateralAsset>,
@@ -312,6 +314,16 @@ impl LiquidationExecutor {
         // Skip swap if collateral is already the target borrow asset
         if collateral_asset.to_string() == borrow_asset.to_string() {
             tracing::debug!("Collateral is already borrow asset, skipping JIT swap");
+            return Ok(false);
+        }
+
+        // Skip swap if the provider doesn't support this asset pair
+        if !swap_provider.supports_assets(collateral_asset, borrow_asset) {
+            tracing::info!(
+                from = %collateral_asset,
+                to = %borrow_asset,
+                "Swap provider does not support asset pair, holding collateral"
+            );
             return Ok(false);
         }
 
@@ -390,11 +402,16 @@ impl LiquidationExecutor {
                         error = %e,
                         "JIT swap skipped - amount below provider minimum, will batch"
                     );
+                } else if msg.contains("Quote failed") {
+                    tracing::debug!(
+                        swap = %swap_name,
+                        "No swap route available for asset, holding collateral"
+                    );
                 } else {
                     tracing::info!(
                         swap = %swap_name,
                         error = %e,
-                        "JIT swap failed after retries, holding collateral"
+                        "JIT swap failed, holding collateral"
                     );
                 }
                 Ok(false)

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -621,9 +621,10 @@ impl Liquidator {
                 return Ok(LiquidationOutcome::Unprofitable);
             }
 
-            // Step 6: Push fresh prices to on-chain oracle before first execution.
+            // Step 6: Push fresh prices to underlying Pyth oracle(s) before first execution.
             // The market contract reads from the on-chain oracle during liquidation,
             // so prices must be fresh there — not just in our HTTP-fetched view.
+            // Resolves proxy/LST oracles to their underlying Pyth targets.
             // Only push once per liquidate() call (covers loop iterations too).
             if !prices_pushed_onchain && !dry_run {
                 let oracle_account = &self.market_config.price_oracle_configuration.account_id;
@@ -635,14 +636,19 @@ impl Liquidator {
                         .price_oracle_configuration
                         .collateral_asset_price_id,
                 ];
-                if let Err(e) = self
+                match self
                     .oracle_fetcher
-                    .update_pyth_prices(oracle_account, price_ids)
+                    .update_onchain_prices(oracle_account, price_ids)
                     .await
                 {
-                    tracing::warn!(error = %e, "Failed to update on-chain prices, proceeding with existing");
+                    Ok(_) => {
+                        prices_pushed_onchain = true;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "Failed to update on-chain prices, proceeding with existing");
+                        prices_pushed_onchain = true;
+                    }
                 }
-                prices_pushed_onchain = true;
             }
 
             // Execute liquidation (contract determines optimal collateral amount)

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -97,6 +97,8 @@ pub enum LiquidatorError {
     GetConfigurationError(rpc::RpcError),
     #[error("Failed to fetch oracle prices: {0}")]
     PriceFetchError(rpc::RpcError),
+    #[error("Failed to update on-chain oracle prices: {0}")]
+    OracleUpdateError(String),
     #[error("Failed to get access key data: {0}")]
     AccessKeyDataError(rpc::RpcError),
     #[error("Liquidation transaction error: {0}")]
@@ -191,6 +193,7 @@ impl Liquidator {
         swap_retry_config: crate::swap::SwapRetryConfig,
         min_swap_value_usd: f64,
         proxy_oracle_cache: Option<oracle::ProxyOracleCache>,
+        signer_for_oracle: Option<(AccountId, near_crypto::SecretKey)>,
     ) -> Self {
         let scanner = scanner::MarketScanner::new(client.clone(), market.clone());
         let oracle_fetcher = oracle::OracleFetcher::new(
@@ -198,6 +201,7 @@ impl Liquidator {
             hermes_url,
             redstone_gateway_url,
             proxy_oracle_cache,
+            signer_for_oracle,
         );
         let executor = executor::LiquidationExecutor::new(
             client.clone(),
@@ -303,6 +307,7 @@ impl Liquidator {
         let loop_enabled = self.loop_liquidation && !dry_run;
         let mut loop_iteration = 0;
         let max_iterations = if dry_run { 1 } else { self.max_loop_iterations };
+        let mut prices_pushed_onchain = false;
         let mut total_liquidated_amount = 0u128;
         let mut total_collateral_received = 0u128;
         let mut position = position;
@@ -616,7 +621,31 @@ impl Liquidator {
                 return Ok(LiquidationOutcome::Unprofitable);
             }
 
-            // Step 6: Execute liquidation (contract determines optimal collateral amount)
+            // Step 6: Push fresh prices to on-chain oracle before first execution.
+            // The market contract reads from the on-chain oracle during liquidation,
+            // so prices must be fresh there — not just in our HTTP-fetched view.
+            // Only push once per liquidate() call (covers loop iterations too).
+            if !prices_pushed_onchain && !dry_run {
+                let oracle_account = &self.market_config.price_oracle_configuration.account_id;
+                let price_ids = &[
+                    self.market_config
+                        .price_oracle_configuration
+                        .borrow_asset_price_id,
+                    self.market_config
+                        .price_oracle_configuration
+                        .collateral_asset_price_id,
+                ];
+                if let Err(e) = self
+                    .oracle_fetcher
+                    .update_pyth_prices(oracle_account, price_ids)
+                    .await
+                {
+                    tracing::warn!(error = %e, "Failed to update on-chain prices, proceeding with existing");
+                }
+                prices_pushed_onchain = true;
+            }
+
+            // Execute liquidation (contract determines optimal collateral amount)
             let outcome = self
                 .executor
                 .execute_liquidation(

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -113,8 +113,6 @@ pub enum LiquidatorError {
     StrategyError(String),
     #[error("Insufficient balance for liquidation")]
     InsufficientBalance,
-    #[error("Failed to update Pyth prices: {0}")]
-    PriceUpdateError(String),
 }
 
 pub type LiquidatorResult<T = ()> = Result<T, LiquidatorError>;
@@ -155,8 +153,6 @@ pub struct Liquidator {
     max_loop_iterations: u32,
     /// Market version (major, minor, patch) - used for version-specific liquidation logic
     market_version: Option<(u32, u32, u32)>,
-    /// Enable automatic Pyth price updates before liquidations
-    auto_update_prices: bool,
 }
 
 impl Liquidator {
@@ -191,17 +187,17 @@ impl Liquidator {
         loop_liquidation: bool,
         max_loop_iterations: u32,
         hermes_url: Option<String>,
-        auto_update_prices: bool,
-        signer_for_oracle: &Option<(AccountId, near_crypto::SecretKey)>,
+        redstone_gateway_url: Option<String>,
         swap_retry_config: crate::swap::SwapRetryConfig,
         min_swap_value_usd: f64,
+        proxy_oracle_cache: Option<oracle::ProxyOracleCache>,
     ) -> Self {
         let scanner = scanner::MarketScanner::new(client.clone(), market.clone());
         let oracle_fetcher = oracle::OracleFetcher::new(
             client.clone(),
             hermes_url,
-            signer_for_oracle.as_ref().map(|(id, _)| id.clone()),
-            signer_for_oracle.as_ref().map(|(_, key)| key.clone()),
+            redstone_gateway_url,
+            proxy_oracle_cache,
         );
         let executor = executor::LiquidationExecutor::new(
             client.clone(),
@@ -226,7 +222,6 @@ impl Liquidator {
             loop_liquidation,
             max_loop_iterations,
             market_version: None,
-            auto_update_prices,
         }
     }
 
@@ -685,7 +680,6 @@ impl Liquidator {
         tracing::info!(
             strategy = %self.strategy.strategy_name(),
             percentage = max_percentage,
-            auto_update_prices = self.auto_update_prices,
             "Starting liquidation run"
         );
 
@@ -707,80 +701,14 @@ impl Liquidator {
             .price_oracle_configuration
             .price_maximum_age_s;
 
-        // Fetch oracle prices
-        let mut oracle_response = self
+        // Fetch oracle prices via HTTP APIs (Hermes for Pyth, gateway for RedStone)
+        let oracle_response = self
             .oracle_fetcher
             .get_oracle_prices(oracle_account.clone(), &price_ids, price_max_age)
             .await?;
 
-        // Check if any prices are missing or stale
-        let now = if let Ok(duration) =
-            std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH)
-        {
-            duration.as_secs().try_into().unwrap_or(i64::MAX)
-        } else {
-            tracing::error!("System time is before UNIX epoch");
-            return Err(LiquidatorError::PriceUpdateError(
-                "System time error".to_string(),
-            ));
-        };
-
-        let has_stale_prices = oracle_response.is_empty()
-            || price_ids.iter().any(|price_id| {
-                oracle_response
-                    .get(price_id)
-                    .and_then(|opt| opt.as_ref())
-                    .is_none_or(|price| {
-                        (now - price.publish_time.as_secs()) > i64::from(price_max_age)
-                    })
-            });
-
-        // If prices are missing/stale and auto-update is enabled, try to update them
-        let dry_run = self.executor.is_dry_run();
-        if has_stale_prices && self.auto_update_prices {
-            if dry_run {
-                tracing::info!(
-                    price_ids = ?price_ids,
-                    max_age_s = price_max_age,
-                    "[DRY RUN] Oracle prices are missing or stale, skipping on-chain update"
-                );
-            } else {
-                tracing::warn!(
-                    price_ids = ?price_ids,
-                    max_age_s = price_max_age,
-                    "Oracle prices are missing or stale, attempting to update from Pyth Hermes (AUTO_UPDATE_PRICES=true)"
-                );
-
-                match self
-                    .oracle_fetcher
-                    .update_pyth_prices(&oracle_account, &price_ids)
-                    .await
-                {
-                    Ok(true) => {
-                        tracing::info!("Successfully updated Pyth prices, re-fetching");
-                        oracle_response = self
-                            .oracle_fetcher
-                            .get_oracle_prices(oracle_account.clone(), &price_ids, price_max_age)
-                            .await?;
-                    }
-                    Ok(false) => {
-                        tracing::warn!("Price update was skipped (no signer or already fresh)");
-                    }
-                    Err(e) => {
-                        tracing::error!(error = %e, "Failed to update Pyth prices");
-                    }
-                }
-            }
-        } else if has_stale_prices {
-            tracing::warn!(
-                auto_update_prices = self.auto_update_prices,
-                price_ids = ?price_ids,
-                max_age_s = price_max_age,
-                "Oracle prices are missing or stale. Enable AUTO_UPDATE_PRICES=true to automatically update prices before liquidations."
-            );
-        }
-
         if oracle_response.is_empty() {
+            tracing::warn!("Oracle returned no prices, skipping market");
             return Ok(());
         }
 

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -223,11 +223,11 @@ impl OracleFetcher {
 
         for feed in &parsed {
             // Parse the hex ID back to a PriceIdentifier
-            let id_bytes = hex::decode(&feed.id)
-                .map_err(|e| {
-                    tracing::warn!(id = %feed.id, error = %e, "Invalid hex price ID from Hermes");
-                })
-                .ok()?;
+            let Ok(id_bytes) = hex::decode(&feed.id).map_err(|e| {
+                tracing::warn!(id = %feed.id, error = %e, "Invalid hex price ID from Hermes");
+            }) else {
+                continue;
+            };
             if id_bytes.len() != 32 {
                 continue;
             }
@@ -235,8 +235,13 @@ impl OracleFetcher {
             arr.copy_from_slice(&id_bytes);
             let price_id = PriceIdentifier(arr);
 
-            let price_val: i64 = feed.ema_price.price.parse().ok()?;
-            let conf_val: u64 = feed.ema_price.conf.parse().ok()?;
+            let (Ok(price_val), Ok(conf_val)) = (
+                feed.ema_price.price.parse::<i64>(),
+                feed.ema_price.conf.parse::<u64>(),
+            ) else {
+                tracing::warn!(id = %feed.id, "Invalid Hermes price payload, skipping feed");
+                continue;
+            };
 
             result.insert(
                 price_id,
@@ -375,10 +380,7 @@ impl OracleFetcher {
         for (&original_price_id, transformer) in &transformers {
             if let Some(Some(underlying_price)) = underlying_prices.remove(&transformer.price_id) {
                 // Fetch the input value for transformation
-                match self
-                    .fetch_transformer_input(&transformer.call, &lst_oracle)
-                    .await
-                {
+                match self.fetch_transformer_input(&transformer.call).await {
                     Ok(input) => {
                         if let Some(transformed_price) =
                             transformer.action.apply(underlying_price, input)
@@ -663,11 +665,8 @@ impl OracleFetcher {
             .await?;
 
         // Fetch the transformer input (e.g., LST redemption rate).
-        // The dummy account is needed for the trait method signature but unused in practice.
-        #[allow(deprecated)]
-        let dummy_account = AccountId::new_unvalidated(String::new());
         let input = self
-            .fetch_transformer_input(&transformer.call, &dummy_account)
+            .fetch_transformer_input(&transformer.call)
             .await
             .map_err(|e| {
                 tracing::warn!(
@@ -684,7 +683,6 @@ impl OracleFetcher {
     async fn fetch_transformer_input(
         &self,
         call: &templar_common::oracle::price_transformer::Call,
-        _oracle: &AccountId,
     ) -> Result<Decimal, RpcError> {
         // Use the rpc_call() method to create a view query
         let query = call.rpc_call();

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -290,6 +290,133 @@ impl OracleFetcher {
 
     // ── On-chain price updates ────────────────────────────────────────────────
 
+    /// Resolves the market-facing oracle account + price IDs to the actual
+    /// underlying Pyth oracle and feed IDs that need `update_price_feeds`.
+    ///
+    /// - **Direct Pyth oracle**: returns as-is.
+    /// - **LST oracle**: resolves via `oracle_id()` + transformers to get
+    ///   the underlying Pyth oracle and transformed feed IDs.
+    /// - **Proxy oracle**: reads proxy entries, collects all
+    ///   `OracleRequest::Pyth` targets (`oracle_id` + `price_id`).
+    ///
+    /// Returns a map of `pyth_oracle_account` → `Vec<feed_ids>`.
+    pub async fn resolve_pyth_update_targets(
+        &self,
+        oracle: &AccountId,
+        price_ids: &[PriceIdentifier],
+    ) -> HashMap<AccountId, Vec<PriceIdentifier>> {
+        let mut targets: HashMap<AccountId, Vec<PriceIdentifier>> = HashMap::new();
+
+        // LST oracle: resolve underlying oracle + transform price IDs
+        if let Ok(Some(underlying_oracle)) = self.is_lst_oracle(oracle).await {
+            let mut underlying_ids = Vec::new();
+            for &pid in price_ids {
+                match view::<Option<PriceTransformer>>(
+                    &self.client,
+                    oracle.clone(),
+                    "get_transformer",
+                    json!({ "price_identifier": pid }),
+                )
+                .await
+                {
+                    Ok(Some(transformer)) => underlying_ids.push(transformer.price_id),
+                    _ => underlying_ids.push(pid),
+                }
+            }
+            targets
+                .entry(underlying_oracle)
+                .or_default()
+                .extend(underlying_ids);
+            return targets;
+        }
+
+        // Proxy oracle: collect Pyth entries from proxy config
+        if self.proxy_oracle_cache.read().await.contains(oracle) {
+            for &pid in price_ids {
+                let proxy: Option<Proxy> = view(
+                    &self.client,
+                    oracle.clone(),
+                    "get_proxy",
+                    json!({ "id": pid }),
+                )
+                .await
+                .ok()
+                .flatten();
+
+                let Some(proxy) = proxy else { continue };
+
+                for entry in &proxy.entries {
+                    Self::collect_pyth_targets_from_source(&entry.source, &mut targets);
+                }
+            }
+            return targets;
+        }
+
+        // Direct Pyth oracle
+        targets
+            .entry(oracle.clone())
+            .or_default()
+            .extend(price_ids.iter().copied());
+        targets
+    }
+
+    /// Collects Pyth oracle targets from a proxy source entry.
+    fn collect_pyth_targets_from_source(
+        source: &Source,
+        targets: &mut HashMap<AccountId, Vec<PriceIdentifier>>,
+    ) {
+        match source {
+            Source::Request(OracleRequest::Pyth(pyth_req)) => {
+                targets
+                    .entry(pyth_req.oracle_id.clone())
+                    .or_default()
+                    .push(pyth_req.price_id);
+            }
+            Source::Request(OracleRequest::RedStone(_)) => {
+                // RedStone prices are pushed by the relayer, not by us
+            }
+            Source::Transformer(transformer) => {
+                // Transformer wraps an underlying request — extract its Pyth target
+                Self::collect_pyth_targets_from_source(
+                    &Source::Request(transformer.request.clone()),
+                    targets,
+                );
+            }
+        }
+    }
+
+    /// Resolves market-level oracle config to underlying Pyth targets and pushes
+    /// fresh prices on-chain for each. Returns `Ok(true)` if any update was sent.
+    pub async fn update_onchain_prices(
+        &self,
+        oracle: &AccountId,
+        price_ids: &[PriceIdentifier],
+    ) -> LiquidatorResult<bool> {
+        let targets = self.resolve_pyth_update_targets(oracle, price_ids).await;
+
+        if targets.is_empty() {
+            tracing::debug!("No Pyth targets to update on-chain");
+            return Ok(false);
+        }
+
+        let mut any_updated = false;
+        for (pyth_oracle, feed_ids) in &targets {
+            match self.update_pyth_prices(pyth_oracle, feed_ids).await {
+                Ok(true) => any_updated = true,
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(
+                        oracle = %pyth_oracle,
+                        error = %e,
+                        "Failed to update on-chain Pyth prices"
+                    );
+                }
+            }
+        }
+
+        Ok(any_updated)
+    }
+
     /// Pushes fresh Pyth prices on-chain by fetching a VAA from Hermes and
     /// submitting an `update_price_feeds` transaction to the oracle contract.
     ///
@@ -299,7 +426,7 @@ impl OracleFetcher {
     ///
     /// Returns `Ok(true)` if update was sent, `Ok(false)` if no signer configured.
     #[tracing::instrument(skip(self), level = "info")]
-    pub async fn update_pyth_prices(
+    async fn update_pyth_prices(
         &self,
         oracle: &AccountId,
         price_ids: &[PriceIdentifier],

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -293,9 +293,9 @@ impl OracleFetcher {
         self.fetch_pyth_prices_from_hermes(price_ids)
             .await
             .ok_or_else(|| {
-                LiquidatorError::PriceFetchError(crate::rpc::RpcError::WrongResponseKind(
-                    format!("Failed to fetch Pyth prices from Hermes for oracle {oracle}"),
-                ))
+                LiquidatorError::PriceFetchError(crate::rpc::RpcError::WrongResponseKind(format!(
+                    "Failed to fetch Pyth prices from Hermes for oracle {oracle}"
+                )))
             })
     }
 

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -1,26 +1,23 @@
 //! Oracle price fetching module.
 //!
 //! Handles fetching prices from various oracle types including:
-//! - Standard Pyth oracles
+//! - Pyth oracles (via Hermes HTTP API)
+//! - RedStone oracles (via gateway HTTP API)
 //! - LST oracles with price transformers
-//! - Updating stale Pyth prices via Hermes API
+//! - Proxy oracles with off-chain aggregation
 
-use near_jsonrpc_client::{
-    methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest, JsonRpcClient,
-};
-use near_primitives::{
-    action::FunctionCallAction,
-    transaction::{Transaction, TransactionV0},
-    types::BlockReference,
-};
+use near_jsonrpc_client::JsonRpcClient;
 use near_sdk::{serde_json::json, AccountId};
 use std::collections::HashMap;
 use templar_common::{
     number::Decimal,
     oracle::{
         price_transformer::PriceTransformer,
-        pyth::{OracleResponse, PriceIdentifier},
+        proxy::{Proxy, Source},
+        pyth::{self, OracleResponse, PriceIdentifier},
+        redstone, OracleRequest,
     },
+    time::Nanoseconds,
 };
 
 use crate::{
@@ -28,52 +25,118 @@ use crate::{
     LiquidatorError, LiquidatorResult,
 };
 
+// ── Hermes (Pyth) gateway types ──────────────────────────────────────────────
+
+/// Parsed response from Pyth Hermes `/v2/updates/price/latest?parsed=true`.
 #[derive(serde::Deserialize)]
 struct HermesResponse {
-    binary: HermesBinary,
+    parsed: Option<Vec<HermesParsedFeed>>,
 }
 
 #[derive(serde::Deserialize)]
-struct HermesBinary {
-    data: Vec<String>,
+struct HermesParsedFeed {
+    id: String,
+    ema_price: HermesParsedPrice,
 }
+
+#[derive(serde::Deserialize)]
+struct HermesParsedPrice {
+    price: String,
+    conf: String,
+    expo: i32,
+    publish_time: i64,
+}
+
+// ── RedStone gateway types ───────────────────────────────────────────────────
+
+/// Default RedStone gateway URL.
+const DEFAULT_REDSTONE_GATEWAY_URL: &str = "https://oracle-gateway-1.a.redstone.vip";
+
+/// Default RedStone data service ID.
+const REDSTONE_DATA_SERVICE_ID: &str = "redstone-primary-prod";
+
+/// A single data point inside a RedStone gateway data package.
+#[derive(serde::Deserialize)]
+struct RedStoneGatewayDataPoint {
+    value: f64,
+}
+
+/// A signed data package from the RedStone gateway.
+#[derive(serde::Deserialize)]
+struct RedStoneGatewayPackage {
+    #[serde(rename = "dataPoints")]
+    data_points: Vec<RedStoneGatewayDataPoint>,
+    #[serde(rename = "timestampMilliseconds")]
+    timestamp_milliseconds: u64,
+}
+
+// ── Shared types ─────────────────────────────────────────────────────────────
+
+/// Shared cache of detected proxy oracle accounts.
+pub type ProxyOracleCache =
+    std::sync::Arc<tokio::sync::RwLock<std::collections::HashSet<AccountId>>>;
 
 /// Oracle price fetcher.
 ///
-/// Responsible for:
-/// - Fetching prices from Pyth oracles
-/// - Handling LST oracles with transformers
-/// - Applying price transformations
-/// - Updating stale Pyth prices via Hermes API
+/// Fetches prices directly from HTTP APIs (Pyth Hermes, RedStone gateway).
+/// Supports LST oracles with transformers and proxy oracles with off-chain
+/// aggregation.
 pub struct OracleFetcher {
     client: JsonRpcClient,
     /// Cache of which oracles are LST oracles (`oracle_account` -> `underlying_oracle`)
     lst_oracle_cache: std::sync::Arc<tokio::sync::RwLock<HashMap<AccountId, Option<AccountId>>>>,
-    /// HTTP client for Hermes API
+    /// Cache of detected proxy oracles (oracles that use cross-contract calls).
+    /// Shared across all `OracleFetcher` instances so detection during registry
+    /// refresh propagates to per-market fetchers.
+    proxy_oracle_cache: ProxyOracleCache,
+    /// HTTP client for API calls
     http_client: reqwest::Client,
-    /// Hermes API URL (e.g., <https://hermes.pyth.network>)
+    /// Pyth Hermes API URL (e.g., <https://hermes.pyth.network>)
     hermes_url: String,
-    /// Signer for updating oracle prices
-    signer_id: Option<AccountId>,
-    /// Private key for signing transactions
-    signer_key: Option<near_crypto::SecretKey>,
+    /// RedStone gateway URL for fetching fresh prices directly
+    redstone_gateway_url: String,
 }
 
 impl OracleFetcher {
     /// Creates a new oracle fetcher.
+    ///
+    /// `proxy_oracle_cache` allows sharing the proxy oracle cache across multiple
+    /// `OracleFetcher` instances. Pass `None` to create a standalone cache.
     pub fn new(
         client: JsonRpcClient,
         hermes_url: Option<String>,
-        signer_id: Option<AccountId>,
-        signer_key: Option<near_crypto::SecretKey>,
+        redstone_gateway_url: Option<String>,
+        proxy_oracle_cache: Option<ProxyOracleCache>,
     ) -> Self {
         Self {
             client,
             lst_oracle_cache: std::sync::Arc::new(tokio::sync::RwLock::new(HashMap::new())),
+            proxy_oracle_cache: proxy_oracle_cache.unwrap_or_else(|| {
+                std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()))
+            }),
             http_client: reqwest::Client::new(),
             hermes_url: hermes_url.unwrap_or_else(|| "https://hermes.pyth.network".to_string()),
-            signer_id,
-            signer_key,
+            redstone_gateway_url: redstone_gateway_url
+                .unwrap_or_else(|| DEFAULT_REDSTONE_GATEWAY_URL.to_string()),
+        }
+    }
+
+    /// Returns a clone of the shared proxy oracle cache handle.
+    pub fn proxy_oracle_cache(&self) -> ProxyOracleCache {
+        self.proxy_oracle_cache.clone()
+    }
+
+    /// Detects whether an oracle is a proxy oracle by checking if its account
+    /// name starts with `proxy-oracle-`. Proxy oracles are deployed via the
+    /// registry with this naming convention.
+    pub async fn detect_and_register_proxy_oracle(&self, oracle: &AccountId) {
+        if oracle.as_str().starts_with("proxy-oracle-")
+            && self.proxy_oracle_cache.write().await.insert(oracle.clone())
+        {
+            tracing::info!(
+                oracle = %oracle,
+                "Registered proxy oracle"
+            );
         }
     }
 
@@ -113,166 +176,95 @@ impl OracleFetcher {
         Ok(result)
     }
 
-    /// Updates Pyth oracle prices by fetching latest data from Hermes and pushing to oracle contract.
+    // ── Pyth / Hermes ────────────────────────────────────────────────────────
+
+    /// Fetches EMA prices from the Pyth Hermes HTTP API.
     ///
-    /// This method:
-    /// 1. Fetches latest price updates (VAA) from Pyth Hermes API
-    /// 2. Submits update transaction to the oracle contract
-    ///
-    /// Returns Ok(true) if update was sent, Ok(false) if no signer configured, Err on failure.
-    #[tracing::instrument(skip(self), level = "info")]
-    pub async fn update_pyth_prices(
+    /// Returns an `OracleResponse` keyed by `PriceIdentifier`.
+    #[tracing::instrument(skip(self), level = "debug")]
+    async fn fetch_pyth_prices_from_hermes(
         &self,
-        oracle: &AccountId,
         price_ids: &[PriceIdentifier],
-    ) -> LiquidatorResult<bool> {
-        // Check if we have credentials to update
-        let (Some(_signer_id), Some(_signer_key)) = (&self.signer_id, &self.signer_key) else {
-            tracing::warn!("No signer configured, cannot update Pyth prices");
-            return Ok(false);
-        };
-
-        tracing::info!(
-            oracle = %oracle,
-            price_ids = ?price_ids,
-            hermes_url = %self.hermes_url,
-            "Fetching latest price updates from Hermes"
-        );
-
-        // Build Hermes API request
+    ) -> Option<OracleResponse> {
         let url = format!("{}/v2/updates/price/latest", self.hermes_url);
-        let query_params: Vec<_> = price_ids
+        let mut query_params: Vec<(&str, String)> = price_ids
             .iter()
             .map(|id| ("ids[]", id.to_string()))
             .collect();
+        query_params.push(("parsed", "true".to_string()));
 
-        // Fetch VAA from Hermes
         let response = self
             .http_client
             .get(&url)
             .query(&query_params)
+            .timeout(std::time::Duration::from_secs(5))
             .send()
             .await
-            .map_err(|e| LiquidatorError::PriceUpdateError(format!("Hermes API error: {e}")))?;
+            .map_err(|e| {
+                tracing::debug!(error = %e, "Hermes HTTP request failed");
+            })
+            .ok()?;
 
         if !response.status().is_success() {
-            return Err(LiquidatorError::PriceUpdateError(format!(
-                "Hermes API returned status: {}",
-                response.status()
-            )));
+            tracing::debug!(status = %response.status(), "Hermes returned error status");
+            return None;
         }
 
-        let body: HermesResponse = response.json().await.map_err(|e| {
-            LiquidatorError::PriceUpdateError(format!("Failed to parse Hermes response: {e}"))
-        })?;
+        let body: HermesResponse = response
+            .json()
+            .await
+            .map_err(|e| {
+                tracing::debug!(error = %e, "Failed to parse Hermes response");
+            })
+            .ok()?;
 
-        let vaa_hex = body.binary.data.first().ok_or_else(|| {
-            LiquidatorError::PriceUpdateError("No VAA data in Hermes response".to_string())
-        })?;
+        let parsed = body.parsed?;
+        let mut result = OracleResponse::new();
 
-        tracing::info!(
-            vaa_size = vaa_hex.len(),
-            "Successfully fetched VAA from Hermes, submitting to oracle"
+        for feed in &parsed {
+            // Parse the hex ID back to a PriceIdentifier
+            let id_bytes = hex::decode(&feed.id)
+                .map_err(|e| {
+                    tracing::warn!(id = %feed.id, error = %e, "Invalid hex price ID from Hermes");
+                })
+                .ok()?;
+            if id_bytes.len() != 32 {
+                continue;
+            }
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&id_bytes);
+            let price_id = PriceIdentifier(arr);
+
+            let price_val: i64 = feed.ema_price.price.parse().ok()?;
+            let conf_val: u64 = feed.ema_price.conf.parse().ok()?;
+
+            result.insert(
+                price_id,
+                Some(pyth::Price {
+                    price: near_sdk::json_types::I64(price_val),
+                    conf: near_sdk::json_types::U64(conf_val),
+                    expo: feed.ema_price.expo,
+                    publish_time: pyth::PythTimestamp::from_secs(feed.ema_price.publish_time),
+                }),
+            );
+        }
+
+        tracing::debug!(
+            price_count = result.len(),
+            "Fetched Pyth EMA prices from Hermes"
         );
 
-        // Submit update to oracle using NEAR transaction
-        let signer_id = self.signer_id.as_ref().ok_or_else(|| {
-            LiquidatorError::PriceUpdateError("No signer_id configured".to_string())
-        })?;
-        let signer_key = self.signer_key.as_ref().ok_or_else(|| {
-            LiquidatorError::PriceUpdateError("No signer_key configured".to_string())
-        })?;
-
-        // Get current nonce
-        let access_key_query_response = self
-            .client
-            .call(near_jsonrpc_client::methods::query::RpcQueryRequest {
-                block_reference: BlockReference::latest(),
-                request: near_primitives::views::QueryRequest::ViewAccessKey {
-                    account_id: signer_id.clone(),
-                    public_key: signer_key.public_key(),
-                },
-            })
-            .await
-            .map_err(|e| {
-                LiquidatorError::PriceUpdateError(format!("Failed to query access key: {e}"))
-            })?;
-
-        let current_nonce = match access_key_query_response.kind {
-            near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(access_key) => {
-                access_key.nonce
-            }
-            _ => {
-                return Err(LiquidatorError::PriceUpdateError(
-                    "Unexpected query response kind".to_string(),
-                ))
-            }
-        };
-
-        // Get latest block hash
-        let block = self
-            .client
-            .call(near_jsonrpc_client::methods::block::RpcBlockRequest {
-                block_reference: BlockReference::latest(),
-            })
-            .await
-            .map_err(|e| {
-                LiquidatorError::PriceUpdateError(format!("Failed to get latest block: {e}"))
-            })?;
-
-        // Construct transaction
-        let transaction = Transaction::V0(TransactionV0 {
-            signer_id: signer_id.clone(),
-            public_key: signer_key.public_key(),
-            nonce: current_nonce + 1,
-            receiver_id: oracle.clone(),
-            block_hash: block.header.hash,
-            actions: vec![FunctionCallAction {
-                method_name: "update_price_feeds".to_string(),
-                args: near_sdk::serde_json::json!({
-                    "data": vaa_hex
-                })
-                .to_string()
-                .into_bytes(),
-                gas: 100_000_000_000_000,               // 100 TGas
-                deposit: 1_000_000_000_000_000_000_000, // 0.001 NEAR
-            }
-            .into()],
-        });
-
-        // Sign and send transaction
-        let signer =
-            near_crypto::InMemorySigner::from_secret_key(signer_id.clone(), signer_key.clone());
-        let signed_transaction = transaction.sign(&signer);
-        let request = RpcBroadcastTxCommitRequest { signed_transaction };
-
-        match self.client.call(request).await {
-            Ok(response) => {
-                tracing::info!(
-                    tx_hash = %response.transaction.hash,
-                    oracle = %oracle,
-                    "Successfully updated Pyth prices"
-                );
-                Ok(true)
-            }
-            Err(e) => {
-                tracing::error!(
-                    error = %e,
-                    oracle = %oracle,
-                    "Failed to submit price update transaction"
-                );
-                Err(LiquidatorError::PriceUpdateError(format!(
-                    "Transaction failed: {e}"
-                )))
-            }
-        }
+        Some(result)
     }
+
+    // ── Main entry point ─────────────────────────────────────────────────────
 
     /// Fetches current oracle prices.
     ///
     /// Detects oracle type and uses the appropriate method:
     /// - LST oracles: Fetch from underlying oracle and apply transformers
-    /// - Pyth oracles: Direct fetch with `list_ema_prices_unsafe` or `list_ema_prices_no_older_than`
+    /// - Proxy oracles: Fetch from underlying oracles via proxy configuration
+    /// - Pyth oracles: Hermes HTTP API
     #[tracing::instrument(skip(self), level = "debug")]
     pub async fn get_oracle_prices(
         &self,
@@ -292,52 +284,22 @@ impl OracleFetcher {
                 .await;
         }
 
-        // Standard Pyth oracle - try unsafe method first (faster)
-        let result: Result<OracleResponse, _> = view(
-            &self.client,
-            oracle.clone(),
-            "list_ema_prices_unsafe",
-            json!({ "price_ids": price_ids }),
-        )
-        .await;
-
-        match result {
-            Ok(response) => Ok(response),
-            Err(e) => {
-                let error_msg = format!("{e:?}");
-                tracing::debug!("First oracle call failed for {}: {}", oracle, error_msg);
-
-                // If method not found, try the standard method with age validation
-                if error_msg.contains("MethodNotFound") || error_msg.contains("MethodResolveError")
-                {
-                    tracing::debug!(
-                        "Oracle {} doesn't support list_ema_prices_unsafe, trying list_ema_prices_no_older_than",
-                        oracle
-                    );
-
-                    match view(
-                        &self.client,
-                        oracle.clone(),
-                        "list_ema_prices_no_older_than",
-                        json!({ "price_ids": price_ids, "age": age }),
-                    )
-                    .await
-                    {
-                        Ok(response) => {
-                            tracing::info!(
-                                "Successfully fetched prices from {} using list_ema_prices_no_older_than",
-                                oracle
-                            );
-                            Ok(response)
-                        }
-                        Err(fallback_err) => Err(LiquidatorError::PriceFetchError(fallback_err)),
-                    }
-                } else {
-                    Err(LiquidatorError::PriceFetchError(e))
-                }
-            }
+        // Check if this is a cached proxy oracle
+        if self.proxy_oracle_cache.read().await.contains(&oracle) {
+            return self.get_proxy_oracle_prices(oracle, price_ids, age).await;
         }
+
+        // Standard Pyth oracle — fetch from Hermes HTTP API
+        self.fetch_pyth_prices_from_hermes(price_ids)
+            .await
+            .ok_or_else(|| {
+                LiquidatorError::PriceFetchError(crate::rpc::RpcError::WrongResponseKind(
+                    format!("Failed to fetch Pyth prices from Hermes for oracle {oracle}"),
+                ))
+            })
     }
+
+    // ── LST oracle ───────────────────────────────────────────────────────────
 
     /// Fetches prices from LST oracle by calling underlying Pyth oracle and applying transformers.
     #[tracing::instrument(skip(self), level = "debug")]
@@ -471,6 +433,253 @@ impl OracleFetcher {
         Ok(final_prices)
     }
 
+    // ── Proxy oracle ─────────────────────────────────────────────────────────
+
+    /// Fetches prices from a proxy oracle by reading its configuration and querying
+    /// underlying oracles (Pyth/RedStone) directly, then applying aggregation off-chain.
+    ///
+    /// Proxy oracles aggregate prices from multiple sources (Pyth + RedStone) using
+    /// cross-contract calls on-chain, which fails in view mode. This method replicates
+    /// the aggregation off-chain by:
+    /// 1. Reading proxy config (`get_proxy`) for each price ID
+    /// 2. Fetching prices from underlying oracles directly
+    /// 3. Applying transformers (e.g., LST redemption rates)
+    /// 4. Running the aggregation algorithm locally
+    #[tracing::instrument(skip(self), level = "debug")]
+    async fn get_proxy_oracle_prices(
+        &self,
+        proxy_oracle: AccountId,
+        price_ids: &[PriceIdentifier],
+        age: u32,
+    ) -> LiquidatorResult<OracleResponse> {
+        let mut result = OracleResponse::new();
+
+        for &price_id in price_ids {
+            let proxy: Option<Proxy> = view(
+                &self.client,
+                proxy_oracle.clone(),
+                "get_proxy",
+                json!({ "id": price_id }),
+            )
+            .await
+            .map_err(LiquidatorError::PriceFetchError)?;
+
+            let Some(proxy) = proxy else {
+                tracing::warn!(
+                    oracle = %proxy_oracle,
+                    price_id = ?price_id,
+                    "No proxy configuration found for price ID"
+                );
+                result.insert(price_id, None);
+                continue;
+            };
+
+            // Collect prices from underlying oracles for each entry
+            let mut prices: Vec<(pyth::Price, u32)> = Vec::new();
+
+            for entry in &proxy.entries {
+                let price = match &entry.source {
+                    Source::Request(request) => self.fetch_oracle_request_price(request, age).await,
+                    Source::Transformer(transformer) => {
+                        self.fetch_proxy_transformed_price(transformer, age).await
+                    }
+                };
+
+                if let Some(price) = price {
+                    prices.push((price, entry.weight));
+                }
+            }
+
+            // Apply aggregation using the same logic as the on-chain proxy
+            let now = system_nanoseconds();
+            let aggregated = proxy.aggregator.aggregate(&prices, now);
+            result.insert(price_id, aggregated.map(Into::into));
+
+            if result.get(&price_id).and_then(|p| p.as_ref()).is_some() {
+                tracing::debug!(
+                    oracle = %proxy_oracle,
+                    price_id = ?price_id,
+                    source_count = prices.len(),
+                    "Proxy oracle: aggregated price from underlying sources"
+                );
+            } else {
+                tracing::warn!(
+                    oracle = %proxy_oracle,
+                    price_id = ?price_id,
+                    source_count = prices.len(),
+                    "Proxy oracle: aggregation returned no price"
+                );
+            }
+        }
+
+        Ok(result)
+    }
+
+    // ── Individual source fetchers ───────────────────────────────────────────
+
+    /// Fetches a price from a single oracle request (Pyth or RedStone).
+    ///
+    /// For Pyth requests, calls `get_oracle_prices` directly on the underlying
+    /// Pyth oracle (not the proxy), which avoids infinite recursion since a
+    /// real Pyth oracle won't trigger the proxy path.
+    async fn fetch_oracle_request_price(
+        &self,
+        request: &OracleRequest,
+        age: u32,
+    ) -> Option<pyth::Price> {
+        match request {
+            OracleRequest::Pyth(pyth_req) => {
+                // Use Box::pin to break the recursive async type cycle:
+                // get_oracle_prices → get_proxy_oracle_prices → fetch_oracle_request_price → get_oracle_prices
+                let response = Box::pin(self.get_oracle_prices(
+                    pyth_req.oracle_id.clone(),
+                    &[pyth_req.price_id],
+                    age,
+                ))
+                .await
+                .ok()?;
+                response.get(&pyth_req.price_id)?.clone()
+            }
+            OracleRequest::RedStone(rs_req) => {
+                self.fetch_redstone_price_from_gateway(&rs_req.price_id)
+                    .await
+            }
+        }
+    }
+
+    /// Fetches a fresh price directly from the RedStone gateway HTTP API.
+    ///
+    /// The gateway returns signed data packages from multiple signers.
+    /// We take the median price across packages for robustness, and use
+    /// the package timestamp to construct a fresh `pyth::Price`.
+    #[allow(
+        clippy::cast_possible_truncation,
+        clippy::cast_precision_loss,
+        clippy::cast_possible_wrap
+    )]
+    async fn fetch_redstone_price_from_gateway(
+        &self,
+        feed_id: &redstone::FeedId,
+    ) -> Option<pyth::Price> {
+        let url = format!(
+            "{}/v2/data-packages/latest/{}",
+            self.redstone_gateway_url, REDSTONE_DATA_SERVICE_ID,
+        );
+
+        let response = self
+            .http_client
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    feed_id = %feed_id,
+                    error = %e,
+                    "RedStone gateway HTTP request failed"
+                );
+            })
+            .ok()?;
+
+        if !response.status().is_success() {
+            tracing::warn!(
+                feed_id = %feed_id,
+                status = %response.status(),
+                "RedStone gateway returned error status"
+            );
+            return None;
+        }
+
+        let body: HashMap<String, Vec<RedStoneGatewayPackage>> = response
+            .json()
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    feed_id = %feed_id,
+                    error = %e,
+                    "Failed to parse RedStone gateway response"
+                );
+            })
+            .ok()?;
+
+        let feed_id_str: &str = feed_id;
+        let packages = body.get(feed_id_str)?;
+
+        if packages.is_empty() {
+            tracing::warn!(feed_id = %feed_id, "No data packages from RedStone gateway");
+            return None;
+        }
+
+        // Extract prices and timestamp from all packages
+        let mut values: Vec<f64> = packages
+            .iter()
+            .filter_map(|pkg| pkg.data_points.first().map(|dp| dp.value))
+            .collect();
+
+        if values.is_empty() {
+            return None;
+        }
+
+        // Use median price for robustness
+        values.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
+        let median = values[values.len() / 2];
+
+        // Use the timestamp from the first package (all packages share the same timestamp)
+        let timestamp_ms = packages[0].timestamp_milliseconds;
+
+        // Convert price to i64 mantissa with 8-decimal exponent.
+        // RedStone prices use 8 decimals, so multiply by 10^8.
+        let raw_value = (median * 1e8) as i64;
+
+        let price = pyth::Price {
+            price: near_sdk::json_types::I64(raw_value),
+            conf: near_sdk::json_types::U64(0),
+            expo: -8,
+            publish_time: pyth::PythTimestamp::from_ms(timestamp_ms as i64),
+        };
+
+        tracing::debug!(
+            feed_id = %feed_id,
+            price = raw_value,
+            timestamp_ms = timestamp_ms,
+            signer_count = packages.len(),
+            "Fetched fresh RedStone price from gateway"
+        );
+
+        Some(price)
+    }
+
+    // ── Transformers ─────────────────────────────────────────────────────────
+
+    /// Fetches a transformed price from a proxy entry (underlying oracle + transformer input).
+    async fn fetch_proxy_transformed_price(
+        &self,
+        transformer: &templar_common::oracle::price_transformer::ProxyPriceTransformer,
+        age: u32,
+    ) -> Option<pyth::Price> {
+        // Fetch the underlying price
+        let underlying = self
+            .fetch_oracle_request_price(&transformer.request, age)
+            .await?;
+
+        // Fetch the transformer input (e.g., LST redemption rate).
+        // The dummy account is needed for the trait method signature but unused in practice.
+        #[allow(deprecated)]
+        let dummy_account = AccountId::new_unvalidated(String::new());
+        let input = self
+            .fetch_transformer_input(&transformer.call, &dummy_account)
+            .await
+            .map_err(|e| {
+                tracing::warn!(
+                    error = ?e,
+                    "Failed to fetch proxy transformer input"
+                );
+            })
+            .ok()?;
+
+        transformer.action.apply(underlying, input)
+    }
+
     /// Fetches the input value needed for price transformation (e.g., LST redemption rate).
     async fn fetch_transformer_input(
         &self,
@@ -501,4 +710,13 @@ impl OracleFetcher {
             ))
         }
     }
+}
+
+/// Returns the current system time as `Nanoseconds` (off-chain equivalent of `Nanoseconds::now()`).
+#[allow(clippy::cast_possible_truncation)]
+fn system_nanoseconds() -> Nanoseconds {
+    let dur = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    Nanoseconds::from_ns(dur.as_nanos() as u64)
 }

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -6,8 +6,12 @@
 //! - LST oracles with price transformers
 //! - Proxy oracles with off-chain aggregation
 
-use near_jsonrpc_client::JsonRpcClient;
-use near_sdk::{serde_json::json, AccountId};
+use near_jsonrpc_client::{
+    methods::broadcast_tx_commit::RpcBroadcastTxCommitRequest, JsonRpcClient,
+};
+use near_primitives::transaction::{Transaction, TransactionV0};
+use near_sdk::Gas;
+use near_sdk::{serde_json::json, AccountId, NearToken};
 use std::collections::HashMap;
 use templar_common::{
     number::Decimal,
@@ -45,6 +49,17 @@ struct HermesParsedPrice {
     conf: String,
     expo: i32,
     publish_time: i64,
+}
+
+/// Binary (VAA) response from Pyth Hermes for on-chain price updates.
+#[derive(serde::Deserialize)]
+struct HermesBinaryResponse {
+    binary: HermesBinaryData,
+}
+
+#[derive(serde::Deserialize)]
+struct HermesBinaryData {
+    data: Vec<String>,
 }
 
 // ── RedStone gateway types ───────────────────────────────────────────────────
@@ -95,6 +110,10 @@ pub struct OracleFetcher {
     hermes_url: String,
     /// RedStone gateway URL for fetching fresh prices directly
     redstone_gateway_url: String,
+    /// Signer account for on-chain oracle price updates
+    signer_id: Option<AccountId>,
+    /// Signer key for on-chain oracle price updates
+    signer_key: Option<near_crypto::SecretKey>,
 }
 
 impl OracleFetcher {
@@ -107,7 +126,12 @@ impl OracleFetcher {
         hermes_url: Option<String>,
         redstone_gateway_url: Option<String>,
         proxy_oracle_cache: Option<ProxyOracleCache>,
+        signer_for_oracle: Option<(AccountId, near_crypto::SecretKey)>,
     ) -> Self {
+        let (signer_id, signer_key) = match signer_for_oracle {
+            Some((id, key)) => (Some(id), Some(key)),
+            None => (None, None),
+        };
         Self {
             client,
             lst_oracle_cache: std::sync::Arc::new(tokio::sync::RwLock::new(HashMap::new())),
@@ -118,6 +142,8 @@ impl OracleFetcher {
             hermes_url: hermes_url.unwrap_or_else(|| "https://hermes.pyth.network".to_string()),
             redstone_gateway_url: redstone_gateway_url
                 .unwrap_or_else(|| DEFAULT_REDSTONE_GATEWAY_URL.to_string()),
+            signer_id,
+            signer_key,
         }
     }
 
@@ -260,6 +286,143 @@ impl OracleFetcher {
         );
 
         Some(result)
+    }
+
+    // ── On-chain price updates ────────────────────────────────────────────────
+
+    /// Pushes fresh Pyth prices on-chain by fetching a VAA from Hermes and
+    /// submitting an `update_price_feeds` transaction to the oracle contract.
+    ///
+    /// The market contract reads prices from the on-chain oracle during
+    /// liquidation execution, so prices must be fresh there — not just in the
+    /// liquidator's local HTTP-fetched view.
+    ///
+    /// Returns `Ok(true)` if update was sent, `Ok(false)` if no signer configured.
+    #[tracing::instrument(skip(self), level = "info")]
+    pub async fn update_pyth_prices(
+        &self,
+        oracle: &AccountId,
+        price_ids: &[PriceIdentifier],
+    ) -> LiquidatorResult<bool> {
+        let (Some(signer_id), Some(signer_key)) = (&self.signer_id, &self.signer_key) else {
+            tracing::warn!("No signer configured, cannot update Pyth prices");
+            return Ok(false);
+        };
+
+        tracing::info!(
+            oracle = %oracle,
+            price_ids = ?price_ids,
+            "Fetching VAA from Hermes for on-chain price update"
+        );
+
+        // Fetch binary VAA from Hermes
+        let url = format!("{}/v2/updates/price/latest", self.hermes_url);
+        let query_params: Vec<_> = price_ids
+            .iter()
+            .map(|id| ("ids[]", id.to_string()))
+            .collect();
+
+        let response = self
+            .http_client
+            .get(&url)
+            .query(&query_params)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|e| LiquidatorError::OracleUpdateError(format!("Hermes API error: {e}")))?;
+
+        if !response.status().is_success() {
+            return Err(LiquidatorError::OracleUpdateError(format!(
+                "Hermes API returned status: {}",
+                response.status()
+            )));
+        }
+
+        let body: HermesBinaryResponse = response.json().await.map_err(|e| {
+            LiquidatorError::OracleUpdateError(format!("Failed to parse Hermes response: {e}"))
+        })?;
+
+        let vaa_hex = body.binary.data.first().ok_or_else(|| {
+            LiquidatorError::OracleUpdateError("No VAA data in Hermes response".to_string())
+        })?;
+
+        tracing::info!(
+            vaa_size = vaa_hex.len(),
+            "Fetched VAA from Hermes, submitting to oracle"
+        );
+
+        // Get current nonce and block hash
+        let access_key_query_response = self
+            .client
+            .call(near_jsonrpc_client::methods::query::RpcQueryRequest {
+                block_reference: near_primitives::types::BlockReference::latest(),
+                request: near_primitives::views::QueryRequest::ViewAccessKey {
+                    account_id: signer_id.clone(),
+                    public_key: signer_key.public_key(),
+                },
+            })
+            .await
+            .map_err(|e| {
+                LiquidatorError::OracleUpdateError(format!("Failed to query access key: {e}"))
+            })?;
+
+        let current_nonce = match access_key_query_response.kind {
+            near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(access_key) => {
+                access_key.nonce
+            }
+            _ => {
+                return Err(LiquidatorError::OracleUpdateError(
+                    "Unexpected query response kind".to_string(),
+                ))
+            }
+        };
+
+        let block_hash = access_key_query_response.block_hash;
+
+        // Construct and send update transaction
+        let transaction = Transaction::V0(TransactionV0 {
+            signer_id: signer_id.clone(),
+            public_key: signer_key.public_key(),
+            nonce: current_nonce + 1,
+            receiver_id: oracle.clone(),
+            block_hash,
+            actions: vec![near_primitives::action::FunctionCallAction {
+                method_name: "update_price_feeds".to_string(),
+                args: json!({ "data": vaa_hex }).to_string().into_bytes(),
+                gas: Gas::from_tgas(100).as_gas(),
+                deposit: NearToken::from_millinear(1).as_yoctonear(),
+            }
+            .into()],
+        });
+
+        let signer =
+            near_crypto::InMemorySigner::from_secret_key(signer_id.clone(), signer_key.clone());
+        let signed_transaction = transaction.sign(&signer);
+
+        match self
+            .client
+            .call(RpcBroadcastTxCommitRequest { signed_transaction })
+            .await
+        {
+            Ok(response) => {
+                tracing::info!(
+                    tx_hash = %response.transaction.hash,
+                    oracle = %oracle,
+                    "Successfully updated on-chain Pyth prices"
+                );
+                Ok(true)
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    oracle = %oracle,
+                    "Failed to submit price update transaction"
+                );
+                Err(LiquidatorError::OracleUpdateError(format!(
+                    "Transaction failed: {e}"
+                )))
+            }
+        }
     }
 
     // ── Main entry point ─────────────────────────────────────────────────────

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -147,11 +147,12 @@ impl LiquidatorService {
         let (_, oneclick_provider) =
             Self::create_swap_providers(&config, &client, Arc::new(signer.clone()));
 
-        // Create oracle fetcher for batch swap price checks
+        // Create oracle fetcher for batch swap price checks (no signer needed for reads)
         let oracle_fetcher = crate::OracleFetcher::new(
             client.clone(),
             Some(config.hermes_url.clone()),
             Some(config.redstone_gateway_url.clone()),
+            None,
             None,
         );
 
@@ -552,6 +553,10 @@ impl LiquidatorService {
                     self.config.swap_retry_config.clone(),
                     self.config.min_swap_value_usd,
                     Some(self.oracle_fetcher.proxy_oracle_cache()),
+                    Some((
+                        self.config.signer_account.clone(),
+                        self.config.signer_key.clone(),
+                    )),
                 );
 
                 // Fetch market version for version-specific liquidation logic

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -88,10 +88,10 @@ pub struct ServiceConfig {
     pub loop_liquidation: bool,
     /// Maximum iterations for loop liquidation (safety limit)
     pub max_loop_iterations: u32,
-    /// Pyth Hermes API URL for price updates
+    /// Pyth Hermes API URL for fetching price data
     pub hermes_url: String,
-    /// Enable automatic Pyth price updates before liquidations
-    pub auto_update_prices: bool,
+    /// RedStone gateway URL for fetching fresh prices
+    pub redstone_gateway_url: String,
     /// Minimum USD value to attempt a swap (JIT or batch)
     pub min_swap_value_usd: f64,
     /// Enable batch swap of accumulated collateral at round start
@@ -148,18 +148,11 @@ impl LiquidatorService {
             Self::create_swap_providers(&config, &client, Arc::new(signer.clone()));
 
         // Create oracle fetcher for batch swap price checks
-        let signer_for_oracle = if config.auto_update_prices {
-            Some((config.signer_account.clone(), config.signer_key.clone()))
-        } else {
-            None
-        };
         let oracle_fetcher = crate::OracleFetcher::new(
             client.clone(),
             Some(config.hermes_url.clone()),
-            signer_for_oracle
-                .as_ref()
-                .map(|(account, _)| account.clone()),
-            signer_for_oracle.map(|(_, key)| key),
+            Some(config.redstone_gateway_url.clone()),
+            None,
         );
 
         // Log swap configuration
@@ -262,6 +255,11 @@ impl LiquidatorService {
             self.config.liquidation_scan_interval,
         ));
         liquidation_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        // Load 1-Click supported tokens cache
+        if let Some(ref provider) = self.oneclick_provider {
+            provider.load_supported_tokens().await;
+        }
 
         // Run initial registry refresh immediately
         match self.refresh_registry().await {
@@ -419,14 +417,53 @@ impl LiquidatorService {
                 "Found deployments from registries"
             );
 
-            // Fetch configurations for all markets
+            // Filter deployments using registry metadata, then fetch market configs
             let mut market_configs = Vec::new();
             for market in &all_markets {
-                // Check contract version using NEP-330
+                // Step 1: Fetch market configuration — this is the definitive check
+                // for whether a deployment is a market contract. Non-market contracts
+                // (proxy-oracles, redstone-adapters) won't have this method.
+                let config = match view::<templar_common::market::MarketConfiguration>(
+                    &self.client,
+                    market.clone(),
+                    "get_configuration",
+                    near_sdk::serde_json::json!({}),
+                )
+                .await
+                {
+                    Ok(config) => {
+                        tracing::debug!(
+                            market = %market,
+                            borrow_asset = %config.borrow_asset,
+                            collateral_asset = %config.collateral_asset,
+                            "Fetched market configuration"
+                        );
+                        config
+                    }
+                    Err(e) => {
+                        let err_msg = format!("{e:?}");
+                        if err_msg.contains("MethodNotFound")
+                            || err_msg.contains("MethodResolveError")
+                        {
+                            tracing::info!(
+                                deployment = %market,
+                                "Skipping non-market deployment (no get_configuration method)"
+                            );
+                        } else {
+                            tracing::warn!(
+                                market = %market,
+                                error = ?e,
+                                "Failed to fetch market configuration, skipping"
+                            );
+                        }
+                        continue;
+                    }
+                };
+
+                // Step 2: Check contract version using NEP-330
                 let version_result = crate::rpc::get_contract_version(&self.client, market).await;
 
                 if let Some(version) = version_result {
-                    // Parse semver and verify compatibility
                     let parts: Vec<&str> = version.split('.').collect();
                     let is_supported = if let [maj, min, _patch] = parts.as_slice() {
                         let major = maj.parse::<u32>().unwrap_or(0);
@@ -458,44 +495,24 @@ impl LiquidatorService {
                     continue;
                 }
 
-                // Fetch market configuration
-                match view::<templar_common::market::MarketConfiguration>(
-                    &self.client,
-                    market.clone(),
-                    "get_configuration",
-                    near_sdk::serde_json::json!({}),
-                )
-                .await
-                {
-                    Ok(config) => {
-                        tracing::debug!(
-                            market = %market,
-                            borrow_asset = %config.borrow_asset,
-                            collateral_asset = %config.collateral_asset,
-                            "Fetched market configuration"
-                        );
+                // Step 3: Detect proxy oracle upfront via list_proxies probe
+                let oracle_account = &config.price_oracle_configuration.account_id;
+                self.oracle_fetcher
+                    .detect_and_register_proxy_oracle(oracle_account)
+                    .await;
 
-                        // Apply market filtering rules
-                        let (should_process, filter_reason) = self.should_process_market(&config);
+                // Step 4: Apply market filtering rules (collateral asset allow/ignore lists)
+                let (should_process, filter_reason) = self.should_process_market(&config);
 
-                        if should_process {
-                            market_configs.push((market.clone(), config));
-                        } else {
-                            tracing::info!(
-                                market = %market,
-                                collateral_asset = %config.collateral_asset,
-                                reason = filter_reason.unwrap_or_default(),
-                                "Market filtered out"
-                            );
-                        }
-                    }
-                    Err(e) => {
-                        tracing::warn!(
-                            market = %market,
-                            error = ?e,
-                            "Failed to fetch market configuration, skipping"
-                        );
-                    }
+                if should_process {
+                    market_configs.push((market.clone(), config));
+                } else {
+                    tracing::info!(
+                        market = %market,
+                        collateral_asset = %config.collateral_asset,
+                        reason = filter_reason.unwrap_or_default(),
+                        "Market filtered out"
+                    );
                 }
             }
 
@@ -517,16 +534,6 @@ impl LiquidatorService {
                 // Clone Signer enum
                 let signer = Arc::new(self.signer.clone());
 
-                let signer_for_oracle = if self.config.auto_update_prices {
-                    // Use config which has account and key
-                    Some((
-                        self.config.signer_account.clone(),
-                        self.config.signer_key.clone(),
-                    ))
-                } else {
-                    None
-                };
-
                 let mut liquidator = Liquidator::new(
                     &self.client,
                     signer,
@@ -541,10 +548,10 @@ impl LiquidatorService {
                     self.config.loop_liquidation,
                     self.config.max_loop_iterations,
                     Some(self.config.hermes_url.clone()),
-                    self.config.auto_update_prices,
-                    &signer_for_oracle,
+                    Some(self.config.redstone_gateway_url.clone()),
                     self.config.swap_retry_config.clone(),
                     self.config.min_swap_value_usd,
+                    Some(self.oracle_fetcher.proxy_oracle_cache()),
                 );
 
                 // Fetch market version for version-specific liquidation logic
@@ -577,6 +584,11 @@ impl LiquidatorService {
                 collateral_assets = self.collateral_price_map.len(),
                 "Built collateral price map"
             );
+
+            // Refresh 1-Click supported tokens cache
+            if let Some(ref provider) = self.oneclick_provider {
+                provider.load_supported_tokens().await;
+            }
 
             Ok(())
         }
@@ -755,6 +767,20 @@ impl LiquidatorService {
                 continue;
             };
 
+            // Skip if swap provider doesn't support this asset pair
+            if let Some(ref provider) = self.oneclick_provider {
+                use crate::swap::SwapProvider;
+                if !provider.supports_assets(collateral_asset, &info.target_borrow_asset) {
+                    tracing::info!(
+                        from = %asset_key,
+                        to = %info.target_borrow_asset,
+                        "Swap provider does not support asset pair, skipping batch swap"
+                    );
+                    skipped += 1;
+                    continue;
+                }
+            }
+
             // Dry run: log what would happen, skip actual swap
             if dry_run {
                 tracing::info!(
@@ -831,6 +857,11 @@ impl LiquidatorService {
                             from = %asset_key,
                             error = %e,
                             "Batch swap skipped - amount too low for provider"
+                        );
+                    } else if msg.contains("Quote failed") {
+                        tracing::debug!(
+                            from = %asset_key,
+                            "No swap route available for asset, skipping batch swap"
                         );
                     } else {
                         tracing::info!(

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -495,7 +495,7 @@ impl LiquidatorService {
                     continue;
                 }
 
-                // Step 3: Detect proxy oracle upfront via list_proxies probe
+                // Step 3: Detect proxy oracle via account name prefix convention
                 let oracle_account = &config.price_oracle_configuration.account_id;
                 self.oracle_fetcher
                     .detect_and_register_proxy_oracle(oracle_account)

--- a/service/liquidator/src/swap/oneclick.rs
+++ b/service/liquidator/src/swap/oneclick.rs
@@ -339,7 +339,19 @@ impl OneClickSwap {
     /// registry refresh to keep the cache up to date.
     pub async fn load_supported_tokens(&self) {
         let url = format!("{ONECLICK_API_BASE}/v0/tokens");
-        match self.http_client.get(&url).send().await {
+        match self
+            .http_client
+            .get(&url)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(response) if !response.status().is_success() => {
+                tracing::warn!(
+                    status = %response.status(),
+                    "1-Click /v0/tokens returned error status"
+                );
+            }
             Ok(response) => match response.json::<Vec<TokenInfo>>().await {
                 Ok(tokens) => {
                     let mut cache = self

--- a/service/liquidator/src/swap/oneclick.rs
+++ b/service/liquidator/src/swap/oneclick.rs
@@ -278,6 +278,13 @@ struct TxHashWithExplorer {
     explorer_url: String,
 }
 
+/// Response structure for `/v0/tokens` endpoint.
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenInfo {
+    asset_id: String,
+}
+
 /// 1-Click API swap provider
 #[derive(Debug, Clone)]
 pub struct OneClickSwap {
@@ -293,6 +300,8 @@ pub struct OneClickSwap {
     http_client: reqwest::Client,
     /// Optional API token for fee reduction
     api_token: Option<String>,
+    /// Cached set of 1-Click supported token `assetId` values
+    supported_tokens: std::sync::Arc<std::sync::RwLock<std::collections::HashSet<String>>>,
 }
 
 impl OneClickSwap {
@@ -317,6 +326,48 @@ impl OneClickSwap {
             timeout: DEFAULT_TIMEOUT,
             http_client: reqwest::Client::new(),
             api_token,
+            supported_tokens: std::sync::Arc::new(std::sync::RwLock::new(
+                std::collections::HashSet::new(),
+            )),
+        }
+    }
+
+    /// Fetches the list of supported tokens from the 1-Click API `/v0/tokens`
+    /// endpoint and populates the local cache.
+    ///
+    /// Should be called during service initialization and periodically during
+    /// registry refresh to keep the cache up to date.
+    pub async fn load_supported_tokens(&self) {
+        let url = format!("{ONECLICK_API_BASE}/v0/tokens");
+        match self.http_client.get(&url).send().await {
+            Ok(response) => match response.json::<Vec<TokenInfo>>().await {
+                Ok(tokens) => {
+                    let mut cache = self
+                        .supported_tokens
+                        .write()
+                        .unwrap_or_else(|e| e.into_inner());
+                    cache.clear();
+                    for token in &tokens {
+                        cache.insert(token.asset_id.clone());
+                    }
+                    tracing::info!(
+                        token_count = cache.len(),
+                        "1-Click supported tokens cache loaded"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = ?e,
+                        "Failed to parse 1-Click /v0/tokens response"
+                    );
+                }
+            },
+            Err(e) => {
+                tracing::warn!(
+                    error = ?e,
+                    "Failed to fetch 1-Click supported tokens"
+                );
+            }
         }
     }
 
@@ -1216,8 +1267,37 @@ impl SwapProvider for OneClickSwap {
         let from_is_nep245 = from_asset.clone().into_nep245().is_some();
         let to_is_nep245 = to_asset.clone().into_nep245().is_some();
 
-        // Support if at least one is Intent token
-        from_is_nep245 || to_is_nep245
+        if !(from_is_nep245 || to_is_nep245) {
+            return false;
+        }
+
+        // Check against the cached supported tokens list from /v0/tokens.
+        // If the cache is empty (not yet loaded), allow the swap to proceed —
+        // a quote failure will surface the issue at runtime.
+        let cache = self
+            .supported_tokens
+            .read()
+            .unwrap_or_else(|e| e.into_inner());
+        if cache.is_empty() {
+            return true;
+        }
+
+        let from_id = Self::to_oneclick_asset_id(from_asset);
+        let to_id = Self::to_oneclick_asset_id(to_asset);
+        let from_ok = cache.contains(&from_id);
+        let to_ok = cache.contains(&to_id);
+
+        if !from_ok || !to_ok {
+            tracing::debug!(
+                from = %from_id,
+                to = %to_id,
+                from_supported = from_ok,
+                to_supported = to_ok,
+                "1-Click does not support one or both tokens"
+            );
+        }
+
+        from_ok && to_ok
     }
 
     async fn ensure_storage_registration<F: AssetClass>(

--- a/service/liquidator/src/swap/provider.rs
+++ b/service/liquidator/src/swap/provider.rs
@@ -34,6 +34,13 @@ impl SwapProviderImpl {
     pub fn oneclick(provider: OneClickSwap) -> Self {
         Self::OneClick(provider)
     }
+
+    /// Loads supported tokens for the 1-Click provider (no-op for others).
+    pub async fn load_supported_tokens(&self) {
+        if let Self::OneClick(provider) = self {
+            provider.load_supported_tokens().await;
+        }
+    }
 }
 
 #[async_trait::async_trait]

--- a/service/liquidator/src/swap/retry.rs
+++ b/service/liquidator/src/swap/retry.rs
@@ -50,11 +50,14 @@ pub enum SwapErrorKind {
 
 impl SwapErrorKind {
     /// Returns true if this error type should be retried.
+    ///
+    /// `QuoteFailed` is not retried — "Failed to get quote" from the 1-Click API means no
+    /// swap route exists for the asset pair, which is a permanent condition, not transient.
+    /// Transient API failures are captured by `NetworkError` and `ServerError` instead.
     pub fn is_retryable(&self) -> bool {
         matches!(
             self,
-            Self::QuoteFailed { .. }
-                | Self::NetworkError { .. }
+            Self::NetworkError { .. }
                 | Self::ServerError { .. }
                 | Self::RateLimited
                 | Self::Timeout { .. }
@@ -218,7 +221,8 @@ mod tests {
 
     #[test]
     fn test_retryable_classification() {
-        assert!(SwapErrorKind::QuoteFailed {
+        // QuoteFailed is not retryable — permanent "no route" condition
+        assert!(!SwapErrorKind::QuoteFailed {
             message: String::new()
         }
         .is_retryable());
@@ -266,7 +270,8 @@ mod tests {
     fn test_quote_failed_classification() {
         let kind =
             SwapErrorKind::from_oneclick_response(400, r#"{"message":"Failed to get quote"}"#);
-        assert!(kind.is_retryable());
+        // QuoteFailed is not retryable — "no route" is a permanent condition
+        assert!(!kind.is_retryable());
         assert!(!kind.is_amount_too_low());
     }
 


### PR DESCRIPTION
Three improvements to the liquidator service:

1. **Filter non-market registry deployments** — use `get_configuration()` as a check for whether a deployment is a market contract, skipping proxy-oracles and redstone-adapters

2. **Fetch oracle prices via HTTP APIs** — replace all on-chain oracle interactions for price reading with direct HTTP calls to Pyth Hermes and RedStone gateway APIs, removing the `update_pyth_prices` transaction flow and `AUTO_UPDATE_PRICES` config entirely

3. **Check swap eligibility** — cache supported tokens from 1-Click API `/v0/tokens` on startup and registry refresh, skip unsupported asset pairs without attempting swaps

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/389)
<!-- Reviewable:end -->
