### PR TITLE
fix: cap governance timelocks

### DIFF
--- a/contract/vault/soroban/governance/src/lib.rs
+++ b/contract/vault/soroban/governance/src/lib.rs
@@ -896,11 +896,7 @@ fn load_timelocks(env: &Env) -> Timelocks {
         .instance()
         .get(&DataKey::TimelockNs)
         .unwrap_or(0);
-    let timelocks = Timelocks::from_default(default_ns);
-    env.storage()
-        .instance()
-        .set(&DataKey::Timelocks, &timelocks);
-    timelocks
+    Timelocks::from_default(default_ns)
 }
 
 fn next_proposal_id(env: &Env) -> Result<u64, GovernanceError> {

--- a/contract/vault/soroban/governance/src/lib.rs
+++ b/contract/vault/soroban/governance/src/lib.rs
@@ -30,7 +30,8 @@ use templar_vault_kernel::{DurationNs, TimestampNs};
 const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
 const INSTANCE_TTL_EXTEND_TO: u32 = 3_110_400;
 const MIN_TIMELOCK_NS: u64 = 0;
-const MAX_TIMELOCK_NS: u64 = u64::MAX;
+const DAY_NS: u64 = 86_400_000_000_000;
+const MAX_TIMELOCK_NS: u64 = 30 * DAY_NS;
 
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 enum ProposalKey {

--- a/contract/vault/soroban/governance/src/tests.rs
+++ b/contract/vault/soroban/governance/src/tests.rs
@@ -719,6 +719,51 @@ fn revoke_kind_removes_all_matching() {
 }
 
 #[test]
+fn timelock_getters_do_not_materialize_missing_timelocks_storage() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let vault = env.register(MockVault, ());
+    let default_ns = 5_000_000_000u64;
+    let governance = env.register(
+        SorobanVaultGovernanceContract,
+        (&admin, &vault, &default_ns),
+    );
+
+    env.as_contract(&governance, || {
+        // Simulate a legacy/pre-migration state that has the scalar default
+        // timelock but not the per-kind map. Getter-style APIs must read the
+        // fallback value without materializing storage.
+        env.storage().instance().remove(&DataKey::Timelocks);
+
+        let before: Option<Timelocks> = env.storage().instance().get(&DataKey::Timelocks);
+        assert!(before.is_none());
+
+        assert_eq!(
+            SorobanVaultGovernanceContract::timelock_ns(env.clone(), TimelockKind::Cap),
+            default_ns
+        );
+
+        let after_timelock_ns: Option<Timelocks> =
+            env.storage().instance().get(&DataKey::Timelocks);
+        assert!(
+            after_timelock_ns.is_none(),
+            "timelock_ns getter must not write Timelocks storage"
+        );
+
+        let observed = SorobanVaultGovernanceContract::timelocks(env.clone());
+        assert!(observed == Timelocks::from_default(default_ns));
+
+        let after_timelocks: Option<Timelocks> = env.storage().instance().get(&DataKey::Timelocks);
+        assert!(
+            after_timelocks.is_none(),
+            "timelocks getter must not write Timelocks storage"
+        );
+    });
+}
+
+#[test]
 fn timelock_config_increase_immediate_decrease_timelocked() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contract/vault/soroban/governance/src/tests.rs
+++ b/contract/vault/soroban/governance/src/tests.rs
@@ -767,6 +767,44 @@ fn timelock_config_increase_immediate_decrease_timelocked() {
 }
 
 #[test]
+fn timelock_config_rejects_u64_max_without_mutating_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        ..Default::default()
+    });
+
+    let admin = Address::generate(&env);
+    let vault = env.register(MockVault, ());
+    let governance = env.register(
+        SorobanVaultGovernanceContract,
+        (&admin, &vault, &(5_000_000_000u64)),
+    );
+
+    let result = env.as_contract(&governance, || {
+        SorobanVaultGovernanceContract::submit_set_timelock(
+            env.clone(),
+            admin.clone(),
+            TimelockKind::TimelockConfig,
+            u64::MAX,
+        )
+    });
+    assert_eq!(result, Err(GovernanceError::TimelockOutOfBounds));
+
+    let current = env.as_contract(&governance, || {
+        SorobanVaultGovernanceContract::timelock_ns(env.clone(), TimelockKind::TimelockConfig)
+    });
+    assert_eq!(current, 5_000_000_000);
+
+    let pending = env.as_contract(&governance, || {
+        SorobanVaultGovernanceContract::pending_ids(env.clone())
+    });
+    assert_eq!(pending.len(), 0);
+}
+
+#[test]
 fn other_action_approval_and_consume() {
     let env = Env::default();
     env.mock_all_auths();


### PR DESCRIPTION
## Summary

Fixes governance timelock-model findings in `governance-control-plane`:

- A-040 / Nexus `890b1bbf-ea61-47f3-ac17-383678f0d713`: `TimelockConfig` could be raised to `u64::MAX` immediately, making later reductions practically unrecoverable.
- A-092 / Nexus `98dbd8f7-6f6b-4096-b917-c01f9fd68e35`: `load_timelocks` lazily materialized `DataKey::Timelocks` from the legacy scalar fallback during getter/view-style paths.

This PR keeps the timelock-model fixes consolidated in the existing governance timelock PR: it caps Soroban governance timelocks at 30 days, matching the NEAR vault governance upper bound, and makes legacy/fallback timelock reads side-effect-free while preserving explicit `SetTimelock` write behavior.

## Changes

- Replace Soroban governance `MAX_TIMELOCK_NS = u64::MAX` with `30 * DAY_NS`.
- Add regression test proving `submit_set_timelock(..., TimelockKind::TimelockConfig, u64::MAX)` returns `GovernanceError::TimelockOutOfBounds` and leaves the current `TimelockConfig` plus pending queue unchanged.
- Make `load_timelocks` return `Timelocks::from_default(default_ns)` without writing `DataKey::Timelocks` when only the legacy `DataKey::TimelockNs` scalar exists.
- Add regression test proving `timelock_ns` and `timelocks` getters do not materialize missing `Timelocks` storage.

## Verification

Folded A-092 commit: `0358c07b9340ad820092dc8918a79238b8a241ec`.

- `cargo test -p templar-soroban-governance timelock_config_rejects_u64_max_without_mutating_state -- --nocapture`
- `cargo test -p templar-soroban-governance timelock_getters_do_not_materialize_missing_timelocks_storage -- --nocapture`
- `cargo test -p templar-soroban-governance -- --nocapture` (31 passed)
- `git diff --check origin/audit/governance-a040..HEAD`
- `just -f contract/vault/soroban/justfile size-budget-check`

RED evidence recorded locally before fixes:

- A-040: focused regression failed with `left: Ok(1)`, proving `u64::MAX` was accepted immediately.
- A-092: focused getter regression failed because `timelock_ns` wrote `DataKey::Timelocks` storage while reading from fallback state.

Runtime deploy WASM size from current folded branch size gate:

- `93961` bytes / `91.76 KiB`
- Budget: `131072` bytes / `128 KiB`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/436)
<!-- Reviewable:end -->