### PR TITLE
Fix governance auth before command decode

### DIFF
--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -6,11 +6,10 @@
 use super::helpers::{
     adapter_for_market, address_from_alloc_string, addresses_from_alloc_strings, apply_fee_change,
     current_supply_queue_len, emit_admin_event, emit_alloc_event, emit_pause_state_event,
-    extend_storage_ttl, get_config_address, governance_caller, kernel_address_from_sdk,
-    load_virtual_offsets, migrate_legacy_paused, migration_in_progress, require_contract_address,
-    require_governance, require_signed, sdk_string_to_alloc, set_config_address,
-    set_migration_in_progress, store_fees_spec, store_virtual_offsets,
-    with_contract_vault_contract_error,
+    extend_storage_ttl, get_config_address, kernel_address_from_sdk, load_virtual_offsets,
+    migrate_legacy_paused, migration_in_progress, require_contract_address, require_governance,
+    require_signed, sdk_string_to_alloc, set_config_address, set_migration_in_progress,
+    store_fees_spec, store_virtual_offsets, with_contract_vault_contract_error,
 };
 use super::*;
 use templar_soroban_shared_types::{
@@ -479,14 +478,13 @@ fn refresh_markets_impl(
 
 fn set_governance_config_impl(
     env: &Env,
-    caller: soroban_sdk::Address,
+    _caller: soroban_sdk::Address,
     kind: u32,
     primary: Option<soroban_sdk::Address>,
     many: Option<soroban_sdk::Vec<soroban_sdk::Address>>,
     value_a: Option<i128>,
     value_b: Option<i128>,
 ) -> Result<(), ContractError> {
-    require_governance(env, &caller)?;
     match kind {
         GOVERNANCE_CONFIG_KIND_CURATOR => apply_curator_config(env, required_address(primary)?),
         GOVERNANCE_CONFIG_KIND_GOVERNANCE => {
@@ -524,7 +522,7 @@ fn set_governance_policy_impl(
     value_b: Option<i128>,
     value_c: Option<i128>,
 ) -> Result<(), ContractError> {
-    let caller_kernel = governance_caller(env, &caller)?;
+    let caller_kernel = kernel_address_from_sdk(env, &caller);
     match kind {
         GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE => apply_supply_queue_policy(
             env,
@@ -574,10 +572,9 @@ fn set_governance_policy_impl(
 
 fn skim_impl(
     env: &Env,
-    caller: soroban_sdk::Address,
+    _caller: soroban_sdk::Address,
     token: soroban_sdk::Address,
 ) -> Result<(), ContractError> {
-    require_governance(env, &caller)?;
     let asset = get_config_address(env, &VaultDataKey::AssetToken)?;
     let share = get_config_address(env, &VaultDataKey::ShareToken)?;
     if token == asset || token == share {
@@ -829,6 +826,7 @@ impl SorobanVaultContract {
         caller: soroban_sdk::Address,
         payload: Bytes,
     ) -> Result<(), ContractError> {
+        require_governance(&env, &caller)?;
         let command = GovernanceCommand::decode(&payload.to_alloc_vec())
             .map_err(|_| ContractError::InvalidInput)?;
         execute_governance_command(&env, caller, command)

--- a/contract/vault/soroban/src/contract/helpers.rs
+++ b/contract/vault/soroban/src/contract/helpers.rs
@@ -542,9 +542,3 @@ pub(crate) fn require_governance(env: &Env, caller: &SdkAddress) -> Result<(), C
     }
     Ok(())
 }
-
-#[inline(never)]
-pub(crate) fn governance_caller(env: &Env, caller: &SdkAddress) -> Result<Address, ContractError> {
-    require_governance(env, caller)?;
-    Ok(kernel_address_from_sdk(env, caller))
-}

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -2902,6 +2902,29 @@ mod storage_tests {
     }
 
     #[test]
+    fn test_execute_governance_unauthorized_caller_rejected_before_body_decode() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = SdkAddress::generate(&env);
+        let governance = SdkAddress::generate(&env);
+        let attacker = SdkAddress::generate(&env);
+        let asset = SdkAddress::generate(&env);
+        let share = SdkAddress::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(env.clone(), curator, governance, asset, share, 0, 0)
+                .unwrap();
+        });
+
+        let malformed_skim_payload = Bytes::from_slice(&env, &[2, 0xff, 0xff, 0xff, 0xff]);
+        let result = env.as_contract(&contract_id, || {
+            SorobanVaultContract::execute_governance(env.clone(), attacker, malformed_skim_payload)
+        });
+        assert_eq!(result, Err(crate::error::ContractError::Unauthorized));
+    }
+
+    #[test]
     fn test_execute_governance_group_membership_requires_market_id() {
         let env = Env::default();
         env.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
## Fixed Findings

- A-056 / Nexus `4ca30771-41fc-4b53-b8b2-95168b12803d`

## Summary

- Stack on Governance ABI/validation cleanup PR #441.
- Move the runtime `execute_governance` authorization boundary ahead of governance command body decode.
- Keep the public ABI unchanged.
- Remove duplicate private governance-command auth after the bridge has authenticated the governance caller, avoiding double `require_auth` failures while preserving direct public governance guards outside the bridge.

## Root Cause

`SorobanVaultContract::execute_governance` decoded the full governance command payload before checking that `caller` was the configured governance contract. Unauthorized callers could therefore force command-body decode/allocation before the call failed.

## Verification

RED before fix:

- `cargo test -p templar-soroban-runtime test_execute_governance_unauthorized_caller_rejected_before_body_decode -- --nocapture`
  - Failed with `left: Err(InvalidInput)`, `right: Err(Unauthorized)`, proving the malformed body decoded/failed before authorization.

GREEN after fix:

- `cargo test -p templar-soroban-runtime test_execute_governance_unauthorized_caller_rejected_before_body_decode -- --nocapture`
- `cargo test -p templar-soroban-runtime test_execute_governance_group_membership_requires_market_id -- --nocapture`
- `cargo test -p templar-soroban-runtime --lib -- --nocapture`
- `cargo test -p templar-soroban-runtime -- --nocapture`
- `cargo fmt --check`
- `git diff --check`
- `just -f contract/vault/soroban/justfile build`
- `just -f contract/vault/soroban/justfile size-budget-check`
  - Runtime deploy WASM: `93782` bytes / `91.58 KiB` <= `131072` bytes / `128.00 KiB`

## Stack

- Base: `audit/governance-abi-validation-a062` / PR #441
- This PR: `audit/governance-abi-validation-a056`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/442)
<!-- Reviewable:end -->
