### PR TITLE
ca6dd926-fd39-405d-b710-af4fe8744727 5af46c5f-dbd8-46e6-93fb-0e21dd4aaf69 12319f5b-fa52-46b1-8b49-d91fbceeca7d harden share-token observability

### DIFF
--- a/contract/vault/soroban/share-token/Cargo.toml
+++ b/contract/vault/soroban/share-token/Cargo.toml
@@ -15,7 +15,7 @@ default = []
 testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
-soroban-sdk = { version = "25.3.0", features = ["alloc", "experimental_spec_shaking_v2"] }
+soroban-sdk = { version = "25.3.0", features = ["alloc", "experimental_spec_shaking_v2", "hazmat-address"] }
 stellar-tokens.workspace = true
 
 [dev-dependencies]

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -3,7 +3,10 @@
 mod types;
 pub use types::*;
 
-use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, MuxedAddress, String};
+use soroban_sdk::{
+    address_payload::AddressPayload, contract, contractimpl, panic_with_error, symbol_short,
+    Address, Env, MuxedAddress, String,
+};
 use stellar_tokens::fungible::{
     burnable::{emit_burn, FungibleBurnable},
     Base, FungibleToken,
@@ -78,6 +81,9 @@ impl FungibleBurnable for SorobanShareTokenContract {
         Base::spend_allowance(e, &from, &spender, amount);
         Base::update(e, Some(&from), None, amount);
         emit_burn(e, &from, amount);
+        #[allow(deprecated)]
+        e.events()
+            .publish((symbol_short!("burn_from"), spender, from), amount);
     }
 }
 
@@ -171,8 +177,10 @@ fn require_vault_invoker(env: &Env) {
 }
 
 fn is_contract_address(addr: &Address) -> bool {
-    let bytes = addr.to_string().to_bytes();
-    matches!(bytes.get(0), Some(b'C'))
+    matches!(
+        AddressPayload::from_address(addr),
+        Some(AddressPayload::ContractIdHash(_))
+    )
 }
 
 fn require_contract_address(env: &Env, addr: &Address) {

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -1,7 +1,11 @@
 use super::*;
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::testutils::{Ledger, LedgerInfo};
-use soroban_sdk::{contract, contractimpl, IntoVal, MuxedAddress};
+use soroban_sdk::testutils::{Events, Ledger, LedgerInfo};
+use soroban_sdk::xdr::{ContractEventBody, ScVal};
+use soroban_sdk::{
+    address_payload::AddressPayload, contract, contractimpl, symbol_short, BytesN, IntoVal,
+    MuxedAddress, TryFromVal, Val,
+};
 
 #[contract]
 struct VaultCaller;
@@ -23,17 +27,34 @@ impl VaultCaller {
             (from, amount).into_val(&env),
         );
     }
+
+    fn approve(
+        env: Env,
+        token: Address,
+        owner: Address,
+        spender: Address,
+        amount: i128,
+        live_until_ledger: u32,
+    ) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "approve"),
+            (owner, spender, amount, live_until_ledger).into_val(&env),
+        );
+    }
+
+    fn burn_from(env: Env, token: Address, spender: Address, from: Address, amount: i128) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "burn_from"),
+            (spender, from, amount).into_val(&env),
+        );
+    }
 }
 
 fn setup() -> (Env, Address, Address, Address) {
     let env = Env::default();
-    env.mock_all_auths();
-    env.ledger().set(LedgerInfo {
-        timestamp: 100,
-        protocol_version: 25,
-        sequence_number: 100,
-        ..Default::default()
-    });
+    init_env(&env);
 
     let admin = Address::generate(&env);
     let vault = env.register(VaultCaller, ());
@@ -48,6 +69,54 @@ fn setup() -> (Env, Address, Address, Address) {
         ),
     );
     (env, admin, vault, token)
+}
+
+fn init_env(env: &Env) {
+    env.mock_all_auths_allowing_non_root_auth();
+    env.ledger().set(LedgerInfo {
+        timestamp: 100,
+        protocol_version: 25,
+        sequence_number: 100,
+        max_entry_ttl: 1_000,
+        ..Default::default()
+    });
+}
+
+fn account_address(env: &Env) -> Address {
+    AddressPayload::AccountIdPublicKeyEd25519(BytesN::from_array(env, &[7; 32])).to_address(env)
+}
+
+#[test]
+#[should_panic]
+fn constructor_rejects_account_vault_address() {
+    let env = Env::default();
+    init_env(&env);
+
+    let admin = Address::generate(&env);
+    let account_vault = account_address(&env);
+    env.register(
+        SorobanShareTokenContract,
+        (
+            &admin,
+            &account_vault,
+            &String::from_str(&env, "Templar Share"),
+            &String::from_str(&env, "tvSHARE"),
+            &7u32,
+        ),
+    );
+}
+
+#[test]
+#[should_panic]
+fn set_vault_rejects_account_address() {
+    let (env, admin, _vault, token) = setup();
+    let account_vault = account_address(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_vault"),
+        (&admin, &account_vault).into_val(&env),
+    );
 }
 
 #[test]
@@ -85,6 +154,223 @@ fn vault_can_burn() {
         (&user,).into_val(&env),
     );
     assert_eq!(bal, 600);
+}
+
+#[test]
+fn burn_from_emits_supplemental_spender_event() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+    });
+    env.as_contract(&vault, || {
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            400,
+            300,
+        );
+    });
+    env.events().all();
+
+    env.as_contract(&vault, || {
+        VaultCaller::burn_from(
+            env.clone(),
+            token.clone(),
+            spender.clone(),
+            from.clone(),
+            250,
+        );
+    });
+
+    let events = env.events().all().filter_by_contract(&token);
+    assert_eq!(events.events().len(), 2);
+    let burn_from_event = &events.events()[1];
+    let ContractEventBody::V0(body) = &burn_from_event.body;
+    assert_eq!(body.topics.len(), 3);
+    assert_eq!(
+        body.topics[0],
+        ScVal::try_from_val(&env, &symbol_short!("burn_from")).unwrap()
+    );
+    let spender_val: Val = spender.clone().into_val(&env);
+    let from_val: Val = from.clone().into_val(&env);
+    let amount_val: Val = 250i128.into_val(&env);
+    assert_eq!(
+        body.topics[1],
+        ScVal::try_from_val(&env, &spender_val).unwrap()
+    );
+    assert_eq!(
+        body.topics[2],
+        ScVal::try_from_val(&env, &from_val).unwrap()
+    );
+    assert_eq!(body.data, ScVal::try_from_val(&env, &amount_val).unwrap());
+
+    let bal: i128 = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "balance"),
+        (&from,).into_val(&env),
+    );
+    let allowance: i128 = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "allowance"),
+        (&from, &spender).into_val(&env),
+    );
+    assert_eq!(bal, 750);
+    assert_eq!(allowance, 150);
+}
+
+#[test]
+fn set_admin_rotates_admin() {
+    let (env, admin, _vault, token) = setup();
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &new_admin).into_val(&env),
+    );
+
+    let stored_admin: Address = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "admin"),
+        ().into_val(&env),
+    );
+    assert_eq!(stored_admin, new_admin);
+}
+
+#[test]
+#[should_panic]
+fn non_admin_cannot_set_admin() {
+    let (env, _admin, _vault, token) = setup();
+    let non_admin = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&non_admin, &new_admin).into_val(&env),
+    );
+}
+
+#[test]
+#[should_panic]
+fn old_admin_loses_privilege_after_rotation() {
+    let (env, admin, _vault, token) = setup();
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &new_admin).into_val(&env),
+    );
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &Address::generate(&env)).into_val(&env),
+    );
+}
+
+#[test]
+#[should_panic]
+fn burn_from_without_allowance_panics() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::burn_from(env.clone(), token.clone(), spender.clone(), from.clone(), 1);
+    });
+}
+
+#[test]
+#[should_panic]
+fn burn_from_over_allowance_panics() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            100,
+            300,
+        );
+        VaultCaller::burn_from(
+            env.clone(),
+            token.clone(),
+            spender.clone(),
+            from.clone(),
+            101,
+        );
+    });
+}
+
+#[test]
+#[should_panic]
+fn burn_from_after_allowance_expiry_panics() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            100,
+            101,
+        );
+    });
+    env.ledger().set(LedgerInfo {
+        timestamp: 101,
+        protocol_version: 25,
+        sequence_number: 102,
+        max_entry_ttl: 1_000,
+        ..Default::default()
+    });
+
+    env.as_contract(&vault, || {
+        VaultCaller::burn_from(env.clone(), token.clone(), spender.clone(), from.clone(), 1);
+    });
+}
+
+#[test]
+#[should_panic]
+fn direct_caller_cannot_burn_from_even_with_allowance() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let spender = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::approve(
+            env.clone(),
+            token.clone(),
+            from.clone(),
+            spender.clone(),
+            100,
+            300,
+        );
+    });
+
+    env.mock_auths(&[]);
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "burn_from"),
+        (&spender, &from, &1i128).into_val(&env),
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Fixed Findings

- A-093 / Nexus `ca6dd926-fd39-405d-b710-af4fe8744727`
  - Replaces StrKey text-prefix contract-address validation with `soroban_sdk::address_payload::AddressPayload` discrimination.
  - Adds account-address rejection coverage for constructor vault binding and `set_vault`.
- A-094 / Nexus `5af46c5f-dbd8-46e6-93fb-0e21dd4aaf69`
  - Keeps the standard burn event and emits a supplemental `burn_from` event keyed by spender and owner, so delegated burns are distinguishable from direct burns.
- A-097 / Nexus `12319f5b-fa52-46b1-8b49-d91fbceeca7d`
  - Adds share-token admin rotation, old-admin revocation, allowance, allowance expiry, and vault-invoker security coverage.

## Stack

- Base: `audit/share-token-metadata-a050` / PR #440
- Branch: `audit/share-token-burn-from-event-a094`
- Fix commit: `141b0e8`

## Verification

- `RUSTUP_TOOLCHAIN=1.89.0 cargo fmt --all --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-share-token -- --nocapture` — 17 passed
- Focused tests:
  - `burn_from_emits_supplemental_spender_event`
  - `constructor_rejects_account_vault_address`
  - `set_vault_rejects_account_address`
  - `set_admin_rotates_admin`
  - `direct_caller_cannot_burn_from_even_with_allowance`
- `just -f contract/vault/soroban/justfile build`
- `just -f contract/vault/soroban/justfile size-budget-check` — 93,961 bytes <= 131,072 bytes
- Post-commit hook reran Soroban size-budget-check and passed at 93,961 bytes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/443)
<!-- Reviewable:end -->

## Superseded

This A-093/A-094/A-097 follow-up PR has been folded into the consolidated share-token cluster PR #429.

- Superseding PR: https://github.com/Templar-Protocol/contracts/pull/429
- Folded commit on #429 branch: `3c5d098`
- Covered findings:
  - A-093 / Nexus `ca6dd926-fd39-405d-b710-af4fe8744727`
  - A-094 / Nexus `5af46c5f-dbd8-46e6-93fb-0e21dd4aaf69`
  - A-097 / Nexus `12319f5b-fa52-46b1-8b49-d91fbceeca7d`

Closing to keep share-token remediation in PR #429.
