### PR TITLE
Add incident exposure reviews for Rhea and SWEAT exploits

### DIFF
--- a/audits/2026-04-29/rhea-exploit-analysis.md
+++ b/audits/2026-04-29/rhea-exploit-analysis.md
@@ -1,0 +1,90 @@
+# Rhea Finance (Burrow) margin-trading exploit — Templar exposure review
+
+- Date: 2026-04-29 (incident: 2026-04-16)
+- Author: claude (Templar audit branch)
+- Status: review only — no code change required
+
+## Incident summary
+
+On 2026-04-16, Rhea Finance (the merged Ref + Burrow protocol on NEAR) was exploited for ~$18.4M (Rhea team's revised final figure; CertiK initially reported $7.6M). The exploit targeted the margin-trading subsystem of the lending contract (`burrowland`). The attacker prepared by creating fake token pools on Ref Finance days in advance and seeding them with liquidity, then opened margin positions whose swap routes traversed those fake pools and bypassed the protocol's slippage protection.
+
+## Investigation constraints
+
+External writeups (Halborn, Phemex, AMBCrypto, TechFlowPost, Rhea's own X post) all return 403 from this sandbox's egress proxy; I could only fetch GitHub. The analysis below is therefore based on direct review of the deployed Burrow source at `github.com/rhea-finance/burrowland` (mirrored at `github.com/ref-finance/burrowland`) cross-referenced against the publicly reported root cause: "the slippage protection algorithm summed all `min_amount_out` values across swap actions and did not account for swap actions where the output token of one step is reused as the input of the next."
+
+## Root cause
+
+The buggy code is in `contracts/contract/src/margin_trading.rs`, in `RefV1TokenReceiverMessage::get_token_in` and `RefV1TokenReceiverMessage::get_token_out` (lines 86-113):
+
+```rust
+/// get token_in, amount_in
+pub fn get_token_in(&self) -> (AccountId, Balance) {
+    let RefV1TokenReceiverMessage::Execute { actions, .. } = self;
+    let action  = actions.first().unwrap();
+    let token_in = action.get_token_in();
+    let amount_in = actions.iter()
+        .filter(|a| a.get_token_in() == token_in)
+        .map(|a| a.get_amount_in())
+        .sum();
+    (token_in, amount_in)
+}
+
+/// get token_out, min_amount_out
+pub fn get_token_out(&self) -> (AccountId, Balance) {
+    let RefV1TokenReceiverMessage::Execute { actions, .. } = self;
+    let action = actions.last().unwrap();
+    let token_out = action.get_token_out();
+    let min_amount_out = actions.iter()
+        .filter(|a| a.get_token_out() == token_out)
+        .map(|a| a.get_min_amount_out())
+        .sum();
+    (token_out, min_amount_out)
+}
+```
+
+The protocol uses these helpers to verify that a user-supplied multi-hop Ref swap message will deliver the expected token-in / token-out pair before forwarding the swap to Ref. The verification looks at the FIRST action's `token_in` and the LAST action's `token_out`, and aggregates `amount_in` / `min_amount_out` across every step that *happens to share that token name*.
+
+This aggregation is incorrect when a multi-hop route reuses a token in the middle of the chain. Consider a route `A -> X -> A -> Y -> Z`:
+
+- `get_token_in` returns `(A, action₁.amount_in + action₃.amount_in)`. Step 3's `amount_in` is *not* user-deposited input — it is the output of step 2 — but the protocol counts it as part of the user's input, so accounting for the user's actual deposit / debt becomes inconsistent with the size of the swap going to Ref.
+- `get_token_out` returns `(Z, sum of min_amount_out for any step that produced Z)`. If only the last step produces Z, the slippage floor is `action₅.min_amount_out` alone — which the attacker can set arbitrarily low. But because the verification thinks the swap is delivering Z worth `min_amount_out`, while the *route* may extract value via fake intermediate pools, the protocol books a position that is over-collateralised on paper but undercollateralised in reality.
+
+The attacker pre-staged this by:
+
+1. Creating attacker-controlled fake token pools on Ref Finance ahead of the incident.
+2. Building a multi-step swap route that touches a real lending asset (e.g., a stable) more than once and whose intermediate steps go through those fake pools.
+3. Opening margin positions whose `swap_indication.swap_action_text` encoded that route. Burrow's `parse_swap_indication` (`margin_trading.rs:297`) accepts the JSON, `verify_token_in`/`verify_token_out` (lines 224-249) sanity-check it via the buggy helpers above, and `on_open_trade_return` (line 328) commits the position state on the protocol side.
+4. Closing positions / triggering liquidations such that Burrow's accounting paid out more than the attacker actually delivered, multiplied across the fake-pool routes. This drained the protocol's reserve pool (the figures published as $7.6M-$18.4M).
+
+The fix mentioned by the Rhea team is to compute slippage *per step*, taking only the user-supplied input on the first step and only the route-level output on the final step (and refusing routes that reuse tokens in unsafe ways), rather than summing across every action whose token name happens to match.
+
+## Templar exposure
+
+Templar does **not** implement margin trading, multi-hop swap routing, or any DEX integration that consumes user-supplied swap-action chains. It is a single-asset lending market with a vault on top.
+
+I checked the analogous surfaces:
+
+| Burrow attack ingredient | Templar analog | Verdict |
+|---|---|---|
+| Margin trading subsystem | None. There is no margin trading, no `MarginPosition`, no `SwapIndication`, no `RefV1SwapAction`. `grep -rn "margin\|swap\|RefV1\|RefV2\|dex_id\|aggregator"` over `contract/` and `common/` returns only the proxy-oracle's `Aggregator` (price aggregator over multiple oracle sources) — not a DEX swap aggregator. | Safe |
+| User-supplied multi-step swap message parsed and forwarded to a DEX | None. Templar's vault and market never accept a user-controlled swap-action chain. The vault's withdraw queue routes through Templar markets only; the routing list is `Vec<MarketId>` (see `contract/vault/near/src/lib.rs:492` `execute_withdrawal(route: Vec<MarketId>)`), not arbitrary swap actions, and is gated by `crate::auth::require_action(crate::auth::ActionKind::ExecuteWithdraw)` (Allocator-class). | Safe |
+| Slippage computed by aggregating `min_amount_out` across multiple actions | None. Templar's slippage protection is single-step. `templar_vault_kernel::actions::deposit` (`contract/vault/kernel/src/actions/mod.rs:670-690`) does `if shares_out < min_shares_out { Err(KernelError::Slippage { ... }) }` against the directly computed deposit-to-shares conversion. `plan_withdrawal_request` (`mod.rs:887-907`) does the same for `min_assets_out`. There is no chain of actions to confuse. | Safe |
+| Trusting attacker-chosen pool / token in a swap | None. The market and vault FT receivers (`contract/market/src/impl_token_receiver.rs:26-32` and `contract/vault/near/src/impl_token_receiver.rs:115-118`) refuse any token whose predecessor is not the configured underlying / collateral / borrow asset. There is no path in which an attacker-chosen token contract can credit position balance. | Safe |
+| Manipulable price feed enabling under-collateralised positions | Templar prices come from `proxy-oracle` which uses a `median_low` or `priority` `Aggregator` (`common/src/oracle/proxy/aggregator.rs`, `common/src/oracle/proxy/mod.rs:14-32`) over a curated set of sources (Pyth, RedStone, LST oracle), with all configuration changes timelocked via `Governance<Operation>` (`contract/proxy-oracle/src/impl_governance.rs:36-79`). An attacker cannot insert a fake oracle source on the fly. | Safe |
+
+## Conclusion
+
+Templar's lending design closes off this exploit class structurally:
+
+1. **No margin / leverage / swap-routing surface.** The attack requires a protocol that accepts user-supplied multi-hop swap action chains and forwards them to a DEX while computing its own slippage check. Templar has no such surface.
+2. **Single-step slippage checks.** Where Templar accepts a `min_*_out` from the user (`Deposit`, `RequestWithdraw`), the kernel compares it against a single-step conversion (`convert_to_shares` / `convert_to_assets`) — there is no aggregation that can be confused by token reuse.
+3. **Fixed asset whitelist on FT receivers.** The market and vault `ft_on_transfer` paths panic if the predecessor is not the configured asset; an attacker cannot smuggle a fake token into the position accounting.
+4. **Curated, timelocked oracle aggregation.** Even if an attacker tried to manipulate price input upstream, the proxy oracle aggregates over a curated source set whose membership and weights are governed via timelocked proposals.
+
+No code change is required.
+
+## What this analysis does not cover
+
+- We could not retrieve Rhea's post-mortem write-ups directly; the buggy lines, attacker flow, and root-cause description above were reconstructed from the on-disk Burrow source plus public summaries, not from a primary write-up. If the team wants a stronger reference, please pull the Halborn post-mortem manually and cross-check against this note.
+- This review covers smart-contract exposure only. Operational risk of off-chain Templar services routing into Ref pools is out of scope.
+- Soroban-side withdrawal entrypoints in `contract/vault/soroban/...` were spot-checked for the same single-step slippage semantics; full audit of the Soroban deployment is out of scope of this note.

--- a/audits/2026-04-29/rhea-exploit-analysis.md
+++ b/audits/2026-04-29/rhea-exploit-analysis.md
@@ -62,7 +62,85 @@ The fix mentioned by the Rhea team is to compute slippage *per step*, taking onl
 
 Templar does **not** implement margin trading, multi-hop swap routing, or any DEX integration that consumes user-supplied swap-action chains. It is a single-asset lending market with a vault on top.
 
-I checked the analogous surfaces:
+### Isolated markets vs. Burrow's shared pool
+
+The first structural difference is the deployment model. Burrow puts every supported asset and every user into a **single contract** holding shared maps:
+
+```rust
+// burrowland/contracts/contract/src/lib.rs:114-128
+pub struct Contract {
+    pub accounts: UnorderedMap<AccountId, VAccount>,
+    pub storage:  LookupMap<AccountId, VStorage>,
+    pub assets:   LookupMap<TokenId, VAsset>,
+    pub asset_ids: UnorderedSet<TokenId>,
+    ...
+    pub margin_accounts: UnorderedMap<AccountId, VMarginAccount>,
+}
+```
+
+A bug anywhere in this contract — including the margin subsystem — touches the shared pool used by every asset and every user. The Rhea team's confirmed loss (~$18.4M) is the protocol's reserve pool drained from this single contract.
+
+Templar takes the **isolated-market** approach. Each lending market is its own deployed contract with exactly one borrow asset and one collateral asset:
+
+```rust
+// contract/market/src/lib.rs:20-25
+pub struct Contract {
+    pub market: Market,
+    storage_usage_snapshot: u64,
+    storage_usage_supply_position: u64,
+    storage_usage_borrow_position: u64,
+}
+
+// common/src/market/configuration.rs:113-145
+pub struct MarketConfiguration {
+    pub borrow_asset:     FungibleAsset<BorrowAsset>,
+    pub collateral_asset: FungibleAsset<CollateralAsset>,
+    pub price_oracle_configuration: PriceOracleConfiguration,
+    ...
+}
+```
+
+`MarketConfiguration::validate` (`common/src/market/configuration.rs:225-247`) explicitly rejects configurations where `borrow_asset == collateral_asset`. There is no `assets: LookupMap<TokenId, _>` and no shared `accounts` map across markets.
+
+Each market is provisioned through the `registry` contract:
+
+```rust
+// contract/registry/src/lib.rs:175-264 (excerpt)
+pub fn deploy(
+    &mut self,
+    name: String,
+    version_key: String,
+    init_args: Base64VecU8,
+    ...
+) -> Promise {
+    self.assert_owner();
+    ...
+    let market_id: AccountId = format!("{name}.{current_account_id}").parse()...;
+    require!(market_id.is_sub_account_of(&current_account_id), ...);
+    require!(!self.registry.contains_key(&market_id), "Market ID collision");
+
+    Promise::new(market_id.clone())
+        .create_account()
+        .transfer(env::attached_deposit())
+        ...
+        .deploy_contract(code.clone())
+        .function_call_weight("new", init_args.0, ...)
+        ...
+}
+```
+
+Every market lives at its own `name.<registry>` subaccount, with its own state, its own oracle configuration, its own interest-rate curve, and its own collateral/borrow asset pair.
+
+The vault is a separate contract on top of these markets, also with a single `underlying_asset` (`contract/vault/near/src/lib.rs:300-381`); it routes liquidity through a curated set of Templar markets rather than co-mingling assets in one pool.
+
+The practical implication for an exploit of this class:
+
+- **Burrow / Rhea:** a slippage-validation bug in one subsystem (margin trading) drained the protocol's shared reserve pool, affecting all assets and all users at once.
+- **Templar:** even a comparable hypothetical bug in one market's logic is bounded by that single market's TVL. Other markets — different underlying, different curator-approved oracle, different state — continue to operate. The vault's exposure to any single failed market is also bounded: the curator sets a per-market `cap`, and `set_supply_queue` enforces that only markets with `cap > 0` may receive vault deposits (`contract/vault/near/src/governance.rs:655-693`).
+
+Isolation does not make individual markets correct — that still depends on the contract logic — but it removes the "one bug drains the protocol" failure mode that made the Rhea incident as severe as it was.
+
+### Analogous surfaces checked
 
 | Burrow attack ingredient | Templar analog | Verdict |
 |---|---|---|
@@ -76,10 +154,12 @@ I checked the analogous surfaces:
 
 Templar's lending design closes off this exploit class structurally:
 
-1. **No margin / leverage / swap-routing surface.** The attack requires a protocol that accepts user-supplied multi-hop swap action chains and forwards them to a DEX while computing its own slippage check. Templar has no such surface.
-2. **Single-step slippage checks.** Where Templar accepts a `min_*_out` from the user (`Deposit`, `RequestWithdraw`), the kernel compares it against a single-step conversion (`convert_to_shares` / `convert_to_assets`) — there is no aggregation that can be confused by token reuse.
-3. **Fixed asset whitelist on FT receivers.** The market and vault `ft_on_transfer` paths panic if the predecessor is not the configured asset; an attacker cannot smuggle a fake token into the position accounting.
-4. **Curated, timelocked oracle aggregation.** Even if an attacker tried to manipulate price input upstream, the proxy oracle aggregates over a curated source set whose membership and weights are governed via timelocked proposals.
+1. **Isolated markets, not shared pools.** Each market is its own deployed contract with exactly one borrow asset and one collateral asset (rejected if equal). No shared `assets` / `accounts` / `margin_accounts` maps across the protocol. A bug in one market is bounded to that market's TVL; other markets, the vault, and the registry continue to operate.
+2. **No margin / leverage / swap-routing surface.** The attack requires a protocol that accepts user-supplied multi-hop swap action chains and forwards them to a DEX while computing its own slippage check. Templar has no such surface.
+3. **Single-step slippage checks.** Where Templar accepts a `min_*_out` from the user (`Deposit`, `RequestWithdraw`), the kernel compares it against a single-step conversion (`convert_to_shares` / `convert_to_assets`) — there is no aggregation that can be confused by token reuse.
+4. **Fixed asset whitelist on FT receivers.** The market and vault `ft_on_transfer` paths panic if the predecessor is not the configured asset; an attacker cannot smuggle a fake token into the position accounting.
+5. **Curated, timelocked oracle aggregation.** Even if an attacker tried to manipulate price input upstream, the proxy oracle aggregates over a curated source set whose membership and weights are governed via timelocked proposals.
+6. **Capped, curated vault exposure to markets.** The vault exposes user deposits to markets only via a per-market `cap`, set by curator/owner through the timelocked governance state machine; unsupported markets cannot enter the supply queue.
 
 No code change is required.
 

--- a/audits/2026-04-29/sweat-exploit-analysis.md
+++ b/audits/2026-04-29/sweat-exploit-analysis.md
@@ -1,0 +1,86 @@
+# SWEAT (`hodl-lockup.sweat`) exploit — Templar exposure review
+
+- Date: 2026-04-29
+- Author: claude (Templar audit branch)
+- Status: review only — no code change required
+
+## Incident summary
+
+On 2026-04-29 ~13:36 UTC, multiple Sweat Foundation accounts on NEAR were drained over a ~30-second window. The largest single transaction (`DvrSMfY85Anc6AuLUmoEDkDdab7qX5NUZLu76HN8NoPn`) drained 11.11B SWEAT from `hodl-lockup.sweat`. Total extracted ≈13.71B SWEAT (~65% of supply), routed via Ref Finance and Wormhole/Portal Bridge. The exploiter ran a custom drainer crate named `exploit-resolve`.
+
+## Investigation constraints
+
+This analysis was performed without on-chain access. The sandbox egress proxy refused every NEAR RPC and explorer endpoint we tried (`rpc.mainnet.fastnear.com`, `rpc.mainnet.near.org`, `archival-rpc.mainnet.near.org`, `near.lava.build`, `1rpc.io/near`, `rpc.ankr.com/near`, `api.nearblocks.io`, `nearblocks.io`) — all returned `403 Host not in allowlist`. We therefore could not pull the exploit transaction or `hodl-lockup.sweat` state directly.
+
+Instead we reviewed the deployed contract source from `github.com/sweatco/hodl-lockup` (`Cargo.toml` matches: `name = "hodl-lockup"`, `version = "1.1.0"`, `authors = ["Sweat Economy"]`).
+
+## SWEAT contract surface review
+
+The `hodl-lockup` contract exposes several admin paths that, individually, require either the `manager` account or a member of `deposit_whitelist`. Each one has **no timelock and no multi-sig gate**, so a single hot-key compromise drains every lockup.
+
+### Privileged paths that can move funds
+
+1. **`edit(index, schedule, termination_config)`** — `contract/src/lib.rs:471-495`
+   - Gated by `assert_deposit_whitelist + assert_one_yocto`.
+   - Lets the caller overwrite `schedule` and `termination_config` for any lockup whose `account_id` matches the hardcoded `EDITABLE_ACCOUNTS` constant at `contract/src/lib.rs:54-57`:
+     ```rust
+     const EDITABLE_ACCOUNTS: &[&str] = &[
+         "baalhasulam5785.near",
+         "e8b49a44e01f2927638a9475e608089238de2befe98eae3807d0844724231b64",
+     ];
+     ```
+   - The second entry has the same shape (64-hex-char implicit account) as the exploiter's address, suggesting the on-chain owner of one of those lockups is controlled by the attacker — overwriting the schedule to fully unlocked then calling `claim()` drains it.
+
+2. **`terminate(lockup_index, hashed_schedule, termination_timestamp)`** — `contract/src/lib.rs:236-281`
+   - Gated by `assert_deposit_whitelist + assert_one_yocto`.
+   - Sends `unvested_balance` to `termination_config.beneficiary_id`, set at lockup creation. A leaked `deposit_whitelist` key drains every lockup that was created with a beneficiary the attacker can later get tokens out of, including via subsequent `ft_transfer_call` flows on the receiving account.
+   - For `VestingConditions::Hash`, the caller supplies the revealed schedule; arbitrary schedules are accepted as long as they hash to the stored value.
+
+3. **`update_contract(code, callback)`** — derived by `SelfUpdate` in `near-self-update-proc/src/lib.rs:18-34`
+   - Gated by `assert_account_can_update()` which is `predecessor == self.manager` (`contract/src/lib.rs:99-105`).
+   - A leaked `manager` key replaces the entire WASM with attacker code, after which any drain logic the attacker wants is callable. The `exploit-resolve` crate name is consistent with this: deploy a "resolve" contract that bulk-drains via the new entrypoints it adds.
+
+### Secondary smell
+
+`SelfCallbacks::convert_drafts(draft_ids)` at `contract/src/callbacks.rs:95-136` is in the `#[ext_contract]` trait but lacks `#[private]`. It is reachable externally. In practice it only converts already-funded drafts to lockups for predetermined beneficiaries (no attacker-chosen recipient), so it doesn't redirect funds — but it is a sloppy trait surface.
+
+### Most likely root cause (best guess)
+
+A **privileged hot-key compromise** (Sweat Foundation `manager` or one of the `deposit_whitelist` operational accounts), exploited via `update_contract` → custom drainer code. This pattern is consistent with:
+- the simultaneity (~30 s) across multiple Sweat Foundation accounts,
+- the ~65 % of supply drained in one tx,
+- the drainer crate name `exploit-resolve`,
+- and the absence of any callback-privacy bug visible in the on-disk source.
+
+`edit` + `claim` and `terminate` could each individually drain specific lockups; they do not naturally explain a single 11.11B SWEAT outflow in one transaction.
+
+## Templar exposure — same exploit classes
+
+We mapped each SWEAT vector to the analogous Templar surface. **No analogous vulnerability exists.**
+
+| SWEAT vector | Templar analog | Verdict |
+|---|---|---|
+| Unprotected `resolve_*` / `*_callback` | All vault callbacks at `contract/vault/near/src/impl_callbacks.rs:77, 131, 223, 254, 273, 328, 407, 542, 595, 657, 786, 800, 885, 904, 961`; market callbacks at `contract/market/src/impl_helper.rs:114, 157, 181, 210, 228, 248, 303, 330`; oracle callbacks at `contract/proxy-oracle/src/lib.rs:170` and `contract/lst-oracle/src/lib.rs:97, 143`; registry callbacks at `contract/registry/src/lib.rs:146, 266, 288` — every one carries `#[private]`. | Safe |
+| Hardcoded "editable accounts" / per-user admin override | None. No `EDITABLE_*` constant; no `edit()` for user state. Vault `skim` (`contract/vault/near/src/lib.rs:956-967`) explicitly refuses to skim the underlying token or share token. | Safe |
+| `terminate`-style flow letting an admin redirect user funds | None. Withdrawals are initiated by the position owner via `redeem`/`withdraw` (`contract/vault/near/src/lib.rs:396-488`). Admins can move config (caps, fees, restrictions, supply queue) but not user balances. | Safe |
+| `update_contract(code)` gated by a single hot key, no timelock | Code deployment lives in `registry` (`contract/registry/src/lib.rs:94-264`), gated by `assert_owner + assert_one_yocto`, deploys to a fresh `name.<registry>` subaccount. State migration uses the canonical pattern in `common/src/versioned_state.rs:152-167`, which requires `predecessor == current_account_id` ("migrate function is private"). | Safe |
+| Single-key admin with no timelock for sensitive changes | Vault uses a timelocked governance state machine (`contract/vault/near/src/governance.rs`): `submit_*` → wait → `accept_*`, with `Owner / Curator / Sentinel / Allocator` roles in `contract/vault/near/src/auth.rs`, plus an `Abdicator` for permanently disabling individual methods. Proxy oracle uses a `Governance<Operation>` with TTL gate in `common/src/governance.rs:233-294` and `contract/proxy-oracle/src/impl_governance.rs:36-79`. Even with a leaked owner key, sensitive operations cannot be executed instantly. | Safe |
+| FT receiver trusts attacker-chosen token | Both market (`contract/market/src/impl_token_receiver.rs:26-32`) and vault (`contract/vault/near/src/impl_token_receiver.rs:115-118`) verify `predecessor == configured asset` before crediting any state. | Safe |
+
+Note: `update_idle_balance` at `contract/vault/near/src/impl_callbacks.rs:1296-1299` is `pub`, but it is defined inside a plain `impl Contract` block (starting at line 1091), not a `#[near] impl Contract` block. It is not exposed as a contract entrypoint.
+
+## Conclusion
+
+No code change required. Templar's defenses against this class of exploit are:
+
+1. Every cross-contract callback is `#[private]`.
+2. Every `ft_on_transfer` / `mt_on_transfer` validates the predecessor before crediting balance.
+3. There is no admin path that can move user funds — `skim` excludes the underlying and share tokens, and there is no `edit` / `terminate` / `force_*` for individual user balances.
+4. Sensitive admin actions (fees, caps, restrictions, sentinel/curator changes, market removal) are gated behind a timelocked governance state machine with role-based auth, not a single hot key.
+5. Code upgrades go through `registry` (owner + 1 yocto) into a fresh subaccount; in-place state migration requires `predecessor == current_account_id`.
+
+## What this analysis does not cover
+
+- We could not confirm the exact transaction trace of the exploit. The above is the most likely root-cause class given the deployed source and the public incident details.
+- We did not review the `service/`, `client/`, or `tools/` crates here, since the attack class is a smart-contract authorization bug.
+- Operational key-management hygiene for Templar's owner / sentinel / curator accounts is out of scope of this on-chain audit but is the *primary* defense suggested by this incident — see SECURITY.md.


### PR DESCRIPTION
## Summary

Add two audit documents analyzing recent protocol exploits (Rhea Finance margin-trading and SWEAT lockup drains) and confirming that Templar's architecture and implementation are not vulnerable to the same attack classes.

## Changes

- **`audits/2026-04-29/rhea-exploit-analysis.md`** — Analysis of the Rhea Finance (Burrow) $18.4M margin-trading exploit
  - Documents the root cause: slippage validation that incorrectly aggregates `min_amount_out` across multi-hop swaps when tokens are reused in the route
  - Maps the attack surface (margin trading, multi-step swap routing, shared pool architecture) to Templar's design
  - Confirms Templar is safe via isolated markets, no margin/swap-routing surface, single-step slippage checks, and fixed asset whitelists on FT receivers

- **`audits/2026-04-29/sweat-exploit-analysis.md`** — Analysis of the SWEAT lockup drain (~13.71B SWEAT, ~65% of supply)
  - Identifies the likely root cause as a privileged hot-key compromise exploited via unprotected `update_contract` 
  - Documents secondary issues: hardcoded editable accounts, untimelocked admin paths, and an unprotected callback surface
  - Confirms Templar is safe via `#[private]` on all callbacks, predecessor validation on FT receivers, no admin paths that move user funds, and timelocked governance for sensitive operations

## Notable Details

Both analyses are marked "review only — no code change required" and serve as incident exposure documentation rather than bug reports. They establish that Templar's isolated-market design, lack of leverage/swap-routing features, and timelocked governance structurally prevent the attack classes that affected Rhea and SWEAT.

https://claude.ai/code/session_01WWkR2nd7eL9PsjhsjgdNte

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/424)
<!-- Reviewable:end -->
