### PR TITLE
fix(soroban): make share-token vault immutable

### DIFF
--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -928,15 +928,6 @@ set-supply-queue target_ids_json:
 	just gov-invoke accept --caller "$admin" --proposal_id "$proposal_id"; \
 	echo "✓ Supply queue updated"
 
-# Set share token metadata (SEP-41).
-set-metadata name="Templar Vault Share" symbol="tvSHARE" decimals="7":
-	@echo "Setting share token metadata..."
-	@just invoke set_metadata \
-		--name "{{name}}" \
-		--symbol "{{symbol}}" \
-		--decimals "{{decimals}}"
-	@echo "✓ Metadata set"
-
 # =============================================================================
 # VIEW FUNCTIONS (Read-only)
 # =============================================================================
@@ -1125,7 +1116,6 @@ help:
 	@echo "ADMIN:"
 	@echo "  just pause / unpause"
 	@echo "  just set-curator <new_curator_address>"
-	@echo "  just set-metadata [name] [symbol] [decimals]"
 	@echo ""
 	@echo "VIEW:"
 	@echo "  just vault-state              Show vault summary"

--- a/contract/vault/soroban/share-token/Cargo.toml
+++ b/contract/vault/soroban/share-token/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { version = "25.3.0", features = ["alloc", "experimental_spec_shaking_v2"] }
+soroban-sdk = { version = "25.3.0", features = ["alloc", "experimental_spec_shaking_v2", "hazmat-address"] }
 stellar-tokens.workspace = true
 
 [dev-dependencies]

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -119,10 +119,10 @@ impl SorobanShareTokenContract {
         panic_with_error!(&env, ShareTokenError::VaultImmutable);
     }
 
-    pub fn set_metadata(env: Env, caller: Address, name: String, symbol: String, decimals: u32) {
+    pub fn set_metadata(env: Env, caller: Address, _name: String, _symbol: String, _decimals: u32) {
         extend_instance_ttl(&env);
         require_admin(&env, &caller);
-        Base::set_metadata(&env, decimals, name, symbol);
+        panic_with_error!(&env, ShareTokenError::MetadataImmutable);
     }
 
     pub fn admin(env: Env) -> Address {

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -116,7 +116,7 @@ impl SorobanShareTokenContract {
         extend_instance_ttl(&env);
         require_admin(&env, &caller);
         require_contract_address(&env, &vault);
-        env.storage().instance().set(&DataKey::Vault, &vault);
+        panic_with_error!(&env, ShareTokenError::VaultImmutable);
     }
 
     pub fn set_metadata(env: Env, caller: Address, name: String, symbol: String, decimals: u32) {

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -3,7 +3,10 @@
 mod types;
 pub use types::*;
 
-use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, MuxedAddress, String};
+use soroban_sdk::{
+    address_payload::AddressPayload, contract, contractimpl, panic_with_error, symbol_short,
+    Address, Env, MuxedAddress, String,
+};
 use stellar_tokens::fungible::{
     burnable::{emit_burn, FungibleBurnable},
     Base, FungibleToken,
@@ -78,6 +81,9 @@ impl FungibleBurnable for SorobanShareTokenContract {
         Base::spend_allowance(e, &from, &spender, amount);
         Base::update(e, Some(&from), None, amount);
         emit_burn(e, &from, amount);
+        #[allow(deprecated)]
+        e.events()
+            .publish((symbol_short!("burn_from"), spender, from), amount);
     }
 }
 
@@ -171,8 +177,10 @@ fn require_vault_invoker(env: &Env) {
 }
 
 fn is_contract_address(addr: &Address) -> bool {
-    let bytes = addr.to_string().to_bytes();
-    matches!(bytes.get(0), Some(b'C'))
+    matches!(
+        AddressPayload::from_address(addr),
+        Some(AddressPayload::ContractIdHash(_))
+    )
 }
 
 fn require_contract_address(env: &Env, addr: &Address) {

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -1,7 +1,7 @@
 use super::*;
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::testutils::{Ledger, LedgerInfo};
-use soroban_sdk::{contract, contractimpl, IntoVal, MuxedAddress};
+use soroban_sdk::{contract, contractimpl, IntoVal, MuxedAddress, Symbol};
 
 #[contract]
 struct VaultCaller;
@@ -196,4 +196,67 @@ fn total_supply_tracks_mint_and_burn() {
         ().into_val(&env),
     );
     assert_eq!(supply, 300);
+}
+
+#[test]
+fn admin_cannot_rebind_vault_after_init() {
+    let (env, admin, vault, token) = setup();
+    let replacement_vault = env.register(VaultCaller, ());
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "set_vault"),
+        (&admin, &replacement_vault).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::VaultImmutable)));
+
+    let configured_vault: Address =
+        env.invoke_contract(&token, &Symbol::new(&env, "vault"), ().into_val(&env));
+    assert_eq!(configured_vault, vault);
+}
+
+#[test]
+fn non_admin_cannot_rebind_vault() {
+    let (env, _admin, vault, token) = setup();
+    let attacker = Address::generate(&env);
+    let replacement_vault = env.register(VaultCaller, ());
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "set_vault"),
+        (&attacker, &replacement_vault).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::Unauthorized)));
+
+    let configured_vault: Address =
+        env.invoke_contract(&token, &Symbol::new(&env, "vault"), ().into_val(&env));
+    assert_eq!(configured_vault, vault);
+}
+
+#[test]
+fn original_vault_keeps_mint_burn_authority_after_failed_rebind() {
+    let (env, admin, vault, token) = setup();
+    let replacement_vault = env.register(VaultCaller, ());
+    let user = Address::generate(&env);
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "set_vault"),
+        (&admin, &replacement_vault).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::VaultImmutable)));
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), user.clone(), 500);
+    });
+    env.as_contract(&vault, || {
+        VaultCaller::burn(env.clone(), token.clone(), user.clone(), 125);
+    });
+
+    let balance: i128 = env.invoke_contract(
+        &token,
+        &Symbol::new(&env, "balance"),
+        (&user,).into_val(&env),
+    );
+    assert_eq!(balance, 375);
 }

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -1,7 +1,11 @@
 use super::*;
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::testutils::{Ledger, LedgerInfo};
-use soroban_sdk::{contract, contractimpl, IntoVal, MuxedAddress, Symbol};
+use soroban_sdk::testutils::{Events, Ledger, LedgerInfo};
+use soroban_sdk::xdr::{ContractEventBody, ScVal};
+use soroban_sdk::{
+    address_payload::AddressPayload, contract, contractimpl, symbol_short, BytesN, IntoVal,
+    MuxedAddress, Symbol, TryFromVal, Val,
+};
 
 #[contract]
 struct VaultCaller;
@@ -23,17 +27,34 @@ impl VaultCaller {
             (from, amount).into_val(&env),
         );
     }
+
+    fn approve(
+        env: Env,
+        token: Address,
+        owner: Address,
+        spender: Address,
+        amount: i128,
+        live_until_ledger: u32,
+    ) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "approve"),
+            (owner, spender, amount, live_until_ledger).into_val(&env),
+        );
+    }
+
+    fn burn_from(env: Env, token: Address, spender: Address, from: Address, amount: i128) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "burn_from"),
+            (spender, from, amount).into_val(&env),
+        );
+    }
 }
 
 fn setup() -> (Env, Address, Address, Address) {
     let env = Env::default();
-    env.mock_all_auths();
-    env.ledger().set(LedgerInfo {
-        timestamp: 100,
-        protocol_version: 25,
-        sequence_number: 100,
-        ..Default::default()
-    });
+    init_env(&env);
 
     let admin = Address::generate(&env);
     let vault = env.register(VaultCaller, ());
@@ -48,6 +69,54 @@ fn setup() -> (Env, Address, Address, Address) {
         ),
     );
     (env, admin, vault, token)
+}
+
+fn init_env(env: &Env) {
+    env.mock_all_auths_allowing_non_root_auth();
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        sequence_number: 100,
+        max_entry_ttl: 1_000,
+        ..Default::default()
+    });
+}
+
+fn account_address(env: &Env) -> Address {
+    AddressPayload::AccountIdPublicKeyEd25519(BytesN::from_array(env, &[7; 32])).to_address(env)
+}
+
+#[test]
+#[should_panic]
+fn constructor_rejects_account_vault_address() {
+    let env = Env::default();
+    init_env(&env);
+
+    let admin = Address::generate(&env);
+    let account_vault = account_address(&env);
+    env.register(
+        SorobanShareTokenContract,
+        (
+            &admin,
+            &account_vault,
+            &String::from_str(&env, "Templar Share"),
+            &String::from_str(&env, "tvSHARE"),
+            &7u32,
+        ),
+    );
+}
+
+#[test]
+#[should_panic]
+fn set_vault_rejects_account_address() {
+    let (env, admin, _vault, token) = setup();
+    let account_vault = account_address(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_vault"),
+        (&admin, &account_vault).into_val(&env),
+    );
 }
 
 #[test]
@@ -85,6 +154,223 @@ fn vault_can_burn() {
         (&user,).into_val(&env),
     );
     assert_eq!(bal, 600);
+}
+
+#[test]
+fn burn_from_emits_supplemental_spender_event() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+    });
+    env.as_contract(&vault, || {
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            400,
+            300,
+        );
+    });
+    env.events().all();
+
+    env.as_contract(&vault, || {
+        VaultCaller::burn_from(
+            env.clone(),
+            token.clone(),
+            spender.clone(),
+            from.clone(),
+            250,
+        );
+    });
+
+    let events = env.events().all().filter_by_contract(&token);
+    assert_eq!(events.events().len(), 2);
+    let burn_from_event = &events.events()[1];
+    let ContractEventBody::V0(body) = &burn_from_event.body;
+    assert_eq!(body.topics.len(), 3);
+    assert_eq!(
+        body.topics[0],
+        ScVal::try_from_val(&env, &symbol_short!("burn_from")).unwrap()
+    );
+    let spender_val: Val = spender.clone().into_val(&env);
+    let from_val: Val = from.clone().into_val(&env);
+    let amount_val: Val = 250i128.into_val(&env);
+    assert_eq!(
+        body.topics[1],
+        ScVal::try_from_val(&env, &spender_val).unwrap()
+    );
+    assert_eq!(
+        body.topics[2],
+        ScVal::try_from_val(&env, &from_val).unwrap()
+    );
+    assert_eq!(body.data, ScVal::try_from_val(&env, &amount_val).unwrap());
+
+    let bal: i128 = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "balance"),
+        (&from,).into_val(&env),
+    );
+    let allowance: i128 = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "allowance"),
+        (&from, &spender).into_val(&env),
+    );
+    assert_eq!(bal, 750);
+    assert_eq!(allowance, 150);
+}
+
+#[test]
+fn set_admin_rotates_admin() {
+    let (env, admin, _vault, token) = setup();
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &new_admin).into_val(&env),
+    );
+
+    let stored_admin: Address = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "admin"),
+        ().into_val(&env),
+    );
+    assert_eq!(stored_admin, new_admin);
+}
+
+#[test]
+#[should_panic]
+fn non_admin_cannot_set_admin() {
+    let (env, _admin, _vault, token) = setup();
+    let non_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&non_admin, &new_admin).into_val(&env),
+    );
+}
+
+#[test]
+#[should_panic]
+fn old_admin_loses_privilege_after_rotation() {
+    let (env, admin, _vault, token) = setup();
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &new_admin).into_val(&env),
+    );
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &Address::generate(&env)).into_val(&env),
+    );
+}
+
+#[test]
+#[should_panic]
+fn burn_from_without_allowance_panics() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::burn_from(env.clone(), token.clone(), spender.clone(), from.clone(), 1);
+    });
+}
+
+#[test]
+#[should_panic]
+fn burn_from_over_allowance_panics() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            100,
+            300,
+        );
+        VaultCaller::burn_from(
+            env.clone(),
+            token.clone(),
+            spender.clone(),
+            from.clone(),
+            101,
+        );
+    });
+}
+
+#[test]
+#[should_panic]
+fn burn_from_after_allowance_expiry_panics() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            100,
+            101,
+        );
+    });
+    env.ledger().set(LedgerInfo {
+        timestamp: 101,
+        protocol_version: 25,
+        sequence_number: 102,
+        max_entry_ttl: 1_000,
+        ..Default::default()
+    });
+
+    env.as_contract(&vault, || {
+        VaultCaller::burn_from(env.clone(), token.clone(), spender.clone(), from.clone(), 1);
+    });
+}
+
+#[test]
+#[should_panic]
+fn direct_caller_cannot_burn_from_even_with_allowance() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            100,
+            300,
+        );
+    });
+
+    env.mock_auths(&[]);
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "burn_from"),
+        (&spender, &from, &1i128).into_val(&env),
+    );
 }
 
 #[test]

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -179,7 +179,7 @@ fn burn_from_emits_supplemental_spender_event() {
             300,
         );
     });
-    env.events().all();
+    let event_count_before_burn_from = env.events().all().filter_by_contract(&token).events().len();
 
     env.as_contract(&vault, || {
         VaultCaller::burn_from(
@@ -192,8 +192,15 @@ fn burn_from_emits_supplemental_spender_event() {
     });
 
     let events = env.events().all().filter_by_contract(&token);
-    assert_eq!(events.events().len(), 2);
-    let burn_from_event = &events.events()[1];
+    let new_events = &events.events()[event_count_before_burn_from..];
+    let burn_from_event = new_events
+        .iter()
+        .find(|event| {
+            let ContractEventBody::V0(body) = &event.body;
+            body.topics.first()
+                == Some(&ScVal::try_from_val(&env, &symbol_short!("burn_from")).unwrap())
+        })
+        .expect("burn_from event must be emitted");
     let ContractEventBody::V0(body) = &burn_from_event.body;
     assert_eq!(body.topics.len(), 3);
     assert_eq!(
@@ -247,21 +254,20 @@ fn set_admin_rotates_admin() {
 }
 
 #[test]
-#[should_panic]
 fn non_admin_cannot_set_admin() {
     let (env, _admin, _vault, token) = setup();
     let non_admin = Address::generate(&env);
     let new_admin = Address::generate(&env);
 
-    env.invoke_contract::<()>(
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
         &soroban_sdk::Symbol::new(&env, "set_admin"),
         (&non_admin, &new_admin).into_val(&env),
     );
+    assert_eq!(err, Err(Ok(ShareTokenError::Unauthorized)));
 }
 
 #[test]
-#[should_panic]
 fn old_admin_loses_privilege_after_rotation() {
     let (env, admin, _vault, token) = setup();
     let new_admin = Address::generate(&env);
@@ -272,29 +278,33 @@ fn old_admin_loses_privilege_after_rotation() {
         (&admin, &new_admin).into_val(&env),
     );
 
-    env.invoke_contract::<()>(
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
         &soroban_sdk::Symbol::new(&env, "set_admin"),
         (&admin, &Address::generate(&env)).into_val(&env),
     );
+    assert_eq!(err, Err(Ok(ShareTokenError::Unauthorized)));
 }
 
 #[test]
-#[should_panic]
-fn burn_from_without_allowance_panics() {
+fn burn_from_without_allowance_fails() {
     let (env, _admin, vault, token) = setup();
     let from = Address::generate(&env);
     let spender = Address::generate(&env);
 
     env.as_contract(&vault, || {
         VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
-        VaultCaller::burn_from(env.clone(), token.clone(), spender.clone(), from.clone(), 1);
+        let err = env.try_invoke_contract::<(), ShareTokenError>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "burn_from"),
+            (&spender, &from, &1i128).into_val(&env),
+        );
+        assert!(err.is_err());
     });
 }
 
 #[test]
-#[should_panic]
-fn burn_from_over_allowance_panics() {
+fn burn_from_over_allowance_fails() {
     let (env, _admin, vault, token) = setup();
     let from = Address::generate(&env);
     let spender = Address::generate(&env);
@@ -309,19 +319,17 @@ fn burn_from_over_allowance_panics() {
             100,
             300,
         );
-        VaultCaller::burn_from(
-            env.clone(),
-            token.clone(),
-            spender.clone(),
-            from.clone(),
-            101,
+        let err = env.try_invoke_contract::<(), ShareTokenError>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "burn_from"),
+            (&spender, &from, &101i128).into_val(&env),
         );
+        assert!(err.is_err());
     });
 }
 
 #[test]
-#[should_panic]
-fn burn_from_after_allowance_expiry_panics() {
+fn burn_from_after_allowance_expiry_fails() {
     let (env, _admin, vault, token) = setup();
     let from = Address::generate(&env);
     let spender = Address::generate(&env);
@@ -346,12 +354,16 @@ fn burn_from_after_allowance_expiry_panics() {
     });
 
     env.as_contract(&vault, || {
-        VaultCaller::burn_from(env.clone(), token.clone(), spender.clone(), from.clone(), 1);
+        let err = env.try_invoke_contract::<(), ShareTokenError>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "burn_from"),
+            (&spender, &from, &1i128).into_val(&env),
+        );
+        assert!(err.is_err());
     });
 }
 
 #[test]
-#[should_panic]
 fn direct_caller_cannot_burn_from_even_with_allowance() {
     let (env, _admin, vault, token) = setup();
     let from = Address::generate(&env);
@@ -370,11 +382,12 @@ fn direct_caller_cannot_burn_from_even_with_allowance() {
     });
 
     env.mock_auths(&[]);
-    env.invoke_contract::<()>(
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
         &soroban_sdk::Symbol::new(&env, "burn_from"),
         (&spender, &from, &1i128).into_val(&env),
     );
+    assert!(err.is_err());
 }
 
 #[test]
@@ -408,8 +421,7 @@ fn user_can_transfer_with_auth() {
 }
 
 #[test]
-#[should_panic]
-fn transfer_without_from_auth_panics() {
+fn transfer_without_from_auth_fails() {
     let (env, _admin, vault, token) = setup();
     let from = Address::generate(&env);
     let to = Address::generate(&env);
@@ -419,13 +431,14 @@ fn transfer_without_from_auth_panics() {
         VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
     });
 
-    // Don't mock auths — this should panic on from.require_auth()
+    // Don't mock auths — this should fail on from.require_auth()
     env.mock_auths(&[]);
-    env.invoke_contract::<()>(
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
         &soroban_sdk::Symbol::new(&env, "transfer"),
         (&from, MuxedAddress::from(to), &1i128).into_val(&env),
     );
+    assert!(err.is_err());
 }
 
 #[test]

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -107,16 +107,20 @@ fn constructor_rejects_account_vault_address() {
 }
 
 #[test]
-#[should_panic]
 fn set_vault_rejects_account_address() {
-    let (env, admin, _vault, token) = setup();
+    let (env, admin, vault, token) = setup();
     let account_vault = account_address(&env);
 
-    env.invoke_contract::<()>(
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
-        &soroban_sdk::Symbol::new(&env, "set_vault"),
+        &Symbol::new(&env, "set_vault"),
         (&admin, &account_vault).into_val(&env),
     );
+    assert_eq!(err, Err(Ok(ShareTokenError::InvalidInput)));
+
+    let configured_vault: Address =
+        env.invoke_contract(&token, &Symbol::new(&env, "vault"), ().into_val(&env));
+    assert_eq!(configured_vault, vault);
 }
 
 #[test]
@@ -450,13 +454,12 @@ fn metadata_returns_constructor_values() {
 }
 
 #[test]
-#[should_panic]
 fn admin_cannot_change_metadata_after_deployment() {
     let (env, admin, _vault, token) = setup();
 
-    env.invoke_contract::<()>(
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
-        &soroban_sdk::Symbol::new(&env, "set_metadata"),
+        &Symbol::new(&env, "set_metadata"),
         (
             &admin,
             &String::from_str(&env, "Mutable Share"),
@@ -465,6 +468,17 @@ fn admin_cannot_change_metadata_after_deployment() {
         )
             .into_val(&env),
     );
+    assert_eq!(err, Err(Ok(ShareTokenError::MetadataImmutable)));
+
+    let name: String = env.invoke_contract(&token, &Symbol::new(&env, "name"), ().into_val(&env));
+    let symbol: String =
+        env.invoke_contract(&token, &Symbol::new(&env, "symbol"), ().into_val(&env));
+    let decimals: u32 =
+        env.invoke_contract(&token, &Symbol::new(&env, "decimals"), ().into_val(&env));
+
+    assert_eq!(name, String::from_str(&env, "Templar Share"));
+    assert_eq!(symbol, String::from_str(&env, "tvSHARE"));
+    assert_eq!(decimals, 7);
 }
 
 #[test]

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -164,6 +164,24 @@ fn metadata_returns_constructor_values() {
 }
 
 #[test]
+#[should_panic]
+fn admin_cannot_change_metadata_after_deployment() {
+    let (env, admin, _vault, token) = setup();
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_metadata"),
+        (
+            &admin,
+            &String::from_str(&env, "Mutable Share"),
+            &String::from_str(&env, "MUT"),
+            &18u32,
+        )
+            .into_val(&env),
+    );
+}
+
+#[test]
 fn total_supply_tracks_mint_and_burn() {
     let (env, _admin, vault, token) = setup();
     let user = Address::generate(&env);

--- a/contract/vault/soroban/share-token/src/types.rs
+++ b/contract/vault/soroban/share-token/src/types.rs
@@ -16,4 +16,5 @@ pub enum ShareTokenError {
     InvalidInput = 2,
     MissingConfig = 3,
     VaultImmutable = 4,
+    MetadataImmutable = 5,
 }

--- a/contract/vault/soroban/share-token/src/types.rs
+++ b/contract/vault/soroban/share-token/src/types.rs
@@ -15,4 +15,5 @@ pub enum ShareTokenError {
     Unauthorized = 1,
     InvalidInput = 2,
     MissingConfig = 3,
+    VaultImmutable = 4,
 }


### PR DESCRIPTION


## Summary
- consolidates the share-token audit remediation in one PR for A-012, A-050, A-093, A-094, and A-097
- makes the share-token vault binding and metadata effectively immutable after construction while preserving ABI-compatible admin entrypoints that now fail closed
- hardens share-token contract-address validation, delegated-burn observability, admin rotation, allowance, allowance-expiry, transfer-auth, and vault-invoker security coverage

## Audit Context
- Cluster: `share-token-admin`
- Findings:
  - A-012 — Share-token admin can redirect vault-mint privilege without timelock or event
  - A-050 — Share-token metadata can be changed after deployment without timelock or event
  - A-093 — Share-token contract-address validation relies on StrKey prefix inspection
  - A-094 — Share-token burn and burn_from emit indistinguishable burn events
  - A-097 — Share-token tests omit admin rotation and allowance security coverage
- Base: PR 417 branch `spr/refactor/vault-ergonomics/4f330057` at `a657f92`
- Tracker: `contracts-audit-clusters/share-token-admin.audit.md`

## Verification
- `cargo fmt --all`
- `cargo +1.86.0 test -p templar-soroban-share-token -- --nocapture` — blocked before package tests by existing workspace dependency compile failure in `stellar-contract-utils 0.7.1` (`use of unstable library feature unsigned_is_multiple_of` in `src/crypto/merkle.rs:102`)
- `RUSTFLAGS='-Zcrate-attr=feature(unsigned_is_multiple_of)' cargo +nightly test -p templar-soroban-share-token -- --nocapture` — 9 passed
- post-commit hook: Soroban `size-budget-check` passed at `93961` bytes

## Halborn Finding IDs

Included for Halborn SSC GitHub remediation detection:

- A-012 / Finding ID `6157e4aa-116a-4fcd-a45f-1ea4f695f5af` — Share-token admin can redirect vault-mint privilege without timelock or event
- A-050 / Finding ID `37a5412f-fb6a-455f-9b9c-3aa8227c255a` — Share-token metadata can be changed after deployment without timelock or event
- A-093 / Finding ID `ca6dd926-fd39-405d-b710-af4fe8744727` — Share-token contract-address validation relies on StrKey prefix inspection
- A-094 / Finding ID `5af46c5f-dbd8-46e6-93fb-0e21dd4aaf69` — Share-token burn and burn_from emit indistinguishable burn events
- A-097 / Finding ID `12319f5b-fa52-46b1-8b49-d91fbceeca7d` — Share-token tests omit admin rotation and allowance security coverage

## Folded Share-Token Findings

This PR is the consolidated share-token cluster PR. It now also folds the formerly separate A-050/A-093/A-094/A-097 work; PR #440 and PR #443 are superseded by this PR.

- A-050 / Nexus `37a5412f-fb6a-455f-9b9c-3aa8227c255a`
  - Keeps constructor-time metadata initialization but makes post-deployment `set_metadata` fail after admin auth with `ShareTokenError::MetadataImmutable`.
  - Removes the stale operator `set-metadata` justfile recipe/help.
- A-093 / Nexus `ca6dd926-fd39-405d-b710-af4fe8744727`
  - Replaces StrKey text-prefix contract-address validation with `soroban_sdk::address_payload::AddressPayload` discrimination.
  - Adds account-address rejection coverage for constructor vault binding and `set_vault`.
- A-094 / Nexus `5af46c5f-dbd8-46e6-93fb-0e21dd4aaf69`
  - Keeps the standard burn event and emits a supplemental `burn_from` event keyed by spender and owner, so delegated burns are distinguishable from direct burns.
- A-097 / Nexus `12319f5b-fa52-46b1-8b49-d91fbceeca7d`
  - Adds share-token admin rotation, old-admin revocation, allowance, allowance expiry, transfer-auth, and vault-invoker security coverage.

### Fold Verification

- `RUSTUP_TOOLCHAIN=1.89.0 cargo fmt --all --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-share-token -- --nocapture` — 20 passed
- `just -f contract/vault/soroban/justfile build`
- `just -f contract/vault/soroban/justfile size-budget-check` — 93,961 bytes <= 131,072 bytes
- Post-commit hook reran Soroban size-budget-check for folded commits and passed at 93,961 bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/429)
<!-- Reviewable:end -->


