### PR TITLE
fix: add missing client dir to liquidator Dockerfile

### DIFF
--- a/service/liquidator/Dockerfile
+++ b/service/liquidator/Dockerfile
@@ -16,6 +16,7 @@ WORKDIR /app
 
 # Copy workspace files
 COPY Cargo.toml Cargo.lock ./
+COPY client ./client
 COPY common ./common
 COPY contract ./contract
 COPY fuzz ./fuzz


### PR DESCRIPTION
## Summary
- The workspace `Cargo.toml` references `client/*` as a member, but the liquidator Dockerfile wasn't copying it, causing Docker builds to fail.

## Test plan
- [x] Verified Docker build succeeds locally with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/392)
<!-- Reviewable:end -->
