### PR TITLE
feat: add IGNORED_MARKETS env var for market-level filtering

### DIFF
--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -148,6 +148,10 @@ CONCURRENCY=10
 #   - Ignore LINEAR: nep141:linear-protocol.near
 IGNORED_COLLATERAL_ASSETS=nep141:meta-pool.near
 
+# Ignored markets (comma-separated account IDs)
+# These specific markets will be skipped entirely
+# IGNORED_MARKETS=liqtest-market.v1.tmplr.near
+
 # ============================================
 # TESTING & DEBUGGING
 # ============================================

--- a/service/liquidator/scripts/run-mainnet.sh
+++ b/service/liquidator/scripts/run-mainnet.sh
@@ -61,6 +61,7 @@ REF_CONTRACT="${REF_CONTRACT:-v2.ref-finance.near}"  # Mainnet default
 # Market filtering configuration
 ALLOWED_COLLATERAL_ASSETS="${ALLOWED_COLLATERAL_ASSETS}"
 IGNORED_COLLATERAL_ASSETS="${IGNORED_COLLATERAL_ASSETS}"
+IGNORED_MARKETS="${IGNORED_MARKETS}"
 
 # Oracle price update configuration
 PYTH_HERMES_URL="${PYTH_HERMES_URL:-https://hermes.pyth.network}"
@@ -104,6 +105,9 @@ if [ -n "$ALLOWED_COLLATERAL_ASSETS" ]; then
 fi
 if [ -n "$IGNORED_COLLATERAL_ASSETS" ]; then
     echo "  Ignored Assets:       $IGNORED_COLLATERAL_ASSETS"
+fi
+if [ -n "$IGNORED_MARKETS" ]; then
+    echo "  Ignored Markets:      $IGNORED_MARKETS"
 fi
 
 echo ""
@@ -170,6 +174,13 @@ if [ -n "$IGNORED_COLLATERAL_ASSETS" ]; then
     IFS=',' read -ra ASSETS <<< "$IGNORED_COLLATERAL_ASSETS"
     for asset in "${ASSETS[@]}"; do
         CMD_ARGS+=("--ignored-collateral-assets" "$asset")
+    done
+fi
+
+if [ -n "$IGNORED_MARKETS" ]; then
+    IFS=',' read -ra MARKETS <<< "$IGNORED_MARKETS"
+    for market in "${MARKETS[@]}"; do
+        CMD_ARGS+=("--ignored-markets" "$market")
     done
 fi
 

--- a/service/liquidator/scripts/run-testnet.sh
+++ b/service/liquidator/scripts/run-testnet.sh
@@ -61,6 +61,7 @@ REF_CONTRACT="${REF_CONTRACT:-v2.ref-dev.testnet}"  # Testnet default
 # Market filtering configuration
 ALLOWED_COLLATERAL_ASSETS="${ALLOWED_COLLATERAL_ASSETS}"
 IGNORED_COLLATERAL_ASSETS="${IGNORED_COLLATERAL_ASSETS}"
+IGNORED_MARKETS="${IGNORED_MARKETS}"
 
 # Oracle price update configuration
 PYTH_HERMES_URL="${PYTH_HERMES_URL:-https://hermes-beta.pyth.network}"
@@ -104,6 +105,9 @@ if [ -n "$ALLOWED_COLLATERAL_ASSETS" ]; then
 fi
 if [ -n "$IGNORED_COLLATERAL_ASSETS" ]; then
     echo "  Ignored Assets:       $IGNORED_COLLATERAL_ASSETS"
+fi
+if [ -n "$IGNORED_MARKETS" ]; then
+    echo "  Ignored Markets:      $IGNORED_MARKETS"
 fi
 
 echo ""
@@ -171,6 +175,13 @@ if [ -n "$IGNORED_COLLATERAL_ASSETS" ]; then
     IFS=',' read -ra ASSETS <<< "$IGNORED_COLLATERAL_ASSETS"
     for asset in "${ASSETS[@]}"; do
         CMD_ARGS+=("--ignored-collateral-assets" "$asset")
+    done
+fi
+
+if [ -n "$IGNORED_MARKETS" ]; then
+    IFS=',' read -ra MARKETS <<< "$IGNORED_MARKETS"
+    for market in "${MARKETS[@]}"; do
+        CMD_ARGS+=("--ignored-markets" "$market")
     done
 fi
 

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -128,6 +128,10 @@ pub struct Args {
     #[arg(long, env = "IGNORED_COLLATERAL_ASSETS", value_delimiter = ',')]
     pub ignored_collateral_assets: Vec<String>,
 
+    /// Market account IDs to ignore (comma-separated)
+    #[arg(long, env = "IGNORED_MARKETS", value_delimiter = ',')]
+    pub ignored_markets: Vec<String>,
+
     /// Enable loop liquidation - repeatedly liquidate until position is healthy
     #[arg(long, env = "LOOP_LIQUIDATION", default_value_t = false)]
     pub loop_liquidation: bool,
@@ -304,6 +308,30 @@ impl Args {
             );
         }
 
+        let ignored_markets: Vec<AccountId> = self
+            .ignored_markets
+            .iter()
+            .filter_map(|s| {
+                s.parse::<AccountId>()
+                    .map_err(|e| {
+                        tracing::warn!(
+                            market = %s,
+                            error = ?e,
+                            "Failed to parse ignored market account ID, skipping"
+                        );
+                        e
+                    })
+                    .ok()
+            })
+            .collect();
+
+        if !ignored_markets.is_empty() {
+            tracing::info!(
+                ignored_markets = ?ignored_markets,
+                "Market filtering: ignoring specified markets"
+            );
+        }
+
         // Build notifier — require both bot token and chat ID
         let bot_token = self.telegram_bot_token.trim();
         let chat_id = self.telegram_chat_id.trim();
@@ -344,6 +372,7 @@ impl Args {
             ref_contract: self.ref_contract.clone(),
             allowed_collateral_assets,
             ignored_collateral_assets,
+            ignored_markets,
             loop_liquidation: self.loop_liquidation,
             max_loop_iterations: self.max_loop_iterations,
             hermes_url: self.hermes_url.clone(),

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -252,6 +252,7 @@ impl Args {
     }
 
     /// Build service configuration from arguments
+    #[allow(clippy::too_many_lines)]
     pub fn build_config(&self) -> ServiceConfig {
         let strategy = self.create_strategy();
         let collateral_strategy = self.parse_collateral_strategy();
@@ -312,7 +313,8 @@ impl Args {
             .ignored_markets
             .iter()
             .filter_map(|s| {
-                s.parse::<AccountId>()
+                s.trim()
+                    .parse::<AccountId>()
                     .map_err(|e| {
                         tracing::warn!(
                             market = %s,
@@ -430,6 +432,7 @@ mod tests {
             ref_contract: None,
             allowed_collateral_assets: vec![],
             ignored_collateral_assets: vec![],
+            ignored_markets: vec![],
             loop_liquidation: false,
             max_loop_iterations: 10,
             hermes_url: "https://hermes.pyth.network".to_string(),

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -84,6 +84,8 @@ pub struct ServiceConfig {
     /// Collateral assets to ignore in market filtering
     pub ignored_collateral_assets:
         Vec<templar_common::asset::FungibleAsset<templar_common::asset::CollateralAsset>>,
+    /// Market account IDs to ignore
+    pub ignored_markets: Vec<near_sdk::AccountId>,
     /// Enable loop liquidation - repeatedly liquidate until position is healthy
     pub loop_liquidation: bool,
     /// Maximum iterations for loop liquidation (safety limit)
@@ -372,13 +374,14 @@ impl LiquidatorService {
     /// Check if a market should be processed based on asset filtering rules.
     ///
     /// Returns (`should_process`, `reason_if_filtered`).
+    /// Note: ignored markets are checked earlier (before RPC calls) in `refresh_registry`.
     fn should_process_market(
         &self,
         config: &templar_common::market::MarketConfiguration,
     ) -> (bool, Option<String>) {
         let collateral_asset = &config.collateral_asset;
 
-        // Check ignore list
+        // Check ignored collateral assets list
         if !self.config.ignored_collateral_assets.is_empty() {
             for ignored_asset in &self.config.ignored_collateral_assets {
                 if collateral_asset == ignored_asset {
@@ -437,6 +440,15 @@ impl LiquidatorService {
             // Filter deployments using registry metadata, then fetch market configs
             let mut market_configs = Vec::new();
             for market in &all_markets {
+                // Step 0: Skip ignored markets before any RPC calls
+                if self.config.ignored_markets.contains(market) {
+                    tracing::info!(
+                        market = %market,
+                        "Market filtered out (ignored market)"
+                    );
+                    continue;
+                }
+
                 // Step 1: Fetch market configuration — this is the definitive check
                 // for whether a deployment is a market contract. Non-market contracts
                 // (proxy-oracles, redstone-adapters) won't have this method.
@@ -518,7 +530,7 @@ impl LiquidatorService {
                     .detect_and_register_proxy_oracle(oracle_account)
                     .await;
 
-                // Step 4: Apply market filtering rules (collateral asset allow/ignore lists)
+                // Step 4: Apply market filtering rules
                 let (should_process, filter_reason) = self.should_process_market(&config);
 
                 if should_process {


### PR DESCRIPTION
## Summary
- Adds `IGNORED_MARKETS` env var to skip specific markets by account ID
- Filtering happens before RPC calls, avoiding unnecessary config fetches
- Updated run scripts (mainnet/testnet) and .env.example

## Test plan
- [x] Builds cleanly
- [x] Tested locally — ignored markets are skipped before any RPC calls
- [ ] Deploy and verify `liqtest-ixlm-ixlmusdc*.v1.tmplr.near` markets no longer appear in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/397)
<!-- Reviewable:end -->
