### PR TITLE
feat(proxy-curator): add Soroban curator operations proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ _site/
 # generated soroban test snapshots
 contract/vault/**/test_snapshots/
 contract/proxy-4626-soroban/test_snapshots/
+contract/proxy-curator-soroban/test_snapshots/
 
 # generated bindings
 client/vault/dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13192,6 +13192,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "templar-curator-proxy-soroban"
+version = "0.1.0"
+dependencies = [
+ "soroban-sdk 25.3.0",
+ "templar-soroban-governance",
+ "templar-soroban-runtime",
+ "templar-soroban-shared-types",
+]
+
+[[package]]
 name = "templar-funding-bridge"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "contract/lst-oracle",
     "contract/market",
     "contract/proxy-4626-soroban",
+    "contract/proxy-curator-soroban",
     "contract/proxy-oracle",
     "contract/redstone-adapter",
     "contract/registry",

--- a/contract/proxy-curator-soroban/Cargo.toml
+++ b/contract/proxy-curator-soroban/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "templar-curator-proxy-soroban"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Typed Soroban curator operations proxy for Templar Protocol"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+doctest = false
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "25.0.1", features = ["alloc"] }
+templar-soroban-governance = { path = "../vault/soroban/governance" }
+templar-soroban-shared-types = { path = "../vault/soroban/shared-types" }
+
+[dev-dependencies]
+soroban-sdk = { version = "25.0.1", features = ["testutils", "alloc"] }
+templar-soroban-runtime = { path = "../vault/soroban", features = ["testutils"] }

--- a/contract/proxy-curator-soroban/src/contract.rs
+++ b/contract/proxy-curator-soroban/src/contract.rs
@@ -1,0 +1,592 @@
+//! Typed curator and governance operations facade for the Soroban vault.
+
+use alloc::string::String as AllocString;
+
+use soroban_sdk::{
+    contract, contractimpl, symbol_short, Address, Bytes, BytesN, Env, IntoVal, InvokeError,
+    String, Symbol, TryFromVal, Val, Vec,
+};
+use templar_soroban_governance::{
+    GovernanceActionKind, GovernanceError, PendingProposal, TimelockKind, Timelocks,
+};
+use templar_soroban_shared_types::{
+    VaultCommand as WireVaultCommand, VaultCommandResult as WireVaultCommandResult,
+};
+
+use crate::error::ContractError;
+
+#[derive(Clone, Eq, PartialEq)]
+pub(crate) enum VaultCommand {
+    Allocate {
+        caller: Address,
+        market: u32,
+        amount: i128,
+        supply: bool,
+    },
+    RefreshMarkets {
+        caller: Address,
+        markets: Vec<u32>,
+    },
+    ResyncIdleBalance,
+    CancelMigration {
+        caller: Address,
+    },
+    ExtendTtl,
+}
+
+impl VaultCommand {
+    fn into_wire(self) -> Result<WireVaultCommand, ContractError> {
+        match self {
+            Self::Allocate {
+                caller,
+                market,
+                amount,
+                supply,
+            } => Ok(WireVaultCommand::Allocate {
+                caller: address_to_wire(&caller)?,
+                market,
+                amount,
+                supply,
+            }),
+            Self::RefreshMarkets { caller, markets } => Ok(WireVaultCommand::RefreshMarkets {
+                caller: address_to_wire(&caller)?,
+                markets: soroban_u32_vec_to_alloc(markets),
+            }),
+            Self::ResyncIdleBalance => Ok(WireVaultCommand::ResyncIdleBalance),
+            Self::CancelMigration { caller } => Ok(WireVaultCommand::CancelMigration {
+                caller: address_to_wire(&caller)?,
+            }),
+            Self::ExtendTtl => Ok(WireVaultCommand::ExtendTtl),
+        }
+    }
+}
+
+#[allow(non_upper_case_globals)]
+pub struct ProxyDataKey;
+
+#[allow(non_upper_case_globals)]
+impl ProxyDataKey {
+    pub const VaultAddress: Symbol = symbol_short!("vault");
+    pub const GovernanceAddress: Symbol = symbol_short!("gov");
+    pub const Initialized: Symbol = symbol_short!("init");
+}
+
+#[contract]
+pub struct SorobanCuratorProxyContract;
+
+#[contractimpl]
+impl SorobanCuratorProxyContract {
+    pub fn initialize(
+        env: Env,
+        vault_address: Address,
+        governance_address: Address,
+    ) -> Result<(), ContractError> {
+        if is_initialized(&env) {
+            return Err(ContractError::AlreadyInitialized);
+        }
+
+        env.storage()
+            .instance()
+            .set(&ProxyDataKey::VaultAddress, &vault_address);
+        env.storage()
+            .instance()
+            .set(&ProxyDataKey::GovernanceAddress, &governance_address);
+        env.storage()
+            .instance()
+            .set(&ProxyDataKey::Initialized, &true);
+        Ok(())
+    }
+
+    pub fn vault(env: Env) -> Result<Address, ContractError> {
+        read_vault_address(&env)
+    }
+
+    pub fn governance(env: Env) -> Result<Address, ContractError> {
+        read_governance_address(&env)
+    }
+
+    pub fn supply_market(
+        env: Env,
+        caller: Address,
+        market: u32,
+        amount: i128,
+    ) -> Result<i128, ContractError> {
+        caller.require_auth();
+        expect_i128_result(invoke_vault_execute(
+            &env,
+            VaultCommand::Allocate {
+                caller,
+                market,
+                amount,
+                supply: true,
+            },
+        )?)
+    }
+
+    pub fn withdraw_market(
+        env: Env,
+        caller: Address,
+        market: u32,
+        amount: i128,
+    ) -> Result<i128, ContractError> {
+        caller.require_auth();
+        expect_i128_result(invoke_vault_execute(
+            &env,
+            VaultCommand::Allocate {
+                caller,
+                market,
+                amount,
+                supply: false,
+            },
+        )?)
+    }
+
+    pub fn refresh_markets(
+        env: Env,
+        caller: Address,
+        markets: Vec<u32>,
+    ) -> Result<i128, ContractError> {
+        caller.require_auth();
+        expect_i128_result(invoke_vault_execute(
+            &env,
+            VaultCommand::RefreshMarkets { caller, markets },
+        )?)
+    }
+
+    pub fn resync_idle_balance(env: Env) -> Result<(), ContractError> {
+        expect_unit_result(invoke_vault_execute(&env, VaultCommand::ResyncIdleBalance)?)
+    }
+
+    pub fn extend_vault_ttl(env: Env) -> Result<(), ContractError> {
+        expect_unit_result(invoke_vault_execute(&env, VaultCommand::ExtendTtl)?)
+    }
+
+    pub fn cancel_migration(env: Env, caller: Address) -> Result<(), ContractError> {
+        caller.require_auth();
+        expect_unit_result(invoke_vault_execute(
+            &env,
+            VaultCommand::CancelMigration { caller },
+        )?)
+    }
+
+    pub fn submit_set_paused(
+        env: Env,
+        caller: Address,
+        paused: bool,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "submit_set_paused", (caller, paused).into_val(&env))
+    }
+
+    pub fn submit_set_curator(
+        env: Env,
+        caller: Address,
+        new_curator: Address,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_curator",
+            (caller, new_curator).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_governance(
+        env: Env,
+        caller: Address,
+        governance: Address,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_governance",
+            (caller, governance).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_supply_queue(
+        env: Env,
+        caller: Address,
+        target_ids: Vec<u32>,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_supply_queue",
+            (caller, target_ids).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_fees(
+        env: Env,
+        caller: Address,
+        performance_fee_wad: i128,
+        performance_recipient: Address,
+        management_fee_wad: i128,
+        management_recipient: Address,
+        max_growth_rate_wad: Option<i128>,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_fees",
+            (
+                caller,
+                performance_fee_wad,
+                performance_recipient,
+                management_fee_wad,
+                management_recipient,
+                max_growth_rate_wad,
+            )
+                .into_val(&env),
+        )
+    }
+
+    pub fn submit_set_restrictions(
+        env: Env,
+        caller: Address,
+        mode: u32,
+        accounts: Vec<Address>,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_restrictions",
+            (caller, mode, accounts).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_guardian(
+        env: Env,
+        caller: Address,
+        guardian: Address,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_guardian",
+            (caller, guardian).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_sentinel(
+        env: Env,
+        caller: Address,
+        sentinel: Address,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_sentinel",
+            (caller, sentinel).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_timelock(
+        env: Env,
+        caller: Address,
+        kind: TimelockKind,
+        new_timelock_ns: u64,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_timelock",
+            (caller, kind, new_timelock_ns).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_cap(
+        env: Env,
+        caller: Address,
+        market_id: u32,
+        new_cap: i128,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_cap",
+            (caller, market_id, new_cap).into_val(&env),
+        )
+    }
+
+    pub fn submit_remove_market(
+        env: Env,
+        caller: Address,
+        market_id: u32,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_remove_market",
+            (caller, market_id).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_group_cap(
+        env: Env,
+        caller: Address,
+        cap_group_id: String,
+        new_cap: i128,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_group_cap",
+            (caller, cap_group_id, new_cap).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_group_rel_cap(
+        env: Env,
+        caller: Address,
+        cap_group_id: String,
+        new_relative_cap_wad: i128,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_group_rel_cap",
+            (caller, cap_group_id, new_relative_cap_wad).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_group_member(
+        env: Env,
+        caller: Address,
+        market_id: u32,
+        cap_group_id: String,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_group_member",
+            (caller, market_id, cap_group_id).into_val(&env),
+        )
+    }
+
+    pub fn submit_set_skim_recipient(
+        env: Env,
+        caller: Address,
+        recipient: Address,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_set_skim_recipient",
+            (caller, recipient).into_val(&env),
+        )
+    }
+
+    pub fn submit_skim(env: Env, caller: Address, token: Address) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "submit_skim", (caller, token).into_val(&env))
+    }
+
+    pub fn submit_other(
+        env: Env,
+        caller: Address,
+        key: Symbol,
+        payload_hash: BytesN<32>,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "submit_other",
+            (caller, key, payload_hash).into_val(&env),
+        )
+    }
+
+    pub fn accept(env: Env, caller: Address, proposal_id: u64) -> Result<(), ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "accept", (caller, proposal_id).into_val(&env))
+    }
+
+    pub fn accept_kind(
+        env: Env,
+        caller: Address,
+        kind: GovernanceActionKind,
+    ) -> Result<u64, ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "accept_kind", (caller, kind).into_val(&env))
+    }
+
+    pub fn revoke(env: Env, caller: Address, proposal_id: u64) -> Result<(), ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "revoke", (caller, proposal_id).into_val(&env))
+    }
+
+    pub fn revoke_kind(
+        env: Env,
+        caller: Address,
+        kind: GovernanceActionKind,
+    ) -> Result<u32, ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "revoke_kind", (caller, kind).into_val(&env))
+    }
+
+    pub fn revoke_other_pending(
+        env: Env,
+        caller: Address,
+        key: Symbol,
+        payload_hash: BytesN<32>,
+    ) -> Result<u32, ContractError> {
+        caller.require_auth();
+        invoke_governance(
+            &env,
+            "revoke_other_pending",
+            (caller, key, payload_hash).into_val(&env),
+        )
+    }
+
+    pub fn abdicate(
+        env: Env,
+        caller: Address,
+        kind: GovernanceActionKind,
+    ) -> Result<(), ContractError> {
+        caller.require_auth();
+        invoke_governance(&env, "abdicate", (caller, kind).into_val(&env))
+    }
+
+    pub fn pending(env: Env, proposal_id: u64) -> Result<PendingProposal, ContractError> {
+        invoke_governance(&env, "pending", (proposal_id,).into_val(&env))
+    }
+
+    pub fn pending_ids(env: Env) -> Result<Vec<u64>, ContractError> {
+        invoke_governance(&env, "pending_ids", Vec::new(&env))
+    }
+
+    pub fn timelock_ns(env: Env, kind: TimelockKind) -> Result<u64, ContractError> {
+        invoke_governance(&env, "timelock_ns", (kind,).into_val(&env))
+    }
+
+    pub fn timelocks(env: Env) -> Result<Timelocks, ContractError> {
+        invoke_governance(&env, "timelocks", Vec::new(&env))
+    }
+
+    pub fn admin(env: Env) -> Result<Address, ContractError> {
+        invoke_governance(&env, "admin", Vec::new(&env))
+    }
+
+    pub fn guardian(env: Env) -> Result<Option<Address>, ContractError> {
+        invoke_governance(&env, "guardian", Vec::new(&env))
+    }
+
+    pub fn sentinel(env: Env) -> Result<Option<Address>, ContractError> {
+        invoke_governance(&env, "sentinel", Vec::new(&env))
+    }
+
+    pub fn is_abdicated(env: Env, kind: GovernanceActionKind) -> Result<bool, ContractError> {
+        invoke_governance(&env, "is_abdicated", (kind,).into_val(&env))
+    }
+
+    pub fn check_other(
+        env: Env,
+        key: Symbol,
+        payload_hash: BytesN<32>,
+    ) -> Result<bool, ContractError> {
+        invoke_governance(&env, "check_other", (key, payload_hash).into_val(&env))
+    }
+}
+
+pub(crate) fn is_initialized(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&ProxyDataKey::Initialized)
+        .unwrap_or(false)
+}
+
+pub(crate) fn require_initialized(env: &Env) -> Result<(), ContractError> {
+    is_initialized(env)
+        .then_some(())
+        .ok_or(ContractError::NotInitialized)
+}
+
+pub(crate) fn read_vault_address(env: &Env) -> Result<Address, ContractError> {
+    require_initialized(env)?;
+    env.storage()
+        .instance()
+        .get(&ProxyDataKey::VaultAddress)
+        .ok_or(ContractError::NotInitialized)
+}
+
+pub(crate) fn read_governance_address(env: &Env) -> Result<Address, ContractError> {
+    require_initialized(env)?;
+    env.storage()
+        .instance()
+        .get(&ProxyDataKey::GovernanceAddress)
+        .ok_or(ContractError::NotInitialized)
+}
+
+pub(crate) fn invoke_vault_execute(
+    env: &Env,
+    command: VaultCommand,
+) -> Result<WireVaultCommandResult, ContractError> {
+    let vault_address = read_vault_address(env)?;
+    let command = command.into_wire()?;
+    let payload = Bytes::from_slice(env, &command.encode());
+    let result = env.try_invoke_contract::<Bytes, ContractError>(
+        &vault_address,
+        &Symbol::new(env, "execute"),
+        (&payload,).into_val(env),
+    );
+
+    let bytes = match result {
+        Ok(Ok(bytes)) => bytes,
+        Ok(Err(_)) => return Err(ContractError::VaultError),
+        Err(Ok(error)) => return Err(error),
+        Err(Err(invoke_error)) => {
+            return Err(match invoke_error {
+                InvokeError::Abort => ContractError::VaultError,
+                InvokeError::Contract(code) => ContractError::from_vault_error_code(code),
+            })
+        }
+    };
+
+    WireVaultCommandResult::decode(&bytes.to_alloc_vec()).map_err(Into::into)
+}
+
+fn invoke_governance<T>(env: &Env, method: &str, args: Vec<Val>) -> Result<T, ContractError>
+where
+    T: TryFromVal<Env, Val>,
+{
+    let governance_address = read_governance_address(env)?;
+    match env.try_invoke_contract::<T, GovernanceError>(
+        &governance_address,
+        &Symbol::new(env, method),
+        args,
+    ) {
+        Ok(Ok(value)) => Ok(value),
+        Ok(Err(_)) | Err(Ok(_)) => Err(ContractError::GovernanceError),
+        Err(Err(InvokeError::Abort | InvokeError::Contract(_))) => {
+            Err(ContractError::GovernanceError)
+        }
+    }
+}
+
+fn expect_i128_result(result: WireVaultCommandResult) -> Result<i128, ContractError> {
+    match result {
+        WireVaultCommandResult::I128(value) => Ok(value),
+        _ => Err(ContractError::VaultError),
+    }
+}
+
+fn expect_unit_result(result: WireVaultCommandResult) -> Result<(), ContractError> {
+    match result {
+        WireVaultCommandResult::Unit => Ok(()),
+        _ => Err(ContractError::VaultError),
+    }
+}
+
+fn address_to_wire(address: &Address) -> Result<AllocString, ContractError> {
+    let raw = address.to_string().to_bytes().to_alloc_vec();
+    AllocString::from_utf8(raw).map_err(|_| ContractError::InvalidInput)
+}
+
+fn soroban_u32_vec_to_alloc(values: Vec<u32>) -> alloc::vec::Vec<u32> {
+    let mut result = alloc::vec::Vec::new();
+    for value in values.iter() {
+        result.push(value);
+    }
+    result
+}

--- a/contract/proxy-curator-soroban/src/error.rs
+++ b/contract/proxy-curator-soroban/src/error.rs
@@ -1,0 +1,32 @@
+//! Error types for the Soroban curator operations proxy.
+
+use soroban_sdk::contracterror;
+
+use templar_soroban_shared_types::CodecError;
+
+#[contracterror]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum ContractError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    InvalidInput = 3,
+    VaultError = 4,
+    GovernanceError = 5,
+}
+
+impl From<CodecError> for ContractError {
+    fn from(_: CodecError) -> Self {
+        Self::InvalidInput
+    }
+}
+
+impl ContractError {
+    pub(crate) const fn from_vault_error_code(code: u32) -> Self {
+        match code {
+            3 => Self::InvalidInput,
+            8 => Self::AlreadyInitialized,
+            _ => Self::VaultError,
+        }
+    }
+}

--- a/contract/proxy-curator-soroban/src/lib.rs
+++ b/contract/proxy-curator-soroban/src/lib.rs
@@ -1,0 +1,19 @@
+#![no_std]
+
+extern crate alloc;
+
+#[cfg(test)]
+extern crate std;
+
+mod contract;
+mod error;
+
+pub use contract::SorobanCuratorProxyContract;
+pub use error::ContractError;
+pub use templar_soroban_governance::{
+    GovernanceActionKind, PendingProposal, TimelockKind, Timelocks,
+};
+pub use templar_soroban_shared_types::VaultCommandResult;
+
+#[cfg(test)]
+mod tests;

--- a/contract/proxy-curator-soroban/src/tests.rs
+++ b/contract/proxy-curator-soroban/src/tests.rs
@@ -1,0 +1,400 @@
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Vec};
+use templar_soroban_governance::{
+    GovernanceAction, GovernanceActionKind, GovernanceError, PendingProposal, TimelockKind,
+    Timelocks,
+};
+use templar_soroban_shared_types::{
+    VaultCommand as WireVaultCommand, VaultCommandResult as WireVaultCommandResult,
+};
+
+use crate::{
+    contract::{ProxyDataKey, SorobanCuratorProxyContract},
+    error::ContractError,
+};
+
+#[derive(Clone)]
+#[contracttype]
+enum MockVaultDataKey {
+    RecordedPayloads,
+}
+
+#[contract]
+struct MockVaultContract;
+
+#[contractimpl]
+impl MockVaultContract {
+    pub fn recorded_payloads(env: Env) -> Vec<Bytes> {
+        env.storage()
+            .instance()
+            .get(&MockVaultDataKey::RecordedPayloads)
+            .unwrap_or(Vec::new(&env))
+    }
+
+    pub fn execute(env: Env, payload: Bytes) -> Bytes {
+        let mut payloads = Self::recorded_payloads(env.clone());
+        payloads.push_back(payload.clone());
+        env.storage()
+            .instance()
+            .set(&MockVaultDataKey::RecordedPayloads, &payloads);
+
+        let command = WireVaultCommand::decode(&payload.to_alloc_vec()).expect("decode command");
+        let result = match command {
+            WireVaultCommand::Allocate { .. } => WireVaultCommandResult::I128(123),
+            WireVaultCommand::RefreshMarkets { .. } => WireVaultCommandResult::I128(456),
+            WireVaultCommand::ResyncIdleBalance
+            | WireVaultCommand::CancelMigration { .. }
+            | WireVaultCommand::ExtendTtl => WireVaultCommandResult::Unit,
+            _ => WireVaultCommandResult::Unit,
+        };
+
+        Bytes::from_slice(&env, &result.encode())
+    }
+}
+
+#[derive(Clone)]
+#[contracttype]
+enum MockGovernanceDataKey {
+    LastSetCap,
+    LastAccept,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+struct MockSetCapCall {
+    caller: Address,
+    market_id: u32,
+    new_cap: i128,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+struct MockAcceptCall {
+    caller: Address,
+    proposal_id: u64,
+}
+
+#[contract]
+struct MockGovernanceContract;
+
+#[contractimpl]
+impl MockGovernanceContract {
+    pub fn submit_set_cap(
+        env: Env,
+        caller: Address,
+        market_id: u32,
+        new_cap: i128,
+    ) -> Result<u64, GovernanceError> {
+        env.storage().instance().set(
+            &MockGovernanceDataKey::LastSetCap,
+            &MockSetCapCall {
+                caller,
+                market_id,
+                new_cap,
+            },
+        );
+        Ok(77)
+    }
+
+    pub fn last_set_cap(env: Env) -> Option<MockSetCapCall> {
+        env.storage()
+            .instance()
+            .get(&MockGovernanceDataKey::LastSetCap)
+    }
+
+    pub fn accept(env: Env, caller: Address, proposal_id: u64) -> Result<(), GovernanceError> {
+        env.storage().instance().set(
+            &MockGovernanceDataKey::LastAccept,
+            &MockAcceptCall {
+                caller,
+                proposal_id,
+            },
+        );
+        Ok(())
+    }
+
+    pub fn last_accept(env: Env) -> Option<MockAcceptCall> {
+        env.storage()
+            .instance()
+            .get(&MockGovernanceDataKey::LastAccept)
+    }
+
+    pub fn pending(_env: Env, proposal_id: u64) -> Result<PendingProposal, GovernanceError> {
+        Ok(PendingProposal {
+            id: proposal_id,
+            action: GovernanceAction::SetPaused(true),
+            valid_after_ns: 100,
+        })
+    }
+
+    pub fn timelock_ns(_env: Env, kind: TimelockKind) -> u64 {
+        match kind {
+            TimelockKind::Cap => 55,
+            _ => 11,
+        }
+    }
+
+    pub fn pending_ids(env: Env) -> Vec<u64> {
+        Vec::from_array(&env, [1, 2, 3])
+    }
+
+    pub fn is_abdicated(_env: Env, kind: GovernanceActionKind) -> bool {
+        kind == GovernanceActionKind::Skim
+    }
+
+    pub fn timelocks(_env: Env) -> Timelocks {
+        Timelocks {
+            pause_ns: 7,
+            curator_ns: 7,
+            governance_ns: 7,
+            supply_queue_ns: 7,
+            fees_ns: 7,
+            restrictions_ns: 7,
+            guardian_ns: 7,
+            sentinel_ns: 7,
+            cap_ns: 7,
+            market_removal_ns: 7,
+            cap_group_ns: 7,
+            skim_ns: 7,
+            timelock_config_ns: 7,
+            other_ns: 7,
+        }
+    }
+}
+
+struct Fixture {
+    env: Env,
+    proxy: Address,
+    vault: Address,
+    governance: Address,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let env = Env::default();
+        env.mock_all_auths();
+        let proxy = env.register(SorobanCuratorProxyContract, ());
+        let vault = env.register(MockVaultContract, ());
+        let governance = env.register(MockGovernanceContract, ());
+        Self {
+            env,
+            proxy,
+            vault,
+            governance,
+        }
+    }
+
+    fn initialize(&self) -> Result<(), ContractError> {
+        self.env.as_contract(&self.proxy, || {
+            SorobanCuratorProxyContract::initialize(
+                self.env.clone(),
+                self.vault.clone(),
+                self.governance.clone(),
+            )
+        })
+    }
+
+    fn recorded_payloads(&self) -> Vec<Bytes> {
+        self.env.as_contract(&self.vault, || {
+            MockVaultContract::recorded_payloads(self.env.clone())
+        })
+    }
+}
+
+fn decode_command(payload: &Bytes) -> WireVaultCommand {
+    WireVaultCommand::decode(&payload.to_alloc_vec()).expect("decode recorded payload")
+}
+
+fn address_wire(address: &Address) -> alloc::string::String {
+    alloc::string::String::from_utf8(address.to_string().to_bytes().to_alloc_vec())
+        .expect("valid address")
+}
+
+#[test]
+fn initialize_stores_target_contracts() {
+    let fixture = Fixture::new();
+
+    fixture.initialize().expect("initialize succeeds");
+
+    fixture.env.as_contract(&fixture.proxy, || {
+        let storage = fixture.env.storage().instance();
+        assert_eq!(
+            storage.get(&ProxyDataKey::VaultAddress),
+            Some(fixture.vault.clone())
+        );
+        assert_eq!(
+            storage.get(&ProxyDataKey::GovernanceAddress),
+            Some(fixture.governance.clone())
+        );
+        assert_eq!(storage.get(&ProxyDataKey::Initialized), Some(true));
+    });
+}
+
+#[test]
+fn supply_market_encodes_allocate_command() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+    let caller = Address::generate(&fixture.env);
+
+    let result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::supply_market(fixture.env.clone(), caller.clone(), 7, 500)
+    });
+
+    assert_eq!(result, Ok(123));
+    let payloads = fixture.recorded_payloads();
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(
+        decode_command(&payloads.get_unchecked(0)),
+        WireVaultCommand::Allocate {
+            caller: address_wire(&caller),
+            market: 7,
+            amount: 500,
+            supply: true,
+        }
+    );
+}
+
+#[test]
+fn refresh_markets_encodes_refresh_command() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+    let caller = Address::generate(&fixture.env);
+    let markets = Vec::from_array(&fixture.env, [1u32, 3u32]);
+
+    let result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::refresh_markets(
+            fixture.env.clone(),
+            caller.clone(),
+            markets.clone(),
+        )
+    });
+
+    assert_eq!(result, Ok(456));
+    let payloads = fixture.recorded_payloads();
+    assert_eq!(payloads.len(), 1);
+    assert_eq!(
+        decode_command(&payloads.get_unchecked(0)),
+        WireVaultCommand::RefreshMarkets {
+            caller: address_wire(&caller),
+            markets: alloc::vec![1, 3],
+        }
+    );
+}
+
+#[test]
+fn unit_vault_operations_encode_unit_commands() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+    let caller = Address::generate(&fixture.env);
+
+    fixture
+        .env
+        .as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::resync_idle_balance(fixture.env.clone())
+        })
+        .unwrap();
+    fixture
+        .env
+        .as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::extend_vault_ttl(fixture.env.clone())
+        })
+        .unwrap();
+    fixture
+        .env
+        .as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::cancel_migration(fixture.env.clone(), caller.clone())
+        })
+        .unwrap();
+
+    let payloads = fixture.recorded_payloads();
+    assert_eq!(
+        decode_command(&payloads.get_unchecked(0)),
+        WireVaultCommand::ResyncIdleBalance
+    );
+    assert_eq!(
+        decode_command(&payloads.get_unchecked(1)),
+        WireVaultCommand::ExtendTtl
+    );
+    assert!(matches!(
+        decode_command(&payloads.get_unchecked(2)),
+        WireVaultCommand::CancelMigration { .. }
+    ));
+}
+
+#[test]
+fn governance_submit_forwards_typed_arguments() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+    let caller = Address::generate(&fixture.env);
+
+    let id = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::submit_set_cap(fixture.env.clone(), caller.clone(), 9, 1234)
+    });
+
+    assert_eq!(id, Ok(77));
+    let recorded = fixture
+        .env
+        .as_contract(&fixture.governance, || {
+            MockGovernanceContract::last_set_cap(fixture.env.clone())
+        })
+        .expect("set cap call recorded");
+    assert_eq!(
+        recorded,
+        MockSetCapCall {
+            caller,
+            market_id: 9,
+            new_cap: 1234,
+        }
+    );
+}
+
+#[test]
+fn governance_lifecycle_and_views_forward() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+    let caller = Address::generate(&fixture.env);
+
+    fixture
+        .env
+        .as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::accept(fixture.env.clone(), caller.clone(), 44)
+        })
+        .unwrap();
+    let recorded = fixture
+        .env
+        .as_contract(&fixture.governance, || {
+            MockGovernanceContract::last_accept(fixture.env.clone())
+        })
+        .expect("accept call recorded");
+    assert_eq!(
+        recorded,
+        MockAcceptCall {
+            caller,
+            proposal_id: 44,
+        }
+    );
+
+    let pending = fixture
+        .env
+        .as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::pending(fixture.env.clone(), 12)
+        })
+        .unwrap();
+    assert_eq!(pending.id, 12);
+    assert_eq!(pending.valid_after_ns, 100);
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::timelock_ns(fixture.env.clone(), TimelockKind::Cap)
+        }),
+        Ok(55)
+    );
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::is_abdicated(
+                fixture.env.clone(),
+                GovernanceActionKind::Skim,
+            )
+        }),
+        Ok(true)
+    );
+}

--- a/contract/proxy-curator-soroban/tests/integration_tests.rs
+++ b/contract/proxy-curator-soroban/tests/integration_tests.rs
@@ -1,0 +1,98 @@
+use soroban_sdk::{testutils::Address as _, Address, Env, IntoVal, Symbol};
+use templar_curator_proxy_soroban::SorobanCuratorProxyContract;
+use templar_soroban_governance::SorobanVaultGovernanceContract;
+use templar_soroban_runtime::{SorobanVaultContract, VaultDataKey};
+
+struct Harness {
+    env: Env,
+    admin: Address,
+    vault: Address,
+    governance: Address,
+    proxy: Address,
+}
+
+fn setup_harness() -> Harness {
+    let env = Env::default();
+    env.mock_all_auths_allowing_non_root_auth();
+    let admin = Address::generate(&env);
+    let vault = env.register(SorobanVaultContract, ());
+    let governance = env.register(SorobanVaultGovernanceContract, (&admin, &vault, &0u64));
+    let asset_admin = Address::generate(&env);
+    let asset = env
+        .register_stellar_asset_contract_v2(asset_admin)
+        .address();
+    let share = env
+        .register_stellar_asset_contract_v2(vault.clone())
+        .address();
+
+    env.invoke_contract::<()>(
+        &vault,
+        &Symbol::new(&env, "initialize"),
+        (&governance, &governance, &asset, &share, &0i128, &0i128).into_val(&env),
+    );
+
+    let proxy = env.register(SorobanCuratorProxyContract, ());
+    env.invoke_contract::<()>(
+        &proxy,
+        &Symbol::new(&env, "initialize"),
+        (&vault, &governance).into_val(&env),
+    );
+
+    Harness {
+        env,
+        admin,
+        vault,
+        governance,
+        proxy,
+    }
+}
+
+#[test]
+fn proxy_submits_sentinel_change_through_real_governance_contract() {
+    let harness = setup_harness();
+
+    let proposal_id = harness.env.invoke_contract::<u64>(
+        &harness.proxy,
+        &Symbol::new(&harness.env, "submit_set_sentinel"),
+        (&harness.admin, &harness.admin).into_val(&harness.env),
+    );
+
+    assert_eq!(proposal_id, 1);
+    assert_eq!(
+        harness.env.invoke_contract::<Option<Address>>(
+            &harness.proxy,
+            &Symbol::new(&harness.env, "sentinel"),
+            soroban_sdk::vec![&harness.env],
+        ),
+        Some(harness.admin.clone())
+    );
+    harness.env.as_contract(&harness.vault, || {
+        assert_eq!(
+            harness
+                .env
+                .storage()
+                .instance()
+                .get(&VaultDataKey::Sentinel),
+            Some(harness.admin.clone())
+        );
+    });
+}
+
+#[test]
+fn proxy_exposes_governance_views() {
+    let harness = setup_harness();
+
+    let governance = harness.env.invoke_contract::<Address>(
+        &harness.proxy,
+        &Symbol::new(&harness.env, "governance"),
+        soroban_sdk::vec![&harness.env],
+    );
+    let admin = harness.env.invoke_contract::<Address>(
+        &harness.proxy,
+        &Symbol::new(&harness.env, "admin"),
+        soroban_sdk::vec![&harness.env],
+    );
+
+    assert_eq!(governance, harness.governance);
+    assert_eq!(admin, harness.admin);
+}

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -141,6 +141,14 @@ check-4626-proxy:
 		-p templar-4626-proxy-soroban
 	@echo "✓ Checked: templar-4626-proxy-soroban"
 
+# Check the Soroban curator operations proxy crate.
+check-curator-proxy:
+	@echo "Checking Soroban curator proxy crate..."
+	@RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }{{remap_rustflags}}" cargo check \
+		--manifest-path "{{root}}/Cargo.toml" \
+		-p templar-curator-proxy-soroban
+	@echo "✓ Checked: templar-curator-proxy-soroban"
+
 # Build all WASMs (vault + governance + share token + blend adapter).
 build-all: build build-blend-adapter
 	@echo "✓ All contracts built"


### PR DESCRIPTION
## Summary
- Add a typed Soroban curator operations proxy crate for vault runtime maintenance/allocation calls.
- Forward governance submit/accept/revoke/view calls through the governance contract instead of deopaquing governance in the proxy.
- Add package checks, workspace membership, lockfile entry, and ignore generated Soroban test snapshots.

## Verification
- cargo check -p templar-curator-proxy-soroban --tests
- cargo test -p templar-curator-proxy-soroban --tests
- cargo check -p templar-curator-proxy-soroban -p templar-4626-proxy-soroban -p templar-soroban-runtime -p templar-soroban-governance --tests
- just check-curator-proxy

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/416)
<!-- Reviewable:end -->
