### PR TITLE
37a5412f-fb6a-455f-9b9c-3aa8227c255a make share-token metadata immutable

### DIFF
--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -928,15 +928,6 @@ set-supply-queue target_ids_json:
 	just gov-invoke accept --caller "$admin" --proposal_id "$proposal_id"; \
 	echo "✓ Supply queue updated"
 
-# Set share token metadata (SEP-41).
-set-metadata name="Templar Vault Share" symbol="tvSHARE" decimals="7":
-	@echo "Setting share token metadata..."
-	@just invoke set_metadata \
-		--name "{{name}}" \
-		--symbol "{{symbol}}" \
-		--decimals "{{decimals}}"
-	@echo "✓ Metadata set"
-
 # =============================================================================
 # VIEW FUNCTIONS (Read-only)
 # =============================================================================
@@ -1125,7 +1116,6 @@ help:
 	@echo "ADMIN:"
 	@echo "  just pause / unpause"
 	@echo "  just set-curator <new_curator_address>"
-	@echo "  just set-metadata [name] [symbol] [decimals]"
 	@echo ""
 	@echo "VIEW:"
 	@echo "  just vault-state              Show vault summary"

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -119,10 +119,10 @@ impl SorobanShareTokenContract {
         env.storage().instance().set(&DataKey::Vault, &vault);
     }
 
-    pub fn set_metadata(env: Env, caller: Address, name: String, symbol: String, decimals: u32) {
+    pub fn set_metadata(env: Env, caller: Address, _name: String, _symbol: String, _decimals: u32) {
         extend_instance_ttl(&env);
         require_admin(&env, &caller);
-        Base::set_metadata(&env, decimals, name, symbol);
+        panic_with_error!(&env, ShareTokenError::MetadataImmutable);
     }
 
     pub fn admin(env: Env) -> Address {

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -164,6 +164,24 @@ fn metadata_returns_constructor_values() {
 }
 
 #[test]
+#[should_panic]
+fn admin_cannot_change_metadata_after_deployment() {
+    let (env, admin, _vault, token) = setup();
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_metadata"),
+        (
+            &admin,
+            &String::from_str(&env, "Mutable Share"),
+            &String::from_str(&env, "MUT"),
+            &18u32,
+        )
+            .into_val(&env),
+    );
+}
+
+#[test]
 fn total_supply_tracks_mint_and_burn() {
     let (env, _admin, vault, token) = setup();
     let user = Address::generate(&env);

--- a/contract/vault/soroban/share-token/src/types.rs
+++ b/contract/vault/soroban/share-token/src/types.rs
@@ -15,4 +15,5 @@ pub enum ShareTokenError {
     Unauthorized = 1,
     InvalidInput = 2,
     MissingConfig = 3,
+    MetadataImmutable = 4,
 }


### PR DESCRIPTION
## Fixed Findings

- A-050 / Nexus `37a5412f-fb6a-455f-9b9c-3aa8227c255a` — Share-token metadata can be changed after deployment without timelock or event.

## Root Cause

The share-token constructor initialized SEP-41 metadata correctly, but the public admin-gated `set_metadata(caller, name, symbol, decimals)` entrypoint could rewrite name, symbol, and decimals after deployment via `Base::set_metadata`.

## Fix

- Preserve constructor-time metadata initialization.
- Keep the existing `set_metadata` ABI surface for compatibility, but make post-deployment calls fail after admin authorization with `ShareTokenError::MetadataImmutable`.
- Add regression coverage proving an authorized admin cannot change metadata after deployment.
- Remove the stale Soroban justfile `set-metadata` operator recipe/help entry because metadata is now constructor-bound and immutable.

## Verification

RED before fix:

```text
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-share-token admin_cannot_change_metadata_after_deployment -- --nocapture
# FAILED: test did not panic as expected, proving admin metadata mutation was accepted.
```

GREEN after fix:

```text
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-share-token admin_cannot_change_metadata_after_deployment -- --nocapture
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-share-token -- --nocapture
RUSTUP_TOOLCHAIN=1.89.0 cargo fmt --check
git diff --check
just -f contract/vault/soroban/justfile --list | (! rg "set-metadata")
rg -n "Base::set_metadata|pub fn set_metadata|MetadataImmutable" contract/vault/soroban/share-token/src
# Base::set_metadata remains only in constructor; set_metadata now fails with MetadataImmutable.
```

Post-commit hook:

```text
Soroban size-budget-check passed (93961 bytes)
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/440)
<!-- Reviewable:end -->

## Superseded

This A-050-only PR has been folded into the consolidated share-token cluster PR #429.

- Superseding PR: https://github.com/Templar-Protocol/contracts/pull/429
- Folded commit on #429 branch: `0aad51e`
- Covered finding: A-050 / Nexus `37a5412f-fb6a-455f-9b9c-3aa8227c255a`

Closing to keep share-token remediation in PR #429.
