### PR TITLE
Add Liquidator TG notifications for liquidations and swap

### DIFF
--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -174,3 +174,18 @@ PYTH_HERMES_URL=https://hermes.pyth.network
 # Gateways: https://oracle-gateway-1.a.redstone.vip, https://oracle-gateway-2.a.redstone.finance
 # Default: https://oracle-gateway-1.a.redstone.vip
 REDSTONE_GATEWAY_URL=https://oracle-gateway-1.a.redstone.vip
+
+# ============================================
+# TELEGRAM NOTIFICATIONS
+# ============================================
+
+# Telegram bot token for sending notifications
+# Create a bot via @BotFather on Telegram
+# TELEGRAM_BOT_TOKEN=123456:ABC-DEF1234ghIkl-zyx57W2v1u123ew11
+
+# Telegram chat ID to send notifications to
+# Use @userinfobot or @RawDataBot to get your chat ID
+# TELEGRAM_CHAT_ID=-100123456789
+
+# Optional: Telegram thread/topic ID for sending to a specific topic in a group
+# TELEGRAM_THREAD_ID=42

--- a/service/liquidator/scripts/run-mainnet.sh
+++ b/service/liquidator/scripts/run-mainnet.sh
@@ -177,6 +177,11 @@ fi
 CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
 CMD_ARGS+=("--redstone-gateway-url" "$REDSTONE_GATEWAY_URL")
 
+# Add Telegram notification arguments (use = syntax because chat IDs start with -)
+[ -n "$TELEGRAM_BOT_TOKEN" ] && CMD_ARGS+=("--telegram-bot-token=$TELEGRAM_BOT_TOKEN")
+[ -n "$TELEGRAM_CHAT_ID" ] && CMD_ARGS+=("--telegram-chat-id=$TELEGRAM_CHAT_ID")
+[ -n "$TELEGRAM_THREAD_ID" ] && CMD_ARGS+=("--telegram-thread-id=$TELEGRAM_THREAD_ID")
+
 info "Starting liquidator..."
 echo ""
 exec "$BINARY_PATH" "${CMD_ARGS[@]}"

--- a/service/liquidator/scripts/run-testnet.sh
+++ b/service/liquidator/scripts/run-testnet.sh
@@ -178,6 +178,11 @@ fi
 CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
 CMD_ARGS+=("--redstone-gateway-url" "$REDSTONE_GATEWAY_URL")
 
+# Add Telegram notification arguments (use = syntax because chat IDs start with -)
+[ -n "$TELEGRAM_BOT_TOKEN" ] && CMD_ARGS+=("--telegram-bot-token=$TELEGRAM_BOT_TOKEN")
+[ -n "$TELEGRAM_CHAT_ID" ] && CMD_ARGS+=("--telegram-chat-id=$TELEGRAM_CHAT_ID")
+[ -n "$TELEGRAM_THREAD_ID" ] && CMD_ARGS+=("--telegram-thread-id=$TELEGRAM_THREAD_ID")
+
 info "Starting liquidator..."
 echo ""
 exec "$BINARY_PATH" "${CMD_ARGS[@]}"

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -15,7 +15,20 @@ use crate::{
     CollateralStrategy,
 };
 
-/// Validator function for `partial_percentage` range
+/// Parse a string into `Option<i64>`, treating empty/whitespace as `None`.
+/// Panics if the value is non-empty and not a valid integer.
+fn parse_optional_i64(s: &str) -> Option<i64> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(
+        trimmed
+            .parse::<i64>()
+            .unwrap_or_else(|_| panic!("TELEGRAM_THREAD_ID '{trimmed}' is not a valid integer")),
+    )
+}
+
 fn validate_percentage(s: &str) -> Result<u8, String> {
     let value: u8 = s
         .parse()
@@ -164,9 +177,10 @@ pub struct Args {
     #[arg(long, env = "TELEGRAM_CHAT_ID", default_value = "")]
     pub telegram_chat_id: String,
 
-    /// Telegram thread/topic ID for sending to specific threads in supergroups
-    #[arg(long, env = "TELEGRAM_THREAD_ID")]
-    pub telegram_thread_id: Option<i64>,
+    /// Telegram thread/topic ID for sending to specific threads in supergroups.
+    /// Accepts an empty env var gracefully (treated as unset).
+    #[arg(long, env = "TELEGRAM_THREAD_ID", default_value = "")]
+    pub telegram_thread_id: String,
 }
 
 impl Args {
@@ -303,7 +317,7 @@ impl Args {
                 Some(TelegramConfig {
                     bot_token: bot_token.to_owned().into(),
                     chat_id: chat_id.to_owned(),
-                    thread_id: self.telegram_thread_id,
+                    thread_id: parse_optional_i64(&self.telegram_thread_id),
                 })
             }
             _ => {
@@ -397,7 +411,7 @@ mod tests {
             swap_retry_base_delay_ms: 2000,
             telegram_bot_token: String::new(),
             telegram_chat_id: String::new(),
-            telegram_thread_id: None,
+            telegram_thread_id: String::new(),
         }
     }
 
@@ -546,7 +560,7 @@ mod tests {
         let mut args = create_test_args();
         args.telegram_bot_token = "123:ABC".to_string();
         args.telegram_chat_id = "-100123".to_string();
-        args.telegram_thread_id = Some(42);
+        args.telegram_thread_id = "42".to_string();
         let config = args.build_config();
         assert!(config.notifier.is_enabled());
     }
@@ -576,5 +590,33 @@ mod tests {
         args.telegram_chat_id = "  ".to_string();
         let config = args.build_config();
         assert!(!config.notifier.is_enabled());
+    }
+
+    #[test]
+    fn test_parse_optional_i64_empty() {
+        assert_eq!(parse_optional_i64(""), None);
+        assert_eq!(parse_optional_i64("  "), None);
+    }
+
+    #[test]
+    fn test_parse_optional_i64_valid() {
+        assert_eq!(parse_optional_i64("42"), Some(42));
+        assert_eq!(parse_optional_i64(" -100 "), Some(-100));
+    }
+
+    #[test]
+    #[should_panic(expected = "not a valid integer")]
+    fn test_parse_optional_i64_invalid() {
+        parse_optional_i64("abc");
+    }
+
+    #[test]
+    fn test_telegram_empty_thread_id_env_var() {
+        let mut args = create_test_args();
+        args.telegram_bot_token = "123:ABC".to_string();
+        args.telegram_chat_id = "-100123".to_string();
+        args.telegram_thread_id = String::new();
+        let config = args.build_config();
+        assert!(config.notifier.is_enabled());
     }
 }

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -301,7 +301,7 @@ impl Args {
             (false, false) => {
                 tracing::info!("Telegram notifications enabled");
                 Some(TelegramConfig {
-                    bot_token: bot_token.to_owned(),
+                    bot_token: bot_token.to_owned().into(),
                     chat_id: chat_id.to_owned(),
                     thread_id: self.telegram_thread_id,
                 })

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -290,17 +290,25 @@ impl Args {
             );
         }
 
-        // Build notifier
-        let telegram_config = if self.telegram_bot_token.is_empty() {
-            tracing::info!("Telegram notifications disabled (no bot token)");
-            None
-        } else {
-            tracing::info!("Telegram notifications enabled");
-            Some(TelegramConfig {
-                bot_token: self.telegram_bot_token.clone(),
-                chat_id: self.telegram_chat_id.clone(),
-                thread_id: self.telegram_thread_id,
-            })
+        // Build notifier — require both bot token and chat ID
+        let bot_token = self.telegram_bot_token.trim();
+        let chat_id = self.telegram_chat_id.trim();
+        let telegram_config = match (bot_token.is_empty(), chat_id.is_empty()) {
+            (true, true) => {
+                tracing::info!("Telegram notifications disabled");
+                None
+            }
+            (false, false) => {
+                tracing::info!("Telegram notifications enabled");
+                Some(TelegramConfig {
+                    bot_token: bot_token.to_owned(),
+                    chat_id: chat_id.to_owned(),
+                    thread_id: self.telegram_thread_id,
+                })
+            }
+            _ => {
+                panic!("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must both be set or both be empty");
+            }
         };
         let notifier = Arc::new(Notifier::new(telegram_config));
 
@@ -514,5 +522,59 @@ mod tests {
         assert!(validate_percentage("101").is_err());
         assert!(validate_percentage("abc").is_err());
         assert!(validate_percentage("-5").is_err());
+    }
+
+    #[test]
+    fn test_telegram_disabled_both_empty() {
+        let args = create_test_args();
+        // Both empty → notifier disabled
+        let config = args.build_config();
+        assert!(!config.notifier.is_enabled());
+    }
+
+    #[test]
+    fn test_telegram_enabled_both_set() {
+        let mut args = create_test_args();
+        args.telegram_bot_token = "123:ABC".to_string();
+        args.telegram_chat_id = "-100123".to_string();
+        let config = args.build_config();
+        assert!(config.notifier.is_enabled());
+    }
+
+    #[test]
+    fn test_telegram_enabled_with_thread_id() {
+        let mut args = create_test_args();
+        args.telegram_bot_token = "123:ABC".to_string();
+        args.telegram_chat_id = "-100123".to_string();
+        args.telegram_thread_id = Some(42);
+        let config = args.build_config();
+        assert!(config.notifier.is_enabled());
+    }
+
+    #[test]
+    #[should_panic(expected = "TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must both be set")]
+    fn test_telegram_panics_token_without_chat_id() {
+        let mut args = create_test_args();
+        args.telegram_bot_token = "123:ABC".to_string();
+        args.telegram_chat_id = String::new();
+        args.build_config();
+    }
+
+    #[test]
+    #[should_panic(expected = "TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must both be set")]
+    fn test_telegram_panics_chat_id_without_token() {
+        let mut args = create_test_args();
+        args.telegram_bot_token = String::new();
+        args.telegram_chat_id = "-100123".to_string();
+        args.build_config();
+    }
+
+    #[test]
+    fn test_telegram_whitespace_only_treated_as_empty() {
+        let mut args = create_test_args();
+        args.telegram_bot_token = "  ".to_string();
+        args.telegram_chat_id = "  ".to_string();
+        let config = args.build_config();
+        assert!(!config.notifier.is_enabled());
     }
 }

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -8,7 +8,12 @@ use clap::Parser;
 use near_sdk::AccountId;
 use templar_common::utils::Network;
 
-use crate::{service::ServiceConfig, swap::SwapRetryConfig, CollateralStrategy};
+use crate::{
+    notifier::{Notifier, TelegramConfig},
+    service::ServiceConfig,
+    swap::SwapRetryConfig,
+    CollateralStrategy,
+};
 
 /// Validator function for `partial_percentage` range
 fn validate_percentage(s: &str) -> Result<u8, String> {
@@ -150,6 +155,18 @@ pub struct Args {
     /// Base delay in milliseconds for swap retry exponential backoff (2s, 4s, 8s …)
     #[arg(long, env = "SWAP_RETRY_BASE_DELAY_MS", default_value_t = 2000)]
     pub swap_retry_base_delay_ms: u64,
+
+    /// Telegram bot token for notifications (leave empty to disable)
+    #[arg(long, env = "TELEGRAM_BOT_TOKEN", default_value = "")]
+    pub telegram_bot_token: String,
+
+    /// Telegram chat/channel ID for notifications
+    #[arg(long, env = "TELEGRAM_CHAT_ID", default_value = "")]
+    pub telegram_chat_id: String,
+
+    /// Telegram thread/topic ID for sending to specific threads in supergroups
+    #[arg(long, env = "TELEGRAM_THREAD_ID")]
+    pub telegram_thread_id: Option<i64>,
 }
 
 impl Args {
@@ -273,6 +290,20 @@ impl Args {
             );
         }
 
+        // Build notifier
+        let telegram_config = if self.telegram_bot_token.is_empty() {
+            tracing::info!("Telegram notifications disabled (no bot token)");
+            None
+        } else {
+            tracing::info!("Telegram notifications enabled");
+            Some(TelegramConfig {
+                bot_token: self.telegram_bot_token.clone(),
+                chat_id: self.telegram_chat_id.clone(),
+                thread_id: self.telegram_thread_id,
+            })
+        };
+        let notifier = Arc::new(Notifier::new(telegram_config));
+
         ServiceConfig {
             registries: self.registries.clone(),
             signer_key: self.signer_key.clone(),
@@ -301,6 +332,7 @@ impl Args {
                 max_attempts: self.swap_retry_attempts,
                 base_delay_ms: self.swap_retry_base_delay_ms,
             },
+            notifier,
         }
     }
 
@@ -355,6 +387,9 @@ mod tests {
             batch_swap_on_cycle_start: true,
             swap_retry_attempts: 3,
             swap_retry_base_delay_ms: 2000,
+            telegram_bot_token: String::new(),
+            telegram_chat_id: String::new(),
+            telegram_thread_id: None,
         }
     }
 

--- a/service/liquidator/src/executor.rs
+++ b/service/liquidator/src/executor.rs
@@ -21,10 +21,30 @@ use templar_common::{
 
 use crate::{
     inventory,
-    rpc::{check_transaction_success, get_access_key_data, send_tx},
+    rpc::{check_transaction_success, get_access_key_data, send_tx, NonceTracker},
     swap::SwapProvider,
     CollateralStrategy, LiquidationOutcome, LiquidatorError, LiquidatorResult,
 };
+
+/// Swap issue that occurred after a successful liquidation.
+/// Returned to the caller so notifications can be sent in the right order
+/// (liquidation success first, then swap issue).
+#[derive(Debug)]
+pub enum SwapIssue {
+    /// Swap provider doesn't support this asset pair.
+    Unsupported {
+        from: String,
+        to: String,
+        amount: String,
+    },
+    /// Swap failed with an error.
+    Failed {
+        from: String,
+        to: String,
+        amount: String,
+        error: String,
+    },
+}
 
 /// Liquidation transaction executor.
 ///
@@ -44,6 +64,8 @@ pub struct LiquidationExecutor {
     swap_provider: Option<crate::swap::SwapProviderImpl>,
     swap_retry_config: crate::swap::SwapRetryConfig,
     min_swap_value_usd: f64,
+    collateral_decimals: i32,
+    nonce_tracker: NonceTracker,
 }
 
 impl LiquidationExecutor {
@@ -60,6 +82,8 @@ impl LiquidationExecutor {
         swap_provider: Option<crate::swap::SwapProviderImpl>,
         swap_retry_config: crate::swap::SwapRetryConfig,
         min_swap_value_usd: f64,
+        collateral_decimals: i32,
+        nonce_tracker: NonceTracker,
     ) -> Self {
         Self {
             client,
@@ -72,6 +96,8 @@ impl LiquidationExecutor {
             swap_provider,
             swap_retry_config,
             min_swap_value_usd,
+            collateral_decimals,
+            nonce_tracker,
         }
     }
 
@@ -129,7 +155,7 @@ impl LiquidationExecutor {
         liquidation_amount: BorrowAssetAmount,
         collateral_amount: CollateralAssetAmount,
         expected_collateral_value: BorrowAssetAmount,
-    ) -> LiquidatorResult<LiquidationOutcome> {
+    ) -> LiquidatorResult<(LiquidationOutcome, Option<SwapIssue>)> {
         // Dry run mode - log what would happen, skip execution
         if self.dry_run {
             // Log JIT swap intent if applicable
@@ -160,7 +186,7 @@ impl LiquidationExecutor {
                     );
                 }
             }
-            return Ok(LiquidationOutcome::Liquidated);
+            return Ok((LiquidationOutcome::Liquidated, None));
         }
 
         // Reserve inventory for this liquidation
@@ -177,9 +203,10 @@ impl LiquidationExecutor {
         );
 
         // Execute liquidation transaction
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer)
-            .await
-            .map_err(LiquidatorError::AccessKeyDataError)?;
+        let (nonce, block_hash) =
+            get_access_key_data(&self.client, &self.signer, Some(&self.nonce_tracker))
+                .await
+                .map_err(LiquidatorError::AccessKeyDataError)?;
 
         let tx = self.create_transfer_tx(
             borrow_asset,
@@ -224,8 +251,8 @@ impl LiquidationExecutor {
                             .release(borrow_asset, liquidation_amount);
 
                         // Handle collateral based on strategy
-                        let swap_succeeded = match &self.collateral_strategy {
-                            CollateralStrategy::Hold => false, // No swap performed
+                        let (swap_succeeded, swap_issue) = match &self.collateral_strategy {
+                            CollateralStrategy::Hold => (false, None),
                             CollateralStrategy::SwapToBorrow => {
                                 // Estimate USD value for threshold check.
                                 // The expected_collateral_value is denominated in borrow asset
@@ -242,7 +269,7 @@ impl LiquidationExecutor {
                                     usd_estimate,
                                 )
                                 .await
-                                .unwrap_or(false)
+                                .unwrap_or((false, None))
                             }
                         };
 
@@ -263,7 +290,7 @@ impl LiquidationExecutor {
                             }
                         }
 
-                        Ok(LiquidationOutcome::Liquidated)
+                        Ok((LiquidationOutcome::Liquidated, swap_issue))
                     }
                     Err(error_msg) => {
                         // Receipt failed - release reserved inventory
@@ -303,7 +330,8 @@ impl LiquidationExecutor {
 
     /// Swap collateral immediately after liquidation.
     ///
-    /// Returns `Ok(true)` if swap succeeded, `Ok(false)` if skipped or failed (non-fatal).
+    /// Returns `Ok((succeeded, swap_issue))` where `swap_issue` is populated
+    /// when the swap failed or was unsupported (for notification by the caller).
     #[allow(clippy::too_many_lines)]
     async fn swap_collateral_to_borrow(
         &self,
@@ -311,16 +339,16 @@ impl LiquidationExecutor {
         borrow_asset: &FungibleAsset<BorrowAsset>,
         collateral_amount: CollateralAssetAmount,
         expected_collateral_value_usd: Option<f64>,
-    ) -> LiquidatorResult<bool> {
+    ) -> LiquidatorResult<(bool, Option<SwapIssue>)> {
         let Some(ref swap_provider) = self.swap_provider else {
             tracing::debug!("No swap provider configured, holding collateral");
-            return Ok(false);
+            return Ok((false, None));
         };
 
         // Skip swap if collateral is already the target borrow asset
         if collateral_asset.to_string() == borrow_asset.to_string() {
             tracing::debug!("Collateral is already borrow asset, skipping JIT swap");
-            return Ok(false);
+            return Ok((false, None));
         }
 
         // Skip swap if the provider doesn't support this asset pair
@@ -330,7 +358,18 @@ impl LiquidationExecutor {
                 to = %borrow_asset,
                 "Swap provider does not support asset pair, holding collateral"
             );
-            return Ok(false);
+            return Ok((
+                false,
+                Some(SwapIssue::Unsupported {
+                    from: crate::format::short_asset_name(&collateral_asset.to_string()),
+                    to: crate::format::short_asset_name(&borrow_asset.to_string()),
+                    amount: crate::format::format_amount_short(
+                        u128::from(collateral_amount),
+                        self.collateral_decimals,
+                        &collateral_asset.to_string(),
+                    ),
+                }),
+            ));
         }
 
         // Skip swap if value is below threshold — will be picked up by batch swap
@@ -343,7 +382,7 @@ impl LiquidationExecutor {
                     threshold = format!("${:.2}", self.min_swap_value_usd),
                     "Skipping JIT swap - below threshold, will batch later"
                 );
-                return Ok(false);
+                return Ok((false, None));
             }
         }
 
@@ -390,6 +429,14 @@ impl LiquidationExecutor {
             })
             .await;
 
+        let amount_short = crate::format::format_amount_short(
+            u128::from(collateral_amount),
+            self.collateral_decimals,
+            &from_asset_id,
+        );
+        let from_short = crate::format::short_asset_name(&from_asset_id);
+        let to_short = crate::format::short_asset_name(&to_asset_id);
+
         match result {
             Ok(()) => {
                 tracing::info!(
@@ -398,29 +445,42 @@ impl LiquidationExecutor {
                     amount_raw = %u128::from(collateral_amount),
                     "JIT swap completed - inventory replenished"
                 );
-                Ok(true)
+                Ok((true, None))
             }
             Err(e) => {
                 let msg = e.to_string();
-                if msg.contains("Amount too low") {
+                let issue = if msg.contains("Amount too low") {
                     tracing::info!(
                         swap = %swap_name,
                         error = %e,
                         "JIT swap skipped - amount below provider minimum, will batch"
                     );
+                    None // Not a notification-worthy issue
                 } else if msg.contains("Quote failed") {
                     tracing::debug!(
                         swap = %swap_name,
                         "No swap route available for asset, holding collateral"
                     );
+                    Some(SwapIssue::Failed {
+                        from: from_short,
+                        to: to_short,
+                        amount: amount_short,
+                        error: "No swap route available".to_string(),
+                    })
                 } else {
                     tracing::info!(
                         swap = %swap_name,
                         error = %e,
                         "JIT swap failed, holding collateral"
                     );
-                }
-                Ok(false)
+                    Some(SwapIssue::Failed {
+                        from: from_short,
+                        to: to_short,
+                        amount: amount_short,
+                        error: msg,
+                    })
+                };
+                Ok((false, issue))
             }
         }
     }

--- a/service/liquidator/src/format.rs
+++ b/service/liquidator/src/format.rs
@@ -119,9 +119,10 @@ pub fn short_asset_name(asset_id: &str) -> String {
         return rest.to_string();
     }
 
-    // Last resort: truncate
+    // Last resort: truncate (char-safe to avoid panics on multi-byte UTF-8)
     if inner.len() > 20 {
-        format!("{}…", &inner[..17])
+        let truncated: String = inner.chars().take(17).collect();
+        format!("{truncated}…")
     } else {
         inner.to_string()
     }
@@ -399,6 +400,24 @@ mod tests {
         assert_eq!(
             format_profit_short(-500_000, 12_000_000, 6, "nep141:wrap.near"),
             "-0.500000 wNEAR (-4.2%)"
+        );
+    }
+
+    #[test]
+    fn test_short_asset_name_recursive_nep245_with_nep141() {
+        // nep245 wrapping nep141 should recurse and resolve
+        assert_eq!(
+            short_asset_name("nep245:some.contract:nep141:btc.omft.near"),
+            "BTC"
+        );
+    }
+
+    #[test]
+    fn test_format_profit_short_zero_liquidation_amount() {
+        // Division by zero guard — should produce 0.0%
+        assert_eq!(
+            format_profit_short(0, 0, 6, "nep141:usdc.near"),
+            "+0.000000 USDC (+0.0%)"
         );
     }
 }

--- a/service/liquidator/src/format.rs
+++ b/service/liquidator/src/format.rs
@@ -98,6 +98,17 @@ pub fn short_asset_name(asset_id: &str) -> String {
         }
     }
 
+    // Generic nep245:{contract}:{token_id} — recurse on the token_id part
+    if let Some(rest) = inner.strip_prefix("nep245:") {
+        if let Some((_contract, token_id)) = rest.split_once(':') {
+            return if token_id.starts_with("nep141:") || token_id.starts_with("nep245:") {
+                short_asset_name(token_id)
+            } else {
+                token_id.to_uppercase()
+            };
+        }
+    }
+
     // Fallback: try to extract something readable
     // nep141:something.near → SOMETHING
     if let Some(rest) = inner.strip_prefix("nep141:") {
@@ -315,5 +326,79 @@ mod tests {
         assert_eq!(format_iteration(1, 3), "1/3");
         assert_eq!(format_iteration(2, 3), "2/3");
         assert_eq!(format_iteration(3, 3), "3/3 (final)");
+    }
+
+    #[test]
+    fn test_short_asset_name_known() {
+        assert_eq!(short_asset_name("nep141:btc.omft.near"), "BTC");
+        assert_eq!(short_asset_name("nep141:wrap.near"), "wNEAR");
+        assert_eq!(
+            short_asset_name("17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1"),
+            "USDC"
+        );
+    }
+
+    #[test]
+    fn test_short_asset_name_nep245_intents_wrapper() {
+        // nep245:intents.near: wrapper should be stripped
+        assert_eq!(
+            short_asset_name("nep245:intents.near:nep141:btc.omft.near"),
+            "BTC"
+        );
+    }
+
+    #[test]
+    fn test_short_asset_name_stellar_suffix() {
+        assert_eq!(
+            short_asset_name("nep245:v2_1.omni.hot.tg:1100_111bzQBB65GxAPAVoxqmMcgYo5oS3txhqs1Uh1cgahKQUeTUq1TJu"),
+            "USDC"
+        );
+        assert_eq!(
+            short_asset_name("nep245:v2_1.omni.hot.tg:1100_111bzQBB5v7AhLyPMDwS8uJgQV24KaAPXtwyVWu2KXbbfQU6NXRCz"),
+            "XLM"
+        );
+    }
+
+    #[test]
+    fn test_short_asset_name_generic_nep245() {
+        // Generic nep245:{contract}:{token_id} should extract token_id
+        assert_eq!(short_asset_name("nep245:v2_1.omni.hot.tg:xlm"), "XLM");
+        assert_eq!(short_asset_name("nep245:some.contract:usdc"), "USDC");
+    }
+
+    #[test]
+    fn test_short_asset_name_nep141_near_fallback() {
+        assert_eq!(short_asset_name("nep141:mytoken.near"), "MYTOKEN");
+    }
+
+    #[test]
+    fn test_short_asset_name_truncation() {
+        let long_id = "abcdefghijklmnopqrstuvwxyz12345";
+        let result = short_asset_name(long_id);
+        assert_eq!(result, "abcdefghijklmnopq…");
+    }
+
+    #[test]
+    fn test_format_amount_short() {
+        assert_eq!(
+            format_amount_short(12_000_000, 6, "nep141:btc.omft.near"),
+            "12.000000 BTC"
+        );
+        assert_eq!(
+            format_amount_short(1_500_000, 6, "nep141:wrap.near"),
+            "1.500000 wNEAR"
+        );
+    }
+
+    #[test]
+    fn test_format_profit_short() {
+        assert_eq!(
+            format_profit_short(952_425, 12_000_000, 6, "nep141:btc.omft.near"),
+            "+0.952425 BTC (+7.9%)"
+        );
+        assert_eq!(
+            format_profit_short(-500_000, 12_000_000, 6, "nep141:wrap.near"),
+            "-0.500000 wNEAR (-4.2%)"
+        );
     }
 }

--- a/service/liquidator/src/format.rs
+++ b/service/liquidator/src/format.rs
@@ -4,6 +4,163 @@
 //! for clear, concise logging using actual asset IDs and decimals from
 //! market configuration.
 
+/// Derive a short human-readable ticker from a full asset ID.
+///
+/// Recognizes common patterns:
+/// - `nep141:btc.omft.near` → `BTC`
+/// - `nep141:eth-0xa0b8...omft.near` (ERC-20 USDC) → `USDC`
+/// - `nep141:eth-0x2260...omft.near` (ERC-20 WBTC) → `WBTC`
+/// - `nep141:wrap.near` → `wNEAR`
+/// - `nep141:meta-pool.near` → `stNEAR`
+/// - `17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1` → `USDC`
+/// - Stellar OMNI tokens via known suffix fragments
+/// - Falls back to the raw ID (truncated) if unknown.
+pub fn short_asset_name(asset_id: &str) -> String {
+    // Known full asset IDs
+    static KNOWN: &[(&str, &str)] = &[
+        // NEP-141 OMNI bridge tokens
+        ("nep141:btc.omft.near", "BTC"),
+        ("nep141:zec.omft.near", "ZEC"),
+        (
+            "nep141:eth-0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48.omft.near",
+            "USDC",
+        ),
+        (
+            "nep141:eth-0x2260fac5e5542a773aa44fbcfedf7c193bc2c599.omft.near",
+            "WBTC",
+        ),
+        (
+            "nep141:sol-5ce3bf3a31af18be40ba30f721101b4341690186.omft.near",
+            "USDC",
+        ),
+        // Native NEAR tokens
+        ("nep141:wrap.near", "wNEAR"),
+        ("nep141:meta-pool.near", "stNEAR"),
+        ("nep141:linear-protocol.near", "LiNEAR"),
+        (
+            "17208628f84f5d6ad33f0da3bbbeb27ffcb398eac501a31bd6ad2011e36133a1",
+            "USDC",
+        ),
+    ];
+
+    // Stellar OMNI tokens — match by known base58 suffix fragments
+    static STELLAR_TOKENS: &[(&str, &str)] = &[
+        (
+            "111bzQBB65GxAPAVoxqmMcgYo5oS3txhqs1Uh1cgahKQUeTUq1TJu",
+            "USDC",
+        ),
+        (
+            "111bzQBB5v7AhLyPMDwS8uJgQV24KaAPXtwyVWu2KXbbfQU6NXRCz",
+            "XLM",
+        ),
+        (
+            "111bzQBB62XZkuam1hPr5wsG54FvwhYaPvecKwgZo1ZoKMWEXcE2n",
+            "PYUSD",
+        ),
+        (
+            "111bzQBB5uBD3Wrr7pthp8XhJsreEcwTVnmjQ1wpbzkvHLEQf3ygS",
+            "CETES",
+        ),
+        (
+            "111bzQBB5yT2A5maKJqJQsuNg7BA6VG4S4ZATpqmKYLwYBsfEfh6e",
+            "USTRY",
+        ),
+        (
+            "111bzQBB5y5yhcUCbDKaCx4zNjEHQbwLAdvwucCecVzC5Ub7uNKEb",
+            "DEJTRSY",
+        ),
+        (
+            "111bzQBB66Lr9d7WU1sDna78SqG5x1ZraFjkpPdiYXjHFRnZJUhuV",
+            "DEJAAA",
+        ),
+        (
+            "111bzQBB5xzU1EsXby4ckez2qjWFTBiPoqHzZpPkq1Gr9gB7FQpeZ",
+            "SolvBTC",
+        ),
+    ];
+
+    // Strip outer nep245:intents.near: wrapper if present
+    let inner = asset_id
+        .strip_prefix("nep245:intents.near:")
+        .unwrap_or(asset_id);
+
+    // Check exact matches
+    for &(pattern, name) in KNOWN {
+        if inner == pattern {
+            return name.to_string();
+        }
+    }
+
+    // Check Stellar OMNI token suffixes
+    for &(suffix, name) in STELLAR_TOKENS {
+        if inner.contains(suffix) {
+            return name.to_string();
+        }
+    }
+
+    // Fallback: try to extract something readable
+    // nep141:something.near → SOMETHING
+    if let Some(rest) = inner.strip_prefix("nep141:") {
+        if let Some(name) = rest.strip_suffix(".near") {
+            return name.to_uppercase();
+        }
+        // nep141:something.omft.near already handled above
+        return rest.to_string();
+    }
+
+    // Last resort: truncate
+    if inner.len() > 20 {
+        format!("{}…", &inner[..17])
+    } else {
+        inner.to_string()
+    }
+}
+
+/// Format token amount with short asset name for notifications.
+///
+/// Produces compact output like `66.25 XLM` instead of the verbose log format.
+#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+pub fn format_amount_short(amount: u128, decimals: i32, asset_id: &str) -> String {
+    let divisor = 10f64.powi(decimals);
+    let value = amount as f64 / divisor;
+    let name = short_asset_name(asset_id);
+
+    // Use fewer decimal places for readability
+    let precision = match decimals {
+        0..=2 => 2,
+        3..=6 => decimals as usize,
+        _ => 6,
+    };
+
+    format!("{value:.precision$} {name}")
+}
+
+/// Format profit/loss with short asset name for notifications.
+#[allow(clippy::cast_precision_loss, clippy::cast_sign_loss)]
+pub fn format_profit_short(
+    net_profit: i128,
+    liquidation_amount: u128,
+    decimals: i32,
+    asset_id: &str,
+) -> String {
+    let divisor = 10f64.powi(decimals);
+    let profit_value = net_profit as f64 / divisor;
+    let profit_pct = if liquidation_amount > 0 {
+        (net_profit as f64 / liquidation_amount as f64) * 100.0
+    } else {
+        0.0
+    };
+    let name = short_asset_name(asset_id);
+
+    let precision = match decimals {
+        0..=2 => 2,
+        3..=6 => decimals as usize,
+        _ => 6,
+    };
+
+    format!("{profit_value:+.precision$} {name} ({profit_pct:+.1}%)")
+}
+
 /// Format token amount with asset ID.
 ///
 /// The decimals parameter MUST come from the market's price oracle configuration,

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -35,6 +35,7 @@ pub mod executor;
 pub mod format;
 pub mod inventory;
 pub mod liquidation_strategy;
+pub mod notifier;
 pub mod oracle;
 pub mod profitability;
 pub mod rpc;
@@ -155,6 +156,8 @@ pub struct Liquidator {
     max_loop_iterations: u32,
     /// Market version (major, minor, patch) - used for version-specific liquidation logic
     market_version: Option<(u32, u32, u32)>,
+    /// Shared notifier for Telegram alerts
+    notifier: crate::notifier::SharedNotifier,
 }
 
 impl Liquidator {
@@ -194,7 +197,9 @@ impl Liquidator {
         min_swap_value_usd: f64,
         proxy_oracle_cache: Option<oracle::ProxyOracleCache>,
         signer_for_oracle: Option<(AccountId, near_crypto::SecretKey)>,
+        notifier: crate::notifier::SharedNotifier,
     ) -> Self {
+        let nonce_tracker = crate::rpc::NonceTracker::default();
         let scanner = scanner::MarketScanner::new(client.clone(), market.clone());
         let oracle_fetcher = oracle::OracleFetcher::new(
             client.clone(),
@@ -202,6 +207,7 @@ impl Liquidator {
             redstone_gateway_url,
             proxy_oracle_cache,
             signer_for_oracle,
+            nonce_tracker.clone(),
         );
         let executor = executor::LiquidationExecutor::new(
             client.clone(),
@@ -214,6 +220,10 @@ impl Liquidator {
             swap_provider,
             swap_retry_config,
             min_swap_value_usd,
+            market_config
+                .price_oracle_configuration
+                .collateral_asset_decimals,
+            nonce_tracker,
         );
 
         Self {
@@ -226,6 +236,7 @@ impl Liquidator {
             loop_liquidation,
             max_loop_iterations,
             market_version: None,
+            notifier,
         }
     }
 
@@ -652,7 +663,7 @@ impl Liquidator {
             }
 
             // Execute liquidation (contract determines optimal collateral amount)
-            let outcome = self
+            let (outcome, swap_issue) = self
                 .executor
                 .execute_liquidation(
                     &borrow_account,
@@ -663,6 +674,59 @@ impl Liquidator {
                     templar_common::asset::BorrowAssetAmount::from(expected_collateral_value.0),
                 )
                 .await?;
+
+            // Notify about successful liquidation (sent first, before any swap issues)
+            if outcome == LiquidationOutcome::Liquidated {
+                let (borrow_dec, borrow_asset, coll_dec, coll_asset) = self.asset_info();
+                let signed_profit = if expected_collateral_value.0 >= liquidation_amount.0 {
+                    i128::try_from(expected_collateral_value.0 - liquidation_amount.0)
+                        .unwrap_or(i128::MAX)
+                } else {
+                    -(i128::try_from(liquidation_amount.0 - expected_collateral_value.0)
+                        .unwrap_or(i128::MAX))
+                };
+                self.notifier
+                    .notify_liquidation(
+                        self.market.as_ref(),
+                        borrow_account.as_ref(),
+                        &format::format_amount_short(
+                            liquidation_amount.0,
+                            borrow_dec,
+                            &borrow_asset,
+                        ),
+                        &format::format_amount_short(collateral_amount.0, coll_dec, &coll_asset),
+                        &format::format_profit_short(
+                            signed_profit,
+                            liquidation_amount.0,
+                            borrow_dec,
+                            &borrow_asset,
+                        ),
+                        None,
+                        dry_run,
+                    )
+                    .await;
+            }
+
+            // Notify about swap issues (sent after liquidation notification)
+            if let Some(issue) = swap_issue {
+                match issue {
+                    executor::SwapIssue::Unsupported { from, to, amount } => {
+                        self.notifier
+                            .notify_swap_unsupported(self.market.as_ref(), &from, &to, &amount)
+                            .await;
+                    }
+                    executor::SwapIssue::Failed {
+                        from,
+                        to,
+                        amount,
+                        error,
+                    } => {
+                        self.notifier
+                            .notify_swap_failed(self.market.as_ref(), &from, &to, &amount, &error)
+                            .await;
+                    }
+                }
+            }
 
             // Track cumulative amounts
             total_liquidated_amount += liquidation_amount.0;
@@ -773,6 +837,13 @@ impl Liquidator {
                 Ok(LiquidationOutcome::Unprofitable) => unprofitable += 1,
                 Err(e) => {
                     tracing::warn!(borrower = %account, error = %e, "Liquidation failed");
+                    self.notifier
+                        .notify_liquidation_failed(
+                            self.market.as_ref(),
+                            account.as_ref(),
+                            &e.to_string(),
+                        )
+                        .await;
                     failed += 1;
                 }
             }

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -198,8 +198,8 @@ impl Liquidator {
         proxy_oracle_cache: Option<oracle::ProxyOracleCache>,
         signer_for_oracle: Option<(AccountId, near_crypto::SecretKey)>,
         notifier: crate::notifier::SharedNotifier,
+        nonce_tracker: crate::rpc::NonceTracker,
     ) -> Self {
-        let nonce_tracker = crate::rpc::NonceTracker::default();
         let scanner = scanner::MarketScanner::new(client.clone(), market.clone());
         let oracle_fetcher = oracle::OracleFetcher::new(
             client.clone(),
@@ -678,42 +678,38 @@ impl Liquidator {
             // Notify about successful liquidation (sent first, before any swap issues)
             if outcome == LiquidationOutcome::Liquidated {
                 let (borrow_dec, borrow_asset, coll_dec, coll_asset) = self.asset_info();
-                let signed_profit = if expected_collateral_value.0 >= liquidation_amount.0 {
-                    i128::try_from(expected_collateral_value.0 - liquidation_amount.0)
-                        .unwrap_or(i128::MAX)
+                let total_cost = liquidation_amount.0 + gas_cost.0;
+                let signed_profit = if expected_collateral_value.0 >= total_cost {
+                    i128::try_from(expected_collateral_value.0 - total_cost).unwrap_or(i128::MAX)
                 } else {
-                    -(i128::try_from(liquidation_amount.0 - expected_collateral_value.0)
-                        .unwrap_or(i128::MAX))
+                    -(i128::try_from(total_cost - expected_collateral_value.0).unwrap_or(i128::MAX))
                 };
-                self.notifier
-                    .notify_liquidation(
-                        self.market.as_ref(),
-                        borrow_account.as_ref(),
-                        &format::format_amount_short(
-                            liquidation_amount.0,
-                            borrow_dec,
-                            &borrow_asset,
-                        ),
-                        &format::format_amount_short(collateral_amount.0, coll_dec, &coll_asset),
-                        &format::format_profit_short(
-                            signed_profit,
-                            liquidation_amount.0,
-                            borrow_dec,
-                            &borrow_asset,
-                        ),
-                        None,
-                        dry_run,
-                    )
-                    .await;
+                self.notifier.notify_liquidation(
+                    self.market.as_ref(),
+                    borrow_account.as_ref(),
+                    &format::format_amount_short(liquidation_amount.0, borrow_dec, &borrow_asset),
+                    &format::format_amount_short(collateral_amount.0, coll_dec, &coll_asset),
+                    &format::format_profit_short(
+                        signed_profit,
+                        liquidation_amount.0,
+                        borrow_dec,
+                        &borrow_asset,
+                    ),
+                    None,
+                    dry_run,
+                );
             }
 
             // Notify about swap issues (sent after liquidation notification)
             if let Some(issue) = swap_issue {
                 match issue {
                     executor::SwapIssue::Unsupported { from, to, amount } => {
-                        self.notifier
-                            .notify_swap_unsupported(self.market.as_ref(), &from, &to, &amount)
-                            .await;
+                        self.notifier.notify_swap_unsupported(
+                            self.market.as_ref(),
+                            &from,
+                            &to,
+                            &amount,
+                        );
                     }
                     executor::SwapIssue::Failed {
                         from,
@@ -721,9 +717,13 @@ impl Liquidator {
                         amount,
                         error,
                     } => {
-                        self.notifier
-                            .notify_swap_failed(self.market.as_ref(), &from, &to, &amount, &error)
-                            .await;
+                        self.notifier.notify_swap_failed(
+                            self.market.as_ref(),
+                            &from,
+                            &to,
+                            &amount,
+                            &error,
+                        );
                     }
                 }
             }
@@ -837,13 +837,11 @@ impl Liquidator {
                 Ok(LiquidationOutcome::Unprofitable) => unprofitable += 1,
                 Err(e) => {
                     tracing::warn!(borrower = %account, error = %e, "Liquidation failed");
-                    self.notifier
-                        .notify_liquidation_failed(
-                            self.market.as_ref(),
-                            account.as_ref(),
-                            &e.to_string(),
-                        )
-                        .await;
+                    self.notifier.notify_liquidation_failed(
+                        self.market.as_ref(),
+                        account.as_ref(),
+                        &e.to_string(),
+                    );
                     failed += 1;
                 }
             }

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -1,0 +1,225 @@
+//! Notification system for the liquidator bot.
+//!
+//! Sends alerts to Telegram when significant events occur:
+//! - Successful liquidations
+//! - Failed or skipped swaps (unsupported assets, errors)
+//!
+//! All methods are fire-and-forget: notification failures are logged
+//! but never block liquidation operations.
+
+use std::sync::Arc;
+
+use near_sdk::serde_json::json;
+use reqwest::Client;
+
+/// Telegram notification configuration.
+#[derive(Debug, Clone)]
+pub struct TelegramConfig {
+    pub bot_token: String,
+    pub chat_id: String,
+    pub thread_id: Option<i64>,
+}
+
+/// Shared notifier handle.
+pub type SharedNotifier = Arc<Notifier>;
+
+/// Liquidator event notifier.
+///
+/// When Telegram is configured, sends HTML-formatted messages.
+/// When unconfigured, all methods are silent no-ops.
+#[derive(Debug)]
+pub struct Notifier {
+    telegram: Option<TelegramConfig>,
+    client: Client,
+}
+
+impl Notifier {
+    /// Creates a new notifier. Pass `None` to disable notifications.
+    pub fn new(telegram: Option<TelegramConfig>) -> Self {
+        Self {
+            telegram,
+            client: Client::new(),
+        }
+    }
+
+    /// Returns `true` if Telegram notifications are enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.telegram.is_some()
+    }
+
+    /// Notify about a successful liquidation.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn notify_liquidation(
+        &self,
+        market: &str,
+        borrower: &str,
+        send_amount: &str,
+        receive_amount: &str,
+        profit: &str,
+        tx_hash: Option<&str>,
+        dry_run: bool,
+    ) {
+        let prefix = if dry_run { "🧪 DRY RUN " } else { "" };
+        let tx_line = tx_hash.map_or(String::new(), |h| format!("\nTx: <code>{h}</code>"));
+
+        let message = format!(
+            "{prefix}✅ <b>Liquidation Executed</b>\n\
+             \n\
+             Market: <code>{market}</code>\n\
+             Borrower: <code>{borrower}</code>\n\
+             Sent: {send_amount}\n\
+             Received: {receive_amount}\n\
+             Profit: {profit}{tx_line}"
+        );
+
+        self.send(&message).await;
+    }
+
+    /// Notify about a failed liquidation attempt.
+    pub async fn notify_liquidation_failed(&self, market: &str, borrower: &str, error: &str) {
+        let message = format!(
+            "❌ <b>Liquidation Failed</b>\n\
+             \n\
+             Market: <code>{market}</code>\n\
+             Borrower: <code>{borrower}</code>\n\
+             Error: {error}"
+        );
+
+        self.send(&message).await;
+    }
+
+    /// Notify about a swap failure after liquidation.
+    pub async fn notify_swap_failed(
+        &self,
+        market: &str,
+        from_asset: &str,
+        to_asset: &str,
+        amount: &str,
+        error: &str,
+    ) {
+        let message = format!(
+            "⚠️ <b>Swap Failed</b>\n\
+             \n\
+             Market: <code>{market}</code>\n\
+             From: <code>{from_asset}</code>\n\
+             To: <code>{to_asset}</code>\n\
+             Amount: {amount}\n\
+             Error: {error}"
+        );
+
+        self.send(&message).await;
+    }
+
+    /// Notify when a swap is skipped because the asset pair is unsupported.
+    pub async fn notify_swap_unsupported(
+        &self,
+        market: &str,
+        from_asset: &str,
+        to_asset: &str,
+        amount: &str,
+    ) {
+        let message = format!(
+            "🚫 <b>Swap Unsupported</b>\n\
+             \n\
+             Market: <code>{market}</code>\n\
+             From: <code>{from_asset}</code>\n\
+             To: <code>{to_asset}</code>\n\
+             Amount: {amount}\n\
+             \n\
+             Asset pair not supported by swap provider."
+        );
+
+        self.send(&message).await;
+    }
+
+    // ── Internal ────────────────────────────────────────────────────────────
+
+    /// Sends an HTML message to the configured Telegram chat.
+    /// Failures are logged and swallowed — never propagated.
+    async fn send(&self, text: &str) {
+        let Some(config) = &self.telegram else {
+            return;
+        };
+
+        let url = format!(
+            "https://api.telegram.org/bot{}/sendMessage",
+            config.bot_token
+        );
+
+        let mut payload = json!({
+            "chat_id": config.chat_id,
+            "text": text,
+            "parse_mode": "HTML",
+            "disable_web_page_preview": true,
+        });
+
+        if let Some(tid) = config.thread_id {
+            payload["message_thread_id"] = json!(tid);
+        }
+
+        match self
+            .client
+            .post(&url)
+            .json(&payload)
+            .timeout(std::time::Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(response) if response.status() == 429 => {
+                tracing::warn!("Telegram rate limit hit, skipping notification");
+            }
+            Ok(response) if !response.status().is_success() => {
+                let status = response.status();
+                let body = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "unknown".to_string());
+                tracing::warn!(
+                    status = %status,
+                    body = %body,
+                    "Telegram notification failed"
+                );
+            }
+            Ok(_) => {
+                tracing::debug!("Telegram notification sent");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to send Telegram notification");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_notifier_disabled_by_default() {
+        let notifier = Notifier::new(None);
+        assert!(!notifier.is_enabled());
+    }
+
+    #[test]
+    fn test_notifier_enabled_with_config() {
+        let config = TelegramConfig {
+            bot_token: "123:ABC".to_string(),
+            chat_id: "-100123".to_string(),
+            thread_id: None,
+        };
+        let notifier = Notifier::new(Some(config));
+        assert!(notifier.is_enabled());
+    }
+
+    #[test]
+    fn test_notifier_with_thread_id() {
+        let config = TelegramConfig {
+            bot_token: "123:ABC".to_string(),
+            chat_id: "-100123".to_string(),
+            thread_id: Some(42),
+        };
+        let notifier = Notifier::new(Some(config.clone()));
+        assert!(notifier.is_enabled());
+        assert_eq!(config.thread_id, Some(42));
+    }
+}

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -13,10 +13,33 @@ use std::sync::Arc;
 use near_sdk::serde_json::json;
 use reqwest::Client;
 
+/// A string wrapper that redacts its value in Debug output.
+#[derive(Clone)]
+pub struct SecretString(String);
+
+impl SecretString {
+    /// Access the inner value.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<String> for SecretString {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
+impl std::fmt::Debug for SecretString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("<redacted>")
+    }
+}
+
 /// Telegram notification configuration.
 #[derive(Debug, Clone)]
 pub struct TelegramConfig {
-    pub bot_token: String,
+    pub bot_token: SecretString,
     pub chat_id: String,
     pub thread_id: Option<i64>,
 }
@@ -228,7 +251,7 @@ impl Notifier {
 
         let url = format!(
             "https://api.telegram.org/bot{}/sendMessage",
-            config.bot_token
+            config.bot_token.as_str()
         );
 
         let mut payload = json!({
@@ -289,7 +312,7 @@ mod tests {
     #[test]
     fn test_notifier_enabled_with_config() {
         let config = TelegramConfig {
-            bot_token: "123:ABC".to_string(),
+            bot_token: "123:ABC".to_string().into(),
             chat_id: "-100123".to_string(),
             thread_id: None,
         };
@@ -300,13 +323,32 @@ mod tests {
     #[test]
     fn test_notifier_with_thread_id() {
         let config = TelegramConfig {
-            bot_token: "123:ABC".to_string(),
+            bot_token: "123:ABC".to_string().into(),
             chat_id: "-100123".to_string(),
             thread_id: Some(42),
         };
         let notifier = Notifier::new(Some(config.clone()));
         assert!(notifier.is_enabled());
         assert_eq!(config.thread_id, Some(42));
+    }
+
+    #[test]
+    fn test_secret_string_redacts_debug() {
+        let secret = SecretString::from("my-secret-token".to_string());
+        assert_eq!(format!("{secret:?}"), "<redacted>");
+        assert_eq!(secret.as_str(), "my-secret-token");
+    }
+
+    #[test]
+    fn test_telegram_config_debug_redacts_token() {
+        let config = TelegramConfig {
+            bot_token: "super-secret".to_string().into(),
+            chat_id: "-100123".to_string(),
+            thread_id: None,
+        };
+        let debug = format!("{config:?}");
+        assert!(!debug.contains("super-secret"));
+        assert!(debug.contains("<redacted>"));
     }
 
     #[test]

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -6,12 +6,14 @@
 //!
 //! All `notify_*` methods are truly fire-and-forget: they spawn the HTTP
 //! request on a background task and return immediately, so they never
-//! block liquidation operations.
+//! block liquidation operations. A bounded semaphore limits in-flight
+//! notifications to prevent unbounded task growth.
 
 use std::sync::Arc;
 
 use near_sdk::serde_json::json;
 use reqwest::Client;
+use tokio::sync::Semaphore;
 
 /// A string wrapper that redacts its value in Debug output.
 #[derive(Clone)]
@@ -47,14 +49,19 @@ pub struct TelegramConfig {
 /// Shared notifier handle.
 pub type SharedNotifier = Arc<Notifier>;
 
+/// Maximum number of in-flight Telegram notifications.
+const MAX_INFLIGHT_NOTIFICATIONS: usize = 10;
+
 /// Liquidator event notifier.
 ///
 /// When Telegram is configured, sends HTML-formatted messages via
 /// background tasks. When unconfigured, all methods are silent no-ops.
+/// A semaphore bounds the number of concurrent in-flight notifications.
 #[derive(Debug)]
 pub struct Notifier {
     telegram: Option<TelegramConfig>,
     client: Client,
+    semaphore: Arc<Semaphore>,
 }
 
 /// Escape HTML special characters in dynamic values so they don't break
@@ -166,6 +173,7 @@ impl Notifier {
         Self {
             telegram,
             client: Client::new(),
+            semaphore: Arc::new(Semaphore::new(MAX_INFLIGHT_NOTIFICATIONS)),
         }
     }
 
@@ -232,13 +240,20 @@ impl Notifier {
     // ── Internal ────────────────────────────────────────────────────────────
 
     /// Spawns the send on a background task so callers never block.
+    /// Uses a semaphore to bound in-flight notifications; drops the
+    /// message if all permits are taken.
     fn spawn_send(self: &Arc<Self>, message: String) {
         if self.telegram.is_none() {
             return;
         }
+        let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() else {
+            tracing::warn!("Notification dropped — too many in-flight messages");
+            return;
+        };
         let this = Arc::clone(self);
         tokio::spawn(async move {
             this.send(&message).await;
+            drop(permit);
         });
     }
 

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -4,8 +4,9 @@
 //! - Successful liquidations
 //! - Failed or skipped swaps (unsupported assets, errors)
 //!
-//! All methods are fire-and-forget: notification failures are logged
-//! but never block liquidation operations.
+//! All `notify_*` methods are truly fire-and-forget: they spawn the HTTP
+//! request on a background task and return immediately, so they never
+//! block liquidation operations.
 
 use std::sync::Arc;
 
@@ -25,12 +26,115 @@ pub type SharedNotifier = Arc<Notifier>;
 
 /// Liquidator event notifier.
 ///
-/// When Telegram is configured, sends HTML-formatted messages.
-/// When unconfigured, all methods are silent no-ops.
+/// When Telegram is configured, sends HTML-formatted messages via
+/// background tasks. When unconfigured, all methods are silent no-ops.
 #[derive(Debug)]
 pub struct Notifier {
     telegram: Option<TelegramConfig>,
     client: Client,
+}
+
+/// Escape HTML special characters in dynamic values so they don't break
+/// Telegram's HTML parse mode or get rejected.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+// ── Message formatting (pure functions, easily testable) ────────────────
+
+/// Format a successful liquidation message.
+#[allow(clippy::too_many_arguments)]
+fn format_liquidation_message(
+    market: &str,
+    borrower: &str,
+    send_amount: &str,
+    receive_amount: &str,
+    profit: &str,
+    tx_hash: Option<&str>,
+    dry_run: bool,
+) -> String {
+    let prefix = if dry_run { "🧪 DRY RUN " } else { "" };
+    let tx_line = tx_hash.map_or(String::new(), |h| {
+        format!("\nTx: <code>{}</code>", html_escape(h))
+    });
+
+    format!(
+        "{prefix}✅ <b>Liquidation Executed</b>\n\
+         \n\
+         Market: <code>{}</code>\n\
+         Borrower: <code>{}</code>\n\
+         Sent: {}\n\
+         Received: {}\n\
+         Profit: {}{tx_line}",
+        html_escape(market),
+        html_escape(borrower),
+        html_escape(send_amount),
+        html_escape(receive_amount),
+        html_escape(profit),
+    )
+}
+
+/// Format a failed liquidation message.
+fn format_liquidation_failed_message(market: &str, borrower: &str, error: &str) -> String {
+    format!(
+        "❌ <b>Liquidation Failed</b>\n\
+         \n\
+         Market: <code>{}</code>\n\
+         Borrower: <code>{}</code>\n\
+         Error: {}",
+        html_escape(market),
+        html_escape(borrower),
+        html_escape(error),
+    )
+}
+
+/// Format a swap failure message.
+fn format_swap_failed_message(
+    market: &str,
+    from_asset: &str,
+    to_asset: &str,
+    amount: &str,
+    error: &str,
+) -> String {
+    format!(
+        "⚠️ <b>Swap Failed</b>\n\
+         \n\
+         Market: <code>{}</code>\n\
+         From: <code>{}</code>\n\
+         To: <code>{}</code>\n\
+         Amount: {}\n\
+         Error: {}",
+        html_escape(market),
+        html_escape(from_asset),
+        html_escape(to_asset),
+        html_escape(amount),
+        html_escape(error),
+    )
+}
+
+/// Format a swap-unsupported message.
+fn format_swap_unsupported_message(
+    market: &str,
+    from_asset: &str,
+    to_asset: &str,
+    amount: &str,
+) -> String {
+    format!(
+        "🚫 <b>Swap Unsupported</b>\n\
+         \n\
+         Market: <code>{}</code>\n\
+         From: <code>{}</code>\n\
+         To: <code>{}</code>\n\
+         Amount: {}\n\
+         \n\
+         Asset pair not supported by swap provider.",
+        html_escape(market),
+        html_escape(from_asset),
+        html_escape(to_asset),
+        html_escape(amount),
+    )
 }
 
 impl Notifier {
@@ -49,8 +153,8 @@ impl Notifier {
 
     /// Notify about a successful liquidation.
     #[allow(clippy::too_many_arguments)]
-    pub async fn notify_liquidation(
-        &self,
+    pub fn notify_liquidation(
+        self: &Arc<Self>,
         market: &str,
         borrower: &str,
         send_amount: &str,
@@ -59,80 +163,61 @@ impl Notifier {
         tx_hash: Option<&str>,
         dry_run: bool,
     ) {
-        let prefix = if dry_run { "🧪 DRY RUN " } else { "" };
-        let tx_line = tx_hash.map_or(String::new(), |h| format!("\nTx: <code>{h}</code>"));
-
-        let message = format!(
-            "{prefix}✅ <b>Liquidation Executed</b>\n\
-             \n\
-             Market: <code>{market}</code>\n\
-             Borrower: <code>{borrower}</code>\n\
-             Sent: {send_amount}\n\
-             Received: {receive_amount}\n\
-             Profit: {profit}{tx_line}"
-        );
-
-        self.send(&message).await;
+        self.spawn_send(format_liquidation_message(
+            market,
+            borrower,
+            send_amount,
+            receive_amount,
+            profit,
+            tx_hash,
+            dry_run,
+        ));
     }
 
     /// Notify about a failed liquidation attempt.
-    pub async fn notify_liquidation_failed(&self, market: &str, borrower: &str, error: &str) {
-        let message = format!(
-            "❌ <b>Liquidation Failed</b>\n\
-             \n\
-             Market: <code>{market}</code>\n\
-             Borrower: <code>{borrower}</code>\n\
-             Error: {error}"
-        );
-
-        self.send(&message).await;
+    pub fn notify_liquidation_failed(self: &Arc<Self>, market: &str, borrower: &str, error: &str) {
+        self.spawn_send(format_liquidation_failed_message(market, borrower, error));
     }
 
     /// Notify about a swap failure after liquidation.
-    pub async fn notify_swap_failed(
-        &self,
+    pub fn notify_swap_failed(
+        self: &Arc<Self>,
         market: &str,
         from_asset: &str,
         to_asset: &str,
         amount: &str,
         error: &str,
     ) {
-        let message = format!(
-            "⚠️ <b>Swap Failed</b>\n\
-             \n\
-             Market: <code>{market}</code>\n\
-             From: <code>{from_asset}</code>\n\
-             To: <code>{to_asset}</code>\n\
-             Amount: {amount}\n\
-             Error: {error}"
-        );
-
-        self.send(&message).await;
+        self.spawn_send(format_swap_failed_message(
+            market, from_asset, to_asset, amount, error,
+        ));
     }
 
     /// Notify when a swap is skipped because the asset pair is unsupported.
-    pub async fn notify_swap_unsupported(
-        &self,
+    pub fn notify_swap_unsupported(
+        self: &Arc<Self>,
         market: &str,
         from_asset: &str,
         to_asset: &str,
         amount: &str,
     ) {
-        let message = format!(
-            "🚫 <b>Swap Unsupported</b>\n\
-             \n\
-             Market: <code>{market}</code>\n\
-             From: <code>{from_asset}</code>\n\
-             To: <code>{to_asset}</code>\n\
-             Amount: {amount}\n\
-             \n\
-             Asset pair not supported by swap provider."
-        );
-
-        self.send(&message).await;
+        self.spawn_send(format_swap_unsupported_message(
+            market, from_asset, to_asset, amount,
+        ));
     }
 
     // ── Internal ────────────────────────────────────────────────────────────
+
+    /// Spawns the send on a background task so callers never block.
+    fn spawn_send(self: &Arc<Self>, message: String) {
+        if self.telegram.is_none() {
+            return;
+        }
+        let this = Arc::clone(self);
+        tokio::spawn(async move {
+            this.send(&message).await;
+        });
+    }
 
     /// Sends an HTML message to the configured Telegram chat.
     /// Failures are logged and swallowed — never propagated.
@@ -184,7 +269,8 @@ impl Notifier {
                 tracing::debug!("Telegram notification sent");
             }
             Err(e) => {
-                tracing::warn!(error = %e, "Failed to send Telegram notification");
+                let safe_error = e.without_url();
+                tracing::warn!(error = %safe_error, "Failed to send Telegram notification");
             }
         }
     }
@@ -221,5 +307,121 @@ mod tests {
         let notifier = Notifier::new(Some(config.clone()));
         assert!(notifier.is_enabled());
         assert_eq!(config.thread_id, Some(42));
+    }
+
+    #[test]
+    fn test_html_escape() {
+        assert_eq!(html_escape("a < b & c > d"), "a &lt; b &amp; c &gt; d");
+        assert_eq!(html_escape("no special chars"), "no special chars");
+        assert_eq!(
+            html_escape("<script>alert(1)</script>"),
+            "&lt;script&gt;alert(1)&lt;/script&gt;"
+        );
+    }
+
+    #[test]
+    fn test_format_liquidation_message() {
+        let msg = format_liquidation_message(
+            "market.near",
+            "borrower.near",
+            "100.00 USDC",
+            "0.005 BTC",
+            "+1.50 USDC (+1.5%)",
+            None,
+            false,
+        );
+        assert!(msg.contains("✅ <b>Liquidation Executed</b>"));
+        assert!(msg.contains("<code>market.near</code>"));
+        assert!(msg.contains("<code>borrower.near</code>"));
+        assert!(msg.contains("100.00 USDC"));
+        assert!(msg.contains("0.005 BTC"));
+        assert!(msg.contains("+1.50 USDC (+1.5%)"));
+        assert!(!msg.contains("Tx:"));
+    }
+
+    #[test]
+    fn test_format_liquidation_message_dry_run() {
+        let msg = format_liquidation_message(
+            "market.near",
+            "borrower.near",
+            "100.00 USDC",
+            "0.005 BTC",
+            "+1.50 USDC",
+            None,
+            true,
+        );
+        assert!(msg.starts_with("🧪 DRY RUN ✅"));
+    }
+
+    #[test]
+    fn test_format_liquidation_message_with_tx_hash() {
+        let msg = format_liquidation_message(
+            "market.near",
+            "borrower.near",
+            "100.00 USDC",
+            "0.005 BTC",
+            "+1.50 USDC",
+            Some("abc123"),
+            false,
+        );
+        assert!(msg.contains("Tx: <code>abc123</code>"));
+    }
+
+    #[test]
+    fn test_format_liquidation_message_escapes_html() {
+        let msg = format_liquidation_message(
+            "a<b>c", "x&y", "10 USDC", "0.1 BTC", "+1 USDC", None, false,
+        );
+        assert!(msg.contains("a&lt;b&gt;c"));
+        assert!(msg.contains("x&amp;y"));
+    }
+
+    #[test]
+    fn test_format_liquidation_failed_message() {
+        let msg = format_liquidation_failed_message(
+            "market.near",
+            "borrower.near",
+            "Transaction timed out",
+        );
+        assert!(msg.contains("❌ <b>Liquidation Failed</b>"));
+        assert!(msg.contains("<code>market.near</code>"));
+        assert!(msg.contains("<code>borrower.near</code>"));
+        assert!(msg.contains("Transaction timed out"));
+    }
+
+    #[test]
+    fn test_format_liquidation_failed_escapes_error() {
+        let msg = format_liquidation_failed_message("m", "b", "error <contains> html & stuff");
+        assert!(msg.contains("error &lt;contains&gt; html &amp; stuff"));
+    }
+
+    #[test]
+    fn test_format_swap_failed_message() {
+        let msg = format_swap_failed_message("market.near", "BTC", "USDC", "0.005 BTC", "No route");
+        assert!(msg.contains("⚠️ <b>Swap Failed</b>"));
+        assert!(msg.contains("<code>BTC</code>"));
+        assert!(msg.contains("<code>USDC</code>"));
+        assert!(msg.contains("0.005 BTC"));
+        assert!(msg.contains("No route"));
+    }
+
+    #[test]
+    fn test_format_swap_unsupported_message() {
+        let msg = format_swap_unsupported_message("market.near", "stNEAR", "USDC", "100 stNEAR");
+        assert!(msg.contains("🚫 <b>Swap Unsupported</b>"));
+        assert!(msg.contains("<code>stNEAR</code>"));
+        assert!(msg.contains("<code>USDC</code>"));
+        assert!(msg.contains("100 stNEAR"));
+        assert!(msg.contains("not supported by swap provider"));
+    }
+
+    #[test]
+    fn test_spawn_send_noop_when_disabled() {
+        let notifier = Arc::new(Notifier::new(None));
+        // Should not panic or spawn anything
+        notifier.notify_liquidation("m", "b", "1", "2", "3", None, false);
+        notifier.notify_liquidation_failed("m", "b", "err");
+        notifier.notify_swap_failed("m", "a", "b", "1", "err");
+        notifier.notify_swap_unsupported("m", "a", "b", "1");
     }
 }

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -25,7 +25,7 @@ use templar_common::{
 };
 
 use crate::{
-    rpc::{view, RpcError},
+    rpc::{view, NonceTracker, RpcError},
     LiquidatorError, LiquidatorResult,
 };
 
@@ -114,6 +114,8 @@ pub struct OracleFetcher {
     signer_id: Option<AccountId>,
     /// Signer key for on-chain oracle price updates
     signer_key: Option<near_crypto::SecretKey>,
+    /// Shared nonce tracker to prevent nonce collisions with other transactions
+    nonce_tracker: NonceTracker,
 }
 
 impl OracleFetcher {
@@ -127,6 +129,7 @@ impl OracleFetcher {
         redstone_gateway_url: Option<String>,
         proxy_oracle_cache: Option<ProxyOracleCache>,
         signer_for_oracle: Option<(AccountId, near_crypto::SecretKey)>,
+        nonce_tracker: NonceTracker,
     ) -> Self {
         let (signer_id, signer_key) = match signer_for_oracle {
             Some((id, key)) => (Some(id), Some(key)),
@@ -144,6 +147,7 @@ impl OracleFetcher {
                 .unwrap_or_else(|| DEFAULT_REDSTONE_GATEWAY_URL.to_string()),
             signer_id,
             signer_key,
+            nonce_tracker,
         }
     }
 
@@ -493,7 +497,7 @@ impl OracleFetcher {
                 LiquidatorError::OracleUpdateError(format!("Failed to query access key: {e}"))
             })?;
 
-        let current_nonce = match access_key_query_response.kind {
+        let rpc_nonce = match access_key_query_response.kind {
             near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKey(access_key) => {
                 access_key.nonce
             }
@@ -505,12 +509,13 @@ impl OracleFetcher {
         };
 
         let block_hash = access_key_query_response.block_hash;
+        let nonce = self.nonce_tracker.next_nonce(rpc_nonce);
 
         // Construct and send update transaction
         let transaction = Transaction::V0(TransactionV0 {
             signer_id: signer_id.clone(),
             public_key: signer_key.public_key(),
-            nonce: current_nonce + 1,
+            nonce,
             receiver_id: oracle.clone(),
             block_hash,
             actions: vec![near_primitives::action::FunctionCallAction {

--- a/service/liquidator/src/rpc.rs
+++ b/service/liquidator/src/rpc.rs
@@ -191,7 +191,7 @@ pub async fn get_contract_version(
 /// # Returns
 ///
 /// Tuple of (nonce, block_hash) to use when constructing a transaction
-#[tracing::instrument(skip(client, nonce_tracker), level = "debug")]
+#[tracing::instrument(skip(client, signer, nonce_tracker), level = "debug")]
 pub async fn get_access_key_data(
     client: &JsonRpcClient,
     signer: &Signer,

--- a/service/liquidator/src/rpc.rs
+++ b/service/liquidator/src/rpc.rs
@@ -626,9 +626,11 @@ mod tests {
     #[test]
     fn test_nonce_tracker_record_used() {
         let tracker = NonceTracker::default();
-        tracker.record_used(50);
+        // Not a cryptographic nonce — this is a NEAR tx sequence counter.
+        let previously_used: u64 = 50; // lgtm[rust/hardcoded-credentials]
+        tracker.record_used(previously_used);
         // next_nonce should be above recorded value
-        assert_eq!(tracker.next_nonce(10), 51);
+        assert_eq!(tracker.next_nonce(10), previously_used + 1);
     }
 
     #[test]

--- a/service/liquidator/src/rpc.rs
+++ b/service/liquidator/src/rpc.rs
@@ -11,7 +11,11 @@
 //! All RPC operations return `RpcResult<T>` which wraps various RPC-level errors.
 //! These are converted to `LiquidatorError` at the application level.
 
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicU64, Arc},
+    time::Duration,
+};
 
 use futures::{StreamExt, TryStreamExt};
 use near_crypto::Signer;
@@ -87,6 +91,36 @@ pub type BorrowPositions = HashMap<AccountId, BorrowPosition>;
 /// Default gas for transactions. 300 `TGas`.
 pub const DEFAULT_GAS: u64 = Gas::from_tgas(300).as_gas();
 
+/// Shared nonce tracker to prevent nonce collisions between concurrent transactions
+/// (e.g., oracle price updates and liquidation transactions).
+///
+/// Tracks the last nonce used by any transaction. When fetching a new nonce,
+/// returns `max(rpc_nonce, tracked_nonce) + 1` to avoid stale-nonce races
+/// where an RPC node hasn't indexed the latest transaction yet.
+#[derive(Debug, Clone, Default)]
+pub struct NonceTracker(Arc<AtomicU64>);
+
+impl NonceTracker {
+    /// Record a nonce that was just used in a transaction.
+    pub fn record_used(&self, nonce: u64) {
+        self.0.fetch_max(nonce, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Given an RPC-reported access key nonce, return the next safe nonce to use.
+    ///
+    /// Takes the max of the RPC nonce and our tracked nonce, then adds 1.
+    pub fn next_nonce(&self, rpc_access_key_nonce: u64) -> u64 {
+        let tracked = self.0.load(std::sync::atomic::Ordering::SeqCst);
+        let base = rpc_access_key_nonce.max(tracked);
+        let next = base + 1;
+        self.0.fetch_max(next, std::sync::atomic::Ordering::SeqCst);
+        next
+    }
+}
+
+/// Shared nonce tracker handle.
+pub type SharedNonceTracker = NonceTracker;
+
 /// Default timeout for view call requests (seconds)
 const VIEW_CALL_TIMEOUT_SECS: u64 = 30;
 
@@ -135,18 +169,24 @@ pub async fn get_contract_version(
 
 /// Get access key data (nonce and block hash) for transaction signing.
 ///
+/// When a `NonceTracker` is provided, the returned nonce is guaranteed to be
+/// higher than any previously used nonce, even if the RPC node hasn't indexed
+/// recent transactions yet.
+///
 /// # Arguments
 ///
 /// * `client` - JSON-RPC client instance
 /// * `signer` - Signer with the account and key to query
+/// * `nonce_tracker` - Optional shared nonce tracker for collision prevention
 ///
 /// # Returns
 ///
 /// Tuple of (nonce, block_hash) to use when constructing a transaction
-#[tracing::instrument(skip(client), level = "debug")]
+#[tracing::instrument(skip(client, nonce_tracker), level = "debug")]
 pub async fn get_access_key_data(
     client: &JsonRpcClient,
     signer: &Signer,
+    nonce_tracker: Option<&NonceTracker>,
 ) -> RpcResult<(u64, CryptoHash)> {
     let access_key_query_response = client
         .call(RpcQueryRequest {
@@ -159,8 +199,8 @@ pub async fn get_access_key_data(
         .await
         .map_err(RpcError::AccessKeyDataError)?;
 
-    let nonce = match access_key_query_response.kind {
-        QueryResponseKind::AccessKey(access_key) => access_key.nonce + 1,
+    let rpc_nonce = match access_key_query_response.kind {
+        QueryResponseKind::AccessKey(access_key) => access_key.nonce,
         _ => {
             return Err(RpcError::WrongResponseKind(format!(
                 "Expected AccessKey got {:?}",
@@ -169,6 +209,12 @@ pub async fn get_access_key_data(
         }
     };
     let block_hash = access_key_query_response.block_hash;
+
+    let nonce = if let Some(tracker) = nonce_tracker {
+        tracker.next_nonce(rpc_nonce)
+    } else {
+        rpc_nonce + 1
+    };
 
     Ok((nonce, block_hash))
 }

--- a/service/liquidator/src/rpc.rs
+++ b/service/liquidator/src/rpc.rs
@@ -108,13 +108,22 @@ impl NonceTracker {
 
     /// Given an RPC-reported access key nonce, return the next safe nonce to use.
     ///
-    /// Takes the max of the RPC nonce and our tracked nonce, then adds 1.
+    /// Atomically reserves a unique nonce via CAS loop so concurrent callers
+    /// never receive the same value.
     pub fn next_nonce(&self, rpc_access_key_nonce: u64) -> u64 {
-        let tracked = self.0.load(std::sync::atomic::Ordering::SeqCst);
-        let base = rpc_access_key_nonce.max(tracked);
-        let next = base + 1;
-        self.0.fetch_max(next, std::sync::atomic::Ordering::SeqCst);
-        next
+        let mut observed = self.0.load(std::sync::atomic::Ordering::SeqCst);
+        loop {
+            let next = rpc_access_key_nonce.max(observed) + 1;
+            match self.0.compare_exchange(
+                observed,
+                next,
+                std::sync::atomic::Ordering::SeqCst,
+                std::sync::atomic::Ordering::SeqCst,
+            ) {
+                Ok(_) => return next,
+                Err(current) => observed = current,
+            }
+        }
     }
 }
 
@@ -593,5 +602,52 @@ mod tests {
         let display = format!("{error}");
         assert!(display.contains("60"));
         assert!(display.contains("65"));
+    }
+
+    #[test]
+    fn test_nonce_tracker_next_nonce_basic() {
+        let tracker = NonceTracker::default();
+        // First call with rpc_nonce=10 → 11
+        assert_eq!(tracker.next_nonce(10), 11);
+        // Second call with same rpc_nonce → 12 (tracked is now 11)
+        assert_eq!(tracker.next_nonce(10), 12);
+    }
+
+    #[test]
+    fn test_nonce_tracker_rpc_jumps_forward() {
+        let tracker = NonceTracker::default();
+        assert_eq!(tracker.next_nonce(10), 11);
+        // RPC reports higher nonce (another source used nonces)
+        assert_eq!(tracker.next_nonce(20), 21);
+        // Tracked is now 21
+        assert_eq!(tracker.next_nonce(15), 22);
+    }
+
+    #[test]
+    fn test_nonce_tracker_record_used() {
+        let tracker = NonceTracker::default();
+        tracker.record_used(50);
+        // next_nonce should be above recorded value
+        assert_eq!(tracker.next_nonce(10), 51);
+    }
+
+    #[test]
+    fn test_nonce_tracker_concurrent_unique() {
+        use std::collections::HashSet;
+        use std::sync::Arc;
+
+        let tracker = Arc::new(NonceTracker::default());
+        let mut handles = Vec::new();
+
+        for _ in 0..100 {
+            let t = tracker.clone();
+            handles.push(std::thread::spawn(move || t.next_nonce(10)));
+        }
+
+        let nonces: HashSet<u64> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+        // All 100 nonces must be unique
+        assert_eq!(nonces.len(), 100);
+        // All should be > 10
+        assert!(nonces.iter().all(|&n| n > 10));
     }
 }

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -98,6 +98,8 @@ pub struct ServiceConfig {
     pub batch_swap_on_cycle_start: bool,
     /// Retry configuration for transient swap errors
     pub swap_retry_config: crate::swap::SwapRetryConfig,
+    /// Shared notifier for Telegram alerts
+    pub notifier: crate::notifier::SharedNotifier,
 }
 
 /// Liquidator service that manages the bot lifecycle
@@ -154,6 +156,7 @@ impl LiquidatorService {
             Some(config.redstone_gateway_url.clone()),
             None,
             None,
+            crate::rpc::NonceTracker::default(),
         );
 
         // Log swap configuration
@@ -557,6 +560,7 @@ impl LiquidatorService {
                         self.config.signer_account.clone(),
                         self.config.signer_key.clone(),
                     )),
+                    self.config.notifier.clone(),
                 );
 
                 // Fetch market version for version-specific liquidation logic

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -115,6 +115,8 @@ pub struct LiquidatorService {
     oracle_fetcher: crate::OracleFetcher,
     /// Collateral asset → price / swap target info (built from market configs)
     collateral_price_map: HashMap<String, CollateralPriceInfo>,
+    /// Shared nonce tracker for all transactions from this signer
+    nonce_tracker: crate::rpc::NonceTracker,
 }
 
 impl LiquidatorService {
@@ -145,9 +147,12 @@ impl LiquidatorService {
             config.signer_account.clone(),
         )));
 
+        // Shared nonce tracker for all transactions from this signer
+        let nonce_tracker = crate::rpc::NonceTracker::default();
+
         // Create swap provider for executor
         let (_, oneclick_provider) =
-            Self::create_swap_providers(&config, &client, Arc::new(signer.clone()));
+            Self::create_swap_providers(&config, &client, Arc::new(signer.clone()), &nonce_tracker);
 
         // Create oracle fetcher for batch swap price checks (no signer needed for reads)
         let oracle_fetcher = crate::OracleFetcher::new(
@@ -156,7 +161,7 @@ impl LiquidatorService {
             Some(config.redstone_gateway_url.clone()),
             None,
             None,
-            crate::rpc::NonceTracker::default(),
+            nonce_tracker.clone(),
         );
 
         // Log swap configuration
@@ -177,6 +182,7 @@ impl LiquidatorService {
             oneclick_provider,
             oracle_fetcher,
             collateral_price_map: HashMap::new(),
+            nonce_tracker,
         }
     }
 
@@ -185,6 +191,7 @@ impl LiquidatorService {
         config: &ServiceConfig,
         client: &JsonRpcClient,
         signer: Arc<near_crypto::Signer>,
+        nonce_tracker: &crate::rpc::NonceTracker,
     ) -> (
         Option<crate::swap::SwapProviderImpl>,
         Option<crate::swap::SwapProviderImpl>,
@@ -203,7 +210,12 @@ impl LiquidatorService {
         let ref_provider = if let Some(ref contract_str) = config.ref_contract {
             match contract_str.parse::<AccountId>() {
                 Ok(contract) => {
-                    let ref_swap = RefSwap::new(contract.clone(), client.clone(), signer.clone());
+                    let ref_swap = RefSwap::new(
+                        contract.clone(),
+                        client.clone(),
+                        signer.clone(),
+                        nonce_tracker.clone(),
+                    );
                     tracing::info!(
                         contract = %contract,
                         "Ref Finance provider initialized"
@@ -233,6 +245,7 @@ impl LiquidatorService {
                 signer,
                 None,
                 config.oneclick_api_token.clone(),
+                nonce_tracker.clone(),
             );
             if config.oneclick_api_token.is_some() {
                 tracing::info!("1-Click API provider initialized with authentication");
@@ -561,6 +574,7 @@ impl LiquidatorService {
                         self.config.signer_key.clone(),
                     )),
                     self.config.notifier.clone(),
+                    self.nonce_tracker.clone(),
                 );
 
                 // Fetch market version for version-specific liquidation logic

--- a/service/liquidator/src/swap/oneclick.rs
+++ b/service/liquidator/src/swap/oneclick.rs
@@ -302,6 +302,8 @@ pub struct OneClickSwap {
     api_token: Option<String>,
     /// Cached set of 1-Click supported token `assetId` values
     supported_tokens: std::sync::Arc<std::sync::RwLock<std::collections::HashSet<String>>>,
+    /// Shared nonce tracker for coordinated nonce management
+    nonce_tracker: crate::rpc::NonceTracker,
 }
 
 impl OneClickSwap {
@@ -318,6 +320,7 @@ impl OneClickSwap {
         signer: Arc<Signer>,
         max_slippage_bps: Option<u32>,
         api_token: Option<String>,
+        nonce_tracker: crate::rpc::NonceTracker,
     ) -> Self {
         Self {
             client,
@@ -329,6 +332,7 @@ impl OneClickSwap {
             supported_tokens: std::sync::Arc::new(std::sync::RwLock::new(
                 std::collections::HashSet::new(),
             )),
+            nonce_tracker,
         }
     }
 
@@ -602,7 +606,8 @@ impl OneClickSwap {
             "Storage deposit minimum from contract"
         );
 
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
+        let (nonce, block_hash) =
+            get_access_key_data(&self.client, &self.signer, Some(&self.nonce_tracker)).await?;
 
         let storage_deposit_action = FunctionCallAction {
             method_name: "storage_deposit".to_string(),
@@ -683,7 +688,8 @@ impl OneClickSwap {
                 "Creating implicit account"
             );
 
-            let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
+            let (nonce, block_hash) =
+                get_access_key_data(&self.client, &self.signer, Some(&self.nonce_tracker)).await?;
 
             // Send 1 yoctoNEAR to create the implicit account (minimum amount needed)
             let create_account_tx = Transaction::V0(TransactionV0 {
@@ -730,7 +736,8 @@ impl OneClickSwap {
         }
 
         // Get transaction parameters
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
+        let (nonce, block_hash) =
+            get_access_key_data(&self.client, &self.signer, Some(&self.nonce_tracker)).await?;
 
         // Create deposit transaction
         // Use simple ft_transfer (not ft_transfer_call) for INTENTS depositType

--- a/service/liquidator/src/swap/oneclick.rs
+++ b/service/liquidator/src/swap/oneclick.rs
@@ -602,7 +602,7 @@ impl OneClickSwap {
             "Storage deposit minimum from contract"
         );
 
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer).await?;
+        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
 
         let storage_deposit_action = FunctionCallAction {
             method_name: "storage_deposit".to_string(),
@@ -683,7 +683,7 @@ impl OneClickSwap {
                 "Creating implicit account"
             );
 
-            let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer).await?;
+            let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
 
             // Send 1 yoctoNEAR to create the implicit account (minimum amount needed)
             let create_account_tx = Transaction::V0(TransactionV0 {
@@ -730,7 +730,7 @@ impl OneClickSwap {
         }
 
         // Get transaction parameters
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer).await?;
+        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
 
         // Create deposit transaction
         // Use simple ft_transfer (not ft_transfer_call) for INTENTS depositType

--- a/service/liquidator/src/swap/ref.rs
+++ b/service/liquidator/src/swap/ref.rs
@@ -473,7 +473,7 @@ impl SwapProvider for RefSwap {
                 .await?;
         }
 
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer).await?;
+        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
 
         // Execute swap via ft_transfer_call
         let tx = Transaction::V0(TransactionV0 {
@@ -544,7 +544,7 @@ impl SwapProvider for RefSwap {
             "Using storage deposit minimum from contract"
         );
 
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer).await?;
+        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
 
         let storage_deposit_action = near_primitives::action::FunctionCallAction {
             method_name: "storage_deposit".to_string(),

--- a/service/liquidator/src/swap/ref.rs
+++ b/service/liquidator/src/swap/ref.rs
@@ -48,11 +48,18 @@ pub struct RefSwap {
     pub max_slippage_bps: u32,
     /// Ref Finance indexer URL
     pub indexer_url: String,
+    /// Shared nonce tracker for coordinated nonce management
+    pub nonce_tracker: crate::rpc::NonceTracker,
 }
 
 impl RefSwap {
     /// Creates a new Ref Finance swap provider
-    pub fn new(contract: AccountId, client: JsonRpcClient, signer: Arc<Signer>) -> Self {
+    pub fn new(
+        contract: AccountId,
+        client: JsonRpcClient,
+        signer: Arc<Signer>,
+        nonce_tracker: crate::rpc::NonceTracker,
+    ) -> Self {
         #[allow(clippy::expect_used)]
         Self {
             contract,
@@ -61,6 +68,7 @@ impl RefSwap {
             wnear_contract: "wrap.near".parse().expect("wrap.near is a valid AccountId"),
             max_slippage_bps: Self::DEFAULT_MAX_SLIPPAGE_BPS,
             indexer_url: "https://indexer.ref.finance".to_string(),
+            nonce_tracker,
         }
     }
 
@@ -473,7 +481,8 @@ impl SwapProvider for RefSwap {
                 .await?;
         }
 
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
+        let (nonce, block_hash) =
+            get_access_key_data(&self.client, &self.signer, Some(&self.nonce_tracker)).await?;
 
         // Execute swap via ft_transfer_call
         let tx = Transaction::V0(TransactionV0 {
@@ -544,7 +553,8 @@ impl SwapProvider for RefSwap {
             "Using storage deposit minimum from contract"
         );
 
-        let (nonce, block_hash) = get_access_key_data(&self.client, &self.signer, None).await?;
+        let (nonce, block_hash) =
+            get_access_key_data(&self.client, &self.signer, Some(&self.nonce_tracker)).await?;
 
         let storage_deposit_action = near_primitives::action::FunctionCallAction {
             method_name: "storage_deposit".to_string(),


### PR DESCRIPTION
Summary

- Add Telegram notifications for liquidation events (success, failure, swap issues)
- Add NonceTracker to prevent nonce collisions between oracle updates and liquidation transactions
- Add short human-readable asset names for notifications (e.g. BTC instead of nep141:btc.omft.near)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/391)
<!-- Reviewable:end -->
