### PR TITLE
fix: remove Blend adapter admin shortcuts

### DIFF
--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -247,96 +247,6 @@ impl BlendAdapterContract {
         get_pool(&env)
     }
 
-    /// Supply tokens already on the adapter into the Blend pool (admin-only).
-    ///
-    /// Use this after transferring tokens to the adapter address.
-    /// Flow: admin transfers tokens to adapter → admin calls supply_balance → adapter supplies to pool.
-    #[allow(deprecated)]
-    pub fn supply_balance(
-        env: Env,
-        caller: Address,
-        asset: Address,
-        amount: i128,
-    ) -> Result<(), AdapterError> {
-        extend_instance_ttl(&env);
-        require_admin(&env, &caller)?;
-        if amount <= 0 {
-            return Err(AdapterError::InvalidInput);
-        }
-
-        let pool = get_pool(&env)?;
-        let client = PoolClient::new(&env, &pool);
-        let adapter = env.current_contract_address();
-        let request = Request {
-            request_type: REQUEST_SUPPLY,
-            address: asset.clone(),
-            amount,
-        };
-        let mut requests = Vec::new(&env);
-        requests.push_back(request);
-
-        env.authorize_as_current_contract(Vec::from_array(
-            &env,
-            [InvokerContractAuthEntry::Contract(SubContractInvocation {
-                context: ContractContext {
-                    contract: asset.clone(),
-                    fn_name: Symbol::new(&env, "transfer"),
-                    args: (adapter.clone(), pool.clone(), amount).into_val(&env),
-                },
-                sub_invocations: Vec::new(&env),
-            })],
-        ));
-
-        client.submit(&adapter, &adapter, &adapter, &requests);
-        env.events()
-            .publish((symbol_short!("supply"), asset), amount);
-        Ok(())
-    }
-
-    /// Withdraw tokens from the Blend pool and send to the vault (admin-only).
-    ///
-    /// Use this when the vault's allocate_withdraw has already updated accounting.
-    #[allow(deprecated)]
-    pub fn withdraw_to_vault(
-        env: Env,
-        caller: Address,
-        asset: Address,
-        amount: i128,
-    ) -> Result<i128, AdapterError> {
-        extend_instance_ttl(&env);
-        require_admin(&env, &caller)?;
-        if amount <= 0 {
-            return Err(AdapterError::InvalidInput);
-        }
-        let vault = get_vault(&env)?;
-
-        let pool = get_pool(&env)?;
-        let client = PoolClient::new(&env, &pool);
-        let adapter = env.current_contract_address();
-        let request = Request {
-            request_type: REQUEST_WITHDRAW,
-            address: asset.clone(),
-            amount,
-        };
-        let mut requests = Vec::new(&env);
-        requests.push_back(request);
-        let token = soroban_sdk::token::Client::new(&env, &asset);
-        let balance_before = token.balance(&adapter);
-        client.submit(&adapter, &adapter, &adapter, &requests);
-
-        let balance_after = token.balance(&adapter);
-        let actual_withdrawn = balance_after
-            .checked_sub(balance_before)
-            .ok_or(AdapterError::ArithmeticUnderflow)?;
-        if actual_withdrawn <= 0 {
-            return Err(AdapterError::ZeroWithdrawal);
-        }
-        token.transfer(&adapter, &vault, &actual_withdrawn);
-        env.events()
-            .publish((symbol_short!("withdraw"), asset), actual_withdrawn);
-        Ok(actual_withdrawn)
-    }
-
     /// Extend instance storage TTL (admin-only).
     pub fn extend_ttl(env: Env, caller: Address) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
@@ -408,12 +318,20 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Events as _};
 
+    const BLEND_ADAPTER_SOURCE: &str = include_str!("lib.rs");
+
     fn adapter_event_count(env: &Env, adapter: &Address) -> usize {
         env.events()
             .all()
             .filter_by_contract(adapter)
             .events()
             .len()
+    }
+
+    #[test]
+    fn admin_accounting_shortcuts_are_not_public_entrypoints() {
+        assert!(!BLEND_ADAPTER_SOURCE.contains(concat!("\n    pub fn ", "supply_balance(")));
+        assert!(!BLEND_ADAPTER_SOURCE.contains(concat!("\n    pub fn ", "withdraw_to_vault(")));
     }
 
     #[test]


### PR DESCRIPTION
## Fixed Findings

- A-034 / Nexus `76f200c7-618d-4fd1-bff3-109530b96144` — Admin-only Blend adapter shortcuts can desynchronize vault accounting.

## Root Cause

The Blend adapter exposed admin-only `supply_balance` and `withdraw_to_vault` entrypoints. Those methods could mutate the adapter's managed Blend position directly, bypassing the vault allocation lifecycle that owns external-asset accounting.

## Fix

- Removed the public `supply_balance` entrypoint.
- Removed the public `withdraw_to_vault` entrypoint.
- Added a regression guard proving those public admin shortcut declarations are not present.
- Kept vault-routed adapter position changes (`supply`, `withdraw`, `total_assets`) intact.

Fix commit: `b98f7f753334d4b796dc160a3610f61d26db8e65`

## Verification

RED evidence:

```text
cargo test -p templar-soroban-blend-adapter admin_accounting_shortcuts_are_not_public_entrypoints -- --nocapture
# failed before deletion on: assertion failed: !BLEND_ADAPTER_SOURCE.contains("pub fn supply_balance(")
```

GREEN / regression evidence:

```text
cargo fmt --all -- --check
git diff --check
cargo test -p templar-soroban-blend-adapter -- --nocapture
cargo test -p templar-soroban-runtime --features testutils --lib -- --nocapture
cargo test -p templar-soroban-runtime --features testutils --test property_tests -- --nocapture
just -f contract/vault/soroban/justfile size-budget-check
```

Results:

- `templar-soroban-blend-adapter`: 20 unit tests + 7 integration tests passed.
- `templar-soroban-runtime --lib`: 103 tests passed.
- `property_tests`: 23 tests passed.
- Runtime deploy WASM: `93961` bytes, under `131072` byte budget.
- Commit hook reran `size-budget-check` and passed at `93961` bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/434)
<!-- Reviewable:end -->
