### PR TITLE
fix: harden adapter accounting and Blend admin boundary

### DIFF
--- a/contract/vault/kernel/src/actions/mod.rs
+++ b/contract/vault/kernel/src/actions/mod.rs
@@ -915,14 +915,6 @@ fn plan_withdrawal_request(
 }
 
 #[inline]
-fn sync_external_in_flight_assets(op_state: &OpState) -> u128 {
-    match op_state {
-        OpState::Allocating(state) => state.remaining,
-        _ => 0,
-    }
-}
-
-#[inline]
 fn ensure_sync_external_state_allowed(op_state: &OpState) -> Result<(), KernelError> {
     match op_state {
         OpState::Allocating(_) | OpState::Withdrawing(_) | OpState::Refreshing(_) => Ok(()),
@@ -941,15 +933,6 @@ fn plan_external_asset_sync(
         .idle_assets
         .checked_add(new_external_assets)
         .ok_or_else(|| KernelError::from(InvalidStateCode::SyncExternalOverflowIdlePlusExternal))?;
-
-    let reference_total = state
-        .total_assets
-        .saturating_add(sync_external_in_flight_assets(&state.op_state));
-    if reference_total > 0 && new_total_assets > reference_total.saturating_mul(2) {
-        return Err(KernelError::from(
-            InvalidStateCode::SyncExternalWouldMoreThanDoubleTotalAssets,
-        ));
-    }
 
     Ok(ExternalAssetSyncPlan {
         new_external_assets,

--- a/contract/vault/kernel/src/actions/tests.rs
+++ b/contract/vault/kernel/src/actions/tests.rs
@@ -1239,15 +1239,15 @@ fn sync_external_assets_withdrawing() {
         None,
         &addr(0xFF),
         KernelAction::SyncExternalAssets {
-            new_external_assets: 400,
+            new_external_assets: 500,
             op_id: 4,
             now_ns: TimestampNs(0),
         },
     )
     .unwrap();
 
-    assert_eq!(result.state.external_assets, 400);
-    assert_eq!(result.state.total_assets, 900);
+    assert_eq!(result.state.external_assets, 500);
+    assert_eq!(result.state.total_assets, 1_000);
 }
 
 #[test]
@@ -1268,14 +1268,14 @@ fn sync_external_assets_refreshing() {
         None,
         &addr(0xFF),
         KernelAction::SyncExternalAssets {
-            new_external_assets: 600,
+            new_external_assets: 500,
             op_id: 5,
             now_ns: TimestampNs(0),
         },
     )
     .unwrap();
 
-    assert_eq!(result.state.external_assets, 600);
+    assert_eq!(result.state.external_assets, 500);
 }
 
 #[test]
@@ -1374,9 +1374,9 @@ fn sync_external_assets_payout_fails() {
 }
 
 #[test]
-fn sync_external_assets_rejects_doubling() {
+fn sync_external_assets_no_longer_applies_in_flight_allocation_bound() {
     use crate::state::op_state::AllocatingState;
-    // total_assets = 1000; trying to set external to 2001 would make new total > 2x
+
     let mut state = idle_state(1_000, 1_000);
     state.op_state = OpState::Allocating(AllocatingState {
         op_id: 1,
@@ -1392,24 +1392,21 @@ fn sync_external_assets_rejects_doubling() {
         None,
         &addr(0xFF),
         KernelAction::SyncExternalAssets {
-            new_external_assets: 2_001,
+            new_external_assets: 501,
             op_id: 1,
             now_ns: TimestampNs(0),
         },
-    );
+    )
+    .unwrap();
 
-    assert!(matches!(
-        result,
-        Err(KernelError::InvalidState(
-            InvalidStateCode::SyncExternalWouldMoreThanDoubleTotalAssets
-        ))
-    ));
+    assert_eq!(result.state.external_assets, 501);
+    assert_eq!(result.state.total_assets, 1_501);
 }
 
 #[test]
-fn sync_external_assets_allows_up_to_double() {
+fn sync_external_assets_allows_up_to_in_flight_allocation() {
     use crate::state::op_state::AllocatingState;
-    // total_assets = 1000; setting external to 1000 with idle=1000 => new total=2000 = 2x, OK
+
     let mut state = idle_state(1_000, 1_000);
     state.op_state = OpState::Allocating(AllocatingState {
         op_id: 1,
@@ -1425,7 +1422,7 @@ fn sync_external_assets_allows_up_to_double() {
         None,
         &addr(0xFF),
         KernelAction::SyncExternalAssets {
-            new_external_assets: 1_000,
+            new_external_assets: 500,
             op_id: 1,
             now_ns: TimestampNs(0),
         },
@@ -1433,7 +1430,66 @@ fn sync_external_assets_allows_up_to_double() {
 
     assert!(result.is_ok());
     let result = result.unwrap();
-    assert_eq!(result.state.total_assets, 2_000);
+    assert_eq!(result.state.external_assets, 500);
+    assert_eq!(result.state.total_assets, 1_500);
+}
+
+#[test]
+fn sync_external_assets_accepts_runtime_validated_refresh_total() {
+    use crate::state::op_state::RefreshingState;
+
+    let mut state = VaultState::with_initial(1_999, 1_000, 1_000, 999, TimestampNs(0));
+    state.op_state = OpState::Refreshing(RefreshingState {
+        op_id: 8,
+        index: 0,
+        plan: vec![0],
+    });
+    let config = test_config();
+
+    let result = apply_action(
+        state,
+        &config,
+        None,
+        &addr(0xFF),
+        KernelAction::SyncExternalAssets {
+            new_external_assets: 2_997,
+            op_id: 8,
+            now_ns: TimestampNs(0),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.state.external_assets, 2_997);
+    assert_eq!(result.state.total_assets, 3_997);
+}
+
+#[test]
+fn sync_external_assets_allows_decrease() {
+    use crate::state::op_state::RefreshingState;
+
+    let mut state = VaultState::with_initial(11_000, 1_000, 1_000, 10_000, TimestampNs(0));
+    state.op_state = OpState::Refreshing(RefreshingState {
+        op_id: 9,
+        index: 0,
+        plan: vec![0],
+    });
+    let config = test_config();
+
+    let result = apply_action(
+        state,
+        &config,
+        None,
+        &addr(0xFF),
+        KernelAction::SyncExternalAssets {
+            new_external_assets: 0,
+            op_id: 9,
+            now_ns: TimestampNs(0),
+        },
+    )
+    .unwrap();
+
+    assert_eq!(result.state.external_assets, 0);
+    assert_eq!(result.state.total_assets, 1_000);
 }
 
 #[test]

--- a/contract/vault/kernel/src/error.rs
+++ b/contract/vault/kernel/src/error.rs
@@ -27,7 +27,6 @@ pub enum InvalidStateCode {
     SyncExternalRequiresActiveOp = 16,
     SyncExternalRequiresAllowedStates = 17,
     SyncExternalOverflowIdlePlusExternal = 18,
-    SyncExternalWouldMoreThanDoubleTotalAssets = 19,
     AbortRefreshingRequiresActiveOp = 20,
     AbortRefreshingRequiresRefreshing = 21,
     AbortAllocatingRequiresAllocating = 22,
@@ -86,9 +85,6 @@ impl InvalidStateCode {
             }
             Self::SyncExternalOverflowIdlePlusExternal => {
                 "sync_external_assets overflow: idle + external exceeds u128"
-            }
-            Self::SyncExternalWouldMoreThanDoubleTotalAssets => {
-                "sync_external_assets would more than double total_assets"
             }
             Self::AbortRefreshingRequiresActiveOp => "abort_refreshing requires active op",
             Self::AbortRefreshingRequiresRefreshing => "abort_refreshing requires Refreshing",

--- a/contract/vault/kernel/tests/property_tests.rs
+++ b/contract/vault/kernel/tests/property_tests.rs
@@ -3819,7 +3819,6 @@ proptest! {
         in_flight in 0u64..1_000_000,
         delta in 0u64..1_000_000,
     ) {
-        let delta = delta.min(in_flight);
         let external = existing_external + delta;
         let mut state = VaultState::new();
         state.idle_assets = idle as u128;

--- a/contract/vault/kernel/tests/property_tests.rs
+++ b/contract/vault/kernel/tests/property_tests.rs
@@ -3815,18 +3815,21 @@ proptest! {
     #[test]
     fn prop_spec_sync_external_assets_updates_total(
         idle in 0u64..1_000_000,
-        external in 0u64..1_000_000,
+        existing_external in 0u64..1_000_000,
+        in_flight in 0u64..1_000_000,
+        delta in 0u64..1_000_000,
     ) {
-        prop_assume!(external <= idle);
+        let delta = delta.min(in_flight);
+        let external = existing_external + delta;
         let mut state = VaultState::new();
         state.idle_assets = idle as u128;
-        state.external_assets = 0;
-        state.total_assets = idle as u128;
+        state.external_assets = existing_external as u128;
+        state.total_assets = idle as u128 + existing_external as u128;
         state.op_state = OpState::Allocating(AllocatingState {
             op_id: 7,
             index: 0,
-            remaining: 0,
-            plan: vec![alloc_step(0, 0)],
+            remaining: in_flight as u128,
+            plan: vec![alloc_step(0, in_flight as u128)],
         });
 
         let config = default_config();

--- a/contract/vault/soroban/blend-adapter/Cargo.toml
+++ b/contract/vault/soroban/blend-adapter/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 testutils = ["soroban-sdk/testutils", "blend-contract-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { version = "25.3.0", features = ["experimental_spec_shaking_v2"] }
+soroban-sdk = { version = "25.3.0", features = ["experimental_spec_shaking_v2", "hazmat-address"] }
 blend-contract-sdk = "2.25.0"
 
 [dev-dependencies]

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -52,11 +52,21 @@ pub struct BlendAdapterContract;
 impl BlendAdapterContract {
     /// Runs atomically during contract deployment — no separate `initialize`
     /// transaction that could be front-run.
-    pub fn __constructor(env: Env, admin: Address, vault: Address, pool: Address) {
+    pub fn __constructor(
+        env: Env,
+        admin: Address,
+        vault: Address,
+        pool: Address,
+    ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
+        require_contract_address(&admin, AdapterError::InvalidInput)?;
+        require_contract_address(&vault, AdapterError::InvalidInput)?;
+        require_contract_address(&pool, AdapterError::InvalidInput)?;
+
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Vault, &vault);
         env.storage().instance().set(&DataKey::Pool, &pool);
+        Ok(())
     }
 
     /// Supply assets from the adapter into the Blend pool (vault-only).
@@ -300,12 +310,29 @@ mod tests {
         assert!(!BLEND_ADAPTER_SOURCE.contains(concat!("\n    pub fn ", "withdraw_to_vault(")));
     }
 
+    #[contract]
+    struct DummyContract;
+
+    #[contractimpl]
+    impl DummyContract {}
+
+    fn register_dummy_contract(env: &Env) -> Address {
+        env.register(DummyContract, ())
+    }
+
+    fn account_address(env: &Env) -> Address {
+        Address::from_str(
+            env,
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        )
+    }
+
     #[test]
     fn constructor_sets_config() {
         let env = Env::default();
-        let admin = Address::generate(&env);
-        let vault = Address::generate(&env);
-        let pool = Address::generate(&env);
+        let admin = register_dummy_contract(&env);
+        let vault = register_dummy_contract(&env);
+        let pool = register_dummy_contract(&env);
 
         let contract_id = env.register(BlendAdapterContract, (&admin, &vault, &pool));
         env.as_contract(&contract_id, || {
@@ -315,11 +342,44 @@ mod tests {
         });
     }
 
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_admin() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let vault = register_dummy_contract(&env);
+        let pool = register_dummy_contract(&env);
+
+        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_vault() {
+        let env = Env::default();
+        let admin = register_dummy_contract(&env);
+        let vault = account_address(&env);
+        let pool = register_dummy_contract(&env);
+
+        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_pool() {
+        let env = Env::default();
+        let admin = register_dummy_contract(&env);
+        let vault = register_dummy_contract(&env);
+        let pool = account_address(&env);
+
+        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+    }
+
     /// Helper: deploy a contract via constructor and return (contract_id, admin, vault, pool).
     fn setup_adapter(env: &Env) -> (Address, Address, Address, Address) {
-        let admin = Address::generate(env);
-        let vault = Address::generate(env);
-        let pool = Address::generate(env);
+        let admin = register_dummy_contract(env);
+        let vault = register_dummy_contract(env);
+        let pool = register_dummy_contract(env);
         let contract_id = env.register(BlendAdapterContract, (&admin, &vault, &pool));
         (contract_id, admin, vault, pool)
     }

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -59,32 +59,6 @@ impl BlendAdapterContract {
         env.storage().instance().set(&DataKey::Pool, &pool);
     }
 
-    /// Update the Blend pool contract address (admin-only).
-    #[allow(deprecated)]
-    pub fn set_pool(env: Env, caller: Address, pool: Address) -> Result<(), AdapterError> {
-        extend_instance_ttl(&env);
-        require_admin(&env, &caller)?;
-        require_contract_address(&pool, AdapterError::InvalidInput)?;
-        let old_pool = get_pool(&env)?;
-        env.storage().instance().set(&DataKey::Pool, &pool);
-        env.events()
-            .publish((symbol_short!("pool_upd"), old_pool), pool);
-        Ok(())
-    }
-
-    /// Update the vault contract address (admin-only).
-    #[allow(deprecated)]
-    pub fn set_vault(env: Env, caller: Address, vault: Address) -> Result<(), AdapterError> {
-        extend_instance_ttl(&env);
-        require_admin(&env, &caller)?;
-        require_contract_address(&vault, AdapterError::InvalidInput)?;
-        let old_vault = get_vault(&env)?;
-        env.storage().instance().set(&DataKey::Vault, &vault);
-        env.events()
-            .publish((symbol_short!("vlt_upd"), old_vault), vault);
-        Ok(())
-    }
-
     /// Supply assets from the adapter into the Blend pool (vault-only).
     #[allow(deprecated)]
     pub fn supply(
@@ -316,17 +290,9 @@ mod tests {
     extern crate std;
 
     use super::*;
-    use soroban_sdk::testutils::{Address as _, Events as _};
+    use soroban_sdk::testutils::Address as _;
 
     const BLEND_ADAPTER_SOURCE: &str = include_str!("lib.rs");
-
-    fn adapter_event_count(env: &Env, adapter: &Address) -> usize {
-        env.events()
-            .all()
-            .filter_by_contract(adapter)
-            .events()
-            .len()
-    }
 
     #[test]
     fn admin_accounting_shortcuts_are_not_public_entrypoints() {
@@ -517,109 +483,12 @@ mod tests {
     }
 
     #[test]
-    fn set_pool_updates_pool() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
-        let new_pool = Address::generate(&env);
-        env.as_contract(&contract_id, || {
-            BlendAdapterContract::set_pool(env.clone(), admin.clone(), new_pool.clone()).unwrap();
-            assert_eq!(BlendAdapterContract::pool(env.clone()).unwrap(), new_pool);
-        });
-    }
-
-    #[test]
-    fn set_vault_updates_vault() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
-        let new_vault = Address::generate(&env);
-        env.as_contract(&contract_id, || {
-            BlendAdapterContract::set_vault(env.clone(), admin.clone(), new_vault.clone()).unwrap();
-            assert_eq!(BlendAdapterContract::vault(env.clone()).unwrap(), new_vault);
-        });
-    }
-
-    #[test]
-    fn set_pool_emits_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, admin, _vault, _old_pool) = setup_adapter(&env);
-        let new_pool = Address::generate(&env);
-        env.as_contract(&contract_id, || {
-            BlendAdapterContract::set_pool(env.clone(), admin, new_pool.clone()).unwrap();
-        });
-        assert_eq!(adapter_event_count(&env, &contract_id), 1);
-    }
-
-    #[test]
-    fn set_vault_emits_event() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, admin, _old_vault, _pool) = setup_adapter(&env);
-        let new_vault = Address::generate(&env);
-        env.as_contract(&contract_id, || {
-            BlendAdapterContract::set_vault(env.clone(), admin, new_vault.clone()).unwrap();
-        });
-        assert_eq!(adapter_event_count(&env, &contract_id), 1);
-    }
-
-    #[test]
-    fn set_pool_unauthorized_rejected() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, _admin, _vault, _pool) = setup_adapter(&env);
-        let impostor = Address::generate(&env);
-        let new_pool = Address::generate(&env);
-        env.as_contract(&contract_id, || {
-            let result =
-                BlendAdapterContract::set_pool(env.clone(), impostor.clone(), new_pool.clone());
-            assert_eq!(result, Err(AdapterError::Unauthorized));
-        });
-    }
-
-    #[test]
-    fn set_pool_rejects_non_contract_address() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
-        let account = Address::from_str(
-            &env,
-            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-        );
-        env.as_contract(&contract_id, || {
-            let result = BlendAdapterContract::set_pool(env.clone(), admin, account);
-            assert_eq!(result, Err(AdapterError::InvalidInput));
-        });
-    }
-
-    #[test]
-    fn set_vault_unauthorized_rejected() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, _admin, _vault, _pool) = setup_adapter(&env);
-        let impostor = Address::generate(&env);
-        let new_vault = Address::generate(&env);
-        env.as_contract(&contract_id, || {
-            let result =
-                BlendAdapterContract::set_vault(env.clone(), impostor.clone(), new_vault.clone());
-            assert_eq!(result, Err(AdapterError::Unauthorized));
-        });
-    }
-
-    #[test]
-    fn set_vault_rejects_non_contract_address() {
-        let env = Env::default();
-        env.mock_all_auths();
-        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
-        let account = Address::from_str(
-            &env,
-            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
-        );
-        env.as_contract(&contract_id, || {
-            let result = BlendAdapterContract::set_vault(env.clone(), admin, account);
-            assert_eq!(result, Err(AdapterError::InvalidInput));
-        });
+    fn blend_adapter_does_not_expose_admin_retarget_entrypoints() {
+        let source = include_str!("lib.rs");
+        assert!(!source.contains(concat!("pub fn ", "set_pool")));
+        assert!(!source.contains(concat!("pub fn ", "set_vault")));
+        assert!(!source.contains(concat!("pool", "_upd")));
+        assert!(!source.contains(concat!("vlt", "_upd")));
     }
 
     // Note: "query before initialize" test not applicable — __constructor

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -247,96 +247,6 @@ impl BlendAdapterContract {
         get_pool(&env)
     }
 
-    /// Supply tokens already on the adapter into the Blend pool (admin-only).
-    ///
-    /// Use this after transferring tokens to the adapter address.
-    /// Flow: admin transfers tokens to adapter → admin calls supply_balance → adapter supplies to pool.
-    #[allow(deprecated)]
-    pub fn supply_balance(
-        env: Env,
-        caller: Address,
-        asset: Address,
-        amount: i128,
-    ) -> Result<(), AdapterError> {
-        extend_instance_ttl(&env);
-        require_admin(&env, &caller)?;
-        if amount <= 0 {
-            return Err(AdapterError::InvalidInput);
-        }
-
-        let pool = get_pool(&env)?;
-        let client = PoolClient::new(&env, &pool);
-        let adapter = env.current_contract_address();
-        let request = Request {
-            request_type: REQUEST_SUPPLY,
-            address: asset.clone(),
-            amount,
-        };
-        let mut requests = Vec::new(&env);
-        requests.push_back(request);
-
-        env.authorize_as_current_contract(Vec::from_array(
-            &env,
-            [InvokerContractAuthEntry::Contract(SubContractInvocation {
-                context: ContractContext {
-                    contract: asset.clone(),
-                    fn_name: Symbol::new(&env, "transfer"),
-                    args: (adapter.clone(), pool.clone(), amount).into_val(&env),
-                },
-                sub_invocations: Vec::new(&env),
-            })],
-        ));
-
-        client.submit(&adapter, &adapter, &adapter, &requests);
-        env.events()
-            .publish((symbol_short!("supply"), asset), amount);
-        Ok(())
-    }
-
-    /// Withdraw tokens from the Blend pool and send to the vault (admin-only).
-    ///
-    /// Use this when the vault's allocate_withdraw has already updated accounting.
-    #[allow(deprecated)]
-    pub fn withdraw_to_vault(
-        env: Env,
-        caller: Address,
-        asset: Address,
-        amount: i128,
-    ) -> Result<i128, AdapterError> {
-        extend_instance_ttl(&env);
-        require_admin(&env, &caller)?;
-        if amount <= 0 {
-            return Err(AdapterError::InvalidInput);
-        }
-        let vault = get_vault(&env)?;
-
-        let pool = get_pool(&env)?;
-        let client = PoolClient::new(&env, &pool);
-        let adapter = env.current_contract_address();
-        let request = Request {
-            request_type: REQUEST_WITHDRAW,
-            address: asset.clone(),
-            amount,
-        };
-        let mut requests = Vec::new(&env);
-        requests.push_back(request);
-        let token = soroban_sdk::token::Client::new(&env, &asset);
-        let balance_before = token.balance(&adapter);
-        client.submit(&adapter, &adapter, &adapter, &requests);
-
-        let balance_after = token.balance(&adapter);
-        let actual_withdrawn = balance_after
-            .checked_sub(balance_before)
-            .ok_or(AdapterError::ArithmeticUnderflow)?;
-        if actual_withdrawn <= 0 {
-            return Err(AdapterError::ZeroWithdrawal);
-        }
-        token.transfer(&adapter, &vault, &actual_withdrawn);
-        env.events()
-            .publish((symbol_short!("withdraw"), asset), actual_withdrawn);
-        Ok(actual_withdrawn)
-    }
-
     /// Extend instance storage TTL (admin-only).
     pub fn extend_ttl(env: Env, caller: Address) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
@@ -408,12 +318,20 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Events as _};
 
+    const BLEND_ADAPTER_SOURCE: &str = include_str!("lib.rs");
+
     fn adapter_event_count(env: &Env, adapter: &Address) -> usize {
         env.events()
             .all()
             .filter_by_contract(adapter)
             .events()
             .len()
+    }
+
+    #[test]
+    fn admin_accounting_shortcuts_are_not_public_entrypoints() {
+        assert!(!BLEND_ADAPTER_SOURCE.contains(concat!("\n    pub fn ", "supply_balance(")));
+        assert!(!BLEND_ADAPTER_SOURCE.contains(concat!("\n    pub fn ", "withdraw_to_vault(")));
     }
 
     #[test]

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 use soroban_sdk::{
+    address_payload::AddressPayload,
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, IntoVal,
     Symbol, Vec,
@@ -277,8 +278,10 @@ fn require_vault(env: &Env, caller: &Address) -> Result<(), AdapterError> {
 }
 
 fn is_contract_address(addr: &Address) -> bool {
-    let bytes = addr.to_string().to_bytes();
-    matches!(bytes.get(0), Some(b'C'))
+    matches!(
+        AddressPayload::from_address(addr),
+        Some(AddressPayload::ContractIdHash(_))
+    )
 }
 
 fn require_contract_address(addr: &Address, err: AdapterError) -> Result<(), AdapterError> {

--- a/contract/vault/soroban/blend-adapter/tests/integration_tests.rs
+++ b/contract/vault/soroban/blend-adapter/tests/integration_tests.rs
@@ -8,6 +8,7 @@ use blend_contract_sdk::{
     testutils::{default_reserve_config, BlendFixture},
 };
 use soroban_sdk::{
+    contract, contractimpl,
     testutils::{Address as _, BytesN as _},
     token::StellarAssetClient,
     Address, BytesN, Env, String,
@@ -15,6 +16,16 @@ use soroban_sdk::{
 use templar_soroban_blend_adapter::{
     AdapterError, BlendAdapterContract, BlendAdapterContractClient,
 };
+
+#[contract]
+struct DummyContract;
+
+#[contractimpl]
+impl DummyContract {}
+
+fn register_dummy_contract(env: &Env) -> Address {
+    env.register(DummyContract, ())
+}
 
 /// Deploy the full Blend protocol, create a pool with one reserve, and activate it.
 fn setup_blend_pool(
@@ -71,7 +82,7 @@ fn setup_adapter<'a>(
     pool: &Address,
     vault: &Address,
 ) -> (Address, Address, BlendAdapterContractClient<'a>) {
-    let admin = Address::generate(env);
+    let admin = register_dummy_contract(env);
     let adapter = env.register(BlendAdapterContract, (&admin, vault, pool));
     let client = BlendAdapterContractClient::new(env, &adapter);
     (adapter, admin, client)
@@ -83,7 +94,7 @@ fn supply_success_deposits_to_pool() {
     env.mock_all_auths();
     let (pool, pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -106,7 +117,7 @@ fn withdraw_success_returns_assets() {
     env.mock_all_auths();
     let (pool, pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -137,7 +148,7 @@ fn total_assets_returns_correct_value_after_supply() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -160,7 +171,7 @@ fn total_assets_missing_position_returns_error() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, _asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, _client) = setup_adapter(&env, &pool, &vault);
 
     // Query without supplying — call via env.as_contract since the client
@@ -181,7 +192,7 @@ fn total_assets_decreases_after_withdraw() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (_adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -210,12 +221,12 @@ fn rescue_transfers_assets_to_receiver() {
     let asset = asset_sac.address();
     let asset_admin = StellarAssetClient::new(&env, &asset);
 
-    let vault = Address::generate(&env);
-    let pool = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
+    let pool = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let rescue_amount: i128 = 5_000_000_000;
-    let receiver = Address::generate(&env);
+    let receiver = register_dummy_contract(&env);
     asset_admin.mint(&adapter, &rescue_amount);
 
     client.rescue(&vault, &asset, &rescue_amount, &receiver);
@@ -243,7 +254,7 @@ fn full_supply_withdraw_cycle() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (_adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let amount: i128 = 20_000_000_000;

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -554,21 +554,6 @@ blend-adapter-pool:
 blend-adapter-total-assets asset_address:
 	@just blend-invoke total_assets --asset "{{asset_address}}"
 
-# Update the Blend pool address (admin only).
-blend-adapter-set-pool new_pool:
-	@admin="${SOROBAN_ADMIN:-$(cat {{state_dir}}/admin_address 2>/dev/null)}"; \
-	echo "Updating Blend adapter pool to {{new_pool}}..."; \
-	just blend-invoke set_pool --caller "$admin" --pool "{{new_pool}}"; \
-	echo "{{new_pool}}" > "{{state_dir}}/blend_pool_id"; \
-	echo "✓ Pool updated"
-
-# Update the Blend adapter's vault reference (admin only).
-blend-adapter-set-vault new_vault:
-	@admin="${SOROBAN_ADMIN:-$(cat {{state_dir}}/admin_address 2>/dev/null)}"; \
-	echo "Updating Blend adapter vault to {{new_vault}}..."; \
-	just blend-invoke set_vault --caller "$admin" --vault "{{new_vault}}"; \
-	echo "✓ Vault updated"
-
 # Rescue stuck assets from the adapter (vault only - for emergencies).
 blend-adapter-rescue asset amount receiver:
 	@vault_id="${SOROBAN_CONTRACT_ID:-$(cat {{state_dir}}/vault_id 2>/dev/null)}"; \

--- a/contract/vault/soroban/src/contract/curator_vault.rs
+++ b/contract/vault/soroban/src/contract/curator_vault.rs
@@ -749,6 +749,52 @@ where
             .unwrap_or_else(|_| abort!("market principal failed"));
     }
 
+    fn set_policy_principal(
+        policy: &mut PolicyState,
+        market: TargetId,
+        principal: u128,
+        message: &'static str,
+    ) -> Result<(), RuntimeError> {
+        policy
+            .set_principal(market, principal)
+            .map_err(|_| invalid_state_error(message))
+    }
+
+    fn validate_supply_observation(
+        policy: &PolicyState,
+        market: TargetId,
+        observed_total_assets: u128,
+        supply_amount: u128,
+    ) -> Result<(), RuntimeError> {
+        let previous_principal = policy
+            .principal_for(market)
+            .ok_or_else(|| invalid_state_error("unknown market principal on supply"))?;
+        let max_principal = previous_principal
+            .checked_add(supply_amount)
+            .ok_or_else(|| invalid_state_error("principal overflow on supply"))?;
+        if observed_total_assets < previous_principal || observed_total_assets > max_principal {
+            return Err(invalid_state_error("supply observation out of bounds"));
+        }
+        Ok(())
+    }
+
+    fn validate_refresh_observation(
+        policy: &PolicyState,
+        market: TargetId,
+        observed_total_assets: u128,
+    ) -> Result<(), RuntimeError> {
+        let cap = policy
+            .market_config(market)
+            .ok_or_else(|| invalid_state_error("unknown refreshed market"))?
+            .cap;
+        if observed_total_assets > cap {
+            return Err(invalid_state_error(
+                "refresh observation exceeds market cap",
+            ));
+        }
+        Ok(())
+    }
+
     pub(crate) fn complete_supply_allocation(
         &mut self,
         caller: Address,
@@ -757,14 +803,35 @@ where
         op_id: u64,
         now_ns: u64,
     ) -> Result<u128, RuntimeError> {
-        self.update_market_principal(market, observed_total_assets);
-        let new_external = self.sync_external_assets(
-            caller,
-            op_id,
-            self.policy_state().external_assets()?,
-            now_ns,
+        let allocation = self
+            .state()?
+            .op_state
+            .as_allocating()
+            .ok_or_else(|| invalid_state_error(""))?;
+        let current_step = allocation
+            .plan
+            .get(allocation.index as usize)
+            .ok_or_else(|| invalid_state_error("allocation step missing"))?;
+        if current_step.target_id != market {
+            return Err(RuntimeError::invalid_input(""));
+        }
+        Self::validate_supply_observation(
+            self.policy_state(),
+            market,
+            observed_total_assets,
+            current_step.amount,
         )?;
+        let mut staged_policy = self.policy_state.clone();
+        Self::set_policy_principal(
+            &mut staged_policy,
+            market,
+            observed_total_assets,
+            "market principal failed",
+        )?;
+        let new_external_assets = staged_policy.external_assets()?;
+        let new_external = self.sync_external_assets(caller, op_id, new_external_assets, now_ns)?;
         self.finish_allocation_internal(caller, op_id, now_ns)?;
+        self.policy_state = staged_policy;
         self.storage.save_policy_state(&self.policy_state)?;
         Ok(new_external)
     }
@@ -816,13 +883,21 @@ where
         Ok(())
     }
 
-    fn apply_refreshed_positions(&mut self, refreshed_positions: &[(TargetId, u128)]) {
-        let policy = self.policy_state_mut();
+    fn stage_refreshed_positions(
+        &self,
+        refreshed_positions: &[(TargetId, u128)],
+    ) -> Result<PolicyState, RuntimeError> {
+        let mut policy = self.policy_state.clone();
         for &(market, total_assets) in refreshed_positions {
-            policy
-                .set_principal(market, total_assets)
-                .unwrap_or_else(|_| abort!("refresh principal failed"));
+            Self::validate_refresh_observation(&policy, market, total_assets)?;
+            Self::set_policy_principal(
+                &mut policy,
+                market,
+                total_assets,
+                "refresh principal failed",
+            )?;
         }
+        Ok(policy)
     }
 
     pub(crate) fn complete_refresh_with_positions(
@@ -834,10 +909,11 @@ where
     ) -> Result<RefreshResult, RuntimeError> {
         let refreshed_positions = Self::classify_refreshed_positions(refreshed_positions);
         self.validate_refreshed_positions_against_plan(&refreshed_positions)?;
-        self.apply_refreshed_positions(&refreshed_positions);
-        let new_external_assets = self.policy_state().external_assets()?;
+        let staged_policy = self.stage_refreshed_positions(&refreshed_positions)?;
+        let new_external_assets = staged_policy.external_assets()?;
         self.sync_external_assets(caller, op_id, new_external_assets, now_ns)?;
         let result = self.finish_refreshing(caller, op_id, now_ns)?;
+        self.policy_state = staged_policy;
         self.storage.save_policy_state(&self.policy_state)?;
         Ok(result)
     }

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -384,14 +384,12 @@ fn allocate_impl(
     }
     let now_ns = ledger_timestamp_ns(env)?;
     let asset_token = get_config_address(env, &VaultDataKey::AssetToken)?;
+    let asset_client = soroban_sdk::token::Client::new(env, &asset_token);
+    let vault_address = env.current_contract_address();
     let mut new_external: u128 = 0;
     let emitted_amount = if supply {
         let amount_u128 = to_u128(amount)?;
-        soroban_sdk::token::Client::new(env, &asset_token).transfer(
-            &env.current_contract_address(),
-            &adapter,
-            &amount,
-        );
+        asset_client.transfer(&vault_address, &adapter, &amount);
         invoke_supply(env, &adapter, &asset_token, amount);
         let observed_total_assets = to_u128(invoke_total_assets(env, &adapter, &asset_token))?;
 
@@ -410,7 +408,15 @@ fn allocate_impl(
         with_contract_vault_contract_error(env, &mut call)?;
         amount
     } else {
+        let balance_before = asset_client.balance(&vault_address);
         let realized_amount = invoke_progress_withdrawal(env, &adapter, &asset_token, amount);
+        let balance_after = asset_client.balance(&vault_address);
+        let observed_delta = balance_after
+            .checked_sub(balance_before)
+            .ok_or(ContractError::InvalidState)?;
+        if realized_amount != observed_delta {
+            return Err(ContractError::InvalidState);
+        }
         let realized_amount_u128 = to_u128(realized_amount)?;
 
         let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -296,6 +296,7 @@ mod contract_tests {
     use alloc::vec;
     use alloc::vec::Vec;
     use soroban_sdk::{Address as SdkAddress, Bytes, Env};
+    use templar_curator_primitives::policy::state::MarketConfig;
     use templar_curator_primitives::PolicyState;
     use templar_soroban_shared_types::{
         GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
@@ -587,6 +588,36 @@ mod contract_tests {
     }
 
     #[test]
+    fn test_complete_supply_allocation_rejects_observed_assets_above_supplied_step() {
+        let mut vault = create_test_vault();
+        let caller = templar_vault_kernel::Address([3u8; 32]);
+
+        {
+            let policy = vault.policy_state_mut();
+            policy
+                .set_market_config(0, MarketConfig::new(true, 10_000, None))
+                .unwrap();
+            policy.set_principal(0, 1_000).unwrap();
+        }
+        {
+            let state = vault.state_mut().unwrap();
+            state.idle_assets = 1_000;
+            state.external_assets = 1_000;
+            state.total_assets = 2_000;
+        }
+        let op_id = begin_allocating(&mut vault, caller, vec![(0, 500)], 1_000).unwrap();
+
+        let error = vault
+            .complete_supply_allocation(caller, 0, 1_501, op_id, 1_000)
+            .expect_err("supply callback must not over-report the active step");
+
+        assert_eq!(error, RuntimeError::InvalidState);
+        assert!(vault.state().unwrap().op_state.is_allocating());
+        assert_eq!(vault.state().unwrap().external_assets, 1_000);
+        assert_eq!(vault.policy_state().principal_for(0), Some(1_000));
+    }
+
+    #[test]
     fn test_sync_external_assets_requires_active_allocation_op_id() {
         let mut vault = create_test_vault();
         let caller = templar_vault_kernel::Address([3u8; 32]); // allocator
@@ -666,6 +697,67 @@ mod contract_tests {
 
         assert_eq!(error, RuntimeError::InvalidInput);
         assert!(vault.state().unwrap().op_state.is_refreshing());
+    }
+
+    #[test]
+    fn test_complete_refresh_rejects_cumulative_adapter_inflation() {
+        let mut vault = create_test_vault();
+        let caller = templar_vault_kernel::Address([3u8; 32]);
+
+        {
+            let policy = vault.policy_state_mut();
+            policy
+                .set_market_config(0, MarketConfig::new(true, 1_998, None))
+                .unwrap();
+            policy.set_principal(0, 999).unwrap();
+        }
+        {
+            let state = vault.state_mut().unwrap();
+            state.idle_assets = 1_000;
+            state.external_assets = 999;
+            state.total_assets = 1_999;
+        }
+        let op_id = vault.begin_refreshing(caller, vec![0], 1_500).unwrap();
+
+        let error = vault
+            .complete_refresh_with_positions(caller, &[(0, 2_997)], op_id, 1_500)
+            .expect_err("refresh must not accept cumulative adapter inflation");
+
+        assert_eq!(error, RuntimeError::InvalidState);
+        assert!(vault.state().unwrap().op_state.is_refreshing());
+        assert_eq!(vault.state().unwrap().external_assets, 999);
+        assert_eq!(vault.policy_state().principal_for(0), Some(999));
+    }
+
+    #[test]
+    fn test_complete_refresh_allows_adapter_reported_decrease_within_cap() {
+        let mut vault = create_test_vault();
+        let caller = templar_vault_kernel::Address([3u8; 32]);
+
+        {
+            let policy = vault.policy_state_mut();
+            policy
+                .set_market_config(0, MarketConfig::new(true, 10_000, None))
+                .unwrap();
+            policy.set_principal(0, 10_000).unwrap();
+        }
+        {
+            let state = vault.state_mut().unwrap();
+            state.idle_assets = 1_000;
+            state.external_assets = 10_000;
+            state.total_assets = 11_000;
+        }
+        let op_id = vault.begin_refreshing(caller, vec![0], 1_500).unwrap();
+
+        let result = vault
+            .complete_refresh_with_positions(caller, &[(0, 0)], op_id, 1_500)
+            .expect("refresh may report a legitimate market decrease");
+
+        assert_eq!(result.markets_refreshed, 1);
+        assert!(vault.state().unwrap().op_state.is_idle());
+        assert_eq!(vault.state().unwrap().external_assets, 0);
+        assert_eq!(vault.state().unwrap().total_assets, 1_000);
+        assert_eq!(vault.policy_state().principal_for(0), Some(0));
     }
 
     #[test]

--- a/contract/vault/soroban/tests/blend_e2e.rs
+++ b/contract/vault/soroban/tests/blend_e2e.rs
@@ -3,6 +3,7 @@ use blend_contract_sdk::{
     testutils::{default_reserve_config, BlendFixture},
 };
 use soroban_sdk::{
+    contract, contractimpl,
     testutils::{Address as _, BytesN as _},
     token::StellarAssetClient,
     Address, Bytes, BytesN, Env, String,
@@ -130,6 +131,24 @@ fn setup_blend_pool(
 
 fn vault_snapshot(env: &Env, vault: &Address) -> (i128, i128, i128) {
     VaultProxy::new(env).snapshot(vault)
+}
+
+#[contract]
+pub struct OverreportingAdapter;
+
+#[contractimpl]
+impl OverreportingAdapter {
+    pub fn supply(env: Env, _vault: Address, _asset: Address, amount: i128) {
+        env.storage().instance().set(&0u32, &amount);
+    }
+
+    pub fn progress_withdrawal(_env: Env, _vault: Address, _asset: Address, amount: i128) -> i128 {
+        amount
+    }
+
+    pub fn total_assets(env: Env, _asset: Address) -> i128 {
+        env.storage().instance().get(&0u32).unwrap_or(0)
+    }
 }
 
 #[test]
@@ -327,4 +346,151 @@ fn vault_allocates_supply_to_blend_and_withdraws_back() {
     let b_tokens_after_withdraw = positions_after_withdraw.supply.get(0).unwrap_or(0);
     assert!(b_tokens_after_withdraw > 0);
     assert!(b_tokens_after_withdraw < b_tokens_after_supply);
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn withdraw_allocation_rejects_adapter_reported_assets_without_matching_balance_delta() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let governance = Address::generate(&env);
+    let allocator = Address::generate(&env);
+    let user = Address::generate(&env);
+    let vault = env.register(SorobanVaultContract, ());
+    let asset_admin = Address::generate(&env);
+    let asset_sac = env.register_stellar_asset_contract_v2(asset_admin);
+    let asset = asset_sac.address();
+    let asset_admin = StellarAssetClient::new(&env, &asset);
+    let share = env
+        .register_stellar_asset_contract_v2(vault.clone())
+        .address();
+    let adapter = env.register(OverreportingAdapter, ());
+    let asset_client = soroban_sdk::token::Client::new(&env, &asset);
+    let proxy = VaultProxy::new(&env);
+
+    env.as_contract(&vault, || {
+        proxy.initialize(&governance, &asset, &share);
+    });
+    env.as_contract(&vault, || {
+        execute_governance_command(
+            &env,
+            &governance,
+            &GovernanceCommand::SetGovernanceConfig {
+                kind: GOVERNANCE_CONFIG_KIND_ALLOCATORS,
+                primary: None,
+                many: Some(vec![address_wire(&allocator)]),
+                value_a: None,
+                value_b: None,
+            },
+        )
+        .unwrap();
+    });
+    env.as_contract(&vault, || {
+        let mut storage = SorobanStorage::new(&env);
+        let mut policy_state = storage.load_policy_state().unwrap().unwrap_or_default();
+        policy_state
+            .set_market_config(0, MarketConfig::new(true, i128::MAX as u128, None))
+            .unwrap();
+        storage.save_policy_state(&policy_state).unwrap();
+    });
+    env.as_contract(&vault, || {
+        execute_governance_command(
+            &env,
+            &governance,
+            &GovernanceCommand::SetGovernancePolicy {
+                kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+                target_ids: Some(vec![0u32]),
+                mode: None,
+                accounts: None,
+                market_id: None,
+                cap_group_id: None,
+                value: None,
+                value_b: None,
+                value_c: None,
+            },
+        )
+        .unwrap();
+    });
+    env.as_contract(&vault, || {
+        execute_governance_command(
+            &env,
+            &governance,
+            &GovernanceCommand::SetGovernanceConfig {
+                kind: GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS,
+                primary: None,
+                many: Some(vec![address_wire(&adapter)]),
+                value_a: None,
+                value_b: None,
+            },
+        )
+        .unwrap();
+    });
+
+    let deposit_amount = 10_000_000_000;
+    let supply_amount = 6_000_000_000;
+    let withdraw_amount = 2_500_000_000;
+
+    asset_admin.mint(&user, &deposit_amount);
+
+    env.as_contract(&vault, || {
+        execute_command(
+            &env,
+            &VaultCommand::DepositWithMin {
+                owner: address_wire(&user),
+                receiver: address_wire(&user),
+                assets: deposit_amount,
+                min_shares_out: 0,
+            },
+        )
+    })
+    .unwrap();
+    env.as_contract(&vault, || {
+        execute_command(
+            &env,
+            &VaultCommand::Allocate {
+                caller: address_wire(&allocator),
+                market: 0,
+                amount: supply_amount,
+                supply: true,
+            },
+        )
+    })
+    .unwrap();
+
+    assert_eq!(
+        vault_snapshot(&env, &vault),
+        (
+            deposit_amount,
+            deposit_amount - supply_amount,
+            supply_amount
+        )
+    );
+    let balance_before = asset_client.balance(&vault);
+
+    let result = env.as_contract(&vault, || {
+        execute_command(
+            &env,
+            &VaultCommand::Allocate {
+                caller: address_wire(&allocator),
+                market: 0,
+                amount: withdraw_amount,
+                supply: false,
+            },
+        )
+    });
+
+    assert!(
+        result.is_err(),
+        "withdraw allocation must reject adapter-reported assets that did not reach the vault"
+    );
+    assert_eq!(asset_client.balance(&vault), balance_before);
+    assert_eq!(
+        vault_snapshot(&env, &vault),
+        (
+            deposit_amount,
+            deposit_amount - supply_amount,
+            supply_amount
+        )
+    );
 }


### PR DESCRIPTION
## Summary

Consolidated adapter follow-up PR for the tracker-defined `adapter-accounting-and-blend-admin` boundary. This supersedes the previously split draft PRs #433, #434, #438, and #439.

Findings covered:

| Local / Nexus finding | Remediation |
|---|---|
| A-032 / Nexus `0c991b9f-9a55-4006-b3fc-e5af3fbb7605` | Verify adapter withdrawal reports against the vault asset-token balance delta before mutating kernel accounting. |
| A-033 / Nexus `bc013b77-b8a9-4b9a-867a-228152a95c3b` | Validate adapter-reported external asset observations at the Soroban runtime policy boundary before kernel sync. |
| A-034 / Nexus `76f200c7-618d-4fd1-bff3-109530b96144` | Remove Blend adapter admin accounting shortcuts (`supply_balance`, `withdraw_to_vault`) so managed positions mutate only through the vault-routed lifecycle. |
| A-035 / Nexus `81068879-6d1a-460a-b176-bc982fb254cd` | Remove undeployed Blend adapter mutable retarget ABI (`set_pool`, `set_vault`) and stale retarget events/recipes. |
| A-060 / Nexus `6a5a3ec7-5477-4c2f-9488-30308ab956d6` | Require constructor-bound Blend adapter admin/vault/pool addresses to be contract addresses before config persistence. |

## Tracker / PR boundary note

The audit tracker's `adapter-identity-and-governance` cluster calls for a single follow-up PR boundary named `adapter-accounting-and-blend-admin` for A-032/A-033/A-034/A-035 plus A-060 if accepted. This PR is now that consolidated boundary.

Superseded split PRs:

- #433 — A-033 — folded into this PR
- #434 — A-034 — folded into this PR
- #438 — A-035 — folded into this PR
- #439 — A-060 — folded into this PR after #438's retarget-ABI deletion

## Verification

- `cargo fmt --all -- --check`
- `git diff --check`
- source-shape sweep found no public Blend adapter `set_pool`, `set_vault`, `supply_balance`, `withdraw_to_vault`, `pool_upd`, or `vlt_upd` symbols
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-adapter-consolidated/.target-consolidated cargo test -p templar-soroban-blend-adapter -- --nocapture` — 16 unit + 7 integration passed
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-adapter-consolidated/.target-consolidated cargo test -p templar-soroban-runtime --features testutils complete_refresh -- --nocapture` — 3 runtime tests + 1 property-filtered test passed
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-adapter-consolidated/.target-consolidated cargo test -p templar-soroban-runtime --test blend_e2e withdraw_allocation_rejects_adapter_reported_assets_without_matching_balance_delta -- --nocapture` — 1 passed
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-adapter-consolidated/.target-consolidated cargo test -p templar-vault-kernel sync_external_assets -- --nocapture` — 10 unit + 1 property-filtered test passed
- post-commit Soroban `size-budget-check` hook passed on consolidated commits at `95908` bytes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/431)
<!-- Reviewable:end -->
