### PR TITLE
fix: repair fee-anchor lifecycle accounting

### DIFF
--- a/contract/vault/kernel/src/actions/mod.rs
+++ b/contract/vault/kernel/src/actions/mod.rs
@@ -517,6 +517,50 @@ pub fn convert_to_assets_ceil(state: &VaultState, config: &VaultConfig, shares: 
     conversions::convert_to_assets_ceil(state, config, shares)
 }
 
+/// Convert assets to shares and reject quotients above the operation's legal cap.
+pub fn convert_to_shares_bounded(
+    state: &VaultState,
+    config: &VaultConfig,
+    assets: u128,
+    cap: u128,
+    error: InvalidStateCode,
+) -> Result<u128, KernelError> {
+    conversions::convert_to_shares_bounded(state, config, assets, cap, error)
+}
+
+/// Convert shares to assets and reject quotients above the operation's legal cap.
+pub fn convert_to_assets_bounded(
+    state: &VaultState,
+    config: &VaultConfig,
+    shares: u128,
+    cap: u128,
+    error: InvalidStateCode,
+) -> Result<u128, KernelError> {
+    conversions::convert_to_assets_bounded(state, config, shares, cap, error)
+}
+
+/// Convert assets to shares with ceil rounding and reject quotients above the operation's cap.
+pub fn convert_to_shares_ceil_bounded(
+    state: &VaultState,
+    config: &VaultConfig,
+    assets: u128,
+    cap: u128,
+    error: InvalidStateCode,
+) -> Result<u128, KernelError> {
+    conversions::convert_to_shares_ceil_bounded(state, config, assets, cap, error)
+}
+
+/// Convert shares to assets with ceil rounding and reject quotients above the operation's cap.
+pub fn convert_to_assets_ceil_bounded(
+    state: &VaultState,
+    config: &VaultConfig,
+    shares: u128,
+    cap: u128,
+    error: InvalidStateCode,
+) -> Result<u128, KernelError> {
+    conversions::convert_to_assets_ceil_bounded(state, config, shares, cap, error)
+}
+
 /// Preview the shares minted for a deposit of `assets` using kernel conversions.
 #[inline]
 #[must_use]
@@ -613,7 +657,13 @@ fn mint_fee_shares(
     recipient: Address,
 ) -> Result<(), KernelError> {
     if shares > Number::zero() {
-        let minted: u128 = shares.into();
+        let remaining = u128::MAX.saturating_sub(*total_supply);
+        if shares > Number::from(remaining) {
+            return Err(KernelError::from(
+                InvalidStateCode::FeeMintOverflowTotalSupply,
+            ));
+        }
+        let minted = shares.as_u128_trunc();
         *total_supply = total_supply
             .checked_add(minted)
             .ok_or_else(|| KernelError::from(InvalidStateCode::FeeMintOverflowTotalSupply))?;
@@ -679,7 +729,13 @@ fn handle_deposit(
         return Err(KernelError::ZeroAmount);
     }
 
-    let shares_out = convert_to_shares(&state, config, assets_in);
+    let shares_out = convert_to_shares_bounded(
+        &state,
+        config,
+        assets_in,
+        u128::MAX.saturating_sub(state.total_shares),
+        InvalidStateCode::MintOverflowTotalShares,
+    )?;
     if shares_out < min_shares_out {
         return Err(KernelError::Slippage {
             min: min_shares_out,
@@ -891,7 +947,13 @@ fn plan_withdrawal_request(
     shares: u128,
     min_assets_out: u128,
 ) -> Result<WithdrawalRequestPlan, KernelError> {
-    let expected_assets = convert_to_assets(state, config, shares);
+    let expected_assets = convert_to_assets_bounded(
+        state,
+        config,
+        shares,
+        state.total_assets,
+        InvalidStateCode::RequestWithdrawExpectedAssetsExceedTotalAssets,
+    )?;
     if expected_assets < min_assets_out {
         return Err(KernelError::Slippage {
             min: min_assets_out,
@@ -1004,7 +1066,13 @@ fn handle_atomic_withdraw(
         assets_out,
     )?;
 
-    let shares = convert_to_shares_ceil(&state, config, assets_out);
+    let shares = convert_to_shares_ceil_bounded(
+        &state,
+        config,
+        assets_out,
+        state.total_shares,
+        InvalidStateCode::AtomicWithdrawBurnExceedsTotalShares,
+    )?;
     if shares == 0 {
         return Err(KernelError::ZeroAmount);
     }
@@ -1065,7 +1133,13 @@ fn handle_atomic_redeem(
     enforce_withdrawal_actors(config, restrictions, self_id, &owner, &receiver)?;
     require_idle_with_nonzero_amount(&state, InvalidStateCode::AtomicWithdrawRequiresIdle, shares)?;
 
-    let assets_out = convert_to_assets(&state, config, shares);
+    let assets_out = convert_to_assets_bounded(
+        &state,
+        config,
+        shares,
+        state.idle_assets,
+        InvalidStateCode::AtomicWithdrawExceedsIdleAssets,
+    )?;
     if assets_out == 0 {
         return Err(KernelError::ZeroAmount);
     }
@@ -1835,6 +1909,17 @@ mod conversions {
         ))
     }
 
+    pub(super) fn convert_to_shares_bounded(
+        state: &VaultState,
+        config: &VaultConfig,
+        assets: u128,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        let t = effective_totals(state, config);
+        mul_div_floor_bounded_u128(assets, t.supply, t.assets, cap, error)
+    }
+
     pub(super) fn convert_to_assets(
         state: &VaultState,
         config: &VaultConfig,
@@ -1846,6 +1931,17 @@ mod conversions {
             Number::from(t.assets),
             Number::from(t.supply),
         ))
+    }
+
+    pub(super) fn convert_to_assets_bounded(
+        state: &VaultState,
+        config: &VaultConfig,
+        shares: u128,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        let t = effective_totals(state, config);
+        mul_div_floor_bounded_u128(shares, t.assets, t.supply, cap, error)
     }
 
     pub(super) fn convert_to_shares_ceil(
@@ -1861,6 +1957,17 @@ mod conversions {
         ))
     }
 
+    pub(super) fn convert_to_shares_ceil_bounded(
+        state: &VaultState,
+        config: &VaultConfig,
+        assets: u128,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        let t = effective_totals(state, config);
+        mul_div_ceil_bounded_u128(assets, t.supply, t.assets, cap, error)
+    }
+
     pub(super) fn convert_to_assets_ceil(
         state: &VaultState,
         config: &VaultConfig,
@@ -1872,6 +1979,56 @@ mod conversions {
             Number::from(t.assets),
             Number::from(t.supply),
         ))
+    }
+
+    pub(super) fn convert_to_assets_ceil_bounded(
+        state: &VaultState,
+        config: &VaultConfig,
+        shares: u128,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        let t = effective_totals(state, config);
+        mul_div_ceil_bounded_u128(shares, t.assets, t.supply, cap, error)
+    }
+
+    fn mul_div_floor_bounded_u128(
+        x: u128,
+        y: u128,
+        denominator: u128,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        bounded_u128(
+            mul_div_floor(Number::from(x), Number::from(y), Number::from(denominator)),
+            cap,
+            error,
+        )
+    }
+
+    fn mul_div_ceil_bounded_u128(
+        x: u128,
+        y: u128,
+        denominator: u128,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        bounded_u128(
+            mul_div_ceil(Number::from(x), Number::from(y), Number::from(denominator)),
+            cap,
+            error,
+        )
+    }
+
+    fn bounded_u128(
+        quotient: Number,
+        cap: u128,
+        error: InvalidStateCode,
+    ) -> Result<u128, KernelError> {
+        if quotient > Number::from(cap) {
+            return Err(KernelError::from(error));
+        }
+        Ok(quotient.as_u128_trunc())
     }
 }
 

--- a/contract/vault/kernel/src/actions/mod.rs
+++ b/contract/vault/kernel/src/actions/mod.rs
@@ -736,6 +736,9 @@ fn handle_deposit(
         u128::MAX.saturating_sub(state.total_shares),
         InvalidStateCode::MintOverflowTotalShares,
     )?;
+    if shares_out == 0 {
+        return Err(KernelError::ZeroAmount);
+    }
     if shares_out < min_shares_out {
         return Err(KernelError::Slippage {
             min: min_shares_out,

--- a/contract/vault/kernel/src/actions/mod.rs
+++ b/contract/vault/kernel/src/actions/mod.rs
@@ -20,7 +20,7 @@ use crate::{
     state::{
         op_state::{AllocationPlanEntry, OpState, PayoutState, TargetId},
         queue::{compute_idle_settlement, is_past_cooldown, QueueError, WithdrawQueue},
-        vault::{VaultConfig, VaultState},
+        vault::{FeeAccrualAnchor, VaultConfig, VaultState},
     },
     transitions::TransitionResult,
 };
@@ -671,6 +671,7 @@ fn handle_deposit(
     receiver: Address,
     assets_in: u128,
     min_shares_out: u128,
+    now_ns: TimestampNs,
 ) -> Result<KernelResult, KernelError> {
     enforce_restrictions(config, restrictions, self_id, &owner)?;
     enforce_restrictions(config, restrictions, self_id, &receiver)?;
@@ -701,6 +702,7 @@ fn handle_deposit(
         .total_shares
         .checked_add(shares_out)
         .ok_or_else(|| KernelError::from(InvalidStateCode::MintOverflowTotalShares))?;
+    state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, now_ns);
 
     let effects = vec![
         KernelEffect::TransferAssetsFrom {
@@ -1904,7 +1906,7 @@ mod dispatch {
                 receiver,
                 assets_in,
                 min_shares_out,
-                now_ns: _,
+                now_ns,
             } => handle_deposit(
                 state,
                 config,
@@ -1914,6 +1916,7 @@ mod dispatch {
                 receiver,
                 assets_in,
                 min_shares_out,
+                now_ns,
             ),
 
             KernelAction::AtomicWithdraw {

--- a/contract/vault/kernel/src/actions/mod.rs
+++ b/contract/vault/kernel/src/actions/mod.rs
@@ -1669,7 +1669,7 @@ fn handle_refresh_fees(
     let anchor = state.fee_anchor;
     let mut effects = Vec::new();
 
-    if total_supply > 0 && anchor.is_uninitialized() {
+    if total_supply > 0 && anchor.is_uninitialized() && cur_total_assets == 0 {
         state.fee_anchor = FeeAccrualAnchor::new(cur_total_assets, now_ns);
         effects.push(KernelEffect::EmitEvent {
             event: crate::effects::KernelEvent::FeesRefreshed {
@@ -1784,6 +1784,7 @@ fn handle_emergency_reset(
     }
 
     state.op_state = OpState::Idle;
+    state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, state.fee_anchor.timestamp_ns);
     effects.push(KernelEffect::EmitEvent {
         event: KernelEvent::EmergencyResetCompleted {
             op_id,

--- a/contract/vault/kernel/src/actions/mod.rs
+++ b/contract/vault/kernel/src/actions/mod.rs
@@ -35,9 +35,6 @@ use alloc::vec::Vec;
 use crate::math::wad::{
     compute_fee_shares_from_assets, compute_management_fee_shares, total_assets_for_fee_accrual,
 };
-#[cfg(any(feature = "action-refresh-fees", test))]
-use crate::state::vault::FeeAccrualAnchor;
-
 #[cfg(any(feature = "action-recovery", test))]
 use crate::transitions::stop_withdrawal;
 
@@ -1594,6 +1591,17 @@ fn handle_refresh_fees(
     let mut total_supply = state.total_shares;
     let anchor = state.fee_anchor;
     let mut effects = Vec::new();
+
+    if total_supply > 0 && anchor.is_uninitialized() {
+        state.fee_anchor = FeeAccrualAnchor::new(cur_total_assets, now_ns);
+        effects.push(KernelEffect::EmitEvent {
+            event: crate::effects::KernelEvent::FeesRefreshed {
+                now_ns: now_ns.into(),
+                total_assets: cur_total_assets,
+            },
+        });
+        return Ok(KernelResult::new(state, effects));
+    }
 
     // Cap effective total_assets for fee accrual (mitigates donation attacks)
     let fee_total_assets = total_assets_for_fee_accrual(

--- a/contract/vault/kernel/src/actions/tests.rs
+++ b/contract/vault/kernel/src/actions/tests.rs
@@ -2933,6 +2933,33 @@ fn base_state(total_assets: u128, total_shares: u128) -> VaultState {
 }
 
 #[test]
+#[ignore = "A-006 fee-anchor lifecycle spec: deposit must advance anchor before implementation"]
+fn deposit_advances_fee_anchor_to_post_deposit_assets() {
+    let config = base_config();
+    let mut state = base_state(1_000, 1_000);
+    state.fee_anchor = FeeAccrualAnchor::new(1_000, TimestampNs(10));
+
+    let result = apply_action(
+        state,
+        &config,
+        None,
+        &Address([0u8; 32]),
+        KernelAction::Deposit {
+            owner: Address([1u8; 32]),
+            receiver: Address([2u8; 32]),
+            assets_in: 250,
+            min_shares_out: 0,
+            now_ns: TimestampNs(20),
+        },
+    )
+    .expect("deposit succeeds");
+
+    assert_eq!(result.state.total_assets, 1_250);
+    assert_eq!(result.state.fee_anchor.total_assets, 1_250);
+    assert_eq!(result.state.fee_anchor.timestamp_ns, TimestampNs(20));
+}
+
+#[test]
 fn convert_to_shares_ceil_matches_floor_on_exact_multiple() {
     let config = base_config();
     let state = base_state(100, 100);

--- a/contract/vault/kernel/src/actions/tests.rs
+++ b/contract/vault/kernel/src/actions/tests.rs
@@ -2933,7 +2933,6 @@ fn base_state(total_assets: u128, total_shares: u128) -> VaultState {
 }
 
 #[test]
-#[ignore = "A-006 fee-anchor lifecycle spec: deposit must advance anchor before implementation"]
 fn deposit_advances_fee_anchor_to_post_deposit_assets() {
     let config = base_config();
     let mut state = base_state(1_000, 1_000);

--- a/contract/vault/kernel/src/actions/tests.rs
+++ b/contract/vault/kernel/src/actions/tests.rs
@@ -3085,7 +3085,7 @@ fn refresh_fees_overflow_total_supply_rejected() {
         None,
     );
     let mut state = base_state(1_000, u128::MAX - 1);
-    state.fee_anchor = FeeAccrualAnchor::new(0, TimestampNs(0));
+    state.fee_anchor = FeeAccrualAnchor::new(1, TimestampNs(0));
 
     let result = apply_action(
         state,

--- a/contract/vault/kernel/src/actions/tests.rs
+++ b/contract/vault/kernel/src/actions/tests.rs
@@ -2607,6 +2607,42 @@ fn refresh_fees_no_profit_skips_performance() {
 }
 
 #[test]
+fn refresh_fees_zero_anchor_excludes_uncapped_donation_growth() {
+    use crate::math::wad::YEAR_NS;
+    let mut state = VaultState::with_initial(2_000, 1_000, 2_000, 0, TimestampNs(0));
+    state.fee_anchor = FeeAccrualAnchor::new(0, TimestampNs(0));
+
+    let perf_recipient = addr(0xAA);
+    let mut config = test_config();
+    config.fees = FeesSpec::new(
+        FeeSlot::new(Wad::one() / 10, perf_recipient),
+        FeeSlot::zero(),
+        Some(Wad::one() / 5),
+    );
+
+    let result = apply_action(
+        state,
+        &config,
+        None,
+        &addr(0xFF),
+        KernelAction::RefreshFees {
+            now_ns: TimestampNs(YEAR_NS),
+        },
+    )
+    .unwrap();
+
+    let minted: Vec<_> = result
+        .effects
+        .iter()
+        .filter(|effect| matches!(effect, KernelEffect::MintShares { .. }))
+        .collect();
+    assert!(minted.is_empty());
+    assert_eq!(result.state.total_shares, 1_000);
+    assert_eq!(result.state.fee_anchor.total_assets, 2_000);
+    assert_eq!(result.state.fee_anchor.timestamp_ns, TimestampNs(YEAR_NS));
+}
+
+#[test]
 fn refresh_fees_max_rate_caps_fee_accrual() {
     use crate::math::wad::YEAR_NS;
     // 1000 -> 2000 (100% profit), but max_rate = 20% per year

--- a/contract/vault/kernel/src/actions/tests.rs
+++ b/contract/vault/kernel/src/actions/tests.rs
@@ -344,6 +344,28 @@ fn deposit_zero_assets_fails_slippage() {
 }
 
 #[test]
+fn deposit_that_would_mint_zero_shares_fails_before_mutation() {
+    let state = idle_state(u128::MAX, 1);
+    let config = test_config();
+
+    let result = apply_action(
+        state,
+        &config,
+        None,
+        &addr(0xFF),
+        KernelAction::Deposit {
+            owner: addr(1),
+            receiver: addr(2),
+            assets_in: 1,
+            min_shares_out: 0,
+            now_ns: TimestampNs(0),
+        },
+    );
+
+    assert!(matches!(result, Err(KernelError::ZeroAmount)));
+}
+
+#[test]
 fn deposit_slippage_check_fails() {
     let state = idle_state(1_000, 1_000);
     let config = test_config();

--- a/contract/vault/kernel/src/error.rs
+++ b/contract/vault/kernel/src/error.rs
@@ -49,6 +49,7 @@ pub enum InvalidStateCode {
     RebalanceWithdrawRequiresIdle = 38,
     RebalanceWithdrawExceedsExternalAssets = 39,
     RebalanceWithdrawOverflowsIdleAssets = 40,
+    RequestWithdrawExpectedAssetsExceedTotalAssets = 41,
 }
 
 impl InvalidStateCode {
@@ -120,6 +121,9 @@ impl InvalidStateCode {
             }
             Self::RebalanceWithdrawOverflowsIdleAssets => {
                 "rebalance_withdraw would overflow idle_assets"
+            }
+            Self::RequestWithdrawExpectedAssetsExceedTotalAssets => {
+                "request_withdraw expected assets exceed total_assets"
             }
         }
     }

--- a/contract/vault/kernel/src/lib.rs
+++ b/contract/vault/kernel/src/lib.rs
@@ -21,10 +21,11 @@ pub mod types;
 pub mod utils;
 
 pub use actions::{
-    apply_action, convert_to_assets, convert_to_assets_ceil, convert_to_shares,
-    convert_to_shares_ceil, effective_totals, plan_idle_payout, preview_deposit_shares,
-    preview_withdraw_assets, EffectiveTotals, IdlePayoutPlan, KernelAction, KernelResult,
-    PayoutOutcome,
+    apply_action, convert_to_assets, convert_to_assets_bounded, convert_to_assets_ceil,
+    convert_to_assets_ceil_bounded, convert_to_shares, convert_to_shares_bounded,
+    convert_to_shares_ceil, convert_to_shares_ceil_bounded, effective_totals, plan_idle_payout,
+    preview_deposit_shares, preview_withdraw_assets, EffectiveTotals, IdlePayoutPlan, KernelAction,
+    KernelResult, PayoutOutcome,
 };
 pub use address_book::AddressBook;
 pub use fee::{Fee, FeeSlot, Fees, FeesSpec};

--- a/contract/vault/kernel/src/math/wad.rs
+++ b/contract/vault/kernel/src/math/wad.rs
@@ -303,7 +303,10 @@ pub const YEAR_NS: u64 = 365 * 24 * 60 * 60 * 1_000_000_000;
 /// to the max rate if configured.
 ///
 /// When `max_rate` is `Some`, limits the effective total_assets to
-/// `anchor_total_assets * (1 + max_rate * elapsed / YEAR)`.
+/// `anchor_total_assets * (1 + max_rate * elapsed / YEAR)`. If the anchor
+/// asset value is zero, any positive current assets are treated as uncapped
+/// zero-anchor growth and excluded from fee accrual until the anchor is
+/// advanced by the caller.
 #[inline]
 #[must_use]
 pub fn total_assets_for_fee_accrual(
@@ -316,11 +319,11 @@ pub fn total_assets_for_fee_accrual(
     let Some(max_rate) = max_rate else {
         return cur_total_assets;
     };
-    if cur_total_assets <= anchor_total_assets
-        || anchor_total_assets == 0
-        || now_ns < anchor_timestamp_ns
-    {
+    if cur_total_assets <= anchor_total_assets || now_ns < anchor_timestamp_ns {
         return cur_total_assets;
+    }
+    if anchor_total_assets == 0 {
+        return 0;
     }
     let elapsed_ns = now_ns - anchor_timestamp_ns;
     if elapsed_ns == 0 {

--- a/contract/vault/kernel/src/state/vault/mod.rs
+++ b/contract/vault/kernel/src/state/vault/mod.rs
@@ -45,6 +45,12 @@ impl FeeAccrualAnchor {
     }
 
     #[inline]
+    #[must_use]
+    pub const fn is_uninitialized(self) -> bool {
+        self.total_assets == 0 && self.timestamp_ns.as_u64() == 0
+    }
+
+    #[inline]
     pub fn update(&mut self, total_assets: u128, timestamp_ns: TimestampNs) {
         self.total_assets = total_assets;
         self.timestamp_ns = timestamp_ns;

--- a/contract/vault/kernel/tests/property_tests.rs
+++ b/contract/vault/kernel/tests/property_tests.rs
@@ -952,21 +952,19 @@ proptest! {
 
     /// Property 45a / A-031: fee minting near u128::MAX either succeeds or errors, never truncates.
     ///
-    /// Ignored as a red spec until A-031 is fixed. The current implementation converts
-    /// the 256-bit fee-share quotient with `Number::as_u128_trunc`, so values above
-    /// `u128::MAX` can wrap to a small mint instead of tripping the total-supply guard.
+    /// Fee minting now checks the full-width quotient against remaining supply before
+    /// converting to `u128`.
     #[test]
-    #[ignore = "A-031 red spec: fee-share quotient truncates before overflow checks"]
     fn prop_a031_fee_mint_overflow_handled(
         total_supply in (u128::MAX - 1_000_000u128)..=u128::MAX,
-        cur_total_assets in 1u128..=1_000_000u128,
+        cur_total_assets in 2u128..=1_000_000u128,
         fee_wad in (Wad::SCALE / 10)..=Wad::SCALE,
     ) {
         let state = VaultState {
             total_assets: cur_total_assets,
             total_shares: total_supply,
             idle_assets: cur_total_assets,
-            fee_anchor: FeeAccrualAnchor::new(0, TimestampNs(0)),
+            fee_anchor: FeeAccrualAnchor::new(1, TimestampNs(0)),
             ..VaultState::default()
         };
 
@@ -986,7 +984,7 @@ proptest! {
         );
 
         let fee_assets =
-            Wad::from(fee_wad).apply_floored(Number::from(cur_total_assets));
+            Wad::from(fee_wad).apply_floored(Number::from(cur_total_assets - 1));
         let fee_shares = compute_fee_shares_from_assets(
             fee_assets,
             Number::from(cur_total_assets),
@@ -1023,12 +1021,10 @@ proptest! {
 
     /// Property 45b / A-031: nonzero deposits must not wrap to zero shares.
     ///
-    /// Ignored as a red spec until conversion helpers fail closed. At the Soroban
-    /// `i128::MAX` share boundary with one effective asset, a two-asset deposit has
-    /// a raw share quotient of exactly `2^128`; truncation wraps it to zero and the
-    /// kernel records the transferred assets as vault NAV without minting shares.
+    /// At the Soroban `i128::MAX` share boundary with one effective asset, a two-asset
+    /// deposit has a raw share quotient of exactly `2^128`; the deposit must reject
+    /// before recording the transferred assets or minting truncated shares.
     #[test]
-    #[ignore = "A-031 red spec: deposit conversion truncates 2^128 to zero shares"]
     fn prop_a031_deposit_payment_does_not_wrap_to_zero_shares(
         total_shares in Just(i128::MAX as u128),
         assets_in in Just(2u128),

--- a/contract/vault/kernel/tests/property_tests.rs
+++ b/contract/vault/kernel/tests/property_tests.rs
@@ -950,9 +950,14 @@ proptest! {
         prop_assert!(result1.0 <= result2.0);
     }
 
-    /// Property 45a: fee minting near u128::MAX either succeeds or errors, never truncates
+    /// Property 45a / A-031: fee minting near u128::MAX either succeeds or errors, never truncates.
+    ///
+    /// Ignored as a red spec until A-031 is fixed. The current implementation converts
+    /// the 256-bit fee-share quotient with `Number::as_u128_trunc`, so values above
+    /// `u128::MAX` can wrap to a small mint instead of tripping the total-supply guard.
     #[test]
-    fn prop_fee_mint_overflow_handled(
+    #[ignore = "A-031 red spec: fee-share quotient truncates before overflow checks"]
+    fn prop_a031_fee_mint_overflow_handled(
         total_supply in (u128::MAX - 1_000_000u128)..=u128::MAX,
         cur_total_assets in 1u128..=1_000_000u128,
         fee_wad in (Wad::SCALE / 10)..=Wad::SCALE,
@@ -1012,6 +1017,59 @@ proptest! {
             }
             Err(_) => {
                 prop_assert!(would_overflow);
+            }
+        }
+    }
+
+    /// Property 45b / A-031: nonzero deposits must not wrap to zero shares.
+    ///
+    /// Ignored as a red spec until conversion helpers fail closed. At the Soroban
+    /// `i128::MAX` share boundary with one effective asset, a two-asset deposit has
+    /// a raw share quotient of exactly `2^128`; truncation wraps it to zero and the
+    /// kernel records the transferred assets as vault NAV without minting shares.
+    #[test]
+    #[ignore = "A-031 red spec: deposit conversion truncates 2^128 to zero shares"]
+    fn prop_a031_deposit_payment_does_not_wrap_to_zero_shares(
+        total_shares in Just(i128::MAX as u128),
+        assets_in in Just(2u128),
+    ) {
+        let state = VaultState {
+            total_assets: 0,
+            total_shares,
+            idle_assets: 0,
+            ..VaultState::default()
+        };
+        let mut config = default_config();
+        config.virtual_shares = 0;
+        config.virtual_assets = 0;
+
+        let result = apply_action(
+            state,
+            &config,
+            None,
+            &self_addr(),
+            KernelAction::Deposit {
+                owner: owner_addr(1),
+                receiver: receiver_addr(1),
+                assets_in,
+                min_shares_out: 0,
+                now_ns: TimestampNs(1),
+            },
+        );
+
+        match result {
+            Ok(result) => {
+                let minted = result.effects.iter().find_map(|effect| match effect {
+                    KernelEffect::MintShares { shares, .. } => Some(*shares),
+                    _ => None,
+                });
+                prop_assert!(
+                    minted.unwrap_or_default() > 0,
+                    "nonzero asset payment minted zero shares after quotient truncation"
+                );
+            }
+            Err(_) => {
+                prop_assert!(true);
             }
         }
     }

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -67,6 +67,20 @@ sequenceDiagram
     Entry-->>Caller: return result
 ```
 
+### Fee Anchor And Idle Balance Accounting
+
+The Soroban vault treats unsolicited underlying transfers as idle assets for existing
+shareholders, not as profit that the next depositor can capture. Read-only conversion and preview
+helpers first compare the persisted `idle_assets` value with the asset token balance held by the
+vault and simulate the reconciled state before quoting shares or assets.
+
+State-changing paths that depend on current share pricing use the same lazy reconciliation rule
+before executing kernel actions. `DepositWithMin`, `RefreshFees`, and `ResyncIdleBalance` all read
+the live asset token balance, update `idle_assets`, recompute `total_assets`, and reset the
+`fee_anchor` to the reconciled total at the current ledger timestamp. This keeps direct transfers,
+fee refreshes, and later deposits on one accounting baseline without requiring a separate keeper
+transaction before every user deposit.
+
 ### Governance Control-Plane Boundary
 
 - The governance contract owns proposal submission, timelocks, approval/revocation, and abdication.

--- a/contract/vault/soroban/shared-types/src/lib.rs
+++ b/contract/vault/soroban/shared-types/src/lib.rs
@@ -528,6 +528,19 @@ mod tests {
     }
 
     #[test]
+    #[ignore = "A-018 fee-anchor lifecycle spec: deployed command ABI needs an explicit fee refresh path before implementation"]
+    fn vault_command_surface_exposes_fee_refresh() {
+        let mut encoded = Vec::new();
+        encoded.push(5);
+        encoded.extend_from_slice(&1_000u64.to_le_bytes());
+
+        assert!(
+            VaultCommand::decode(&encoded).is_ok(),
+            "VaultCommand has no fee-refresh command tag; persisted fee accrual is unreachable through the deployed ABI"
+        );
+    }
+
+    #[test]
     fn governance_command_roundtrip_representative() {
         let commands = vec![
             GovernanceCommand::SetGovernanceConfig {

--- a/contract/vault/soroban/shared-types/src/lib.rs
+++ b/contract/vault/soroban/shared-types/src/lib.rs
@@ -229,6 +229,7 @@ pub enum VaultCommand {
         caller: String,
         markets: Vec<u32>,
     },
+    RefreshFees,
     ResyncIdleBalance,
     CancelMigration {
         caller: String,
@@ -335,6 +336,7 @@ impl VaultCommand {
                 push_string(&mut out, caller);
                 push_u32_vec(&mut out, markets);
             }
+            Self::RefreshFees => push_u8(&mut out, 5),
             Self::ResyncIdleBalance => push_u8(&mut out, 8),
             Self::CancelMigration { caller } => {
                 push_u8(&mut out, 9);
@@ -377,6 +379,7 @@ impl VaultCommand {
                 caller: read_string(bytes, &mut cursor)?,
                 markets: read_u32_vec(bytes, &mut cursor)?,
             }),
+            5 => Ok(Self::RefreshFees),
             8 => Ok(Self::ResyncIdleBalance),
             9 => Ok(Self::CancelMigration {
                 caller: read_string(bytes, &mut cursor)?,
@@ -515,6 +518,7 @@ mod tests {
                 min_shares_out: 1,
             },
             VaultCommand::ResyncIdleBalance,
+            VaultCommand::RefreshFees,
             VaultCommand::CancelMigration {
                 caller: String::from("caller"),
             },
@@ -528,11 +532,9 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "A-018 fee-anchor lifecycle spec: deployed command ABI needs an explicit fee refresh path before implementation"]
     fn vault_command_surface_exposes_fee_refresh() {
         let mut encoded = Vec::new();
         encoded.push(5);
-        encoded.extend_from_slice(&1_000u64.to_le_bytes());
 
         assert!(
             VaultCommand::decode(&encoded).is_ok(),

--- a/contract/vault/soroban/src/contract/curator_vault.rs
+++ b/contract/vault/soroban/src/contract/curator_vault.rs
@@ -332,6 +332,17 @@ where
     }
 
     #[inline(never)]
+    pub fn refresh_fees(&mut self, now_ns: u64) -> Result<(), RuntimeError> {
+        self.apply_kernel_action(
+            KernelAction::RefreshFees {
+                now_ns: TimestampNs(now_ns),
+            },
+            now_ns,
+        )?;
+        Ok(())
+    }
+
+    #[inline(never)]
     pub fn execute_withdraw(
         &mut self,
         caller: Address,

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -925,14 +925,32 @@ impl SorobanVaultContract {
             0
         } else {
             let assets_u128 = to_u128(assets)?;
-            to_i128(convert_to_shares(&state, &config, assets_u128))?
+            to_i128(
+                convert_to_shares_bounded(
+                    &state,
+                    &config,
+                    assets_u128,
+                    i128::MAX as u128,
+                    InvalidStateCode::MintOverflowTotalShares,
+                )
+                .map_err(|_| ContractError::ConversionOverflow)?,
+            )?
         };
 
         let convert_to_assets_value = if shares <= 0 {
             0
         } else {
             let shares_u128 = to_u128(shares)?;
-            to_i128(convert_to_assets(&state, &config, shares_u128))?
+            to_i128(
+                convert_to_assets_bounded(
+                    &state,
+                    &config,
+                    shares_u128,
+                    i128::MAX as u128,
+                    InvalidStateCode::RequestWithdrawExpectedAssetsExceedTotalAssets,
+                )
+                .map_err(|_| ContractError::ConversionOverflow)?,
+            )?
         };
 
         let (max_deposit_value, max_mint_value) = if state.op_state.is_idle() && !config.paused {
@@ -949,10 +967,24 @@ impl SorobanVaultContract {
 
         let owner_shares = share_balance(&env, &owner).max(0) as u128;
         let (max_withdraw_value, max_redeem_value) = if state.op_state.is_idle() {
-            let max_redeem_u128 =
-                owner_shares.min(convert_to_shares(&state, &config, state.idle_assets));
-            let max_withdraw_u128 =
-                convert_to_assets(&state, &config, owner_shares).min(state.idle_assets);
+            let max_redeem_u128 = owner_shares.min(
+                convert_to_shares_bounded(
+                    &state,
+                    &config,
+                    state.idle_assets,
+                    i128::MAX as u128,
+                    InvalidStateCode::MintOverflowTotalShares,
+                )
+                .map_err(|_| ContractError::ConversionOverflow)?,
+            );
+            let max_withdraw_u128 = convert_to_assets_bounded(
+                &state,
+                &config,
+                owner_shares,
+                state.idle_assets.min(i128::MAX as u128),
+                InvalidStateCode::AtomicWithdrawExceedsIdleAssets,
+            )
+            .map_err(|_| ContractError::ConversionOverflow)?;
             (to_i128(max_withdraw_u128)?, to_i128(max_redeem_u128)?)
         } else {
             (0, 0)
@@ -962,14 +994,32 @@ impl SorobanVaultContract {
             0
         } else {
             let shares_u128 = to_u128(shares)?;
-            to_i128(convert_to_assets_ceil(&state, &config, shares_u128))?
+            to_i128(
+                convert_to_assets_ceil_bounded(
+                    &state,
+                    &config,
+                    shares_u128,
+                    i128::MAX as u128,
+                    InvalidStateCode::RequestWithdrawExpectedAssetsExceedTotalAssets,
+                )
+                .map_err(|_| ContractError::ConversionOverflow)?,
+            )?
         };
 
         let preview_withdraw_value = if assets <= 0 {
             0
         } else {
             let assets_u128 = to_u128(assets)?;
-            to_i128(convert_to_shares_ceil(&state, &config, assets_u128))?
+            to_i128(
+                convert_to_shares_ceil_bounded(
+                    &state,
+                    &config,
+                    assets_u128,
+                    i128::MAX as u128,
+                    InvalidStateCode::AtomicWithdrawBurnExceedsTotalShares,
+                )
+                .map_err(|_| ContractError::ConversionOverflow)?,
+            )?
         };
 
         Ok((

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -25,6 +25,7 @@ use templar_soroban_shared_types::{
     GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
 };
 use templar_vault_kernel::state::op_state::AllocationPlanEntry;
+use templar_vault_kernel::{FeeAccrualAnchor, TimestampNs};
 
 fn required_address(
     value: Option<soroban_sdk::Address>,
@@ -321,8 +322,8 @@ fn apply_fees_policy(
     if accounts.len() != 2 {
         return Err(ContractError::InvalidInput);
     }
-    let performance_recipient = accounts.get_unchecked(0);
-    let management_recipient = accounts.get_unchecked(1);
+    let performance_recipient = accounts.get(0).ok_or(ContractError::InvalidInput)?;
+    let management_recipient = accounts.get(1).ok_or(ContractError::InvalidInput)?;
     apply_fee_change(
         env,
         performance_fee_wad,
@@ -332,6 +333,17 @@ fn apply_fees_policy(
         max_growth_rate_wad,
     )?;
     emit_admin_event(env, symbol_short!("s_fees"));
+    Ok(())
+}
+
+fn normalize_fee_anchor(env: &Env) -> Result<(), ContractError> {
+    let mut storage = SorobanStorage::new(env);
+    let Some(mut state) = storage.load_state()? else {
+        return Ok(());
+    };
+    state.fee_anchor =
+        FeeAccrualAnchor::new(state.total_assets, TimestampNs(ledger_timestamp_ns(env)?));
+    storage.save_state(&state)?;
     Ok(())
 }
 
@@ -1093,6 +1105,7 @@ impl SorobanVaultContract {
         }
 
         migrate_legacy_paused(&env);
+        normalize_fee_anchor(&env)?;
         extend_storage_ttl(&env);
         set_migration_in_progress(&env, false);
         emit_admin_event(&env, symbol_short!("migrate"));

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -407,7 +407,14 @@ fn refresh_fees_impl(env: &Env) -> Result<(), ContractError> {
     let now_ns = ledger_timestamp_ns(env)?;
 
     let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {
+        let anchor_before = vault.get_fee_anchor()?;
         reconcile_current_idle_assets(env, vault, now_ns)?;
+        let anchor_after = vault.get_fee_anchor()?;
+        if anchor_before.timestamp_ns != anchor_after.timestamp_ns
+            && anchor_after.timestamp_ns.as_u64() == now_ns
+        {
+            return Ok(());
+        }
         vault.refresh_fees(now_ns)
     };
     with_contract_vault_contract_error(env, &mut call)

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -388,6 +388,16 @@ fn request_withdraw_impl(
     Ok(request_id)
 }
 
+fn refresh_fees_impl(env: &Env) -> Result<(), ContractError> {
+    let now_ns = ledger_timestamp_ns(env)?;
+
+    let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {
+        reconcile_current_idle_assets(env, vault, now_ns)?;
+        vault.refresh_fees(now_ns)
+    };
+    with_contract_vault_contract_error(env, &mut call)
+}
+
 fn execute_withdraw_impl(env: &Env, caller: soroban_sdk::Address) -> Result<(), ContractError> {
     require_signed(&caller);
     let now_ns = ledger_timestamp_ns(env)?;
@@ -715,6 +725,10 @@ fn execute_public_command(
                 address_from_alloc_string(env, &caller)?,
                 sdk_markets,
             )?))
+        }
+        VaultCommand::RefreshFees => {
+            refresh_fees_impl(env)?;
+            Ok(VaultCommandResult::Unit)
         }
         VaultCommand::ResyncIdleBalance => {
             resync_idle_balance_impl(env)?;

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -7,12 +7,13 @@ use super::helpers::{
     adapter_for_market, address_from_alloc_string, addresses_from_alloc_strings, apply_fee_change,
     current_supply_queue_len, emit_admin_event, emit_alloc_event, emit_pause_state_event,
     extend_storage_ttl, get_config_address, governance_caller, kernel_address_from_sdk,
-    load_virtual_offsets, migrate_legacy_paused, migration_in_progress, require_contract_address,
-    require_governance, require_signed, sdk_string_to_alloc, set_config_address,
-    set_migration_in_progress, store_fees_spec, store_virtual_offsets,
-    with_contract_vault_contract_error,
+    load_virtual_offsets, lock_virtual_offsets, migrate_legacy_paused, migration_in_progress,
+    require_contract_address, require_governance, require_signed, sdk_string_to_alloc,
+    set_config_address, set_migration_in_progress, store_fees_spec, store_virtual_offsets,
+    virtual_offsets_locked, with_contract_vault_contract_error,
 };
 use super::*;
+use crate::storage::{SorobanStorage, Storage};
 use templar_soroban_shared_types::{
     GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_ALLOCATORS,
     GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS, GOVERNANCE_CONFIG_KIND_CURATOR,
@@ -141,6 +142,15 @@ fn apply_virtual_offsets_config(
     virtual_shares: i128,
     virtual_assets: i128,
 ) -> Result<(), ContractError> {
+    if virtual_offsets_locked(env) {
+        return Err(ContractError::InvalidState);
+    }
+    if let Some(state) = SorobanStorage::new(env).load_state()? {
+        if state.total_assets != 0 || state.total_shares != 0 {
+            return Err(ContractError::InvalidState);
+        }
+    }
+
     let virtual_shares = to_u128(virtual_shares)?;
     let virtual_assets = to_u128(virtual_assets)?;
     store_virtual_offsets(env, virtual_shares, virtual_assets);
@@ -346,14 +356,19 @@ fn deposit_with_min_impl(
     let now_ns = ledger_timestamp_ns(env)?;
 
     let mut shares_minted = 0u128;
+    let mut is_capitalized = false;
     let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {
         reconcile_current_idle_assets(env, vault, now_ns)?;
         let (caller_k, receiver_k) = vault.map_pair(env, &owner, &receiver)?;
         let result = vault.deposit(caller_k, receiver_k, assets_u128, min_shares_u128, now_ns)?;
         shares_minted = result.shares_minted;
+        is_capitalized = result.total_assets != 0 && result.total_shares != 0;
         Ok(())
     };
     with_contract_vault_contract_error(env, &mut call)?;
+    if shares_minted != 0 && is_capitalized {
+        lock_virtual_offsets(env);
+    }
     to_i128(shares_minted)
 }
 

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -41,6 +41,39 @@ fn required_i128(value: Option<i128>) -> Result<i128, ContractError> {
     value.ok_or(ContractError::InvalidInput)
 }
 
+fn current_idle_assets(env: &Env) -> Result<u128, ContractError> {
+    let asset_token = get_config_address(env, &VaultDataKey::AssetToken)?;
+    let client = soroban_sdk::token::Client::new(env, &asset_token);
+    to_u128(client.balance(&env.current_contract_address()))
+}
+
+fn reconcile_current_idle_assets(
+    env: &Env,
+    vault: &mut ContractVault<'_>,
+    now_ns: u64,
+) -> Result<(), RuntimeError> {
+    let actual_idle_assets =
+        current_idle_assets(env).map_err(|_| RuntimeError::storage_error(""))?;
+    let state = vault.state_mut()?;
+    reconcile_actual_idle_assets(state, actual_idle_assets, now_ns);
+    Ok(())
+}
+
+fn reconcile_current_idle_assets_while_idle(
+    env: &Env,
+    vault: &mut ContractVault<'_>,
+    now_ns: u64,
+) -> Result<(), RuntimeError> {
+    if !vault.state()?.op_state.is_idle() {
+        return Err(RuntimeError::invalid_state(""));
+    }
+    reconcile_current_idle_assets(env, vault, now_ns)?;
+    if !vault.state()?.op_state.is_idle() {
+        return Err(RuntimeError::invalid_state(""));
+    }
+    Ok(())
+}
+
 fn apply_curator_config(env: &Env, new_curator: soroban_sdk::Address) {
     set_config_address(env, &VaultDataKey::Curator, &new_curator);
     emit_admin_event(env, symbol_short!("s_curatr"));
@@ -314,6 +347,7 @@ fn deposit_with_min_impl(
 
     let mut shares_minted = 0u128;
     let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {
+        reconcile_current_idle_assets(env, vault, now_ns)?;
         let (caller_k, receiver_k) = vault.map_pair(env, &owner, &receiver)?;
         let result = vault.deposit(caller_k, receiver_k, assets_u128, min_shares_u128, now_ns)?;
         shares_minted = result.shares_minted;
@@ -604,24 +638,8 @@ fn resync_idle_balance_impl(env: &Env) -> Result<(), ContractError> {
     if last_ns != 0 && now_ns.saturating_sub(last_ns) < cooldown_ns {
         return Err(ContractError::InvalidState);
     }
-    let asset_token = get_config_address(env, &VaultDataKey::AssetToken)?;
-    let client = soroban_sdk::token::Client::new(env, &asset_token);
-    let actual_balance = to_u128(client.balance(&env.current_contract_address()))?;
     let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {
-        let state = vault.state_mut()?;
-        let before_idle = state.idle_assets;
-        if !state.op_state.is_idle() {
-            return Err(RuntimeError::invalid_state(""));
-        }
-
-        state.idle_assets = actual_balance;
-        state.sync_total_assets();
-
-        if actual_balance > before_idle {
-            let delta = actual_balance - before_idle;
-            state.fee_anchor.total_assets = state.fee_anchor.total_assets.saturating_add(delta);
-        }
-
+        reconcile_current_idle_assets_while_idle(env, vault, now_ns)?;
         vault.save_state()?;
         Ok(())
     };

--- a/contract/vault/soroban/src/contract/helpers.rs
+++ b/contract/vault/soroban/src/contract/helpers.rs
@@ -247,6 +247,19 @@ pub(crate) fn store_virtual_offsets(env: &Env, virtual_shares: u128, virtual_ass
         .set(&VaultDataKey::VirtualAssets, &virtual_assets);
 }
 
+pub(crate) fn virtual_offsets_locked(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&VaultDataKey::VirtualOffsetsLocked)
+        .unwrap_or(false)
+}
+
+pub(crate) fn lock_virtual_offsets(env: &Env) {
+    env.storage()
+        .instance()
+        .set(&VaultDataKey::VirtualOffsetsLocked, &true);
+}
+
 #[allow(deprecated)]
 #[inline(never)]
 pub(crate) fn emit_admin_event(env: &Env, action: soroban_sdk::Symbol) {

--- a/contract/vault/soroban/src/contract/mod.rs
+++ b/contract/vault/soroban/src/contract/mod.rs
@@ -45,13 +45,14 @@ use templar_curator_primitives::rbac::{RbacAuth, RbacConfig, Role};
 use templar_curator_primitives::PolicyState;
 use templar_soroban_shared_types::{VaultCommand, VaultCommandResult};
 use templar_vault_kernel::effects::KernelEffect;
+use templar_vault_kernel::error::InvalidStateCode;
 use templar_vault_kernel::state::queue::DEFAULT_COOLDOWN_NS;
 use templar_vault_kernel::{
-    apply_action, convert_to_assets, convert_to_assets_ceil, convert_to_shares,
-    convert_to_shares_ceil, plan_idle_payout, withdrawal_settled, Address, FeeAccrualAnchor,
-    FeeSlot, FeesSpec, KernelAction, OpState, PayoutOutcome, Restrictions, TargetId, TimestampNs,
-    VaultConfig, VaultState, Wad, MAX_MANAGEMENT_FEE_WAD, MAX_PENDING, MAX_PERFORMANCE_FEE_WAD,
-    MIN_WITHDRAWAL_ASSETS,
+    apply_action, convert_to_assets_bounded, convert_to_assets_ceil_bounded,
+    convert_to_shares_bounded, convert_to_shares_ceil_bounded, plan_idle_payout,
+    withdrawal_settled, Address, FeeAccrualAnchor, FeeSlot, FeesSpec, KernelAction, OpState,
+    PayoutOutcome, Restrictions, TargetId, TimestampNs, VaultConfig, VaultState, Wad,
+    MAX_MANAGEMENT_FEE_WAD, MAX_PENDING, MAX_PERFORMANCE_FEE_WAD, MIN_WITHDRAWAL_ASSETS,
 };
 
 pub(crate) const KERNEL_ADDRESS_DOMAIN: &[u8] = b"templar:soroban:address";

--- a/contract/vault/soroban/src/contract/mod.rs
+++ b/contract/vault/soroban/src/contract/mod.rs
@@ -26,7 +26,7 @@ use crate::effects::{
     ShareTokenAdapter, SorobanEffectInterpreter,
 };
 use crate::error::{ContractError, RuntimeError};
-use crate::fungible_vault::{load_state_and_config, share_balance};
+use crate::fungible_vault::{load_state_and_config, reconcile_actual_idle_assets, share_balance};
 use crate::market::{invoke_progress_withdrawal, invoke_supply, invoke_total_assets};
 use crate::storage::{SorobanStorage, Storage, DEFAULT_TTL_EXTEND_TO, DEFAULT_TTL_THRESHOLD};
 use alloc::string::String as AllocString;

--- a/contract/vault/soroban/src/contract/types.rs
+++ b/contract/vault/soroban/src/contract/types.rs
@@ -165,6 +165,7 @@ impl VaultDataKey {
     pub const SkimRecipient: Symbol = soroban_sdk::symbol_short!("skimrcp");
     pub const VirtualShares: Symbol = soroban_sdk::symbol_short!("vshares");
     pub const VirtualAssets: Symbol = soroban_sdk::symbol_short!("vassets");
+    pub const VirtualOffsetsLocked: Symbol = soroban_sdk::symbol_short!("vofflock");
     pub const IdleResyncLastNs: Symbol = soroban_sdk::symbol_short!("idlrsync");
 }
 

--- a/contract/vault/soroban/src/fungible_vault.rs
+++ b/contract/vault/soroban/src/fungible_vault.rs
@@ -22,7 +22,7 @@ use templar_vault_kernel::{
 };
 
 use crate::contract::{load_fees_spec, load_virtual_offsets, VaultDataKey};
-use crate::convert::{ledger_timestamp_ns, runtime_to_contract};
+use crate::convert::{ledger_timestamp_ns, runtime_to_contract, to_u128};
 use crate::error::ContractError;
 use crate::storage::{SorobanStorage, Storage};
 
@@ -85,11 +85,36 @@ fn preview_state_with_fee_accrual(
     Ok(state)
 }
 
+fn load_actual_idle_assets(env: &Env) -> Result<u128, ContractError> {
+    let asset_token: Option<SdkAddress> = env.storage().instance().get(&VaultDataKey::AssetToken);
+    let Some(asset_token) = asset_token else {
+        return Ok(0);
+    };
+    to_u128(token::Client::new(env, &asset_token).balance(&env.current_contract_address()))
+}
+
+pub(crate) fn reconcile_actual_idle_assets(
+    state: &mut VaultState,
+    actual_idle_assets: u128,
+    now_ns: u64,
+) {
+    if !state.is_idle() || state.idle_assets == actual_idle_assets {
+        return;
+    }
+
+    state.idle_assets = actual_idle_assets;
+    state.sync_total_assets();
+    state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, TimestampNs(now_ns));
+}
+
 /// Load kernel state and a default config for read-only conversion math.
 pub(crate) fn load_state_and_config(env: &Env) -> Result<(VaultState, VaultConfig), ContractError> {
     let storage = SorobanStorage::new(env);
     let stored_state = storage.load_state();
-    let state = runtime_to_contract(stored_state)?.unwrap_or_default();
+    let mut state = runtime_to_contract(stored_state)?.unwrap_or_default();
+    let now_ns = ledger_timestamp_ns(env)?;
+    let actual_idle_assets = load_actual_idle_assets(env)?;
+    reconcile_actual_idle_assets(&mut state, actual_idle_assets, now_ns);
     let (virtual_shares, virtual_assets) = load_virtual_offsets(env);
     let config = VaultConfig {
         fees: runtime_to_contract(load_fees_spec(env))?,

--- a/contract/vault/soroban/src/fungible_vault.rs
+++ b/contract/vault/soroban/src/fungible_vault.rs
@@ -104,7 +104,8 @@ pub(crate) fn reconcile_actual_idle_assets(
 
     state.idle_assets = actual_idle_assets;
     state.sync_total_assets();
-    state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, TimestampNs(now_ns));
+    let observed_at = TimestampNs(now_ns);
+    state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, observed_at);
 }
 
 /// Load kernel state and a default config for read-only conversion math.

--- a/contract/vault/soroban/src/fungible_vault.rs
+++ b/contract/vault/soroban/src/fungible_vault.rs
@@ -32,9 +32,16 @@ fn preview_state_with_fee_accrual(
     config: &VaultConfig,
 ) -> Result<VaultState, ContractError> {
     let now_ns = ledger_timestamp_ns(env)?;
-    let anchor = state.fee_anchor;
+    if state.total_shares == 0 {
+        return Ok(state);
+    }
 
-    if state.total_shares == 0 || now_ns <= anchor.timestamp_ns.as_u64() {
+    let anchor = state.fee_anchor;
+    if anchor.is_uninitialized() {
+        state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, TimestampNs(now_ns));
+        return Ok(state);
+    }
+    if now_ns <= anchor.timestamp_ns.as_u64() {
         return Ok(state);
     }
 

--- a/contract/vault/soroban/src/fungible_vault.rs
+++ b/contract/vault/soroban/src/fungible_vault.rs
@@ -37,7 +37,7 @@ fn preview_state_with_fee_accrual(
     }
 
     let anchor = state.fee_anchor;
-    if anchor.is_uninitialized() {
+    if anchor.is_uninitialized() && state.total_assets == 0 {
         state.fee_anchor = FeeAccrualAnchor::new(state.total_assets, TimestampNs(now_ns));
         return Ok(state);
     }

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -1043,6 +1043,122 @@ mod contract_tests {
     }
 
     #[test]
+    fn test_rejects_virtual_offset_updates_after_capitalization() {
+        use soroban_sdk::testutils::Address as _;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = soroban_sdk::Address::generate(&env);
+        let governance = soroban_sdk::Address::generate(&env);
+        let asset = soroban_sdk::Address::generate(&env);
+        let share = soroban_sdk::Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                11,
+                7,
+            )
+            .unwrap();
+
+            let mut storage = SorobanStorage::new(&env);
+            storage
+                .save_state(&VaultState {
+                    total_assets: 1_500,
+                    total_shares: 1_000,
+                    idle_assets: 1_500,
+                    ..Default::default()
+                })
+                .expect("save capitalized state");
+
+            let err = execute_governance_command(
+                &env,
+                &governance,
+                &GovernanceCommand::SetGovernanceConfig {
+                    kind: GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+                    primary: None,
+                    many: None,
+                    value_a: Some(101),
+                    value_b: Some(202),
+                },
+            )
+            .expect_err("capitalized vault must not accept virtual-offset changes");
+
+            assert_eq!(err, crate::error::ContractError::InvalidState);
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualShares),
+                Some(11u128)
+            );
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualAssets),
+                Some(7u128)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rejects_virtual_offset_updates_after_first_deposit_lock() {
+        use soroban_sdk::testutils::Address as _;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = soroban_sdk::Address::generate(&env);
+        let governance = soroban_sdk::Address::generate(&env);
+        let asset = soroban_sdk::Address::generate(&env);
+        let share = soroban_sdk::Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                11,
+                7,
+            )
+            .unwrap();
+            env.storage()
+                .instance()
+                .set(&VaultDataKey::VirtualOffsetsLocked, &true);
+            SorobanStorage::new(&env)
+                .save_state(&VaultState::default())
+                .expect("save fully unwound state");
+
+            let err = execute_governance_command(
+                &env,
+                &governance,
+                &GovernanceCommand::SetGovernanceConfig {
+                    kind: GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+                    primary: None,
+                    many: None,
+                    value_a: Some(101),
+                    value_b: Some(202),
+                },
+            )
+            .expect_err("first-deposit lock must survive zero accounting state");
+
+            assert_eq!(err, crate::error::ContractError::InvalidState);
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualShares),
+                Some(11u128)
+            );
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualAssets),
+                Some(7u128)
+            );
+        });
+    }
+
+    #[test]
     fn test_deposit_uses_configured_virtual_offsets() {
         let mut vault = CuratorVault::new(
             test_config().with_virtual_offsets(11, 7),
@@ -1375,6 +1491,13 @@ mod contract_tests {
             owner_assets_before - deposit_assets
         );
         assert_eq!(asset_client.balance(&contract_id), deposit_assets);
+        assert_eq!(
+            env.as_contract(&contract_id, || env
+                .storage()
+                .instance()
+                .get(&VaultDataKey::VirtualOffsetsLocked)),
+            Some(true)
+        );
     }
 
     #[test]

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -488,7 +488,6 @@ fn soroban_contract_previews_simulate_configured_fee_accrual(
 }
 
 #[rstest]
-#[ignore = "A-007 fee-anchor lifecycle spec: initial anchor must not inflate proxy_view before implementation"]
 fn soroban_contract_proxy_view_does_not_inflate_from_zero_fee_anchor(
     soroban_contract_fixture: SorobanContractFixture,
 ) {

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -587,6 +587,68 @@ fn soroban_contract_proxy_view_does_not_inflate_from_zero_fee_anchor(
 }
 
 #[rstest]
+fn soroban_contract_refresh_fees_command_updates_anchor() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let proxy = VaultProxy::new(&env);
+    let contract_id = env.register(SorobanVaultContract, ());
+    let governance = soroban_sdk::Address::generate(&env);
+    let asset_admin = soroban_sdk::Address::generate(&env);
+    let asset_sac = env.register_stellar_asset_contract_v2(asset_admin.clone());
+    let asset_token = asset_sac.address();
+    let share_sac = env.register_stellar_asset_contract_v2(contract_id.clone());
+    let share_token = share_sac.address();
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        ..Default::default()
+    });
+
+    env.as_contract(&contract_id, || {
+        SorobanVaultContract::initialize(
+            env.clone(),
+            governance.clone(),
+            governance.clone(),
+            asset_token.clone(),
+            share_token.clone(),
+            0,
+            0,
+        )
+        .unwrap();
+
+        let mut storage = SorobanStorage::new(&env);
+        storage
+            .save_state(&VaultState {
+                total_assets: 1_500,
+                total_shares: 1_000,
+                idle_assets: 1_500,
+                fee_anchor: FeeAccrualAnchor::new(1_000, templar_vault_kernel::TimestampNs(0)),
+                ..Default::default()
+            })
+            .expect("save state");
+    });
+
+    asset_admin_client.mint(&contract_id, &1500);
+
+    env.as_contract(&contract_id, || {
+        let storage = SorobanStorage::new(&env);
+        proxy.execute_unit(&VaultCommand::RefreshFees).unwrap();
+
+        let stored_state = storage
+            .load_state()
+            .expect("load state")
+            .expect("state present");
+        assert_eq!(stored_state.fee_anchor.total_assets, 1_500);
+        assert_eq!(
+            stored_state.fee_anchor.timestamp_ns,
+            templar_vault_kernel::TimestampNs(100_000_000_000)
+        );
+    });
+}
+
+#[rstest]
 fn soroban_contract_preview_withdraw_matches_kernel(
     soroban_contract_fixture: SorobanContractFixture,
 ) {

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -21,6 +21,7 @@ use templar_soroban_runtime::{
 };
 use templar_soroban_shared_types::{
     GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+    GOVERNANCE_POLICY_KIND_FEES,
 };
 use templar_vault_kernel::state::queue::DEFAULT_COOLDOWN_NS;
 use templar_vault_kernel::{
@@ -1964,6 +1965,145 @@ fn soroban_contract_resync_idle_balance_fixes_donation_accounting() {
         assert_eq!(
             stored_state.fee_anchor.timestamp_ns,
             templar_vault_kernel::TimestampNs(100_000_000_000)
+        );
+    });
+}
+
+#[rstest]
+fn soroban_contract_resync_idle_balance_anchors_fee_refresh_window() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        ..Default::default()
+    });
+
+    let contract_id = env.register(SorobanVaultContract, ());
+    let governance = soroban_sdk::Address::generate(&env);
+    let management_recipient = soroban_sdk::Address::generate(&env);
+    let performance_recipient = soroban_sdk::Address::generate(&env);
+    let asset_admin = soroban_sdk::Address::generate(&env);
+    let asset_sac = env.register_stellar_asset_contract_v2(asset_admin.clone());
+    let asset_token = asset_sac.address();
+    let share_sac = env.register_stellar_asset_contract_v2(contract_id.clone());
+    let share_token = share_sac.address();
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
+    let share_client = soroban_sdk::token::Client::new(&env, &share_token);
+    let proxy = VaultProxy::new(&env);
+
+    const STARTING_ASSETS: u128 = 1_000_000_000_000;
+    const DONATED_ASSETS: u128 = 100_000_000_000;
+    const RESYNC_NS: u64 = 100_000_000_000;
+    const REFRESH_NS: u64 = 200_000_000_000;
+    let refreshed_assets = STARTING_ASSETS + DONATED_ASSETS;
+    let management_fee_wad = Wad::one() / 20;
+
+    env.as_contract(&contract_id, || {
+        SorobanVaultContract::initialize(
+            env.clone(),
+            governance.clone(),
+            governance.clone(),
+            asset_token.clone(),
+            share_token.clone(),
+            0,
+            0,
+        )
+        .unwrap();
+
+        let mut storage = SorobanStorage::new(&env);
+        storage
+            .save_state(&VaultState {
+                total_assets: STARTING_ASSETS,
+                total_shares: STARTING_ASSETS,
+                idle_assets: STARTING_ASSETS,
+                fee_anchor: FeeAccrualAnchor::new(
+                    STARTING_ASSETS,
+                    templar_vault_kernel::TimestampNs(0),
+                ),
+                ..Default::default()
+            })
+            .expect("save state");
+    });
+
+    asset_admin_client.mint(&contract_id, &(refreshed_assets as i128));
+
+    env.as_contract(&contract_id, || {
+        proxy
+            .execute_governance_unit(
+                &governance,
+                &GovernanceCommand::SetGovernancePolicy {
+                    kind: GOVERNANCE_POLICY_KIND_FEES,
+                    target_ids: None,
+                    mode: None,
+                    accounts: Some(vec![
+                        sdk_wire(&performance_recipient),
+                        sdk_wire(&management_recipient),
+                    ]),
+                    market_id: None,
+                    cap_group_id: None,
+                    value: Some(0),
+                    value_b: Some(management_fee_wad.as_u128_trunc() as i128),
+                    value_c: None,
+                },
+            )
+            .unwrap();
+        proxy
+            .execute_unit(&VaultCommand::ResyncIdleBalance)
+            .unwrap();
+
+        let stored_state = SorobanStorage::new(&env)
+            .load_state()
+            .expect("load state")
+            .expect("state present");
+        assert_eq!(stored_state.total_assets, refreshed_assets);
+        assert_eq!(
+            stored_state.fee_anchor,
+            FeeAccrualAnchor::new(
+                refreshed_assets,
+                templar_vault_kernel::TimestampNs(RESYNC_NS)
+            )
+        );
+    });
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 200,
+        protocol_version: 25,
+        ..Default::default()
+    });
+
+    let expected_management_shares = compute_management_fee_shares(
+        refreshed_assets,
+        refreshed_assets,
+        STARTING_ASSETS,
+        management_fee_wad,
+        RESYNC_NS,
+        REFRESH_NS,
+    )
+    .as_u128_saturating();
+
+    env.as_contract(&contract_id, || {
+        proxy.execute_unit(&VaultCommand::RefreshFees).unwrap();
+
+        let stored_state = SorobanStorage::new(&env)
+            .load_state()
+            .expect("load state")
+            .expect("state present");
+        assert_eq!(
+            stored_state.total_shares,
+            STARTING_ASSETS + expected_management_shares
+        );
+        assert_eq!(
+            share_client.balance(&management_recipient),
+            expected_management_shares as i128
+        );
+        assert_eq!(share_client.balance(&performance_recipient), 0);
+        assert_eq!(
+            stored_state.fee_anchor,
+            FeeAccrualAnchor::new(
+                refreshed_assets,
+                templar_vault_kernel::TimestampNs(REFRESH_NS)
+            )
         );
     });
 }

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -95,6 +95,7 @@ fn user_addr() -> Address {
 struct SorobanContractFixture {
     env: Env,
     contract_id: soroban_sdk::Address,
+    asset_token: soroban_sdk::Address,
 }
 
 struct VaultProxy<'a> {
@@ -219,11 +220,23 @@ fn soroban_contract_fixture() -> SorobanContractFixture {
         .address();
 
     env.as_contract(&contract_id, || {
-        SorobanVaultContract::initialize(env.clone(), curator.clone(), curator, asset, share, 0, 0)
-            .unwrap();
+        SorobanVaultContract::initialize(
+            env.clone(),
+            curator.clone(),
+            curator,
+            asset.clone(),
+            share,
+            0,
+            0,
+        )
+        .unwrap();
     });
 
-    SorobanContractFixture { env, contract_id }
+    SorobanContractFixture {
+        env,
+        contract_id,
+        asset_token: asset,
+    }
 }
 
 #[rstest]
@@ -340,8 +353,10 @@ fn soroban_contract_preview_deposit_matches_kernel(
 ) {
     let env = soroban_contract_fixture.env;
     let contract_id = soroban_contract_fixture.contract_id;
+    let asset_token = soroban_contract_fixture.asset_token;
     let assets_in = 500u128;
     let proxy = VaultProxy::new(&env);
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
 
     env.as_contract(&contract_id, || {
         let mut storage = SorobanStorage::new(&env);
@@ -362,8 +377,17 @@ fn soroban_contract_preview_deposit_matches_kernel(
             ..Default::default()
         };
         storage.save_state(&state).unwrap();
+    });
+    asset_admin_client.mint(&contract_id, &10_000);
 
+    env.as_contract(&contract_id, || {
         let preview = proxy.preview_deposit(assets_in as i128).unwrap();
+        let state = VaultState {
+            total_assets: 10_000,
+            total_shares: 8_000,
+            idle_assets: 10_000,
+            ..Default::default()
+        };
         let minted = mint_shares_from_deposit(state, assets_in, 0, 0);
         assert_eq!(preview as u128, minted);
     });
@@ -375,10 +399,12 @@ fn soroban_contract_preview_deposit_uses_configured_virtual_offsets(
 ) {
     let env = soroban_contract_fixture.env;
     let contract_id = soroban_contract_fixture.contract_id;
+    let asset_token = soroban_contract_fixture.asset_token;
     let assets_in = 500u128;
     let virtual_shares = 123u128;
     let virtual_assets = 456u128;
     let proxy = VaultProxy::new(&env);
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
 
     env.as_contract(&contract_id, || {
         let governance = proxy.governance().unwrap();
@@ -404,15 +430,24 @@ fn soroban_contract_preview_deposit_uses_configured_virtual_offsets(
         };
         storage.save_state(&state).unwrap();
 
-        let preview = proxy.preview_deposit(assets_in as i128).unwrap();
-        let minted = mint_shares_from_deposit(state, assets_in, virtual_shares, virtual_assets);
-        assert_eq!(preview as u128, minted);
-
         let stored_offsets = proxy.virtual_offsets().unwrap();
         assert_eq!(
             stored_offsets,
             (virtual_shares as i128, virtual_assets as i128)
         );
+    });
+    asset_admin_client.mint(&contract_id, &10_000);
+
+    env.as_contract(&contract_id, || {
+        let preview = proxy.preview_deposit(assets_in as i128).unwrap();
+        let state = VaultState {
+            total_assets: 10_000,
+            total_shares: 8_000,
+            idle_assets: 10_000,
+            ..Default::default()
+        };
+        let minted = mint_shares_from_deposit(state, assets_in, virtual_shares, virtual_assets);
+        assert_eq!(preview as u128, minted);
     });
 }
 
@@ -422,7 +457,9 @@ fn soroban_contract_previews_simulate_configured_fee_accrual(
 ) {
     let env = soroban_contract_fixture.env;
     let contract_id = soroban_contract_fixture.contract_id;
+    let asset_token = soroban_contract_fixture.asset_token;
     let proxy = VaultProxy::new(&env);
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
 
     env.ledger().set(LedgerInfo {
         timestamp: 100,
@@ -456,7 +493,15 @@ fn soroban_contract_previews_simulate_configured_fee_accrual(
             ..Default::default()
         };
         storage.save_state(&state).unwrap();
+    });
+    asset_admin_client.mint(&contract_id, &1_500);
 
+    env.as_contract(&contract_id, || {
+        let fees = FeesSpec::new(
+            FeeSlot::new(Wad::one() / 10, Address([1u8; 32])),
+            FeeSlot::new(Wad::one() / 5, Address([2u8; 32])),
+            None,
+        );
         let config = VaultConfig {
             fees,
             min_withdrawal_assets: MIN_WITHDRAWAL_ASSETS,
@@ -466,8 +511,14 @@ fn soroban_contract_previews_simulate_configured_fee_accrual(
             virtual_shares: 0,
             virtual_assets: 0,
         };
+        let state = VaultState {
+            total_assets: 1_500,
+            total_shares: 1_000,
+            idle_assets: 1_500,
+            fee_anchor: FeeAccrualAnchor::new(1_000, templar_vault_kernel::TimestampNs(0)),
+            ..Default::default()
+        };
         let expected_state = fee_aware_preview_state(&env, state, &config);
-
         let preview_deposit = proxy.preview_deposit(1_000).unwrap();
         let preview_withdraw = proxy.preview_withdraw(1_000).unwrap();
         let preview_redeem = proxy.preview_redeem(800).unwrap();
@@ -541,7 +592,9 @@ fn soroban_contract_preview_withdraw_matches_kernel(
 ) {
     let env = soroban_contract_fixture.env;
     let contract_id = soroban_contract_fixture.contract_id;
+    let asset_token = soroban_contract_fixture.asset_token;
     let proxy = VaultProxy::new(&env);
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
     env.as_contract(&contract_id, || {
         let mut storage = SorobanStorage::new(&env);
         let state = VaultState {
@@ -551,7 +604,10 @@ fn soroban_contract_preview_withdraw_matches_kernel(
             ..Default::default()
         };
         storage.save_state(&state).unwrap();
+    });
+    asset_admin_client.mint(&contract_id, &20_000);
 
+    env.as_contract(&contract_id, || {
         let assets_in: i128 = 1000;
         let shares_burned = proxy.preview_withdraw(assets_in).unwrap();
         assert_eq!(shares_burned, 601);
@@ -1682,7 +1738,6 @@ fn test_refresh_state_roundtrip() {
     assert!(matches!(result.new_state, OpState::Refreshing(_)));
 }
 #[rstest]
-#[ignore = "A-015 donation/resync accounting spec: deposits must not mint against stale NAV before implementation"]
 fn soroban_contract_deposit_after_donation_cannot_capture_surplus() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1751,6 +1806,11 @@ fn soroban_contract_deposit_after_donation_cannot_capture_surplus() {
 fn soroban_contract_resync_idle_balance_fixes_donation_accounting() {
     let env = Env::default();
     env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        ..Default::default()
+    });
 
     let contract_id = env.register(SorobanVaultContract, ());
     let governance = soroban_sdk::Address::generate(&env);
@@ -1805,10 +1865,18 @@ fn soroban_contract_resync_idle_balance_fixes_donation_accounting() {
         env.as_contract(&contract_id, || proxy.total_assets().unwrap());
     let (total_shares_after, idle_assets_after, external_assets_after) =
         env.as_contract(&contract_id, || proxy.snapshot().unwrap());
-    assert_eq!(total_assets_after_donation, total_assets_before);
-    assert_eq!(idle_assets_after, 500);
+    assert_eq!(total_assets_after_donation, 800);
+    assert_eq!(idle_assets_after, 800);
     assert_eq!(total_shares_after, 500);
     assert_eq!(external_assets_after, 0);
+    env.as_contract(&contract_id, || {
+        let stored_state = SorobanStorage::new(&env)
+            .load_state()
+            .expect("load state")
+            .expect("state present");
+        assert_eq!(stored_state.total_assets, 500);
+        assert_eq!(stored_state.idle_assets, 500);
+    });
 
     env.as_contract(&contract_id, || {
         proxy
@@ -1823,7 +1891,17 @@ fn soroban_contract_resync_idle_balance_fixes_donation_accounting() {
     assert_eq!(idle_assets_final, 800);
     assert_eq!(total_shares_final, 500);
     assert_eq!(external_assets_final, 0);
-
-    let anchor_total_assets = env.as_contract(&contract_id, || proxy.total_assets().unwrap());
-    assert_eq!(anchor_total_assets, 800);
+    env.as_contract(&contract_id, || {
+        let stored_state = SorobanStorage::new(&env)
+            .load_state()
+            .expect("load state")
+            .expect("state present");
+        assert_eq!(stored_state.total_assets, 800);
+        assert_eq!(stored_state.idle_assets, 800);
+        assert_eq!(stored_state.fee_anchor.total_assets, 800);
+        assert_eq!(
+            stored_state.fee_anchor.timestamp_ns,
+            templar_vault_kernel::TimestampNs(100_000_000_000)
+        );
+    });
 }

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -1683,6 +1683,72 @@ fn test_refresh_state_roundtrip() {
     assert!(matches!(result.new_state, OpState::Refreshing(_)));
 }
 #[rstest]
+#[ignore = "A-015 donation/resync accounting spec: deposits must not mint against stale NAV before implementation"]
+fn soroban_contract_deposit_after_donation_cannot_capture_surplus() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(SorobanVaultContract, ());
+    let governance = soroban_sdk::Address::generate(&env);
+    let asset_admin = soroban_sdk::Address::generate(&env);
+    let asset_sac = env.register_stellar_asset_contract_v2(asset_admin.clone());
+    let asset_token = asset_sac.address();
+    let share_sac = env.register_stellar_asset_contract_v2(contract_id.clone());
+    let share_token = share_sac.address();
+    let asset_admin_client = StellarAssetClient::new(&env, &asset_token);
+    let depositor = soroban_sdk::Address::generate(&env);
+
+    env.as_contract(&contract_id, || {
+        SorobanVaultContract::initialize(
+            env.clone(),
+            governance.clone(),
+            governance.clone(),
+            asset_token.clone(),
+            share_token.clone(),
+            0,
+            0,
+        )
+        .unwrap();
+
+        let mut storage = SorobanStorage::new(&env);
+        storage
+            .save_state(&VaultState {
+                total_assets: 500,
+                total_shares: 500,
+                idle_assets: 500,
+                fee_anchor: FeeAccrualAnchor::new(500, templar_vault_kernel::TimestampNs(0)),
+                ..Default::default()
+            })
+            .expect("save state");
+    });
+
+    asset_admin_client.mint(&contract_id, &500);
+    asset_admin_client.mint(&contract_id, &300);
+    asset_admin_client.mint(&depositor, &100);
+
+    let proxy = VaultProxy::new(&env);
+    let minted = env.as_contract(&contract_id, || {
+        proxy
+            .execute(&VaultCommand::DepositWithMin {
+                owner: sdk_wire(&depositor),
+                receiver: sdk_wire(&depositor),
+                assets: 100,
+                min_shares_out: 0,
+            })
+            .unwrap()
+    });
+
+    let VaultCommandResult::I128(minted_shares) = minted else {
+        panic!("deposit should return minted shares");
+    };
+
+    assert!(
+        minted_shares <= 62,
+        "deposit minted {minted_shares} shares against stale total_assets instead of actual donated NAV"
+    );
+}
+
+#[rstest]
 fn soroban_contract_resync_idle_balance_fixes_donation_accounting() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -488,6 +488,55 @@ fn soroban_contract_previews_simulate_configured_fee_accrual(
 }
 
 #[rstest]
+#[ignore = "A-007 fee-anchor lifecycle spec: initial anchor must not inflate proxy_view before implementation"]
+fn soroban_contract_proxy_view_does_not_inflate_from_zero_fee_anchor(
+    soroban_contract_fixture: SorobanContractFixture,
+) {
+    let env = soroban_contract_fixture.env;
+    let contract_id = soroban_contract_fixture.contract_id;
+    let proxy = VaultProxy::new(&env);
+    let owner = soroban_sdk::Address::generate(&env);
+
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        ..Default::default()
+    });
+
+    env.as_contract(&contract_id, || {
+        let fees = FeesSpec::new(
+            FeeSlot::new(Wad::one() / 2, Address([1u8; 32])),
+            FeeSlot::new(Wad::zero(), Address([2u8; 32])),
+            None,
+        );
+        let mut bytes = Vec::with_capacity(97);
+        bytes.extend_from_slice(&fees.performance.fee_wad.as_u128_trunc().to_le_bytes());
+        bytes.extend_from_slice(fees.performance.recipient.as_bytes());
+        bytes.extend_from_slice(&fees.management.fee_wad.as_u128_trunc().to_le_bytes());
+        bytes.extend_from_slice(fees.management.recipient.as_bytes());
+        bytes.push(0);
+        env.storage().instance().set(
+            &templar_soroban_runtime::contract::VaultDataKey::FeesSpec,
+            &Bytes::from_slice(&env, &bytes),
+        );
+
+        let mut storage = SorobanStorage::new(&env);
+        storage
+            .save_state(&VaultState {
+                total_assets: 1_000,
+                total_shares: 1_000,
+                idle_assets: 1_000,
+                fee_anchor: FeeAccrualAnchor::new(0, templar_vault_kernel::TimestampNs(0)),
+                ..Default::default()
+            })
+            .expect("save state");
+
+        let total_shares = proxy.view(owner, 0, 0).unwrap().0 .2 .0;
+        assert_eq!(total_shares, 1_000);
+    });
+}
+
+#[rstest]
 fn soroban_contract_preview_withdraw_matches_kernel(
     soroban_contract_fixture: SorobanContractFixture,
 ) {

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -1860,8 +1860,8 @@ fn soroban_contract_deposit_after_donation_cannot_capture_surplus() {
     };
 
     assert!(
-        minted_shares <= 62,
-        "deposit minted {minted_shares} shares against stale total_assets instead of actual donated NAV"
+        (1..=62).contains(&minted_shares),
+        "deposit minted {minted_shares} shares outside expected post-donation bounds"
     );
 }
 


### PR DESCRIPTION
## Summary

- Fixes A-006 / Nexus `6c6f1936-9740-4470-9921-b7ffe2741079`: Soroban deposits now advance the fee anchor to post-deposit assets and deposit timestamp.
- Fixes A-007 / Nexus `e95e12c4-99e3-4abf-8188-2c4083600cd9`: zero `(0,0)` fee anchors are treated as uninitialized instead of minting fees against existing supply.
- Fixes A-015 / Nexus `d0261637-ec7c-4abf-b964-b51d18988521`: direct underlying transfers are reconciled before pricing so donated idle balance cannot be captured by the next depositor.
- Fixes A-018 / Nexus `20f09f85-0147-424e-91c3-a9dd6cea1f6e`: `RefreshFees` is reachable through the Soroban command ABI.
- Fixes A-020 / Nexus `0659bbec-769c-4475-b256-ca22013de56b`: `ResyncIdleBalance` keeps `fee_anchor.total_assets` and `fee_anchor.timestamp_ns` coherent, so later fee refreshes use the resync observation time.
- Fixes A-031 / Nexus `68a5a45d-594c-4565-9b5e-726657416c19`: share/asset conversion and fee-mint paths now bound full-width quotients against operation caps before converting to `u128`.
- Fixes A-039 / Nexus `21aa4dfa-595b-42a3-a1a0-cf7cba5e3f93`: virtual conversion offsets are locked after capitalization / first public deposit, including later full unwind to zero state.

## Notes

The first four commits are the original red/spec commits for the audited invariants. The production fixes are kept one commit per Nexus ID for auditor traceability. Commit `3163b84` pins the A-031 red specs; commit `236acee` is the A-031 remediation commit.

The Soroban runtime now uses a lazy actual-balance reconciliation policy for preview-sensitive and pricing-sensitive paths. `DepositWithMin`, `RefreshFees`, and `ResyncIdleBalance` read the live asset token balance, reconcile idle assets, recompute total assets, and reset the fee anchor onto the reconciled baseline before continuing. This is documented in `contract/vault/soroban/README.md`.

A-031 uses bounded-domain math rather than saturation: deposit, withdrawal request planning, atomic withdraw/redeem, fee-share minting, and Soroban `proxy_view` previews compare the full `Number` quotient against the operation legal cap before `u128` conversion. Overflowing actions fail closed with operation-specific errors; signed ABI previews reject values above `i128::MAX`.

A-039 is folded into this fee-anchor cluster PR from superseded PR #435. The Soroban runtime now rejects `SetGovernanceConfig(VIRTUAL_OFFSETS)` while stored vault accounting is nonzero, persists a `VirtualOffsetsLocked` instance flag after the first successful public deposit, and keeps virtual offsets immutable even after a later full unwind to zero state.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- `CARGO_TARGET_DIR=/data/projects/templar/contracts/.shared-target/fee-anchor-spec cargo test -p templar-vault-kernel --lib -- --nocapture` (302 passed)
- `CARGO_TARGET_DIR=/data/projects/templar/contracts/.shared-target/fee-anchor-spec cargo test -p templar-soroban-shared-types -- --nocapture` (6 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/projects/templar/contracts/.shared-target/fee-anchor-spec cargo test -p templar-vault-kernel prop_a031 --test property_tests -- --nocapture` (2 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/projects/templar/contracts/.shared-target/fee-anchor-spec cargo test -p templar-soroban-runtime soroban_contract_resync_idle_balance_anchors_fee_refresh_window --test integration_tests -- --nocapture` (1 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/projects/templar/contracts/.shared-target/fee-anchor-spec cargo test -p templar-soroban-runtime --test integration_tests -- --nocapture` (56 passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/projects/templar/contracts/.shared-target/fee-anchor-spec just -f contract/vault/soroban/justfile size-budget-check` (passed, deploy wasm 95397 bytes)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-audit-fee-anchor-spec/.target-a039-fold cargo test -p templar-soroban-runtime virtual_offset -- --nocapture` (passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-audit-fee-anchor-spec/.target-a039-fold cargo test -p templar-soroban-runtime test_phase1_deposit_with_min_resource_probe -- --nocapture` (passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-audit-fee-anchor-spec/.target-a039-fold cargo test -p templar-soroban-runtime -- --nocapture` (passed)
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-audit-fee-anchor-spec/.target-a039-fold just -f contract/vault/soroban/justfile size-budget-check` (passed, deploy wasm 95716 bytes)

Tracker context: `contracts-audit-clusters/fee-anchor-lifecycle.audit.md`.

## Halborn Finding IDs

Included for Halborn SSC GitHub remediation detection:

- A-006 / Finding ID `6c6f1936-9740-4470-9921-b7ffe2741079` — Soroban deposits do not advance fee accrual anchor while NEAR does
- A-007 / Finding ID `e95e12c4-99e3-4abf-8188-2c4083600cd9` — Initial fee anchor at zero inflates `proxy_view` once fees are enabled
- A-015 / Finding ID `d0261637-ec7c-4abf-b964-b51d18988521` — Direct underlying transfers are mispriced until manual resync
- A-018 / Finding ID `20f09f85-0147-424e-91c3-a9dd6cea1f6e` — Fee accrual is unreachable from the deployed Soroban ABI
- A-020 / Finding ID `0659bbec-769c-4475-b256-ca22013de56b` — `resync_idle_balance` advances `fee_anchor.total_assets` without updating `timestamp_ns`
- A-031 / Finding ID `68a5a45d-594c-4565-9b5e-726657416c19` — Share-conversion helpers truncate 256-bit quotients to u128
- A-039 / Finding ID `21aa4dfa-595b-42a3-a1a0-cf7cba5e3f93` — Virtual conversion offsets can be changed after the vault is capitalized

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/428)
<!-- Reviewable:end -->