### PR TITLE
fix: validate Blend adapter constructor addresses

### DIFF
--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -52,11 +52,21 @@ pub struct BlendAdapterContract;
 impl BlendAdapterContract {
     /// Runs atomically during contract deployment — no separate `initialize`
     /// transaction that could be front-run.
-    pub fn __constructor(env: Env, admin: Address, vault: Address, pool: Address) {
+    pub fn __constructor(
+        env: Env,
+        admin: Address,
+        vault: Address,
+        pool: Address,
+    ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
+        require_contract_address(&admin, AdapterError::InvalidInput)?;
+        require_contract_address(&vault, AdapterError::InvalidInput)?;
+        require_contract_address(&pool, AdapterError::InvalidInput)?;
+
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Vault, &vault);
         env.storage().instance().set(&DataKey::Pool, &pool);
+        Ok(())
     }
 
     /// Supply assets from the adapter into the Blend pool (vault-only).
@@ -382,12 +392,29 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::Address as _;
 
+    #[contract]
+    struct DummyContract;
+
+    #[contractimpl]
+    impl DummyContract {}
+
+    fn register_dummy_contract(env: &Env) -> Address {
+        env.register(DummyContract, ())
+    }
+
+    fn account_address(env: &Env) -> Address {
+        Address::from_str(
+            env,
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        )
+    }
+
     #[test]
     fn constructor_sets_config() {
         let env = Env::default();
-        let admin = Address::generate(&env);
-        let vault = Address::generate(&env);
-        let pool = Address::generate(&env);
+        let admin = register_dummy_contract(&env);
+        let vault = register_dummy_contract(&env);
+        let pool = register_dummy_contract(&env);
 
         let contract_id = env.register(BlendAdapterContract, (&admin, &vault, &pool));
         env.as_contract(&contract_id, || {
@@ -397,11 +424,44 @@ mod tests {
         });
     }
 
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_admin() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let vault = register_dummy_contract(&env);
+        let pool = register_dummy_contract(&env);
+
+        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_vault() {
+        let env = Env::default();
+        let admin = register_dummy_contract(&env);
+        let vault = account_address(&env);
+        let pool = register_dummy_contract(&env);
+
+        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_pool() {
+        let env = Env::default();
+        let admin = register_dummy_contract(&env);
+        let vault = register_dummy_contract(&env);
+        let pool = account_address(&env);
+
+        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+    }
+
     /// Helper: deploy a contract via constructor and return (contract_id, admin, vault, pool).
     fn setup_adapter(env: &Env) -> (Address, Address, Address, Address) {
-        let admin = Address::generate(env);
-        let vault = Address::generate(env);
-        let pool = Address::generate(env);
+        let admin = register_dummy_contract(env);
+        let vault = register_dummy_contract(env);
+        let pool = register_dummy_contract(env);
         let contract_id = env.register(BlendAdapterContract, (&admin, &vault, &pool));
         (contract_id, admin, vault, pool)
     }

--- a/contract/vault/soroban/blend-adapter/tests/integration_tests.rs
+++ b/contract/vault/soroban/blend-adapter/tests/integration_tests.rs
@@ -8,6 +8,7 @@ use blend_contract_sdk::{
     testutils::{default_reserve_config, BlendFixture},
 };
 use soroban_sdk::{
+    contract, contractimpl,
     testutils::{Address as _, BytesN as _},
     token::StellarAssetClient,
     Address, BytesN, Env, String,
@@ -15,6 +16,16 @@ use soroban_sdk::{
 use templar_soroban_blend_adapter::{
     AdapterError, BlendAdapterContract, BlendAdapterContractClient,
 };
+
+#[contract]
+struct DummyContract;
+
+#[contractimpl]
+impl DummyContract {}
+
+fn register_dummy_contract(env: &Env) -> Address {
+    env.register(DummyContract, ())
+}
 
 /// Deploy the full Blend protocol, create a pool with one reserve, and activate it.
 fn setup_blend_pool(
@@ -71,7 +82,7 @@ fn setup_adapter<'a>(
     pool: &Address,
     vault: &Address,
 ) -> (Address, Address, BlendAdapterContractClient<'a>) {
-    let admin = Address::generate(env);
+    let admin = register_dummy_contract(env);
     let adapter = env.register(BlendAdapterContract, (&admin, vault, pool));
     let client = BlendAdapterContractClient::new(env, &adapter);
     (adapter, admin, client)
@@ -83,7 +94,7 @@ fn supply_success_deposits_to_pool() {
     env.mock_all_auths();
     let (pool, pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -106,7 +117,7 @@ fn withdraw_success_returns_assets() {
     env.mock_all_auths();
     let (pool, pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -137,7 +148,7 @@ fn total_assets_returns_correct_value_after_supply() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -160,7 +171,7 @@ fn total_assets_missing_position_returns_error() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, _asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (adapter, _admin, _client) = setup_adapter(&env, &pool, &vault);
 
     // Query without supplying — call via env.as_contract since the client
@@ -181,7 +192,7 @@ fn total_assets_decreases_after_withdraw() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (_adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let supply_amount: i128 = 10_000_000_000;
@@ -210,12 +221,12 @@ fn rescue_transfers_assets_to_receiver() {
     let asset = asset_sac.address();
     let asset_admin = StellarAssetClient::new(&env, &asset);
 
-    let vault = Address::generate(&env);
-    let pool = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
+    let pool = register_dummy_contract(&env);
     let (adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let rescue_amount: i128 = 5_000_000_000;
-    let receiver = Address::generate(&env);
+    let receiver = register_dummy_contract(&env);
     asset_admin.mint(&adapter, &rescue_amount);
 
     client.rescue(&vault, &asset, &rescue_amount, &receiver);
@@ -243,7 +254,7 @@ fn full_supply_withdraw_cycle() {
     env.mock_all_auths();
     let (pool, _pool_client, asset, asset_admin, _deployer) = setup_blend_pool(&env);
 
-    let vault = Address::generate(&env);
+    let vault = register_dummy_contract(&env);
     let (_adapter, _admin, client) = setup_adapter(&env, &pool, &vault);
 
     let amount: i128 = 20_000_000_000;


### PR DESCRIPTION
## Fixed Findings

- A-060 / Nexus `6a5a3ec7-5477-4c2f-9488-30308ab956d6`

## Summary

- Reject non-contract `admin`, `vault`, and `pool` addresses during Blend adapter construction.
- Keep the constructor atomic; invalid deployment inputs now fail before config is persisted.
- Update unit and integration fixtures to use real contract addresses for constructor roles.

## Root Cause

The Blend adapter constructor accepted raw `Address` values and stored them without checking that deployment-bound authorities and dependencies were contract addresses. That allowed account-form addresses to be persisted for the admin/vault/pool configuration even though the adapter's runtime boundary expects contract-address dependencies.

## Verification

RED:

```text
cargo test -p templar-soroban-blend-adapter constructor_rejects_non_contract -- --nocapture
# before fix: 0 passed; 3 failed
# each failure: test did not panic as expected
```

GREEN:

```text
cargo test -p templar-soroban-blend-adapter constructor_rejects_non_contract -- --nocapture
# after fix: 3 passed; 0 failed

cargo test -p templar-soroban-blend-adapter -- --nocapture
# 15 unit tests passed; 7 integration tests passed

cargo fmt --check
# passed

git diff --check
# passed
```

## Stack

Base: `audit/adapter-admin-retarget-a035` / PR #438.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/439)
<!-- Reviewable:end -->
