### PR TITLE
A-039 lock virtual offsets after first deposit

### DIFF
--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -7,12 +7,13 @@ use super::helpers::{
     adapter_for_market, address_from_alloc_string, addresses_from_alloc_strings, apply_fee_change,
     current_supply_queue_len, emit_admin_event, emit_alloc_event, emit_pause_state_event,
     extend_storage_ttl, get_config_address, governance_caller, kernel_address_from_sdk,
-    load_virtual_offsets, migrate_legacy_paused, migration_in_progress, require_contract_address,
-    require_governance, require_signed, sdk_string_to_alloc, set_config_address,
-    set_migration_in_progress, store_fees_spec, store_virtual_offsets,
-    with_contract_vault_contract_error,
+    load_virtual_offsets, lock_virtual_offsets, migrate_legacy_paused, migration_in_progress,
+    require_contract_address, require_governance, require_signed, sdk_string_to_alloc,
+    set_config_address, set_migration_in_progress, store_fees_spec, store_virtual_offsets,
+    virtual_offsets_locked, with_contract_vault_contract_error,
 };
 use super::*;
+use crate::storage::{SorobanStorage, Storage};
 use templar_soroban_shared_types::{
     GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_ALLOCATORS,
     GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS, GOVERNANCE_CONFIG_KIND_CURATOR,
@@ -108,6 +109,15 @@ fn apply_virtual_offsets_config(
     virtual_shares: i128,
     virtual_assets: i128,
 ) -> Result<(), ContractError> {
+    if virtual_offsets_locked(env) {
+        return Err(ContractError::InvalidState);
+    }
+    if let Some(state) = SorobanStorage::new(env).load_state()? {
+        if state.total_assets != 0 || state.total_shares != 0 {
+            return Err(ContractError::InvalidState);
+        }
+    }
+
     let virtual_shares = to_u128(virtual_shares)?;
     let virtual_assets = to_u128(virtual_assets)?;
     store_virtual_offsets(env, virtual_shares, virtual_assets);
@@ -313,13 +323,18 @@ fn deposit_with_min_impl(
     let now_ns = ledger_timestamp_ns(env)?;
 
     let mut shares_minted = 0u128;
+    let mut is_capitalized = false;
     let mut call = |vault: &mut ContractVault<'_>| -> Result<(), RuntimeError> {
         let (caller_k, receiver_k) = vault.map_pair(env, &owner, &receiver)?;
         let result = vault.deposit(caller_k, receiver_k, assets_u128, min_shares_u128, now_ns)?;
         shares_minted = result.shares_minted;
+        is_capitalized = result.total_assets != 0 && result.total_shares != 0;
         Ok(())
     };
     with_contract_vault_contract_error(env, &mut call)?;
+    if shares_minted != 0 && is_capitalized {
+        lock_virtual_offsets(env);
+    }
     to_i128(shares_minted)
 }
 

--- a/contract/vault/soroban/src/contract/helpers.rs
+++ b/contract/vault/soroban/src/contract/helpers.rs
@@ -247,6 +247,19 @@ pub(crate) fn store_virtual_offsets(env: &Env, virtual_shares: u128, virtual_ass
         .set(&VaultDataKey::VirtualAssets, &virtual_assets);
 }
 
+pub(crate) fn virtual_offsets_locked(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&VaultDataKey::VirtualOffsetsLocked)
+        .unwrap_or(false)
+}
+
+pub(crate) fn lock_virtual_offsets(env: &Env) {
+    env.storage()
+        .instance()
+        .set(&VaultDataKey::VirtualOffsetsLocked, &true);
+}
+
 #[allow(deprecated)]
 #[inline(never)]
 pub(crate) fn emit_admin_event(env: &Env, action: soroban_sdk::Symbol) {

--- a/contract/vault/soroban/src/contract/types.rs
+++ b/contract/vault/soroban/src/contract/types.rs
@@ -165,6 +165,7 @@ impl VaultDataKey {
     pub const SkimRecipient: Symbol = soroban_sdk::symbol_short!("skimrcp");
     pub const VirtualShares: Symbol = soroban_sdk::symbol_short!("vshares");
     pub const VirtualAssets: Symbol = soroban_sdk::symbol_short!("vassets");
+    pub const VirtualOffsetsLocked: Symbol = soroban_sdk::symbol_short!("vofflock");
     pub const IdleResyncLastNs: Symbol = soroban_sdk::symbol_short!("idlrsync");
 }
 

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -1043,6 +1043,122 @@ mod contract_tests {
     }
 
     #[test]
+    fn test_rejects_virtual_offset_updates_after_capitalization() {
+        use soroban_sdk::testutils::Address as _;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = soroban_sdk::Address::generate(&env);
+        let governance = soroban_sdk::Address::generate(&env);
+        let asset = soroban_sdk::Address::generate(&env);
+        let share = soroban_sdk::Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                11,
+                7,
+            )
+            .unwrap();
+
+            let mut storage = SorobanStorage::new(&env);
+            storage
+                .save_state(&VaultState {
+                    total_assets: 1_500,
+                    total_shares: 1_000,
+                    idle_assets: 1_500,
+                    ..Default::default()
+                })
+                .expect("save capitalized state");
+
+            let err = execute_governance_command(
+                &env,
+                &governance,
+                &GovernanceCommand::SetGovernanceConfig {
+                    kind: GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+                    primary: None,
+                    many: None,
+                    value_a: Some(101),
+                    value_b: Some(202),
+                },
+            )
+            .expect_err("capitalized vault must not accept virtual-offset changes");
+
+            assert_eq!(err, crate::error::ContractError::InvalidState);
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualShares),
+                Some(11u128)
+            );
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualAssets),
+                Some(7u128)
+            );
+        });
+    }
+
+    #[test]
+    fn test_rejects_virtual_offset_updates_after_first_deposit_lock() {
+        use soroban_sdk::testutils::Address as _;
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = soroban_sdk::Address::generate(&env);
+        let governance = soroban_sdk::Address::generate(&env);
+        let asset = soroban_sdk::Address::generate(&env);
+        let share = soroban_sdk::Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                11,
+                7,
+            )
+            .unwrap();
+            env.storage()
+                .instance()
+                .set(&VaultDataKey::VirtualOffsetsLocked, &true);
+            SorobanStorage::new(&env)
+                .save_state(&VaultState::default())
+                .expect("save fully unwound state");
+
+            let err = execute_governance_command(
+                &env,
+                &governance,
+                &GovernanceCommand::SetGovernanceConfig {
+                    kind: GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+                    primary: None,
+                    many: None,
+                    value_a: Some(101),
+                    value_b: Some(202),
+                },
+            )
+            .expect_err("first-deposit lock must survive zero accounting state");
+
+            assert_eq!(err, crate::error::ContractError::InvalidState);
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualShares),
+                Some(11u128)
+            );
+            assert_eq!(
+                env.storage().instance().get(&VaultDataKey::VirtualAssets),
+                Some(7u128)
+            );
+        });
+    }
+
+    #[test]
     fn test_deposit_uses_configured_virtual_offsets() {
         let mut vault = CuratorVault::new(
             test_config().with_virtual_offsets(11, 7),
@@ -1375,6 +1491,13 @@ mod contract_tests {
             owner_assets_before - deposit_assets
         );
         assert_eq!(asset_client.balance(&contract_id), deposit_assets);
+        assert_eq!(
+            env.as_contract(&contract_id, || env
+                .storage()
+                .instance()
+                .get(&VaultDataKey::VirtualOffsetsLocked)),
+            Some(true)
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Merged into #428

Merged into #428. The A-039 commit was cherry-picked into the fee-anchor lifecycle cluster PR as `d31bf3c911f2e1deb417d0024571892f49e72f19`, so this standalone per-finding PR is closed as merged into the cluster PR to preserve one-PR-per-cluster audit discipline.

## Summary

Fixes Halborn/Nexus finding A-039 (`21aa4dfa-595b-42a3-a1a0-cf7cba5e3f93`): virtual conversion offsets could be changed after vault capitalization.

This PR makes virtual offsets immutable once the vault is capitalized by:

- rejecting `SetGovernanceConfig(VIRTUAL_OFFSETS)` when stored accounting is already nonzero,
- persisting a `VirtualOffsetsLocked` instance-storage flag after the first successful public deposit,
- rejecting future virtual-offset changes while the persistent lock is set, including after a later full unwind to zero state.

## Regression coverage

- `test_rejects_virtual_offset_updates_after_capitalization`
- `test_rejects_virtual_offset_updates_after_first_deposit_lock`
- Existing offset behavior remains covered by `test_set_virtual_offsets_updates_contract_storage`, `test_loads_virtual_offsets_from_storage`, and deposit/preview virtual-offset tests.

## Verification

Base: `spr/refactor/vault-ergonomics/4f330057`

- `cargo fmt --all`
- `git diff --check`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/templar-a039/.target-a039 cargo test -p templar-soroban-runtime virtual_offset -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/templar-a039/.target-a039 cargo test -p templar-soroban-runtime test_phase1_deposit_with_min_resource_probe -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/templar-a039/.target-a039 cargo test -p templar-soroban-runtime -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/templar-a039/.target-a039 just -f contract/vault/soroban/justfile size-budget-check`

Runtime deploy WASM size: `94280` bytes (`92.07 KiB`) <= `131072` bytes (`128.00 KiB`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/435)
<!-- Reviewable:end -->
