### PR TITLE
fix: classify liquidator errors by phase, notify only on execution failures

### DIFF
--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -193,3 +193,9 @@ REDSTONE_GATEWAY_URL=https://oracle-gateway-1.a.redstone.vip
 
 # Optional: Telegram thread/topic ID for sending to a specific topic in a group
 # TELEGRAM_THREAD_ID=42
+
+# Number of consecutive scan failures per market before sending a Telegram alert.
+# A recovery notification is also sent when the market starts working again.
+# Set to 0 to disable scan failure notifications.
+# Default: 2
+# SCAN_FAILURE_NOTIFY_THRESHOLD=2

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -173,6 +173,11 @@ pub struct Args {
     #[arg(long, env = "SWAP_RETRY_BASE_DELAY_MS", default_value_t = 2000)]
     pub swap_retry_base_delay_ms: u64,
 
+    /// Number of consecutive scan failures before sending a Telegram alert.
+    /// Set to 0 to disable scan failure notifications.
+    #[arg(long, env = "SCAN_FAILURE_NOTIFY_THRESHOLD", default_value_t = 2)]
+    pub scan_failure_notify_threshold: u32,
+
     /// Telegram bot token for notifications (leave empty to disable)
     #[arg(long, env = "TELEGRAM_BOT_TOKEN", default_value = "")]
     pub telegram_bot_token: String,
@@ -386,6 +391,7 @@ impl Args {
                 base_delay_ms: self.swap_retry_base_delay_ms,
             },
             notifier,
+            scan_failure_notify_threshold: self.scan_failure_notify_threshold,
         }
     }
 
@@ -441,6 +447,7 @@ mod tests {
             batch_swap_on_cycle_start: true,
             swap_retry_attempts: 3,
             swap_retry_base_delay_ms: 2000,
+            scan_failure_notify_threshold: 2,
             telegram_bot_token: String::new(),
             telegram_chat_id: String::new(),
             telegram_thread_id: String::new(),
@@ -650,5 +657,29 @@ mod tests {
         args.telegram_thread_id = String::new();
         let config = args.build_config();
         assert!(config.notifier.is_enabled());
+    }
+
+    #[test]
+    fn test_scan_failure_threshold_default() {
+        let args = create_test_args();
+        assert_eq!(args.scan_failure_notify_threshold, 2);
+        let config = args.build_config();
+        assert_eq!(config.scan_failure_notify_threshold, 2);
+    }
+
+    #[test]
+    fn test_scan_failure_threshold_disabled() {
+        let mut args = create_test_args();
+        args.scan_failure_notify_threshold = 0;
+        let config = args.build_config();
+        assert_eq!(config.scan_failure_notify_threshold, 0);
+    }
+
+    #[test]
+    fn test_scan_failure_threshold_custom() {
+        let mut args = create_test_args();
+        args.scan_failure_notify_threshold = 5;
+        let config = args.build_config();
+        assert_eq!(config.scan_failure_notify_threshold, 5);
     }
 }

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -118,6 +118,44 @@ pub enum LiquidatorError {
     InsufficientBalance,
 }
 
+impl LiquidatorError {
+    /// Returns `true` when the error occurred during actual liquidation execution
+    /// (transaction submission, on-chain failure, swap after liquidation).
+    /// Pre-execution errors (scanning, balance checks, price fetches) return `false`.
+    pub const fn is_execution_error(&self) -> bool {
+        matches!(
+            self,
+            Self::LiquidationTransactionError(_)
+                | Self::TransactionFailed(_)
+                | Self::SwapProviderError(_)
+        )
+    }
+
+    /// Short human-readable phase label for log messages.
+    pub const fn phase(&self) -> &'static str {
+        match self {
+            // Scan phase — reading on-chain state, fetching prices
+            Self::FetchBorrowStatus(_)
+            | Self::PricePairError(_)
+            | Self::PriceFetchError(_)
+            | Self::ListBorrowPositionsError(_)
+            | Self::ListDeploymentsError(_)
+            | Self::GetConfigurationError(_)
+            | Self::FetchBalanceError(_) => "scan",
+            // Preparation — decided to liquidate but haven't submitted tx yet
+            Self::AccessKeyDataError(_)
+            | Self::SerializeError(_)
+            | Self::StrategyError(_)
+            | Self::InsufficientBalance
+            | Self::OracleUpdateError(_) => "preparation",
+            // Execution — transaction was submitted or on-chain action attempted
+            Self::LiquidationTransactionError(_)
+            | Self::TransactionFailed(_)
+            | Self::SwapProviderError(_) => "execution",
+        }
+    }
+}
+
 pub type LiquidatorResult<T = ()> = Result<T, LiquidatorError>;
 
 /// Collateral management strategy
@@ -836,12 +874,17 @@ impl Liquidator {
                 Ok(LiquidationOutcome::NotLiquidatable) => not_liquidatable += 1,
                 Ok(LiquidationOutcome::Unprofitable) => unprofitable += 1,
                 Err(e) => {
-                    tracing::warn!(borrower = %account, error = %e, "Liquidation failed");
-                    self.notifier.notify_liquidation_failed(
-                        self.market.as_ref(),
-                        account.as_ref(),
-                        &e.to_string(),
-                    );
+                    let phase = e.phase();
+                    if e.is_execution_error() {
+                        tracing::error!(borrower = %account, phase, error = %e, "Liquidation failed");
+                        self.notifier.notify_liquidation_failed(
+                            self.market.as_ref(),
+                            account.as_ref(),
+                            &e.to_string(),
+                        );
+                    } else {
+                        tracing::warn!(borrower = %account, phase, error = %e, "Skipped position");
+                    }
                     failed += 1;
                 }
             }

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -926,3 +926,33 @@ impl Liquidator {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_phase_scan() {
+        let err = LiquidatorError::FetchBorrowStatus(rpc::RpcError::TimeoutError(30, 30));
+        assert_eq!(err.phase(), ErrorPhase::Scan);
+    }
+
+    #[test]
+    fn test_error_phase_preparation() {
+        let err = LiquidatorError::InsufficientBalance;
+        assert_eq!(err.phase(), ErrorPhase::Preparation);
+    }
+
+    #[test]
+    fn test_error_phase_execution() {
+        let err = LiquidatorError::TransactionFailed("receipt failed".to_string());
+        assert_eq!(err.phase(), ErrorPhase::Execution);
+    }
+
+    #[test]
+    fn test_error_phase_display() {
+        assert_eq!(ErrorPhase::Scan.to_string(), "scan");
+        assert_eq!(ErrorPhase::Preparation.to_string(), "preparation");
+        assert_eq!(ErrorPhase::Execution.to_string(), "execution");
+    }
+}

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -148,8 +148,9 @@ impl std::fmt::Display for ErrorPhase {
 impl LiquidatorError {
     /// Classifies the error by pipeline phase.
     ///
-    /// Only `Execution` errors trigger Telegram notifications — these mean a
-    /// liquidation or swap transaction was actually submitted to the network.
+    /// Only `Execution` errors trigger the "Liquidation Failed" Telegram
+    /// notification (successful liquidations and swap issues have their own
+    /// dedicated notifications sent elsewhere).
     /// `OracleUpdateError` is classified as `Preparation` because oracle price
     /// pushes are best-effort and swallowed before execution; they never
     /// propagate to callers in practice.
@@ -175,10 +176,6 @@ impl LiquidatorError {
         }
     }
 
-    /// Returns `true` for errors where a transaction was submitted to the network.
-    pub const fn is_execution_error(&self) -> bool {
-        matches!(self.phase(), ErrorPhase::Execution)
-    }
 }
 
 pub type LiquidatorResult<T = ()> = Result<T, LiquidatorError>;
@@ -900,7 +897,7 @@ impl Liquidator {
                 Ok(LiquidationOutcome::Unprofitable) => unprofitable += 1,
                 Err(e) => {
                     let phase = e.phase();
-                    if e.is_execution_error() {
+                    if phase == ErrorPhase::Execution {
                         tracing::error!(borrower = %account, phase = %phase, error = %e, "Liquidation failed");
                         self.notifier.notify_liquidation_failed(
                             self.market.as_ref(),

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -175,7 +175,6 @@ impl LiquidatorError {
             | Self::SwapProviderError(_) => ErrorPhase::Execution,
         }
     }
-
 }
 
 pub type LiquidatorResult<T = ()> = Result<T, LiquidatorError>;

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -118,41 +118,66 @@ pub enum LiquidatorError {
     InsufficientBalance,
 }
 
-impl LiquidatorError {
-    /// Returns `true` when the error occurred during actual liquidation execution
-    /// (transaction submission, on-chain failure, swap after liquidation).
-    /// Pre-execution errors (scanning, balance checks, price fetches) return `false`.
-    pub const fn is_execution_error(&self) -> bool {
-        matches!(
-            self,
-            Self::LiquidationTransactionError(_)
-                | Self::TransactionFailed(_)
-                | Self::SwapProviderError(_)
-        )
-    }
+/// Classifies where in the liquidation pipeline an error occurred.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorPhase {
+    /// Reading on-chain state, fetching prices, listing positions.
+    Scan,
+    /// Decided to liquidate but haven't submitted a tx yet (nonce, serialization, strategy).
+    Preparation,
+    /// Liquidation or swap transaction was submitted to the network.
+    Execution,
+}
 
-    /// Short human-readable phase label for log messages.
-    pub const fn phase(&self) -> &'static str {
+impl ErrorPhase {
+    pub const fn as_str(self) -> &'static str {
         match self {
-            // Scan phase — reading on-chain state, fetching prices
+            Self::Scan => "scan",
+            Self::Preparation => "preparation",
+            Self::Execution => "execution",
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorPhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl LiquidatorError {
+    /// Classifies the error by pipeline phase.
+    ///
+    /// Only `Execution` errors trigger Telegram notifications — these mean a
+    /// liquidation or swap transaction was actually submitted to the network.
+    /// `OracleUpdateError` is classified as `Preparation` because oracle price
+    /// pushes are best-effort and swallowed before execution; they never
+    /// propagate to callers in practice.
+    pub const fn phase(&self) -> ErrorPhase {
+        match self {
             Self::FetchBorrowStatus(_)
             | Self::PricePairError(_)
             | Self::PriceFetchError(_)
             | Self::ListBorrowPositionsError(_)
             | Self::ListDeploymentsError(_)
             | Self::GetConfigurationError(_)
-            | Self::FetchBalanceError(_) => "scan",
-            // Preparation — decided to liquidate but haven't submitted tx yet
+            | Self::FetchBalanceError(_) => ErrorPhase::Scan,
+
             Self::AccessKeyDataError(_)
             | Self::SerializeError(_)
             | Self::StrategyError(_)
             | Self::InsufficientBalance
-            | Self::OracleUpdateError(_) => "preparation",
-            // Execution — transaction was submitted or on-chain action attempted
+            | Self::OracleUpdateError(_) => ErrorPhase::Preparation,
+
             Self::LiquidationTransactionError(_)
             | Self::TransactionFailed(_)
-            | Self::SwapProviderError(_) => "execution",
+            | Self::SwapProviderError(_) => ErrorPhase::Execution,
         }
+    }
+
+    /// Returns `true` for errors where a transaction was submitted to the network.
+    pub const fn is_execution_error(&self) -> bool {
+        matches!(self.phase(), ErrorPhase::Execution)
     }
 }
 
@@ -876,14 +901,14 @@ impl Liquidator {
                 Err(e) => {
                     let phase = e.phase();
                     if e.is_execution_error() {
-                        tracing::error!(borrower = %account, phase, error = %e, "Liquidation failed");
+                        tracing::error!(borrower = %account, phase = %phase, error = %e, "Liquidation failed");
                         self.notifier.notify_liquidation_failed(
                             self.market.as_ref(),
                             account.as_ref(),
                             &e.to_string(),
                         );
                     } else {
-                        tracing::warn!(borrower = %account, phase, error = %e, "Skipped position");
+                        tracing::warn!(borrower = %account, phase = %phase, error = %e, "Skipped position");
                     }
                     failed += 1;
                 }

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -167,6 +167,30 @@ fn format_swap_unsupported_message(
     )
 }
 
+/// Format a repeated scan failure message.
+fn format_scan_failures_message(market: &str, count: u32, last_error: &str) -> String {
+    format!(
+        "🔴 <b>Market Scan Failing</b>\n\
+         \n\
+         Market: <code>{}</code>\n\
+         Consecutive failures: {count}\n\
+         Last error: {}",
+        html_escape(market),
+        html_escape(last_error),
+    )
+}
+
+/// Format a market recovery message.
+fn format_scan_recovered_message(market: &str, prev_failures: u32) -> String {
+    format!(
+        "🟢 <b>Market Recovered</b>\n\
+         \n\
+         Market: <code>{}</code>\n\
+         After {prev_failures} consecutive failures.",
+        html_escape(market),
+    )
+}
+
 impl Notifier {
     /// Creates a new notifier. Pass `None` to disable notifications.
     pub fn new(telegram: Option<TelegramConfig>) -> Self {
@@ -222,6 +246,16 @@ impl Notifier {
         self.spawn_send(format_swap_failed_message(
             market, from_asset, to_asset, amount, error,
         ));
+    }
+
+    /// Notify about repeated scan failures for a market.
+    pub fn notify_scan_failures(self: &Arc<Self>, market: &str, count: u32, last_error: &str) {
+        self.spawn_send(format_scan_failures_message(market, count, last_error));
+    }
+
+    /// Notify that a market recovered after consecutive scan failures.
+    pub fn notify_scan_recovered(self: &Arc<Self>, market: &str, prev_failures: u32) {
+        self.spawn_send(format_scan_recovered_message(market, prev_failures));
     }
 
     /// Notify when a swap is skipped because the asset pair is unsupported.
@@ -473,6 +507,30 @@ mod tests {
     }
 
     #[test]
+    fn test_format_scan_failures_message() {
+        let msg = format_scan_failures_message("market.near", 3, "Timeout exceeded after 30s");
+        assert!(msg.contains("🔴 <b>Market Scan Failing</b>"));
+        assert!(msg.contains("<code>market.near</code>"));
+        assert!(msg.contains("Consecutive failures: 3"));
+        assert!(msg.contains("Timeout exceeded after 30s"));
+    }
+
+    #[test]
+    fn test_format_scan_failures_escapes_html() {
+        let msg = format_scan_failures_message("m<arket", 2, "err <&> stuff");
+        assert!(msg.contains("m&lt;arket"));
+        assert!(msg.contains("err &lt;&amp;&gt; stuff"));
+    }
+
+    #[test]
+    fn test_format_scan_recovered_message() {
+        let msg = format_scan_recovered_message("market.near", 5);
+        assert!(msg.contains("🟢 <b>Market Recovered</b>"));
+        assert!(msg.contains("<code>market.near</code>"));
+        assert!(msg.contains("After 5 consecutive failures"));
+    }
+
+    #[test]
     fn test_spawn_send_noop_when_disabled() {
         let notifier = Arc::new(Notifier::new(None));
         // Should not panic or spawn anything
@@ -480,5 +538,7 @@ mod tests {
         notifier.notify_liquidation_failed("m", "b", "err");
         notifier.notify_swap_failed("m", "a", "b", "1", "err");
         notifier.notify_swap_unsupported("m", "a", "b", "1");
+        notifier.notify_scan_failures("m", 2, "err");
+        notifier.notify_scan_recovered("m", 3);
     }
 }

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -102,6 +102,8 @@ pub struct ServiceConfig {
     pub swap_retry_config: crate::swap::SwapRetryConfig,
     /// Shared notifier for Telegram alerts
     pub notifier: crate::notifier::SharedNotifier,
+    /// Consecutive scan failures before sending a Telegram alert (0 = disabled)
+    pub scan_failure_notify_threshold: u32,
 }
 
 /// Liquidator service that manages the bot lifecycle
@@ -119,6 +121,8 @@ pub struct LiquidatorService {
     collateral_price_map: HashMap<String, CollateralPriceInfo>,
     /// Shared nonce tracker for all transactions from this signer
     nonce_tracker: crate::rpc::NonceTracker,
+    /// Consecutive scan failure count per market (reset on success)
+    scan_failure_counts: HashMap<AccountId, u32>,
 }
 
 impl LiquidatorService {
@@ -185,6 +189,7 @@ impl LiquidatorService {
             oracle_fetcher,
             collateral_price_map: HashMap::new(),
             nonce_tracker,
+            scan_failure_counts: HashMap::new(),
         }
     }
 
@@ -924,11 +929,17 @@ impl LiquidatorService {
     }
 
     /// Run a single liquidation round across all markets
-    async fn run_liquidation_round(&self) {
+    async fn run_liquidation_round(&mut self) {
         let liquidation_span = tracing::debug_span!("liquidation_round");
+        let market_ids: Vec<AccountId> = self.markets.keys().cloned().collect();
+        let market_count = market_ids.len();
+        let threshold = self.config.scan_failure_notify_threshold;
 
         async {
-            for (i, (market, liquidator)) in self.markets.iter().enumerate() {
+            for (i, market) in market_ids.iter().enumerate() {
+                let Some(liquidator) = self.markets.get(market) else {
+                    continue;
+                };
                 let market_span = tracing::debug_span!("market", market = %market);
 
                 let result = async {
@@ -938,9 +949,21 @@ impl LiquidatorService {
                 .instrument(market_span)
                 .await;
 
-                // Handle errors gracefully
+                // Handle errors gracefully and track consecutive failures
                 match result {
                     Ok(()) => {
+                        // Reset failure counter; notify recovery if we previously alerted
+                        let prev = self
+                            .scan_failure_counts
+                            .remove(market)
+                            .unwrap_or(0);
+                        if threshold > 0 && prev >= threshold {
+                            tracing::info!(market = %market, prev_failures = prev, "Market recovered");
+                            self.config.notifier.notify_scan_recovered(
+                                market.as_ref(),
+                                prev,
+                            );
+                        }
                         tracing::info!(market = %market, "Market scan completed");
                     }
                     Err(e) => {
@@ -961,11 +984,25 @@ impl LiquidatorService {
                                 "Market skipped"
                             );
                         }
+
+                        // Track consecutive scan failures and notify at threshold
+                        let count = self
+                            .scan_failure_counts
+                            .entry(market.clone())
+                            .or_insert(0);
+                        *count += 1;
+                        if threshold > 0 && *count == threshold {
+                            self.config.notifier.notify_scan_failures(
+                                market.as_ref(),
+                                *count,
+                                &e.to_string(),
+                            );
+                        }
                     }
                 }
 
                 // Add delay between markets to avoid rate limiting (except after last market)
-                if i < self.markets.len() - 1 {
+                if i < market_count - 1 {
                     let delay_seconds = 5;
                     tracing::debug!(
                         "Waiting {}s before next market to avoid rate limits",

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -944,18 +944,21 @@ impl LiquidatorService {
                         tracing::info!(market = %market, "Market scan completed");
                     }
                     Err(e) => {
+                        let phase = e.phase();
                         if is_rate_limit_error(&e) {
                             tracing::error!(
                                 market = %market,
+                                phase,
                                 error = %e,
-                                "Rate limit hit while scanning market, sleeping 60 seconds before continuing"
+                                "Rate limited — sleeping 60s before next market"
                             );
                             sleep(Duration::from_secs(60)).await;
                         } else {
-                            tracing::error!(
+                            tracing::warn!(
                                 market = %market,
+                                phase,
                                 error = %e,
-                                "Failed to scan market, continuing to next market"
+                                "Market skipped"
                             );
                         }
                     }

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -948,7 +948,7 @@ impl LiquidatorService {
                         if is_rate_limit_error(&e) {
                             tracing::error!(
                                 market = %market,
-                                phase,
+                                phase = %phase,
                                 error = %e,
                                 "Rate limited — sleeping 60s before next market"
                             );
@@ -956,7 +956,7 @@ impl LiquidatorService {
                         } else {
                             tracing::warn!(
                                 market = %market,
-                                phase,
+                                phase = %phase,
                                 error = %e,
                                 "Market skipped"
                             );


### PR DESCRIPTION
## Summary
- Add `is_execution_error()` and `phase()` methods to `LiquidatorError` classifying all variants into `scan`, `preparation`, or `execution` phases
- Telegram notifications now only fire for actual execution failures (tx submission, receipt failure, swap errors) — not for RPC timeouts during scanning
- Scan/preparation errors logged as `WARN` with `phase` tag instead of misleading `ERROR "Liquidation failed"`
- Market-level scan errors in service loop downgraded from `ERROR` to `WARN`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/406)
<!-- Reviewable:end -->
