### PR TITLE
fix(soroban): bind adapters by market identity

### DIFF
--- a/contract/vault/soroban/governance/src/lib.rs
+++ b/contract/vault/soroban/governance/src/lib.rs
@@ -66,7 +66,7 @@ impl GovernanceAction {
             Self::SetPaused(_) => GovernanceActionKey::Pause,
             Self::SetCurator(_) => GovernanceActionKey::Curator,
             Self::SetGovernance(_) => GovernanceActionKey::Governance,
-            Self::SetSupplyQueue(_) => GovernanceActionKey::SupplyQueue,
+            Self::SetSupplyQueue(_, _) => GovernanceActionKey::SupplyQueue,
             Self::SetFees(_) => GovernanceActionKey::Fees,
             Self::SetRestrictions(_, _) => GovernanceActionKey::Restrictions,
             Self::SetGuardian(_) => GovernanceActionKey::Guardian,
@@ -177,8 +177,13 @@ impl SorobanVaultGovernanceContract {
         env: Env,
         caller: Address,
         target_ids: Vec<u32>,
+        adapters: Vec<Address>,
     ) -> Result<u64, GovernanceError> {
-        Self::submit(env, caller, GovernanceAction::SetSupplyQueue(target_ids))
+        Self::submit(
+            env,
+            caller,
+            GovernanceAction::SetSupplyQueue(target_ids, adapters),
+        )
     }
 
     pub fn submit_set_fees(
@@ -572,7 +577,7 @@ fn action_kind(action: &GovernanceAction) -> GovernanceActionKind {
         GovernanceAction::SetPaused(_) => GovernanceActionKind::Pause,
         GovernanceAction::SetCurator(_) => GovernanceActionKind::Curator,
         GovernanceAction::SetGovernance(_) => GovernanceActionKind::Governance,
-        GovernanceAction::SetSupplyQueue(_) => GovernanceActionKind::SupplyQueue,
+        GovernanceAction::SetSupplyQueue(_, _) => GovernanceActionKind::SupplyQueue,
         GovernanceAction::SetFees(_) => GovernanceActionKind::Fees,
         GovernanceAction::SetRestrictions(_, _) => GovernanceActionKind::Restrictions,
         GovernanceAction::SetGuardian(_) => GovernanceActionKind::Guardian,
@@ -595,7 +600,7 @@ fn timelock_kind_for_action(action: &GovernanceAction) -> TimelockKind {
         GovernanceAction::SetPaused(_) => TimelockKind::Pause,
         GovernanceAction::SetCurator(_) => TimelockKind::Curator,
         GovernanceAction::SetGovernance(_) => TimelockKind::Governance,
-        GovernanceAction::SetSupplyQueue(_) => TimelockKind::SupplyQueue,
+        GovernanceAction::SetSupplyQueue(_, _) => TimelockKind::SupplyQueue,
         GovernanceAction::SetFees(_) => TimelockKind::Fees,
         GovernanceAction::SetRestrictions(_, _) => TimelockKind::Restrictions,
         GovernanceAction::SetGuardian(_) => TimelockKind::Guardian,
@@ -614,6 +619,15 @@ fn timelock_kind_for_action(action: &GovernanceAction) -> TimelockKind {
 fn validate_action(action: &GovernanceAction) -> Result<(), GovernanceError> {
     match action {
         GovernanceAction::SetGovernance(governance) => require_contract_address(governance),
+        GovernanceAction::SetSupplyQueue(target_ids, adapters) => {
+            if !adapters.is_empty() && adapters.len() != target_ids.len() {
+                return Err(GovernanceError::InvalidInput);
+            }
+            for adapter in adapters.iter() {
+                require_contract_address(&adapter)?;
+            }
+            Ok(())
+        }
         GovernanceAction::SetFees(params) => {
             let _ = to_wad(params.performance_fee_wad)?;
             let _ = to_wad(params.management_fee_wad)?;
@@ -825,7 +839,7 @@ fn decide_submission(
         GovernanceAction::Skim(_) => Ok(TimelockDecision::Immediate),
         GovernanceAction::SetCurator(_)
         | GovernanceAction::SetGovernance(_)
-        | GovernanceAction::SetSupplyQueue(_) => Ok(TimelockDecision::Timelocked),
+        | GovernanceAction::SetSupplyQueue(_, _) => Ok(TimelockDecision::Timelocked),
         GovernanceAction::Other(key, payload_hash) => {
             let approved: bool = env
                 .storage()
@@ -1052,7 +1066,7 @@ fn execute_action(env: &Env, action: &GovernanceAction) -> Result<(), Governance
         }
         GovernanceAction::SetCurator(_)
         | GovernanceAction::SetGovernance(_)
-        | GovernanceAction::SetSupplyQueue(_) => {
+        | GovernanceAction::SetSupplyQueue(_, _) => {
             execute_vault_governance_action(env, &vault, action)?
         }
         GovernanceAction::SetFees(params) => {
@@ -1206,12 +1220,16 @@ fn governance_payload_for_action(
         GovernanceAction::Skim(token) => Some(GovernanceCommand::Skim {
             token: sdk_address_to_alloc_string(token)?,
         }),
-        GovernanceAction::SetSupplyQueue(target_ids) => {
+        GovernanceAction::SetSupplyQueue(target_ids, adapters) => {
             Some(GovernanceCommand::SetGovernancePolicy {
                 kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
                 target_ids: Some(soroban_u32_vec_to_alloc(target_ids)),
                 mode: None,
-                accounts: None,
+                accounts: if adapters.is_empty() {
+                    None
+                } else {
+                    Some(soroban_address_vec_to_alloc(adapters)?)
+                },
                 market_id: None,
                 cap_group_id: None,
                 value: None,

--- a/contract/vault/soroban/governance/src/tests.rs
+++ b/contract/vault/soroban/governance/src/tests.rs
@@ -32,6 +32,7 @@ enum MockVaultKey {
     Governance,
     SkimRecipient,
     SupplyQueue,
+    SupplyQueueAdapters,
     LastFeeAccounts,
     RestrictionMode,
     RestrictionAccounts,
@@ -295,6 +296,13 @@ impl MockVault {
             .unwrap_or_else(|| Vec::new(&env))
     }
 
+    pub fn supply_queue_adapters(env: Env) -> Option<Vec<Address>> {
+        env.storage()
+            .instance()
+            .get(&MockVaultKey::SupplyQueueAdapters)
+            .unwrap_or(None)
+    }
+
     pub fn last_fee_accounts(env: Env) -> Option<Vec<Address>> {
         env.storage().instance().get(&MockVaultKey::LastFeeAccounts)
     }
@@ -451,6 +459,9 @@ impl MockVault {
                     .instance()
                     .set(&MockVaultKey::SupplyQueue, &ids);
             }
+            env.storage()
+                .instance()
+                .set(&MockVaultKey::SupplyQueueAdapters, &accounts);
         }
         if kind == GOVERNANCE_POLICY_KIND_RESTRICTIONS {
             if let Some(m) = mode {
@@ -1111,12 +1122,21 @@ fn supply_queue_submission_routes_to_vault() {
     );
 
     let target_ids = sdk_u32_vec(&env, &[1u32, 2u32, 3u32]);
+    let adapters = Vec::from_array(
+        &env,
+        [
+            env.register(MockVault, ()),
+            env.register(MockVault, ()),
+            env.register(MockVault, ()),
+        ],
+    );
 
     let proposal_id = env.as_contract(&governance, || {
         SorobanVaultGovernanceContract::submit_set_supply_queue(
             env.clone(),
             admin.clone(),
             target_ids.clone(),
+            adapters.clone(),
         )
         .unwrap()
     });
@@ -1138,6 +1158,9 @@ fn supply_queue_submission_routes_to_vault() {
 
     let on_vault = env.as_contract(&vault, || MockVault::supply_queue(env.clone()));
     assert_eq!(on_vault, target_ids);
+    let adapters_on_vault =
+        env.as_contract(&vault, || MockVault::supply_queue_adapters(env.clone()));
+    assert_eq!(adapters_on_vault, Some(adapters));
 }
 
 #[test]

--- a/contract/vault/soroban/governance/src/types.rs
+++ b/contract/vault/soroban/governance/src/types.rs
@@ -185,7 +185,7 @@ pub enum GovernanceAction {
     SetPaused(bool),
     SetCurator(Address),
     SetGovernance(Address),
-    SetSupplyQueue(Vec<u32>),
+    SetSupplyQueue(Vec<u32>, Vec<Address>),
     SetFees(FeeParams),
     SetRestrictions(RestrictionMode, Vec<Address>),
     SetGuardian(Address),

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -5,12 +5,11 @@
 
 use super::helpers::{
     adapter_for_market, address_from_alloc_string, addresses_from_alloc_strings, apply_fee_change,
-    current_supply_queue_len, emit_admin_event, emit_alloc_event, emit_pause_state_event,
-    extend_storage_ttl, get_config_address, governance_caller, kernel_address_from_sdk,
-    load_virtual_offsets, migrate_legacy_paused, migration_in_progress, require_contract_address,
-    require_governance, require_signed, sdk_string_to_alloc, set_config_address,
-    set_migration_in_progress, store_fees_spec, store_virtual_offsets,
-    with_contract_vault_contract_error,
+    emit_admin_event, emit_alloc_event, emit_pause_state_event, extend_storage_ttl,
+    get_config_address, governance_caller, kernel_address_from_sdk, load_virtual_offsets,
+    migrate_legacy_paused, migration_in_progress, require_contract_address, require_governance,
+    require_signed, sdk_string_to_alloc, set_config_address, set_migration_in_progress,
+    store_fees_spec, store_virtual_offsets, with_contract_vault_contract_error,
 };
 use super::*;
 use templar_soroban_shared_types::{
@@ -81,9 +80,8 @@ fn apply_allowed_adapters_config(
     env: &Env,
     adapters: soroban_sdk::Vec<soroban_sdk::Address>,
 ) -> Result<(), ContractError> {
-    let queue_len = current_supply_queue_len(env)?;
-    if queue_len > 0 && adapters.len() != queue_len {
-        return Err(ContractError::InvalidInput);
+    for adapter in adapters.iter() {
+        require_contract_address(&adapter)?;
     }
     if adapters.is_empty() {
         env.storage()
@@ -119,16 +117,52 @@ fn apply_supply_queue_policy(
     env: &Env,
     caller_kernel: Address,
     target_ids: soroban_sdk::Vec<u32>,
+    adapters: Option<soroban_sdk::Vec<SdkAddress>>,
 ) -> Result<(), ContractError> {
-    if let Some(adapters) = env
+    let mut bindings = env
         .storage()
         .instance()
-        .get::<_, soroban_sdk::Vec<SdkAddress>>(&VaultDataKey::AllowedAdapters)
-    {
+        .get::<_, soroban_sdk::Map<u32, SdkAddress>>(&VaultDataKey::AdapterBindings)
+        .unwrap_or_else(|| soroban_sdk::Map::new(env));
+
+    if let Some(adapters) = adapters.as_ref() {
         if adapters.len() != target_ids.len() {
             return Err(ContractError::InvalidInput);
         }
     }
+    let allowed_adapters = env
+        .storage()
+        .instance()
+        .get::<_, soroban_sdk::Vec<SdkAddress>>(&VaultDataKey::AllowedAdapters);
+
+    for (idx, target_id) in target_ids.iter().enumerate() {
+        let proposed_adapter = adapters
+            .as_ref()
+            .map(|values| {
+                let index = u32::try_from(idx).map_err(|_| ContractError::InvalidInput)?;
+                values.get(index).ok_or(ContractError::InvalidInput)
+            })
+            .transpose()?;
+        if let Some(existing_adapter) = bindings.get(target_id) {
+            if let Some(proposed_adapter) = proposed_adapter {
+                if proposed_adapter != existing_adapter {
+                    return Err(ContractError::InvalidInput);
+                }
+            }
+        } else {
+            let adapter = proposed_adapter.ok_or(ContractError::InvalidInput)?;
+            require_contract_address(&adapter)?;
+            let allowed = allowed_adapters
+                .as_ref()
+                .map(|allowed| allowed.iter().any(|candidate| candidate == adapter))
+                .unwrap_or(false);
+            if !allowed {
+                return Err(ContractError::InvalidInput);
+            }
+            bindings.set(target_id, adapter);
+        }
+    }
+
     let mut queue_targets: Option<Vec<TargetId>> = {
         let mut v = Vec::with_capacity(target_ids.len() as usize);
         for target_id in target_ids.iter() {
@@ -142,7 +176,13 @@ fn apply_supply_queue_policy(
             .ok_or_else(|| RuntimeError::invalid_state(""))?;
         vault.set_supply_queue(caller_kernel, targets)
     };
-    with_contract_vault_contract_error(env, &mut call)
+    with_contract_vault_contract_error(env, &mut call)?;
+    if !bindings.is_empty() {
+        env.storage()
+            .instance()
+            .set(&VaultDataKey::AdapterBindings, &bindings);
+    }
+    Ok(())
 }
 
 fn apply_cap_policy(
@@ -530,6 +570,7 @@ fn set_governance_policy_impl(
             env,
             caller_kernel,
             target_ids.ok_or(ContractError::InvalidInput)?,
+            accounts,
         ),
         GOVERNANCE_POLICY_KIND_CAP => apply_cap_policy(
             env,

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -149,6 +149,18 @@ fn apply_supply_queue_policy(
                     return Err(ContractError::InvalidInput);
                 }
             }
+            require_contract_address(&existing_adapter)?;
+            let allowed = allowed_adapters
+                .as_ref()
+                .map(|allowed| {
+                    allowed
+                        .iter()
+                        .any(|candidate| candidate == existing_adapter)
+                })
+                .unwrap_or(false);
+            if !allowed {
+                return Err(ContractError::InvalidInput);
+            }
         } else {
             let adapter = proposed_adapter.ok_or(ContractError::InvalidInput)?;
             require_contract_address(&adapter)?;

--- a/contract/vault/soroban/src/contract/helpers.rs
+++ b/contract/vault/soroban/src/contract/helpers.rs
@@ -113,19 +113,6 @@ pub(crate) fn require_contract_address(addr: &SdkAddress) -> Result<(), Contract
         .ok_or(ContractError::InvalidInput)
 }
 
-fn allowed_adapters(env: &Env) -> Option<soroban_sdk::Vec<SdkAddress>> {
-    env.storage().instance().get(&VaultDataKey::AllowedAdapters)
-}
-
-fn load_policy_state(env: &Env) -> Result<PolicyState, ContractError> {
-    if migration_in_progress(env) {
-        return Err(ContractError::InvalidState);
-    }
-
-    let storage = SorobanStorage::new(env);
-    runtime_to_contract(storage.load_policy_state()).map(|state| state.unwrap_or_default())
-}
-
 fn serialize_fees_spec(fees: &FeesSpec) -> Result<Vec<u8>, RuntimeError> {
     let mut bytes = Vec::with_capacity(96);
     bytes.extend_from_slice(&fees.performance.fee_wad.as_u128_trunc().to_le_bytes());
@@ -261,25 +248,13 @@ pub(crate) fn emit_alloc_event(env: &Env, market: u32, amount: i128, supply: boo
 }
 
 pub(crate) fn adapter_for_market(env: &Env, market: u32) -> Result<SdkAddress, ContractError> {
-    let adapters = allowed_adapters(env);
-    let Some(adapters) = adapters else {
-        return Err(ContractError::InvalidInput);
-    };
+    let bindings = env
+        .storage()
+        .instance()
+        .get::<_, soroban_sdk::Map<u32, SdkAddress>>(&VaultDataKey::AdapterBindings)
+        .ok_or(ContractError::InvalidInput)?;
 
-    let policy_state = load_policy_state(env)?;
-    for (idx, entry) in policy_state.supply_queue().entries().iter().enumerate() {
-        if entry.target_id == market {
-            let index = u32::try_from(idx).map_err(|_| ContractError::InvalidInput)?;
-            return adapters.get(index).ok_or(ContractError::InvalidInput);
-        }
-    }
-
-    Err(ContractError::InvalidInput)
-}
-
-pub(crate) fn current_supply_queue_len(env: &Env) -> Result<u32, ContractError> {
-    let policy_state = load_policy_state(env)?;
-    u32::try_from(policy_state.supply_queue().len()).map_err(|_| ContractError::InvalidInput)
+    bindings.get(market).ok_or(ContractError::InvalidInput)
 }
 
 fn require_non_negative_bounded_wad(value: i128, max: u128) -> Result<Wad, ContractError> {

--- a/contract/vault/soroban/src/contract/types.rs
+++ b/contract/vault/soroban/src/contract/types.rs
@@ -162,6 +162,7 @@ impl VaultDataKey {
     pub const Guardians: Symbol = soroban_sdk::symbol_short!("guards");
     pub const Allocators: Symbol = soroban_sdk::symbol_short!("allctrs");
     pub const AllowedAdapters: Symbol = soroban_sdk::symbol_short!("adapters");
+    pub const AdapterBindings: Symbol = soroban_sdk::symbol_short!("adapmap");
     pub const SkimRecipient: Symbol = soroban_sdk::symbol_short!("skimrcp");
     pub const VirtualShares: Symbol = soroban_sdk::symbol_short!("vshares");
     pub const VirtualAssets: Symbol = soroban_sdk::symbol_short!("vassets");

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -1962,8 +1962,8 @@ mod market_tests {
 
 mod storage_tests {
     use crate::contract::helpers::set_config_address;
-    use crate::contract::SorobanVaultContract;
-    use crate::error::RuntimeError;
+    use crate::contract::{adapter_for_market, SorobanVaultContract};
+    use crate::error::{ContractError, RuntimeError};
     use crate::storage::{SorobanStorage, SorobanStorageKey, Storage};
     use crate::test_utils::{fuzz_api, MemoryStorage};
     use alloc::string::{String as AllocString, ToString};
@@ -1972,12 +1972,14 @@ mod storage_tests {
     use soroban_sdk::{Address as SdkAddress, Bytes, Env, Symbol, Vec as SdkVec};
     use templar_curator_primitives::policy::cap_group::{CapGroup, CapGroupId, CapGroupRecord};
     use templar_curator_primitives::policy::state::{MarketConfig, OrderedMap};
+    use templar_curator_primitives::policy::supply_queue::{SupplyQueue, SupplyQueueEntry};
     use templar_curator_primitives::PolicyState;
     use templar_soroban_shared_types::{
         GovernanceCommand, GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS, GOVERNANCE_CONFIG_KIND_CURATOR,
         GOVERNANCE_CONFIG_KIND_GOVERNANCE, GOVERNANCE_CONFIG_KIND_GUARDIANS,
         GOVERNANCE_CONFIG_KIND_SENTINEL, GOVERNANCE_POLICY_KIND_CAP, GOVERNANCE_POLICY_KIND_GROUP,
         GOVERNANCE_POLICY_KIND_PAUSED, GOVERNANCE_POLICY_KIND_REMOVE_MARKET,
+        GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
     };
     use templar_vault_kernel::{
         Address as KernelAddress, AllocationPlanEntry, FeeAccrualAnchor, OpState,
@@ -1987,6 +1989,86 @@ mod storage_tests {
     fn sdk_text(address: &SdkAddress) -> AllocString {
         AllocString::from_utf8(address.to_string().to_bytes().to_alloc_vec())
             .expect("valid address")
+    }
+
+    fn supply_queue_from_ids(ids: &[u32]) -> SupplyQueue {
+        SupplyQueue::try_from_entries(
+            ids.iter()
+                .map(|target_id| SupplyQueueEntry::new(*target_id, 100).unwrap())
+                .collect(),
+            None,
+        )
+        .unwrap()
+    }
+
+    fn policy_state_with_supply_queue(ids: &[u32]) -> PolicyState {
+        let mut policy_state = PolicyState::default();
+        for target_id in ids {
+            policy_state
+                .set_market_config(*target_id, MarketConfig::new(true, 100, None))
+                .unwrap();
+        }
+        policy_state
+            .replace_supply_queue(supply_queue_from_ids(ids))
+            .unwrap();
+        policy_state
+    }
+
+    fn initialize_governance_test_contract(env: &Env, governance: &SdkAddress) {
+        let curator = SdkAddress::generate(env);
+        let asset_token = SdkAddress::generate(env);
+        let share_token = SdkAddress::generate(env);
+        set_config_address(env, &crate::contract::VaultDataKey::Curator, &curator);
+        set_config_address(env, &crate::contract::VaultDataKey::Governance, governance);
+        set_config_address(
+            env,
+            &crate::contract::VaultDataKey::AssetToken,
+            &asset_token,
+        );
+        set_config_address(
+            env,
+            &crate::contract::VaultDataKey::ShareToken,
+            &share_token,
+        );
+        set_config_address(
+            env,
+            &crate::contract::VaultDataKey::SkimRecipient,
+            governance,
+        );
+        let mut storage = SorobanStorage::new(env);
+        storage.save_state(&VaultState::default()).unwrap();
+        storage.save_paused(false).unwrap();
+    }
+
+    fn adapter_contract(env: &Env) -> SdkAddress {
+        env.register(SorobanVaultContract, ())
+    }
+
+    fn account_address(env: &Env) -> SdkAddress {
+        SdkAddress::from_str(
+            env,
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        )
+    }
+
+    fn store_allowed_adapters(env: &Env, adapters: &[SdkAddress]) {
+        let mut values = SdkVec::new(env);
+        for adapter in adapters {
+            values.push_back(adapter.clone());
+        }
+        env.storage()
+            .instance()
+            .set(&crate::contract::VaultDataKey::AllowedAdapters, &values);
+    }
+
+    fn store_test_adapter_bindings(env: &Env, pairs: &[(u32, SdkAddress)]) {
+        let mut bindings = soroban_sdk::Map::new(env);
+        for (target_id, adapter) in pairs {
+            bindings.set(*target_id, adapter.clone());
+        }
+        env.storage()
+            .instance()
+            .set(&crate::contract::VaultDataKey::AdapterBindings, &bindings);
     }
 
     fn execute_governance_command(
@@ -2596,7 +2678,9 @@ mod storage_tests {
         let (env, contract_id) = contract_env;
         env.mock_all_auths_allowing_non_root_auth();
         let governance = SdkAddress::generate(&env);
-        let updated_adapters = SdkVec::from_array(&env, [SdkAddress::generate(&env)]);
+        let updated_adapter_one = adapter_contract(&env);
+        let updated_adapter_two = adapter_contract(&env);
+        let updated_adapters = SdkVec::from_array(&env, [updated_adapter_one, updated_adapter_two]);
 
         env.as_contract(&contract_id, || {
             set_config_address(
@@ -2604,6 +2688,9 @@ mod storage_tests {
                 &crate::contract::VaultDataKey::Governance,
                 &governance,
             );
+            let mut storage = SorobanStorage::new(&env);
+            let policy_state = policy_state_with_supply_queue(&[1]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
             env.storage().instance().set(
                 &crate::contract::VaultDataKey::AllowedAdapters,
                 &SdkVec::from_array(
@@ -2636,6 +2723,509 @@ mod storage_tests {
                     .get(&crate::contract::VaultDataKey::AllowedAdapters),
                 Some(updated_adapters)
             );
+        });
+    }
+
+    #[rstest]
+    fn test_governance_config_rejects_non_contract_allowed_adapter(
+        contract_env: (Env, soroban_sdk::Address),
+    ) {
+        let (env, contract_id) = contract_env;
+        env.mock_all_auths_allowing_non_root_auth();
+        let governance = SdkAddress::generate(&env);
+        let non_contract_adapter = account_address(&env);
+
+        env.as_contract(&contract_id, || {
+            set_config_address(
+                &env,
+                &crate::contract::VaultDataKey::Governance,
+                &governance,
+            );
+
+            let updated = alloc::vec![sdk_text(&non_contract_adapter)];
+            let payload = soroban_sdk::Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernanceConfig {
+                    kind: GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS,
+                    primary: None,
+                    many: Some(updated),
+                    value_a: None,
+                    value_b: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn test_governance_supply_queue_binds_new_market_from_proposal_adapters() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+        let adapter_for_market_two = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let mut policy_state = policy_state_with_supply_queue(&[1]);
+            policy_state
+                .set_market_config(2, MarketConfig::new(true, 100, None))
+                .unwrap();
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(
+                &env,
+                &[
+                    adapter_for_market_one.clone(),
+                    adapter_for_market_two.clone(),
+                ],
+            );
+            store_test_adapter_bindings(&env, &[(1, adapter_for_market_one.clone())]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1, 2]),
+                    mode: None,
+                    accounts: Some(alloc::vec![
+                        sdk_text(&adapter_for_market_one),
+                        sdk_text(&adapter_for_market_two),
+                    ]),
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload)
+                .unwrap();
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+            assert_eq!(adapter_for_market(&env, 2).unwrap(), adapter_for_market_two);
+        });
+    }
+
+    #[test]
+    fn test_governance_rejects_new_supply_queue_market_without_adapter() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let mut policy_state = policy_state_with_supply_queue(&[1]);
+            policy_state
+                .set_market_config(2, MarketConfig::new(true, 100, None))
+                .unwrap();
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_test_adapter_bindings(&env, &[(1, adapter_for_market_one.clone())]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1, 2]),
+                    mode: None,
+                    accounts: None,
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn test_governance_rejects_new_supply_queue_adapter_not_allowed() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+        let disallowed_adapter = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let mut policy_state = policy_state_with_supply_queue(&[1]);
+            policy_state
+                .set_market_config(2, MarketConfig::new(true, 100, None))
+                .unwrap();
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(&env, &[adapter_for_market_one.clone()]);
+            store_test_adapter_bindings(&env, &[(1, adapter_for_market_one.clone())]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1, 2]),
+                    mode: None,
+                    accounts: Some(alloc::vec![
+                        sdk_text(&adapter_for_market_one),
+                        sdk_text(&disallowed_adapter),
+                    ]),
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+            assert_eq!(
+                adapter_for_market(&env, 2),
+                Err(ContractError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn test_governance_rejects_new_supply_queue_adapter_non_contract() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+        let non_contract_adapter = account_address(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let mut policy_state = policy_state_with_supply_queue(&[1]);
+            policy_state
+                .set_market_config(2, MarketConfig::new(true, 100, None))
+                .unwrap();
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(
+                &env,
+                &[adapter_for_market_one.clone(), non_contract_adapter.clone()],
+            );
+            store_test_adapter_bindings(&env, &[(1, adapter_for_market_one.clone())]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1, 2]),
+                    mode: None,
+                    accounts: Some(alloc::vec![
+                        sdk_text(&adapter_for_market_one),
+                        sdk_text(&non_contract_adapter),
+                    ]),
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+            assert_eq!(
+                adapter_for_market(&env, 2),
+                Err(ContractError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn test_governance_rejects_supply_queue_adapter_rebinding() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+        let replacement_adapter = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let policy_state = policy_state_with_supply_queue(&[1]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(
+                &env,
+                &[adapter_for_market_one.clone(), replacement_adapter.clone()],
+            );
+            store_test_adapter_bindings(&env, &[(1, adapter_for_market_one.clone())]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1]),
+                    mode: None,
+                    accounts: Some(alloc::vec![sdk_text(&replacement_adapter)]),
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+        });
+    }
+
+    #[test]
+    fn test_governance_supply_queue_reorder_does_not_require_adapters() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+        let adapter_for_market_two = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let policy_state = policy_state_with_supply_queue(&[1, 2]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_test_adapter_bindings(
+                &env,
+                &[
+                    (1, adapter_for_market_one.clone()),
+                    (2, adapter_for_market_two.clone()),
+                ],
+            );
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![2, 1]),
+                    mode: None,
+                    accounts: None,
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload)
+                .unwrap();
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+            assert_eq!(adapter_for_market(&env, 2).unwrap(), adapter_for_market_two);
+        });
+    }
+
+    #[test]
+    fn test_governance_supply_queue_removal_preserves_adapter_binding() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let adapter_for_market_one = adapter_contract(&env);
+        let adapter_for_market_two = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let policy_state = policy_state_with_supply_queue(&[1, 2]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_test_adapter_bindings(
+                &env,
+                &[
+                    (1, adapter_for_market_one.clone()),
+                    (2, adapter_for_market_two.clone()),
+                ],
+            );
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![2]),
+                    mode: None,
+                    accounts: None,
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload)
+                .unwrap();
+            let bindings: soroban_sdk::Map<u32, SdkAddress> = env
+                .storage()
+                .instance()
+                .get(&crate::contract::VaultDataKey::AdapterBindings)
+                .expect("adapter bindings stored");
+            assert_eq!(bindings.get(1).unwrap(), adapter_for_market_one);
+            assert_eq!(bindings.get(2).unwrap(), adapter_for_market_two);
+        });
+    }
+
+    #[test]
+    fn test_adapter_lookup_requires_keyed_binding() {
+        let env = Env::default();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let adapter_for_market_one = adapter_contract(&env);
+        let adapter_for_market_two = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            let mut storage = SorobanStorage::new(&env);
+            storage.save_state(&VaultState::default()).unwrap();
+            storage.save_paused(false).unwrap();
+            let policy_state = policy_state_with_supply_queue(&[1, 2]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            let adapters = SdkVec::from_array(
+                &env,
+                [
+                    adapter_for_market_one.clone(),
+                    adapter_for_market_two.clone(),
+                ],
+            );
+            env.storage()
+                .instance()
+                .set(&crate::contract::VaultDataKey::AllowedAdapters, &adapters);
+
+            assert_eq!(
+                adapter_for_market(&env, 1),
+                Err(ContractError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn test_adapter_binding_survives_supply_queue_reorder() {
+        let env = Env::default();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let adapter_for_market_one = adapter_contract(&env);
+        let adapter_for_market_two = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            let mut storage = SorobanStorage::new(&env);
+            storage.save_state(&VaultState::default()).unwrap();
+            storage.save_paused(false).unwrap();
+            let mut policy_state = policy_state_with_supply_queue(&[1, 2]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            let adapters = SdkVec::from_array(
+                &env,
+                [
+                    adapter_for_market_one.clone(),
+                    adapter_for_market_two.clone(),
+                ],
+            );
+            env.storage()
+                .instance()
+                .set(&crate::contract::VaultDataKey::AllowedAdapters, &adapters);
+            store_test_adapter_bindings(
+                &env,
+                &[
+                    (1, adapter_for_market_one.clone()),
+                    (2, adapter_for_market_two.clone()),
+                ],
+            );
+            let bindings: soroban_sdk::Map<u32, SdkAddress> = env
+                .storage()
+                .instance()
+                .get(&crate::contract::VaultDataKey::AdapterBindings)
+                .expect("adapter bindings stored");
+            assert_eq!(bindings.get(1).unwrap(), adapter_for_market_one);
+            assert_eq!(bindings.get(2).unwrap(), adapter_for_market_two);
+
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+            assert_eq!(adapter_for_market(&env, 2).unwrap(), adapter_for_market_two);
+
+            policy_state
+                .replace_supply_queue(supply_queue_from_ids(&[2, 1]))
+                .unwrap();
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), adapter_for_market_one);
+            assert_eq!(adapter_for_market(&env, 2).unwrap(), adapter_for_market_two);
+        });
+    }
+
+    #[test]
+    fn test_adapter_binding_survives_multiple_supply_queue_permutations() {
+        let env = Env::default();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let adapters = [
+            adapter_contract(&env),
+            adapter_contract(&env),
+            adapter_contract(&env),
+            adapter_contract(&env),
+        ];
+        let expected = [
+            (10, adapters[0].clone()),
+            (20, adapters[1].clone()),
+            (30, adapters[2].clone()),
+            (40, adapters[3].clone()),
+        ];
+        let permutations = [
+            [40, 30, 20, 10],
+            [20, 10, 40, 30],
+            [30, 40, 10, 20],
+            [10, 40, 20, 30],
+        ];
+
+        env.as_contract(&contract_id, || {
+            let mut storage = SorobanStorage::new(&env);
+            storage.save_state(&VaultState::default()).unwrap();
+            storage.save_paused(false).unwrap();
+            let mut policy_state = policy_state_with_supply_queue(&[10, 20, 30, 40]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_test_adapter_bindings(
+                &env,
+                &[
+                    (10, adapters[0].clone()),
+                    (20, adapters[1].clone()),
+                    (30, adapters[2].clone()),
+                    (40, adapters[3].clone()),
+                ],
+            );
+
+            for (market, adapter) in expected.iter() {
+                assert_eq!(adapter_for_market(&env, *market).unwrap(), *adapter);
+            }
+
+            for permutation in permutations {
+                policy_state
+                    .replace_supply_queue(supply_queue_from_ids(&permutation))
+                    .unwrap();
+                Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+                for (market, adapter) in expected.iter() {
+                    assert_eq!(adapter_for_market(&env, *market).unwrap(), *adapter);
+                }
+            }
         });
     }
 

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -3000,6 +3000,83 @@ mod storage_tests {
     }
 
     #[test]
+    fn test_governance_rejects_supply_queue_reuse_of_non_contract_binding() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let non_contract_adapter = account_address(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let policy_state = policy_state_with_supply_queue(&[1]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_test_adapter_bindings(&env, &[(1, non_contract_adapter)]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1]),
+                    mode: None,
+                    accounts: None,
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn test_governance_rejects_supply_queue_reuse_of_disallowed_binding() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let governance = SdkAddress::generate(&env);
+        let allowed_adapter = adapter_contract(&env);
+        let stale_adapter = adapter_contract(&env);
+
+        env.as_contract(&contract_id, || {
+            initialize_governance_test_contract(&env, &governance);
+            let mut storage = SorobanStorage::new(&env);
+            let policy_state = policy_state_with_supply_queue(&[1]);
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(&env, &[allowed_adapter]);
+            store_test_adapter_bindings(&env, &[(1, stale_adapter.clone())]);
+            let payload = Bytes::from_slice(
+                &env,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                    target_ids: Some(alloc::vec![1]),
+                    mode: None,
+                    accounts: None,
+                    market_id: None,
+                    cap_group_id: None,
+                    value: None,
+                    value_b: None,
+                    value_c: None,
+                }
+                .encode(),
+            );
+
+            assert_eq!(
+                SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload),
+                Err(ContractError::InvalidInput)
+            );
+            assert_eq!(adapter_for_market(&env, 1).unwrap(), stale_adapter);
+        });
+    }
+
+    #[test]
     fn test_governance_supply_queue_reorder_does_not_require_adapters() {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();
@@ -3013,6 +3090,13 @@ mod storage_tests {
             let mut storage = SorobanStorage::new(&env);
             let policy_state = policy_state_with_supply_queue(&[1, 2]);
             Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(
+                &env,
+                &[
+                    adapter_for_market_one.clone(),
+                    adapter_for_market_two.clone(),
+                ],
+            );
             store_test_adapter_bindings(
                 &env,
                 &[
@@ -3057,6 +3141,13 @@ mod storage_tests {
             let mut storage = SorobanStorage::new(&env);
             let policy_state = policy_state_with_supply_queue(&[1, 2]);
             Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+            store_allowed_adapters(
+                &env,
+                &[
+                    adapter_for_market_one.clone(),
+                    adapter_for_market_two.clone(),
+                ],
+            );
             store_test_adapter_bindings(
                 &env,
                 &[

--- a/contract/vault/soroban/tests/blend_e2e.rs
+++ b/contract/vault/soroban/tests/blend_e2e.rs
@@ -181,16 +181,12 @@ fn vault_allocates_supply_to_blend_and_withdraws_back() {
         execute_governance_command(
             &env,
             &governance,
-            &GovernanceCommand::SetGovernancePolicy {
-                kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
-                target_ids: Some(vec![0u32]),
-                mode: None,
-                accounts: None,
-                market_id: None,
-                cap_group_id: None,
-                value: None,
+            &GovernanceCommand::SetGovernanceConfig {
+                kind: GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS,
+                primary: None,
+                many: Some(vec![address_wire(&adapter)]),
+                value_a: None,
                 value_b: None,
-                value_c: None,
             },
         )
         .unwrap();
@@ -199,12 +195,16 @@ fn vault_allocates_supply_to_blend_and_withdraws_back() {
         execute_governance_command(
             &env,
             &governance,
-            &GovernanceCommand::SetGovernanceConfig {
-                kind: GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS,
-                primary: None,
-                many: Some(vec![address_wire(&adapter)]),
-                value_a: None,
+            &GovernanceCommand::SetGovernancePolicy {
+                kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                target_ids: Some(vec![0u32]),
+                mode: None,
+                accounts: Some(vec![address_wire(&adapter)]),
+                market_id: None,
+                cap_group_id: None,
+                value: None,
                 value_b: None,
+                value_c: None,
             },
         )
         .unwrap();


### PR DESCRIPTION
## Summary
- replace positional supply-queue adapter lookup with immutable market-keyed adapter bindings
- create missing market -> adapter bindings atomically from supply-queue governance proposals via aligned `accounts`
- reject missing adapters for new markets and reject attempts to rebind existing markets
- keep pure queue reorders adapter-free and preserve bindings when markets are removed
- update Blend e2e setup to follow the production binding flow

## Audit Context
- Cluster: `adapter-identity-and-governance`
- Finding: A-001 positional adapter mapping can silently remap markets when the supply queue is reordered
- Base: PR 417 branch `spr/refactor/vault-ergonomics/4f330057`

## Verification
- `cargo test -p templar-soroban-runtime --lib -- --nocapture` — 111 passed
- `cargo test -p templar-soroban-runtime --test blend_e2e -- --nocapture` — 1 passed
- `cargo test -p templar-soroban-runtime -- --nocapture` — passed
- post-commit Soroban size-budget-check — passed, 94149 bytes

## Notes
- `AllowedAdapters` remains an allowlist/config surface, but no longer creates or rewrites market identity.
- `adapter_for_market` now returns `InvalidInput` unless an explicit keyed binding exists.

## Halborn Finding IDs

Included for Halborn SSC GitHub remediation detection:

- A-001 / Finding ID `ced39f48-e0fe-4218-80c3-d631ff6c565e` — Positional adapter mapping causes silent market remap on supply queue reorder

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/426)
<!-- Reviewable:end -->
