### PR TITLE
fix: require governance group market id

### DIFF
--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -209,7 +209,6 @@ fn apply_group_policy(
         CapGroupId::try_from(raw).map_err(|_| ContractError::InvalidInput)
     }
 
-    let market_id = market_id.unwrap_or(0);
     let cap_group_raw = sdk_string_to_alloc(
         cap_group_id.unwrap_or_else(|| soroban_sdk::String::from_str(env, "")),
     )?;
@@ -229,6 +228,7 @@ fn apply_group_policy(
             },
         },
         2 => {
+            let market_id = market_id.ok_or(ContractError::InvalidInput)?;
             let group = if cap_group_raw.is_empty() {
                 None
             } else {

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -2902,6 +2902,72 @@ mod storage_tests {
     }
 
     #[test]
+    fn test_execute_governance_group_membership_requires_market_id() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = SdkAddress::generate(&env);
+        let governance = SdkAddress::generate(&env);
+        let asset = SdkAddress::generate(&env);
+        let share = SdkAddress::generate(&env);
+        let cap_group_id = CapGroupId::try_from("group-c".to_string()).unwrap();
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                0,
+                0,
+            )
+            .unwrap();
+
+            let mut storage = SorobanStorage::new(&env);
+            let mut policy_state = PolicyState::default();
+            policy_state.set_cap_group_absolute_cap(cap_group_id.clone(), Some(100));
+            policy_state
+                .set_market_config(0, MarketConfig::new(true, 100, None))
+                .unwrap();
+            Storage::save_policy_state(&mut storage, &policy_state).unwrap();
+        });
+
+        let payload = Bytes::from_slice(
+            &env,
+            &GovernanceCommand::SetGovernancePolicy {
+                kind: GOVERNANCE_POLICY_KIND_GROUP,
+                target_ids: None,
+                mode: Some(2),
+                accounts: None,
+                market_id: None,
+                cap_group_id: Some("group-c".to_string()),
+                value: None,
+                value_b: None,
+                value_c: None,
+            }
+            .encode(),
+        );
+        let result = env.as_contract(&contract_id, || {
+            SorobanVaultContract::execute_governance(env.clone(), governance.clone(), payload)
+        });
+        assert_eq!(result, Err(crate::error::ContractError::InvalidInput));
+
+        env.as_contract(&contract_id, || {
+            let storage = SorobanStorage::new(&env);
+            let reloaded = Storage::load_policy_state(&storage)
+                .unwrap()
+                .unwrap_or_default();
+            assert_eq!(
+                reloaded
+                    .market_config(0)
+                    .and_then(|config| config.cap_group_id.clone()),
+                None
+            );
+        });
+    }
+
+    #[test]
     fn test_execute_governance_remove_market_with_principal_after_timelock() {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
## Fixed Findings

- A-062 / Nexus `e019c107-ebbe-4cbd-8446-06739d060ac0`

## Summary

- Require `market_id` for `SetGovernancePolicy` group-membership commands (`mode == 2`).
- Preserve existing group absolute-cap and relative-cap behavior, which does not use `market_id`.
- Add a regression proving omitted `market_id` now returns `ContractError::InvalidInput` and does not silently update market `0`.

## RED Evidence

Before the fix, the focused regression failed because a group-membership payload with `market_id: None` returned `Ok(())`:

```text
cargo test -p templar-soroban-runtime test_execute_governance_group_membership_requires_market_id -- --nocapture
left: Ok(())
right: Err(InvalidInput)
```

## Verification

- `cargo test -p templar-soroban-runtime test_execute_governance_group_membership_requires_market_id -- --nocapture`
- `cargo test -p templar-soroban-runtime --lib -- --nocapture` (104 passed)
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p templar-soroban-runtime -- --nocapture`
- `just -f contract/vault/soroban/justfile build`
- `just -f contract/vault/soroban/justfile size-budget-check` (`93946 <= 131072` bytes)

## Stack / Base

- Base: PR 417 branch `spr/refactor/vault-ergonomics/4f330057`
- Branch: `audit/governance-abi-validation-a062`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/441)
<!-- Reviewable:end -->
