### PR TITLE
Fix governance list input validation

### DIFF
--- a/contract/vault/soroban/governance/src/lib.rs
+++ b/contract/vault/soroban/governance/src/lib.rs
@@ -611,6 +611,18 @@ fn timelock_kind_for_action(action: &GovernanceAction) -> TimelockKind {
     }
 }
 
+fn require_unique_target_ids(target_ids: &Vec<u32>) -> Result<(), GovernanceError> {
+    for i in 0..target_ids.len() {
+        let target_id = target_ids.get_unchecked(i);
+        for j in (i + 1)..target_ids.len() {
+            if target_id == target_ids.get_unchecked(j) {
+                return Err(GovernanceError::InvalidInput);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn validate_action(action: &GovernanceAction) -> Result<(), GovernanceError> {
     match action {
         GovernanceAction::SetGovernance(governance) => require_contract_address(governance),
@@ -633,6 +645,7 @@ fn validate_action(action: &GovernanceAction) -> Result<(), GovernanceError> {
             }
             Ok(())
         }
+        GovernanceAction::SetSupplyQueue(target_ids) => require_unique_target_ids(target_ids),
         GovernanceAction::SetTimelock(_, new_timelock_ns) => validate_timelock_ns(*new_timelock_ns),
         GovernanceAction::Other(_, _) => Ok(()),
         _ => Ok(()),

--- a/contract/vault/soroban/governance/src/tests.rs
+++ b/contract/vault/soroban/governance/src/tests.rs
@@ -870,6 +870,52 @@ fn abdicated_action_is_rejected() {
 }
 
 #[test]
+fn submit_set_supply_queue_rejects_duplicate_targets() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let vault = env.register(MockVault, ());
+    let governance = env.register(
+        SorobanVaultGovernanceContract,
+        (&admin, &vault, &(5_000_000_000u64)),
+    );
+
+    let err = env.as_contract(&governance, || {
+        SorobanVaultGovernanceContract::submit_set_supply_queue(
+            env.clone(),
+            admin.clone(),
+            sdk_u32_vec(&env, &[7u32, 7u32]),
+        )
+    });
+
+    assert_eq!(err, Err(GovernanceError::InvalidInput));
+}
+
+#[test]
+fn submit_set_supply_queue_allows_empty_clear_policy() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let admin = Address::generate(&env);
+    let vault = env.register(MockVault, ());
+    let governance = env.register(
+        SorobanVaultGovernanceContract,
+        (&admin, &vault, &(5_000_000_000u64)),
+    );
+
+    let proposal_id = env.as_contract(&governance, || {
+        SorobanVaultGovernanceContract::submit_set_supply_queue(
+            env.clone(),
+            admin.clone(),
+            sdk_u32_vec(&env, &[]),
+        )
+    });
+
+    assert_eq!(proposal_id, Ok(1));
+}
+
+#[test]
 fn cap_action_is_timelocked_and_accepts_after_maturity() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -40,6 +40,20 @@ fn required_i128(value: Option<i128>) -> Result<i128, ContractError> {
     value.ok_or(ContractError::InvalidInput)
 }
 
+fn require_unique_addresses(
+    addresses: &soroban_sdk::Vec<soroban_sdk::Address>,
+) -> Result<(), ContractError> {
+    for i in 0..addresses.len() {
+        let address = addresses.get_unchecked(i);
+        for j in (i + 1)..addresses.len() {
+            if address == addresses.get_unchecked(j) {
+                return Err(ContractError::InvalidInput);
+            }
+        }
+    }
+    Ok(())
+}
+
 fn apply_curator_config(env: &Env, new_curator: soroban_sdk::Address) {
     set_config_address(env, &VaultDataKey::Curator, &new_curator);
     emit_admin_event(env, symbol_short!("s_curatr"));
@@ -62,24 +76,35 @@ fn apply_sentinel_config(env: &Env, sentinel: soroban_sdk::Address) {
     emit_admin_event(env, symbol_short!("s_sntnl"));
 }
 
-fn apply_guardians_config(env: &Env, guardians: soroban_sdk::Vec<soroban_sdk::Address>) {
+fn apply_guardians_config(
+    env: &Env,
+    guardians: soroban_sdk::Vec<soroban_sdk::Address>,
+) -> Result<(), ContractError> {
+    require_unique_addresses(&guardians)?;
     env.storage()
         .instance()
         .set(&VaultDataKey::Guardians, &guardians);
     emit_admin_event(env, symbol_short!("s_guards"));
+    Ok(())
 }
 
-fn apply_allocators_config(env: &Env, allocators: soroban_sdk::Vec<soroban_sdk::Address>) {
+fn apply_allocators_config(
+    env: &Env,
+    allocators: soroban_sdk::Vec<soroban_sdk::Address>,
+) -> Result<(), ContractError> {
+    require_unique_addresses(&allocators)?;
     env.storage()
         .instance()
         .set(&VaultDataKey::Allocators, &allocators);
     emit_admin_event(env, symbol_short!("s_allctr"));
+    Ok(())
 }
 
 fn apply_allowed_adapters_config(
     env: &Env,
     adapters: soroban_sdk::Vec<soroban_sdk::Address>,
 ) -> Result<(), ContractError> {
+    require_unique_addresses(&adapters)?;
     let queue_len = current_supply_queue_len(env)?;
     if queue_len > 0 && adapters.len() != queue_len {
         return Err(ContractError::InvalidInput);
@@ -491,9 +516,9 @@ fn set_governance_config_impl(
             apply_governance_config(env, required_address(primary)?)?
         }
         GOVERNANCE_CONFIG_KIND_SENTINEL => apply_sentinel_config(env, required_address(primary)?),
-        GOVERNANCE_CONFIG_KIND_GUARDIANS => apply_guardians_config(env, required_addresses(many)?),
+        GOVERNANCE_CONFIG_KIND_GUARDIANS => apply_guardians_config(env, required_addresses(many)?)?,
         GOVERNANCE_CONFIG_KIND_ALLOCATORS => {
-            apply_allocators_config(env, required_addresses(many)?)
+            apply_allocators_config(env, required_addresses(many)?)?
         }
         GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS => {
             apply_allowed_adapters_config(env, required_addresses(many)?)?

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -1974,7 +1974,8 @@ mod storage_tests {
     use templar_curator_primitives::policy::state::{MarketConfig, OrderedMap};
     use templar_curator_primitives::PolicyState;
     use templar_soroban_shared_types::{
-        GovernanceCommand, GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS, GOVERNANCE_CONFIG_KIND_CURATOR,
+        GovernanceCommand, GOVERNANCE_CONFIG_KIND_ALLOCATORS,
+        GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS, GOVERNANCE_CONFIG_KIND_CURATOR,
         GOVERNANCE_CONFIG_KIND_GOVERNANCE, GOVERNANCE_CONFIG_KIND_GUARDIANS,
         GOVERNANCE_CONFIG_KIND_SENTINEL, GOVERNANCE_POLICY_KIND_CAP, GOVERNANCE_POLICY_KIND_GROUP,
         GOVERNANCE_POLICY_KIND_PAUSED, GOVERNANCE_POLICY_KIND_REMOVE_MARKET,
@@ -3156,6 +3157,124 @@ mod storage_tests {
             let stored_guardians = stored_guardians.expect("guardians should be set");
             assert_eq!(stored_guardians.len(), 1);
             assert_eq!(stored_guardians.get_unchecked(0), guardian);
+        });
+    }
+
+    #[test]
+    fn test_governance_config_rejects_duplicate_address_lists() {
+        use soroban_sdk::{IntoVal, Symbol};
+
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = SdkAddress::generate(&env);
+        let governance = SdkAddress::generate(&env);
+        let asset = SdkAddress::generate(&env);
+        let share = SdkAddress::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                0,
+                0,
+            )
+            .unwrap();
+        });
+
+        for kind in [
+            GOVERNANCE_CONFIG_KIND_GUARDIANS,
+            GOVERNANCE_CONFIG_KIND_ALLOCATORS,
+            GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS,
+        ] {
+            let duplicated = SdkAddress::generate(&env);
+            let command = GovernanceCommand::SetGovernanceConfig {
+                kind,
+                primary: None,
+                many: Some(alloc::vec![sdk_text(&duplicated), sdk_text(&duplicated)]),
+                value_a: None,
+                value_b: None,
+            };
+            let err = env.try_invoke_contract::<(), crate::error::ContractError>(
+                &contract_id,
+                &Symbol::new(&env, "execute_governance"),
+                (&governance, &Bytes::from_slice(&env, &command.encode())).into_val(&env),
+            );
+            assert_eq!(err, Err(Ok(crate::error::ContractError::InvalidInput)));
+        }
+    }
+
+    #[test]
+    fn test_governance_config_empty_lists_keep_clear_semantics() {
+        let env = Env::default();
+        env.mock_all_auths_allowing_non_root_auth();
+        let contract_id = env.register(SorobanVaultContract, ());
+        let curator = SdkAddress::generate(&env);
+        let governance = SdkAddress::generate(&env);
+        let asset = SdkAddress::generate(&env);
+        let share = SdkAddress::generate(&env);
+        let adapter = SdkAddress::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            SorobanVaultContract::initialize(
+                env.clone(),
+                curator,
+                governance.clone(),
+                asset,
+                share,
+                0,
+                0,
+            )
+            .unwrap();
+            env.storage().instance().set(
+                &crate::contract::VaultDataKey::AllowedAdapters,
+                &SdkVec::from_array(&env, [adapter]),
+            );
+        });
+
+        for kind in [
+            GOVERNANCE_CONFIG_KIND_GUARDIANS,
+            GOVERNANCE_CONFIG_KIND_ALLOCATORS,
+            GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS,
+        ] {
+            execute_governance_command(
+                &env,
+                &contract_id,
+                &governance,
+                &GovernanceCommand::SetGovernanceConfig {
+                    kind,
+                    primary: None,
+                    many: Some(alloc::vec![]),
+                    value_a: None,
+                    value_b: None,
+                },
+            );
+        }
+
+        env.as_contract(&contract_id, || {
+            let guardians: Option<SdkVec<SdkAddress>> = env
+                .storage()
+                .instance()
+                .get(&crate::contract::VaultDataKey::Guardians);
+            assert_eq!(guardians.expect("guardians list should be stored").len(), 0);
+
+            let allocators: Option<SdkVec<SdkAddress>> = env
+                .storage()
+                .instance()
+                .get(&crate::contract::VaultDataKey::Allocators);
+            assert_eq!(
+                allocators.expect("allocators list should be stored").len(),
+                0
+            );
+
+            let adapters: Option<SdkVec<SdkAddress>> = env
+                .storage()
+                .instance()
+                .get(&crate::contract::VaultDataKey::AllowedAdapters);
+            assert_eq!(adapters, None);
         });
     }
 


### PR DESCRIPTION
## Summary

Fixes A-066 / Nexus `b7898751-488c-4530-a728-d980d83b8a53`.

This PR makes the vault/governance list-input policy explicit:

- rejects duplicate Soroban governance config address lists for guardians, allocators, and allowed adapters in the runtime `execute_governance` application path;
- rejects duplicate supply-queue `target_ids` at governance `submit_set_supply_queue` time, before a misleading pending proposal can be queued;
- preserves empty-list semantics where they are already meaningful:
  - guardians and allocators store an empty list (clear effective configured role members),
  - allowed adapters removes the optional adapter binding config,
  - empty supply queue remains an explicit clear/disable-auto-allocation proposal.

## Fixed Findings

- A-066 — Nexus `b7898751-488c-4530-a728-d980d83b8a53`
  - Root cause: list-like governance inputs had mixed implicit behavior: runtime supply queue already rejected duplicates, but governance submission still accepted duplicate supply-queue IDs, and runtime governance config address lists accepted duplicate account/address entries.
  - Fix commit: `26cc9a99719790c634ffedf3c5a86cb96cc816ae`
  - Files:
    - `contract/vault/soroban/governance/src/lib.rs`
    - `contract/vault/soroban/governance/src/tests.rs`
    - `contract/vault/soroban/src/contract/entrypoints.rs`
    - `contract/vault/soroban/src/tests.rs`

## Verification

RED evidence observed before fix:

- `cargo test -p templar-soroban-runtime test_governance_config_rejects_duplicate_address_lists -- --nocapture`
  - failed with duplicate config address list returning `Ok(Ok(()))` instead of `Err(Ok(InvalidInput))`.
- `cargo test -p templar-soroban-governance submit_set_supply_queue_rejects_duplicate_targets -- --nocapture`
  - failed with duplicate supply-queue targets returning `Ok(1)` instead of `Err(InvalidInput)`.

GREEN verification:

- `cargo test -p templar-soroban-runtime test_governance_config_rejects_duplicate_address_lists -- --nocapture`
- `cargo test -p templar-soroban-runtime test_governance_config_empty_lists_keep_clear_semantics -- --nocapture`
- `cargo test -p templar-soroban-governance submit_set_supply_queue_rejects_duplicate_targets -- --nocapture`
- `cargo test -p templar-soroban-governance submit_set_supply_queue_allows_empty_clear_policy -- --nocapture`
- `cargo test -p templar-soroban-governance cap_action_is_timelocked_and_accepts_after_maturity -- --nocapture`
- `cargo test -p templar-soroban-runtime --lib -- --nocapture`
- `cargo test -p templar-soroban-governance -- --nocapture`
- `just -f contract/vault/soroban/justfile size-budget-check`
  - runtime deploy artifact: `93969 bytes (91.77 KiB) <= 131072 bytes`
- post-commit hook reran `just -f contract/vault/soroban/justfile size-budget-check`
  - passed at `93969 bytes`

## Stack

Base: `audit/governance-abi-validation-a056` / PR #442.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/444)
<!-- Reviewable:end -->
