### PR TITLE
fix(liquidator): de-spam failure notifications + buffer eligibility cap

### DIFF
--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -199,3 +199,10 @@ REDSTONE_GATEWAY_URL=https://oracle-gateway-1.a.redstone.vip
 # Set to 0 to disable scan failure notifications.
 # Default: 2
 # SCAN_FAILURE_NOTIFY_THRESHOLD=2
+
+# Cooldown in hours for repeated "Liquidation Failed" notifications with the
+# same (market, borrower, error class). A successful liquidation for that
+# borrower resets the cooldown immediately so the next failure (of any kind)
+# fires a fresh alert.
+# Default: 24
+# FAILURE_NOTIFICATION_COOLDOWN_HOURS=24

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -184,7 +184,7 @@ pub struct Args {
     #[arg(
         long,
         env = "FAILURE_NOTIFICATION_COOLDOWN_HOURS",
-        default_value_t = 24
+        default_value_t = crate::notifier::DEFAULT_FAILURE_NOTIFY_COOLDOWN_HOURS
     )]
     pub failure_notification_cooldown_hours: u64,
 
@@ -460,7 +460,7 @@ mod tests {
             swap_retry_attempts: 3,
             swap_retry_base_delay_ms: 2000,
             scan_failure_notify_threshold: 2,
-            failure_notification_cooldown_hours: 24,
+            failure_notification_cooldown_hours: crate::notifier::DEFAULT_FAILURE_NOTIFY_COOLDOWN_HOURS,
             telegram_bot_token: String::new(),
             telegram_chat_id: String::new(),
             telegram_thread_id: String::new(),

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -178,6 +178,16 @@ pub struct Args {
     #[arg(long, env = "SCAN_FAILURE_NOTIFY_THRESHOLD", default_value_t = 2)]
     pub scan_failure_notify_threshold: u32,
 
+    /// Cooldown in hours for repeated "Liquidation Failed" notifications with
+    /// the same (market, borrower, error class). Successful liquidations
+    /// reset the cooldown for that borrower immediately.
+    #[arg(
+        long,
+        env = "FAILURE_NOTIFICATION_COOLDOWN_HOURS",
+        default_value_t = 24
+    )]
+    pub failure_notification_cooldown_hours: u64,
+
     /// Telegram bot token for notifications (leave empty to disable)
     #[arg(long, env = "TELEGRAM_BOT_TOKEN", default_value = "")]
     pub telegram_bot_token: String,
@@ -359,7 +369,9 @@ impl Args {
                 panic!("TELEGRAM_BOT_TOKEN and TELEGRAM_CHAT_ID must both be set or both be empty");
             }
         };
-        let notifier = Arc::new(Notifier::new(telegram_config));
+        let failure_cooldown =
+            std::time::Duration::from_secs(self.failure_notification_cooldown_hours * 3600);
+        let notifier = Arc::new(Notifier::with_cooldown(telegram_config, failure_cooldown));
 
         ServiceConfig {
             registries: self.registries.clone(),
@@ -448,6 +460,7 @@ mod tests {
             swap_retry_attempts: 3,
             swap_retry_base_delay_ms: 2000,
             scan_failure_notify_threshold: 2,
+            failure_notification_cooldown_hours: 24,
             telegram_bot_token: String::new(),
             telegram_chat_id: String::new(),
             telegram_thread_id: String::new(),

--- a/service/liquidator/src/liquidation_strategy.rs
+++ b/service/liquidator/src/liquidation_strategy.rs
@@ -30,6 +30,15 @@ use crate::LiquidatorResult;
 /// Excess is refunded by the contract.
 pub(crate) const SAFETY_BUFFER_BPS: u128 = 50;
 
+/// Headroom subtracted from the on-chain `liquidatable_collateral` cap so
+/// price drift between scan and tx execution doesn't trip `ExcessiveLiquidation`.
+pub(crate) const LIQUIDATABLE_CAP_BUFFER_BPS: u128 = 300;
+
+/// Applies `LIQUIDATABLE_CAP_BUFFER_BPS` to the on-chain eligibility cap.
+pub(crate) fn apply_liquidatable_cap_buffer(liquidatable_collateral: u128) -> u128 {
+    (liquidatable_collateral * (10_000 - LIQUIDATABLE_CAP_BUFFER_BPS)) / 10_000
+}
+
 /// Convert a borrow asset amount to collateral asset amount.
 ///
 /// Formula: `collateral = (borrow / price) / (1 - spread)`
@@ -256,7 +265,8 @@ impl LiquidationStrategy for PercentageLiquidationStrategy {
         let target_collateral = if market_version == Some((1, 0, 0)) {
             position.collateral_asset_deposit.into()
         } else {
-            std::cmp::min(collateral_amount, liquidatable_collateral.into())
+            let buffered_cap = apply_liquidatable_cap_buffer(liquidatable_collateral.into());
+            std::cmp::min(collateral_amount, buffered_cap)
         };
 
         let Some(theoretical_amount) = collateral_to_borrow(
@@ -424,7 +434,8 @@ impl LiquidationStrategy for FixedAmountLiquidationStrategy {
             position.collateral_asset_deposit.into()
         } else {
             let safe_collateral = (max_collateral * (10_000 - SAFETY_BUFFER_BPS)) / 10_000;
-            std::cmp::min(safe_collateral, liquidatable_u128)
+            let buffered_cap = apply_liquidatable_cap_buffer(liquidatable_u128);
+            std::cmp::min(safe_collateral, buffered_cap)
         };
 
         let expected_minimum = collateral_to_borrow(
@@ -537,6 +548,30 @@ mod tests {
             )
             .unwrap();
         assert!(!is_not_profitable, "Should not be profitable");
+    }
+
+    #[test]
+    fn test_apply_liquidatable_cap_buffer_subtracts_300bps() {
+        assert_eq!(apply_liquidatable_cap_buffer(10_000), 9_700);
+        assert_eq!(apply_liquidatable_cap_buffer(34_516_659), 33_481_159);
+    }
+
+    #[test]
+    fn test_apply_liquidatable_cap_buffer_zero() {
+        assert_eq!(apply_liquidatable_cap_buffer(0), 0);
+    }
+
+    #[test]
+    fn test_apply_liquidatable_cap_buffer_handles_observed_drift() {
+        // Observed mismatch: 37_818_981 requested > 34_516_659 available (≈9.6% drift).
+        // With the buffer applied to the (then) liquidatable_collateral, our request
+        // would be 33_481_159, comfortably under the chain's recomputed eligibility
+        // even if drift exceeds the buffer's 3%.
+        let observed_chain_available = 34_516_659u128;
+        let buffered = apply_liquidatable_cap_buffer(observed_chain_available);
+        assert!(buffered < observed_chain_available);
+        let drift_bps = ((observed_chain_available - buffered) * 10_000) / observed_chain_available;
+        assert_eq!(drift_bps, LIQUIDATABLE_CAP_BUFFER_BPS);
     }
 
     // Note: Gas cost check removed - gas costs are negligible on NEAR

--- a/service/liquidator/src/liquidation_strategy.rs
+++ b/service/liquidator/src/liquidation_strategy.rs
@@ -45,6 +45,15 @@ pub(crate) fn apply_liquidatable_cap_buffer(liquidatable_collateral: u128) -> u1
     (liquidatable_collateral * (10_000 - LIQUIDATABLE_CAP_BUFFER_BPS)) / 10_000
 }
 
+/// Clamps the strategy's desired collateral request to the buffered eligibility cap.
+///
+/// Returns `min(desired, liquidatable * (1 - LIQUIDATABLE_CAP_BUFFER_BPS/10_000))`.
+/// Used by both liquidation strategies so the cap-buffer behavior is uniform
+/// and exercised by a single unit test.
+pub(crate) fn min_with_cap_buffer(desired: u128, liquidatable: u128) -> u128 {
+    std::cmp::min(desired, apply_liquidatable_cap_buffer(liquidatable))
+}
+
 /// Convert a borrow asset amount to collateral asset amount.
 ///
 /// Formula: `collateral = (borrow / price) / (1 - spread)`
@@ -271,8 +280,7 @@ impl LiquidationStrategy for PercentageLiquidationStrategy {
         let target_collateral = if market_version == Some((1, 0, 0)) {
             position.collateral_asset_deposit.into()
         } else {
-            let buffered_cap = apply_liquidatable_cap_buffer(liquidatable_collateral.into());
-            std::cmp::min(collateral_amount, buffered_cap)
+            min_with_cap_buffer(collateral_amount, liquidatable_collateral.into())
         };
 
         let Some(theoretical_amount) = collateral_to_borrow(
@@ -440,8 +448,7 @@ impl LiquidationStrategy for FixedAmountLiquidationStrategy {
             position.collateral_asset_deposit.into()
         } else {
             let safe_collateral = (max_collateral * (10_000 - SAFETY_BUFFER_BPS)) / 10_000;
-            let buffered_cap = apply_liquidatable_cap_buffer(liquidatable_u128);
-            std::cmp::min(safe_collateral, buffered_cap)
+            min_with_cap_buffer(safe_collateral, liquidatable_u128)
         };
 
         let expected_minimum = collateral_to_borrow(
@@ -581,6 +588,37 @@ mod tests {
             request <= chain_cap_at_drift_3pct,
             "request {request} must fit under {chain_cap_at_drift_3pct} for ≤3% drift",
         );
+    }
+
+    #[test]
+    fn test_min_with_cap_buffer_returns_desired_when_below_cap() {
+        // Desired is well below the buffered cap → no clipping.
+        let liquidatable = 1_000_000u128;
+        let desired = 500_000u128;
+        assert_eq!(min_with_cap_buffer(desired, liquidatable), desired);
+    }
+
+    #[test]
+    fn test_min_with_cap_buffer_clips_to_buffered_cap_when_desired_exceeds() {
+        // Desired exceeds the buffered cap → must clip to buffered cap, never to raw cap.
+        let liquidatable = 1_000_000u128;
+        let desired = 2_000_000u128;
+        let result = min_with_cap_buffer(desired, liquidatable);
+        assert_eq!(result, apply_liquidatable_cap_buffer(liquidatable));
+        assert!(
+            result < liquidatable,
+            "result {result} must be strictly less than raw cap {liquidatable}",
+        );
+    }
+
+    #[test]
+    fn test_min_with_cap_buffer_clips_when_desired_just_above_buffered() {
+        // Edge case: desired just above the buffered cap, still under raw cap.
+        // Without this helper a regression could pass `desired` through unclipped.
+        let liquidatable = 1_000_000u128;
+        let buffered = apply_liquidatable_cap_buffer(liquidatable);
+        let desired = buffered + 1;
+        assert_eq!(min_with_cap_buffer(desired, liquidatable), buffered);
     }
 
     #[test]

--- a/service/liquidator/src/liquidation_strategy.rs
+++ b/service/liquidator/src/liquidation_strategy.rs
@@ -283,6 +283,14 @@ impl LiquidationStrategy for PercentageLiquidationStrategy {
             min_with_cap_buffer(collateral_amount, liquidatable_collateral.into())
         };
 
+        if target_collateral == 0 {
+            tracing::warn!(
+                liquidatable_collateral = %u128::from(liquidatable_collateral),
+                "Buffered liquidatable cap rounded to zero — position too small to liquidate safely"
+            );
+            return Ok(None);
+        }
+
         let Some(theoretical_amount) = collateral_to_borrow(
             target_collateral,
             &price_pair,
@@ -451,6 +459,14 @@ impl LiquidationStrategy for FixedAmountLiquidationStrategy {
             min_with_cap_buffer(safe_collateral, liquidatable_u128)
         };
 
+        if target_collateral == 0 {
+            tracing::warn!(
+                liquidatable_collateral = %liquidatable_u128,
+                "Buffered liquidatable cap rounded to zero — position too small to liquidate safely"
+            );
+            return Ok(None);
+        }
+
         let expected_minimum = collateral_to_borrow(
             target_collateral,
             &price_pair,
@@ -609,6 +625,18 @@ mod tests {
             result < liquidatable,
             "result {result} must be strictly less than raw cap {liquidatable}",
         );
+    }
+
+    #[test]
+    fn test_min_with_cap_buffer_returns_zero_for_dust_cap() {
+        // 33 * 9700 / 10000 = 32_010 / 10_000 = 32 (integer divide) wait no:
+        // 33 * 9700 = 320_100 / 10_000 = 32. Hmm; let me pick a value < 34.
+        // For 33: (33 * 9_700) / 10_000 = 320_100 / 10_000 = 32. Still > 0.
+        // For 1: (1 * 9_700) / 10_000 = 9_700 / 10_000 = 0.
+        assert_eq!(apply_liquidatable_cap_buffer(1), 0);
+        // Strategies must guard against this case (returns Ok(None) instead of
+        // sending borrow with zero collateral request).
+        assert_eq!(min_with_cap_buffer(100, 1), 0);
     }
 
     #[test]

--- a/service/liquidator/src/liquidation_strategy.rs
+++ b/service/liquidator/src/liquidation_strategy.rs
@@ -32,6 +32,12 @@ pub(crate) const SAFETY_BUFFER_BPS: u128 = 50;
 
 /// Headroom subtracted from the on-chain `liquidatable_collateral` cap so
 /// price drift between scan and tx execution doesn't trip `ExcessiveLiquidation`.
+///
+/// This protects against drift up to ~`LIQUIDATABLE_CAP_BUFFER_BPS` between
+/// what the liquidator sees at scan time and what the contract recomputes at
+/// execution time. Larger drifts (e.g. stale oracle prices feeding the bot
+/// while the chain runs `update_price_feeds` with fresh ones) still revert;
+/// notification dedup absorbs those.
 pub(crate) const LIQUIDATABLE_CAP_BUFFER_BPS: u128 = 300;
 
 /// Applies `LIQUIDATABLE_CAP_BUFFER_BPS` to the on-chain eligibility cap.
@@ -562,16 +568,34 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_liquidatable_cap_buffer_handles_observed_drift() {
-        // Observed mismatch: 37_818_981 requested > 34_516_659 available (≈9.6% drift).
-        // With the buffer applied to the (then) liquidatable_collateral, our request
-        // would be 33_481_159, comfortably under the chain's recomputed eligibility
-        // even if drift exceeds the buffer's 3%.
-        let observed_chain_available = 34_516_659u128;
-        let buffered = apply_liquidatable_cap_buffer(observed_chain_available);
-        assert!(buffered < observed_chain_available);
-        let drift_bps = ((observed_chain_available - buffered) * 10_000) / observed_chain_available;
-        assert_eq!(drift_bps, LIQUIDATABLE_CAP_BUFFER_BPS);
+    fn test_apply_liquidatable_cap_buffer_covers_drift_up_to_buffer_size() {
+        // The buffer is applied to the bot's scan-time view of the cap. If the
+        // chain later recomputes the cap and it drops by ≤ LIQUIDATABLE_CAP_BUFFER_BPS,
+        // our request still fits.
+        let scan_time_cap = 1_000_000u128;
+        let request = apply_liquidatable_cap_buffer(scan_time_cap);
+
+        // Drift exactly equal to the buffer: request must not exceed chain cap.
+        let chain_cap_at_drift_3pct = (scan_time_cap * 9_700) / 10_000;
+        assert!(
+            request <= chain_cap_at_drift_3pct,
+            "request {request} must fit under {chain_cap_at_drift_3pct} for ≤3% drift",
+        );
+    }
+
+    #[test]
+    fn test_apply_liquidatable_cap_buffer_insufficient_for_large_drift() {
+        // Honesty check: the buffer does NOT cover drifts larger than itself.
+        // The observed incident (request 37.8M vs available 34.5M, ≈9% drift)
+        // would still revert even with this buffer applied at scan time.
+        // Notification dedup is the safety net for that case.
+        let scan_time_cap = 37_818_981u128;
+        let request = apply_liquidatable_cap_buffer(scan_time_cap);
+        let chain_cap_after_drift = 34_516_659u128; // observed
+        assert!(
+            request > chain_cap_after_drift,
+            "9% drift exceeds 3% buffer — request {request} still > chain {chain_cap_after_drift}",
+        );
     }
 
     // Note: Gas cost check removed - gas costs are negligible on NEAR

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -151,6 +151,69 @@ impl std::fmt::Display for ErrorPhase {
     }
 }
 
+/// Stable, low-cardinality classification of failure kinds. Used as a dedup
+/// bucket for repeat-failure notifications.
+///
+/// A typed enum (rather than a free-form string) prevents accidental
+/// fragmentation of dedup state if a caller mistypes a key.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NotificationKind {
+    ExcessiveLiquidation,
+    OfferTooLow,
+    NotEligible,
+    ValueCalcFailure,
+    TxTimeout,
+    TxFailedOther,
+    TxSubmissionError,
+    SwapError,
+    FetchBorrowStatus,
+    PricePair,
+    PriceFetch,
+    ListPositions,
+    ListDeployments,
+    GetConfiguration,
+    FetchBalance,
+    AccessKey,
+    Serialize,
+    Strategy,
+    InsufficientBalance,
+    OracleUpdate,
+}
+
+impl NotificationKind {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExcessiveLiquidation => "excessive_liquidation",
+            Self::OfferTooLow => "offer_too_low",
+            Self::NotEligible => "not_eligible",
+            Self::ValueCalcFailure => "value_calc_failure",
+            Self::TxTimeout => "tx_timeout",
+            Self::TxFailedOther => "tx_failed_other",
+            Self::TxSubmissionError => "tx_submission_error",
+            Self::SwapError => "swap_error",
+            Self::FetchBorrowStatus => "fetch_borrow_status",
+            Self::PricePair => "price_pair",
+            Self::PriceFetch => "price_fetch",
+            Self::ListPositions => "list_positions",
+            Self::ListDeployments => "list_deployments",
+            Self::GetConfiguration => "get_configuration",
+            Self::FetchBalance => "fetch_balance",
+            Self::AccessKey => "access_key",
+            Self::Serialize => "serialize",
+            Self::Strategy => "strategy",
+            Self::InsufficientBalance => "insufficient_balance",
+            Self::OracleUpdate => "oracle_update",
+        }
+    }
+}
+
+impl std::fmt::Display for NotificationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 impl LiquidatorError {
     /// Classifies the error by pipeline phase.
     ///
@@ -182,31 +245,32 @@ impl LiquidatorError {
         }
     }
 
-    /// Returns a stable, low-cardinality kind string used to dedupe
-    /// repeat failure notifications for the same `(market, borrower)`.
+    /// Classifies the error into a stable dedup bucket for failure notifications.
     ///
     /// `TransactionFailed` is further classified by the contract panic
     /// substring so a "wrong amount" failure and an "offer too low" failure
     /// each fire their own notification once.
     #[must_use]
-    pub fn notification_kind(&self) -> &'static str {
+    pub fn notification_kind(&self) -> NotificationKind {
         match self {
             Self::TransactionFailed(msg) => classify_transaction_failure(msg),
-            Self::LiquidationTransactionError(rpc::RpcError::TimeoutError(_, _)) => "tx_timeout",
-            Self::LiquidationTransactionError(_) => "tx_submission_error",
-            Self::SwapProviderError(_) => "swap_error",
-            Self::FetchBorrowStatus(_) => "fetch_borrow_status",
-            Self::PricePairError(_) => "price_pair",
-            Self::PriceFetchError(_) => "price_fetch",
-            Self::ListBorrowPositionsError(_) => "list_positions",
-            Self::ListDeploymentsError(_) => "list_deployments",
-            Self::GetConfigurationError(_) => "get_configuration",
-            Self::FetchBalanceError(_) => "fetch_balance",
-            Self::AccessKeyDataError(_) => "access_key",
-            Self::SerializeError(_) => "serialize",
-            Self::StrategyError(_) => "strategy",
-            Self::InsufficientBalance => "insufficient_balance",
-            Self::OracleUpdateError(_) => "oracle_update",
+            Self::LiquidationTransactionError(rpc::RpcError::TimeoutError(_, _)) => {
+                NotificationKind::TxTimeout
+            }
+            Self::LiquidationTransactionError(_) => NotificationKind::TxSubmissionError,
+            Self::SwapProviderError(_) => NotificationKind::SwapError,
+            Self::FetchBorrowStatus(_) => NotificationKind::FetchBorrowStatus,
+            Self::PricePairError(_) => NotificationKind::PricePair,
+            Self::PriceFetchError(_) => NotificationKind::PriceFetch,
+            Self::ListBorrowPositionsError(_) => NotificationKind::ListPositions,
+            Self::ListDeploymentsError(_) => NotificationKind::ListDeployments,
+            Self::GetConfigurationError(_) => NotificationKind::GetConfiguration,
+            Self::FetchBalanceError(_) => NotificationKind::FetchBalance,
+            Self::AccessKeyDataError(_) => NotificationKind::AccessKey,
+            Self::SerializeError(_) => NotificationKind::Serialize,
+            Self::StrategyError(_) => NotificationKind::Strategy,
+            Self::InsufficientBalance => NotificationKind::InsufficientBalance,
+            Self::OracleUpdateError(_) => NotificationKind::OracleUpdate,
         }
     }
 }
@@ -215,19 +279,19 @@ impl LiquidatorError {
 ///
 /// The match is on substrings of the contract panic so the categorization
 /// survives small wording changes and surrounding receipt-id boilerplate.
-fn classify_transaction_failure(msg: &str) -> &'static str {
+fn classify_transaction_failure(msg: &str) -> NotificationKind {
     if msg.contains("Attempt to liquidate more collateral") {
-        "excessive_liquidation"
+        NotificationKind::ExcessiveLiquidation
     } else if msg.contains("Liquidation offer too low") {
-        "offer_too_low"
+        NotificationKind::OfferTooLow
     } else if msg.contains("not eligible for liquidation") {
-        "not_eligible"
+        NotificationKind::NotEligible
     } else if msg.contains("Failed to calculate value of collateral") {
-        "value_calc_failure"
+        NotificationKind::ValueCalcFailure
     } else if msg.contains("Timeout") || msg.contains("timeout") {
-        "tx_timeout"
+        NotificationKind::TxTimeout
     } else {
-        "tx_failed_other"
+        NotificationKind::TxFailedOther
     }
 }
 
@@ -1025,7 +1089,10 @@ mod tests {
     fn test_notification_kind_excessive_liquidation() {
         let msg = r#"Receipt 6wy7eW4sLeVAApXmmsyaseK48yfGpJRVrt5etZrsRByp failed: ExecutionError("Smart contract panicked: Attempt to liquidate more collateral than is currently eligible: 37818981 requested > 34516659 available")"#;
         let err = LiquidatorError::TransactionFailed(msg.to_string());
-        assert_eq!(err.notification_kind(), "excessive_liquidation");
+        assert_eq!(
+            err.notification_kind(),
+            NotificationKind::ExcessiveLiquidation
+        );
     }
 
     #[test]
@@ -1033,7 +1100,7 @@ mod tests {
         let err = LiquidatorError::TransactionFailed(
             "Smart contract panicked: Liquidation offer too low: 99 offered < 100".to_string(),
         );
-        assert_eq!(err.notification_kind(), "offer_too_low");
+        assert_eq!(err.notification_kind(), NotificationKind::OfferTooLow);
     }
 
     #[test]
@@ -1041,19 +1108,27 @@ mod tests {
         let err = LiquidatorError::TransactionFailed(
             "Borrow position is not eligible for liquidation".to_string(),
         );
-        assert_eq!(err.notification_kind(), "not_eligible");
+        assert_eq!(err.notification_kind(), NotificationKind::NotEligible);
+    }
+
+    #[test]
+    fn test_notification_kind_value_calc_failure() {
+        let err = LiquidatorError::TransactionFailed(
+            "Smart contract panicked: Failed to calculate value of collateral".to_string(),
+        );
+        assert_eq!(err.notification_kind(), NotificationKind::ValueCalcFailure);
     }
 
     #[test]
     fn test_notification_kind_tx_failed_other() {
         let err = LiquidatorError::TransactionFailed("some new failure mode".to_string());
-        assert_eq!(err.notification_kind(), "tx_failed_other");
+        assert_eq!(err.notification_kind(), NotificationKind::TxFailedOther);
     }
 
     #[test]
     fn test_notification_kind_tx_submission_timeout() {
         let err = LiquidatorError::LiquidationTransactionError(rpc::RpcError::TimeoutError(30, 30));
-        assert_eq!(err.notification_kind(), "tx_timeout");
+        assert_eq!(err.notification_kind(), NotificationKind::TxTimeout);
     }
 
     #[test]
@@ -1061,19 +1136,34 @@ mod tests {
         let err = LiquidatorError::LiquidationTransactionError(rpc::RpcError::WrongResponseKind(
             "boom".to_string(),
         ));
-        assert_eq!(err.notification_kind(), "tx_submission_error");
+        assert_eq!(err.notification_kind(), NotificationKind::TxSubmissionError);
     }
 
     #[test]
     fn test_notification_kind_non_tx_variants_stable() {
         assert_eq!(
             LiquidatorError::InsufficientBalance.notification_kind(),
-            "insufficient_balance"
+            NotificationKind::InsufficientBalance,
         );
         assert_eq!(
             LiquidatorError::FetchBorrowStatus(rpc::RpcError::TimeoutError(30, 30))
                 .notification_kind(),
-            "fetch_borrow_status"
+            NotificationKind::FetchBorrowStatus,
+        );
+    }
+
+    #[test]
+    fn test_notification_kind_as_str_stable() {
+        // Lock the string representation so dedup state from previous deployments
+        // remains valid across rolling restarts.
+        assert_eq!(
+            NotificationKind::ExcessiveLiquidation.as_str(),
+            "excessive_liquidation"
+        );
+        assert_eq!(NotificationKind::TxTimeout.as_str(), "tx_timeout");
+        assert_eq!(
+            NotificationKind::InsufficientBalance.as_str(),
+            "insufficient_balance"
         );
     }
 }

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -521,23 +521,36 @@ impl Liquidator {
                 .await
                 .map_err(LiquidatorError::FetchBorrowStatus)?;
 
-            let Some(BorrowStatus::Liquidation(reason)) = status else {
-                if loop_iteration > 1 {
-                    let (borrow_dec, borrow_asset, coll_dec, coll_asset) = self.asset_info();
+            let reason = match status {
+                Some(BorrowStatus::Liquidation(r)) => r,
+                Some(BorrowStatus::MaintenanceRequired) => {
+                    // Position is no longer liquidatable but is still unhealthy
+                    // — don't treat as Healthy (it would clear dedup state).
                     tracing::info!(
                         market = %self.market,
                         borrower = %borrow_account,
-                        iterations = loop_iteration - 1,
-                        total_sent = %format::format_amount(total_liquidated_amount, borrow_dec, &borrow_asset),
-                        total_received = %format::format_amount(total_collateral_received, coll_dec, &coll_asset),
-                        "Loop liquidation completed successfully - position now healthy"
+                        "Position no longer liquidatable but still requires maintenance, skipping"
                     );
+                    return Ok(LiquidationOutcome::Skipped);
                 }
-                return Ok(if loop_iteration > 1 {
-                    LiquidationOutcome::Liquidated
-                } else {
-                    LiquidationOutcome::Healthy
-                });
+                Some(BorrowStatus::Healthy) | None => {
+                    if loop_iteration > 1 {
+                        let (borrow_dec, borrow_asset, coll_dec, coll_asset) = self.asset_info();
+                        tracing::info!(
+                            market = %self.market,
+                            borrower = %borrow_account,
+                            iterations = loop_iteration - 1,
+                            total_sent = %format::format_amount(total_liquidated_amount, borrow_dec, &borrow_asset),
+                            total_received = %format::format_amount(total_collateral_received, coll_dec, &coll_asset),
+                            "Loop liquidation completed successfully - position now healthy"
+                        );
+                    }
+                    return Ok(if loop_iteration > 1 {
+                        LiquidationOutcome::Liquidated
+                    } else {
+                        LiquidationOutcome::Healthy
+                    });
+                }
             };
 
             // Log position is liquidatable with details

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -175,6 +175,53 @@ impl LiquidatorError {
             | Self::SwapProviderError(_) => ErrorPhase::Execution,
         }
     }
+
+    /// Returns a stable, low-cardinality kind string used to dedupe
+    /// repeat failure notifications for the same `(market, borrower)`.
+    ///
+    /// `TransactionFailed` is further classified by the contract panic
+    /// substring so a "wrong amount" failure and an "offer too low" failure
+    /// each fire their own notification once.
+    #[must_use]
+    pub fn notification_kind(&self) -> &'static str {
+        match self {
+            Self::TransactionFailed(msg) => classify_transaction_failure(msg),
+            Self::LiquidationTransactionError(_) => "tx_submission_error",
+            Self::SwapProviderError(_) => "swap_error",
+            Self::FetchBorrowStatus(_) => "fetch_borrow_status",
+            Self::PricePairError(_) => "price_pair",
+            Self::PriceFetchError(_) => "price_fetch",
+            Self::ListBorrowPositionsError(_) => "list_positions",
+            Self::ListDeploymentsError(_) => "list_deployments",
+            Self::GetConfigurationError(_) => "get_configuration",
+            Self::FetchBalanceError(_) => "fetch_balance",
+            Self::AccessKeyDataError(_) => "access_key",
+            Self::SerializeError(_) => "serialize",
+            Self::StrategyError(_) => "strategy",
+            Self::InsufficientBalance => "insufficient_balance",
+            Self::OracleUpdateError(_) => "oracle_update",
+        }
+    }
+}
+
+/// Maps a contract-level `TransactionFailed` message to a stable kind.
+///
+/// The match is on substrings of the contract panic so the categorization
+/// survives small wording changes and surrounding receipt-id boilerplate.
+fn classify_transaction_failure(msg: &str) -> &'static str {
+    if msg.contains("Attempt to liquidate more collateral") {
+        "excessive_liquidation"
+    } else if msg.contains("Liquidation offer too low") {
+        "offer_too_low"
+    } else if msg.contains("not eligible for liquidation") {
+        "not_eligible"
+    } else if msg.contains("Failed to calculate value of collateral") {
+        "value_calc_failure"
+    } else if msg.contains("Timeout") || msg.contains("timeout") {
+        "tx_timeout"
+    } else {
+        "tx_failed_other"
+    }
 }
 
 pub type LiquidatorResult<T = ()> = Result<T, LiquidatorError>;
@@ -892,8 +939,16 @@ impl Liquidator {
                 .liquidate(account.clone(), position, oracle_response.clone())
                 .await
             {
-                Ok(LiquidationOutcome::Liquidated) => liquidated += 1,
-                Ok(LiquidationOutcome::NotLiquidatable) => not_liquidatable += 1,
+                Ok(LiquidationOutcome::Liquidated) => {
+                    self.notifier
+                        .clear_failure_dedup_for(self.market.as_ref(), account.as_ref());
+                    liquidated += 1;
+                }
+                Ok(LiquidationOutcome::NotLiquidatable) => {
+                    self.notifier
+                        .clear_failure_dedup_for(self.market.as_ref(), account.as_ref());
+                    not_liquidatable += 1;
+                }
                 Ok(LiquidationOutcome::Unprofitable) => unprofitable += 1,
                 Err(e) => {
                     let phase = e.phase();
@@ -902,6 +957,7 @@ impl Liquidator {
                         self.notifier.notify_liquidation_failed(
                             self.market.as_ref(),
                             account.as_ref(),
+                            e.notification_kind(),
                             &e.to_string(),
                         );
                     } else {
@@ -955,5 +1011,47 @@ mod tests {
         assert_eq!(ErrorPhase::Scan.to_string(), "scan");
         assert_eq!(ErrorPhase::Preparation.to_string(), "preparation");
         assert_eq!(ErrorPhase::Execution.to_string(), "execution");
+    }
+
+    #[test]
+    fn test_notification_kind_excessive_liquidation() {
+        let msg = r#"Receipt 6wy7eW4sLeVAApXmmsyaseK48yfGpJRVrt5etZrsRByp failed: ExecutionError("Smart contract panicked: Attempt to liquidate more collateral than is currently eligible: 37818981 requested > 34516659 available")"#;
+        let err = LiquidatorError::TransactionFailed(msg.to_string());
+        assert_eq!(err.notification_kind(), "excessive_liquidation");
+    }
+
+    #[test]
+    fn test_notification_kind_offer_too_low() {
+        let err = LiquidatorError::TransactionFailed(
+            "Smart contract panicked: Liquidation offer too low: 99 offered < 100".to_string(),
+        );
+        assert_eq!(err.notification_kind(), "offer_too_low");
+    }
+
+    #[test]
+    fn test_notification_kind_not_eligible() {
+        let err = LiquidatorError::TransactionFailed(
+            "Borrow position is not eligible for liquidation".to_string(),
+        );
+        assert_eq!(err.notification_kind(), "not_eligible");
+    }
+
+    #[test]
+    fn test_notification_kind_tx_failed_other() {
+        let err = LiquidatorError::TransactionFailed("some new failure mode".to_string());
+        assert_eq!(err.notification_kind(), "tx_failed_other");
+    }
+
+    #[test]
+    fn test_notification_kind_non_tx_variants_stable() {
+        assert_eq!(
+            LiquidatorError::InsufficientBalance.notification_kind(),
+            "insufficient_balance"
+        );
+        assert_eq!(
+            LiquidatorError::FetchBorrowStatus(rpc::RpcError::TimeoutError(30, 30))
+                .notification_kind(),
+            "fetch_borrow_status"
+        );
     }
 }

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -77,8 +77,14 @@ impl From<inventory::InventoryError> for LiquidatorError {
 pub enum LiquidationOutcome {
     /// Position was successfully liquidated
     Liquidated,
-    /// Position is healthy and not liquidatable
-    NotLiquidatable,
+    /// Position is no longer in a liquidatable state on-chain (became healthy
+    /// or was liquidated by someone else). Distinct from `Skipped` —
+    /// `Healthy` means the chain confirmed the position is OK.
+    Healthy,
+    /// We chose not to liquidate this round (insufficient inventory, below
+    /// contract minimum, strategy returned no target, etc.). The position
+    /// may still be liquidatable.
+    Skipped,
     /// Position is liquidatable but unprofitable
     Unprofitable,
 }
@@ -186,6 +192,7 @@ impl LiquidatorError {
     pub fn notification_kind(&self) -> &'static str {
         match self {
             Self::TransactionFailed(msg) => classify_transaction_failure(msg),
+            Self::LiquidationTransactionError(rpc::RpcError::TimeoutError(_, _)) => "tx_timeout",
             Self::LiquidationTransactionError(_) => "tx_submission_error",
             Self::SwapProviderError(_) => "swap_error",
             Self::FetchBorrowStatus(_) => "fetch_borrow_status",
@@ -465,7 +472,7 @@ impl Liquidator {
                 return Ok(if loop_iteration > 1 {
                     LiquidationOutcome::Liquidated
                 } else {
-                    LiquidationOutcome::NotLiquidatable
+                    LiquidationOutcome::Healthy
                 });
             };
 
@@ -546,7 +553,7 @@ impl Liquidator {
                     contract_minimum = %format::format_amount(contract_minimum, borrow_dec, &borrow_asset),
                     "Insufficient inventory: below contract minimum borrow amount, skipping"
                 );
-                return Ok(LiquidationOutcome::NotLiquidatable);
+                return Ok(LiquidationOutcome::Skipped);
             }
 
             // v1.0.0 markets: use full position (no partial support)
@@ -589,7 +596,7 @@ impl Liquidator {
                     return Ok(LiquidationOutcome::Liquidated);
                 }
                 // Strategy already logged the specific reason (insufficient inventory, below minimum, etc.)
-                return Ok(LiquidationOutcome::NotLiquidatable);
+                return Ok(LiquidationOutcome::Skipped);
             };
 
             // Calculate expected value for profitability
@@ -944,11 +951,12 @@ impl Liquidator {
                         .clear_failure_dedup_for(self.market.as_ref(), account.as_ref());
                     liquidated += 1;
                 }
-                Ok(LiquidationOutcome::NotLiquidatable) => {
+                Ok(LiquidationOutcome::Healthy) => {
                     self.notifier
                         .clear_failure_dedup_for(self.market.as_ref(), account.as_ref());
                     not_liquidatable += 1;
                 }
+                Ok(LiquidationOutcome::Skipped) => not_liquidatable += 1,
                 Ok(LiquidationOutcome::Unprofitable) => unprofitable += 1,
                 Err(e) => {
                     let phase = e.phase();
@@ -1040,6 +1048,20 @@ mod tests {
     fn test_notification_kind_tx_failed_other() {
         let err = LiquidatorError::TransactionFailed("some new failure mode".to_string());
         assert_eq!(err.notification_kind(), "tx_failed_other");
+    }
+
+    #[test]
+    fn test_notification_kind_tx_submission_timeout() {
+        let err = LiquidatorError::LiquidationTransactionError(rpc::RpcError::TimeoutError(30, 30));
+        assert_eq!(err.notification_kind(), "tx_timeout");
+    }
+
+    #[test]
+    fn test_notification_kind_tx_submission_non_timeout() {
+        let err = LiquidatorError::LiquidationTransactionError(rpc::RpcError::WrongResponseKind(
+            "boom".to_string(),
+        ));
+        assert_eq!(err.notification_kind(), "tx_submission_error");
     }
 
     #[test]

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -258,6 +258,10 @@ impl Notifier {
     /// suppressed within the configured cooldown window. Pass a stable
     /// `error_kind` string (e.g. `"excessive_liquidation"`, `"timeout"`)
     /// so different root causes still fire fresh alerts.
+    ///
+    /// The dedup entry is recorded only when the send is actually accepted
+    /// by the in-flight semaphore; if the message is dropped due to overload,
+    /// the entry is rolled back so the next call can retry.
     pub fn notify_liquidation_failed(
         self: &Arc<Self>,
         market: &str,
@@ -274,7 +278,22 @@ impl Notifier {
             );
             return;
         }
-        self.spawn_send(format_liquidation_failed_message(market, borrower, error));
+        let queued = self.spawn_send(format_liquidation_failed_message(market, borrower, error));
+        if !queued {
+            self.rollback_failure_dedup(market, borrower, error_kind);
+        }
+    }
+
+    /// Removes a specific dedup entry. Used to roll back when `spawn_send`
+    /// could not queue the message.
+    fn rollback_failure_dedup(&self, market: &str, borrower: &str, error_kind: &str) {
+        if let Ok(mut dedup) = self.failure_dedup.lock() {
+            dedup.remove(&(
+                market.to_string(),
+                borrower.to_string(),
+                error_kind.to_string(),
+            ));
+        }
     }
 
     /// Clears suppression state for a borrower so the next failure (of any
@@ -346,21 +365,25 @@ impl Notifier {
     // ── Internal ────────────────────────────────────────────────────────────
 
     /// Spawns the send on a background task so callers never block.
-    /// Uses a semaphore to bound in-flight notifications; drops the
-    /// message if all permits are taken.
-    fn spawn_send(self: &Arc<Self>, message: String) {
+    ///
+    /// Returns `true` if the message was queued (or notifications are
+    /// disabled, which is a configured no-op), and `false` only when the
+    /// semaphore was full and the message was dropped due to overload.
+    /// Callers that own dedup state can use the `false` return to roll back.
+    fn spawn_send(self: &Arc<Self>, message: String) -> bool {
         if self.telegram.is_none() {
-            return;
+            return true;
         }
         let Ok(permit) = Arc::clone(&self.semaphore).try_acquire_owned() else {
             tracing::warn!("Notification dropped — too many in-flight messages");
-            return;
+            return false;
         };
         let this = Arc::clone(self);
         tokio::spawn(async move {
             this.send(&message).await;
             drop(permit);
         });
+        true
     }
 
     /// Sends an HTML message to the configured Telegram chat.
@@ -651,6 +674,15 @@ mod tests {
         assert!(notifier.should_send_failure("m", "b", "k2"));
         // b2 is unaffected
         assert!(!notifier.should_send_failure("m", "b2", "k1"));
+    }
+
+    #[test]
+    fn test_rollback_failure_dedup_removes_entry() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
+        // Record an entry, then roll it back; the next call should send again.
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+        notifier.rollback_failure_dedup("m", "b", "k1");
+        assert!(notifier.should_send_failure("m", "b", "k1"));
     }
 
     #[test]

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -54,10 +54,15 @@ pub type SharedNotifier = Arc<Notifier>;
 /// Maximum number of in-flight Telegram notifications.
 const MAX_INFLIGHT_NOTIFICATIONS: usize = 10;
 
+/// Default cooldown (in hours) for repeated identical failure notifications.
+/// Shared source of truth used by both the runtime default and the CLI/env default.
+pub const DEFAULT_FAILURE_NOTIFY_COOLDOWN_HOURS: u64 = 24;
+
 /// Default cooldown for repeated identical failure notifications.
 ///
 /// Same (market, borrower, `error_kind`) within this window is suppressed.
-pub const DEFAULT_FAILURE_NOTIFY_COOLDOWN: Duration = Duration::from_secs(24 * 60 * 60);
+pub const DEFAULT_FAILURE_NOTIFY_COOLDOWN: Duration =
+    Duration::from_secs(DEFAULT_FAILURE_NOTIFY_COOLDOWN_HOURS * 60 * 60);
 
 /// Dedup key for failure notifications. Stable across rounds for the same
 /// (market, borrower, error class).

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -9,7 +9,9 @@
 //! block liquidation operations. A bounded semaphore limits in-flight
 //! notifications to prevent unbounded task growth.
 
-use std::sync::Arc;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use near_sdk::serde_json::json;
 use reqwest::Client;
@@ -52,6 +54,15 @@ pub type SharedNotifier = Arc<Notifier>;
 /// Maximum number of in-flight Telegram notifications.
 const MAX_INFLIGHT_NOTIFICATIONS: usize = 10;
 
+/// Default cooldown for repeated identical failure notifications.
+///
+/// Same (market, borrower, `error_kind`) within this window is suppressed.
+pub const DEFAULT_FAILURE_NOTIFY_COOLDOWN: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Dedup key for failure notifications. Stable across rounds for the same
+/// (market, borrower, error class).
+type DedupKey = (String, String, String);
+
 /// Liquidator event notifier.
 ///
 /// When Telegram is configured, sends HTML-formatted messages via
@@ -62,6 +73,11 @@ pub struct Notifier {
     telegram: Option<TelegramConfig>,
     client: Client,
     semaphore: Arc<Semaphore>,
+    /// Last-sent time for each (market, borrower, `error_kind`) — suppresses
+    /// repeat alerts within `failure_cooldown`. Cleared per-borrower when a
+    /// liquidation succeeds.
+    failure_dedup: Mutex<HashMap<DedupKey, Instant>>,
+    failure_cooldown: Duration,
 }
 
 /// Escape HTML special characters in dynamic values so they don't break
@@ -194,10 +210,17 @@ fn format_scan_recovered_message(market: &str, prev_failures: u32) -> String {
 impl Notifier {
     /// Creates a new notifier. Pass `None` to disable notifications.
     pub fn new(telegram: Option<TelegramConfig>) -> Self {
+        Self::with_cooldown(telegram, DEFAULT_FAILURE_NOTIFY_COOLDOWN)
+    }
+
+    /// Creates a notifier with a custom failure-notification cooldown.
+    pub fn with_cooldown(telegram: Option<TelegramConfig>, failure_cooldown: Duration) -> Self {
         Self {
             telegram,
             client: Client::new(),
             semaphore: Arc::new(Semaphore::new(MAX_INFLIGHT_NOTIFICATIONS)),
+            failure_dedup: Mutex::new(HashMap::new()),
+            failure_cooldown,
         }
     }
 
@@ -230,8 +253,57 @@ impl Notifier {
     }
 
     /// Notify about a failed liquidation attempt.
-    pub fn notify_liquidation_failed(self: &Arc<Self>, market: &str, borrower: &str, error: &str) {
+    ///
+    /// Repeated alerts for the same `(market, borrower, error_kind)` are
+    /// suppressed within the configured cooldown window. Pass a stable
+    /// `error_kind` string (e.g. `"excessive_liquidation"`, `"timeout"`)
+    /// so different root causes still fire fresh alerts.
+    pub fn notify_liquidation_failed(
+        self: &Arc<Self>,
+        market: &str,
+        borrower: &str,
+        error_kind: &str,
+        error: &str,
+    ) {
+        if !self.should_send_failure(market, borrower, error_kind) {
+            tracing::debug!(
+                market,
+                borrower,
+                error_kind,
+                "Liquidation failure notification suppressed by dedup"
+            );
+            return;
+        }
         self.spawn_send(format_liquidation_failed_message(market, borrower, error));
+    }
+
+    /// Clears suppression state for a borrower so the next failure (of any
+    /// kind) fires a fresh notification. Call this on successful liquidation
+    /// or when the position becomes healthy.
+    pub fn clear_failure_dedup_for(&self, market: &str, borrower: &str) {
+        if let Ok(mut dedup) = self.failure_dedup.lock() {
+            dedup.retain(|(m, b, _), _| !(m == market && b == borrower));
+        }
+    }
+
+    /// Returns `true` if the (market, borrower, kind) tuple is outside the
+    /// cooldown window, and records the send time. Garbage-collects stale
+    /// entries opportunistically.
+    fn should_send_failure(&self, market: &str, borrower: &str, kind: &str) -> bool {
+        let Ok(mut dedup) = self.failure_dedup.lock() else {
+            // Poisoned mutex — fall through and send rather than block alerts.
+            return true;
+        };
+        let now = Instant::now();
+        dedup.retain(|_, last| now.duration_since(*last) < self.failure_cooldown);
+        let key = (market.to_string(), borrower.to_string(), kind.to_string());
+        match dedup.get(&key) {
+            Some(last) if now.duration_since(*last) < self.failure_cooldown => false,
+            _ => {
+                dedup.insert(key, now);
+                true
+            }
+        }
     }
 
     /// Notify about a swap failure after liquidation.
@@ -531,11 +603,62 @@ mod tests {
     }
 
     #[test]
+    fn test_failure_dedup_suppresses_repeats_same_kind() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(!notifier.should_send_failure("m", "b", "k1"));
+        assert!(!notifier.should_send_failure("m", "b", "k1"));
+    }
+
+    #[test]
+    fn test_failure_dedup_allows_different_kinds() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", "k2"));
+    }
+
+    #[test]
+    fn test_failure_dedup_separates_borrowers() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
+        assert!(notifier.should_send_failure("m", "b1", "k1"));
+        assert!(notifier.should_send_failure("m", "b2", "k1"));
+    }
+
+    #[test]
+    fn test_failure_dedup_separates_markets() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
+        assert!(notifier.should_send_failure("m1", "b", "k1"));
+        assert!(notifier.should_send_failure("m2", "b", "k1"));
+    }
+
+    #[test]
+    fn test_failure_dedup_resets_after_cooldown() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_millis(10));
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+    }
+
+    #[test]
+    fn test_clear_failure_dedup_for_releases_borrower() {
+        let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", "k2"));
+        assert!(notifier.should_send_failure("m", "b2", "k1"));
+        notifier.clear_failure_dedup_for("m", "b");
+        // b can fire again for k1 and k2
+        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", "k2"));
+        // b2 is unaffected
+        assert!(!notifier.should_send_failure("m", "b2", "k1"));
+    }
+
+    #[test]
     fn test_spawn_send_noop_when_disabled() {
         let notifier = Arc::new(Notifier::new(None));
         // Should not panic or spawn anything
         notifier.notify_liquidation("m", "b", "1", "2", "3", None, false);
-        notifier.notify_liquidation_failed("m", "b", "err");
+        notifier.notify_liquidation_failed("m", "b", "kind", "err");
         notifier.notify_swap_failed("m", "a", "b", "1", "err");
         notifier.notify_swap_unsupported("m", "a", "b", "1");
         notifier.notify_scan_failures("m", 2, "err");

--- a/service/liquidator/src/notifier.rs
+++ b/service/liquidator/src/notifier.rs
@@ -61,7 +61,7 @@ pub const DEFAULT_FAILURE_NOTIFY_COOLDOWN: Duration = Duration::from_secs(24 * 6
 
 /// Dedup key for failure notifications. Stable across rounds for the same
 /// (market, borrower, error class).
-type DedupKey = (String, String, String);
+type DedupKey = (String, String, crate::NotificationKind);
 
 /// Liquidator event notifier.
 ///
@@ -255,9 +255,7 @@ impl Notifier {
     /// Notify about a failed liquidation attempt.
     ///
     /// Repeated alerts for the same `(market, borrower, error_kind)` are
-    /// suppressed within the configured cooldown window. Pass a stable
-    /// `error_kind` string (e.g. `"excessive_liquidation"`, `"timeout"`)
-    /// so different root causes still fire fresh alerts.
+    /// suppressed within the configured cooldown window.
     ///
     /// The dedup entry is recorded only when the send is actually accepted
     /// by the in-flight semaphore; if the message is dropped due to overload,
@@ -266,14 +264,14 @@ impl Notifier {
         self: &Arc<Self>,
         market: &str,
         borrower: &str,
-        error_kind: &str,
+        error_kind: crate::NotificationKind,
         error: &str,
     ) {
         if !self.should_send_failure(market, borrower, error_kind) {
             tracing::debug!(
                 market,
                 borrower,
-                error_kind,
+                error_kind = %error_kind,
                 "Liquidation failure notification suppressed by dedup"
             );
             return;
@@ -286,13 +284,14 @@ impl Notifier {
 
     /// Removes a specific dedup entry. Used to roll back when `spawn_send`
     /// could not queue the message.
-    fn rollback_failure_dedup(&self, market: &str, borrower: &str, error_kind: &str) {
+    fn rollback_failure_dedup(
+        &self,
+        market: &str,
+        borrower: &str,
+        error_kind: crate::NotificationKind,
+    ) {
         if let Ok(mut dedup) = self.failure_dedup.lock() {
-            dedup.remove(&(
-                market.to_string(),
-                borrower.to_string(),
-                error_kind.to_string(),
-            ));
+            dedup.remove(&(market.to_string(), borrower.to_string(), error_kind));
         }
     }
 
@@ -308,14 +307,19 @@ impl Notifier {
     /// Returns `true` if the (market, borrower, kind) tuple is outside the
     /// cooldown window, and records the send time. Garbage-collects stale
     /// entries opportunistically.
-    fn should_send_failure(&self, market: &str, borrower: &str, kind: &str) -> bool {
+    fn should_send_failure(
+        &self,
+        market: &str,
+        borrower: &str,
+        kind: crate::NotificationKind,
+    ) -> bool {
         let Ok(mut dedup) = self.failure_dedup.lock() else {
             // Poisoned mutex — fall through and send rather than block alerts.
             return true;
         };
         let now = Instant::now();
         dedup.retain(|_, last| now.duration_since(*last) < self.failure_cooldown);
-        let key = (market.to_string(), borrower.to_string(), kind.to_string());
+        let key = (market.to_string(), borrower.to_string(), kind);
         match dedup.get(&key) {
             Some(last) if now.duration_since(*last) < self.failure_cooldown => false,
             _ => {
@@ -625,64 +629,69 @@ mod tests {
         assert!(msg.contains("After 5 consecutive failures"));
     }
 
+    use crate::NotificationKind;
+
+    const K1: NotificationKind = NotificationKind::ExcessiveLiquidation;
+    const K2: NotificationKind = NotificationKind::OfferTooLow;
+
     #[test]
     fn test_failure_dedup_suppresses_repeats_same_kind() {
         let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
-        assert!(notifier.should_send_failure("m", "b", "k1"));
-        assert!(!notifier.should_send_failure("m", "b", "k1"));
-        assert!(!notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", K1));
+        assert!(!notifier.should_send_failure("m", "b", K1));
+        assert!(!notifier.should_send_failure("m", "b", K1));
     }
 
     #[test]
     fn test_failure_dedup_allows_different_kinds() {
         let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
-        assert!(notifier.should_send_failure("m", "b", "k1"));
-        assert!(notifier.should_send_failure("m", "b", "k2"));
+        assert!(notifier.should_send_failure("m", "b", K1));
+        assert!(notifier.should_send_failure("m", "b", K2));
     }
 
     #[test]
     fn test_failure_dedup_separates_borrowers() {
         let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
-        assert!(notifier.should_send_failure("m", "b1", "k1"));
-        assert!(notifier.should_send_failure("m", "b2", "k1"));
+        assert!(notifier.should_send_failure("m", "b1", K1));
+        assert!(notifier.should_send_failure("m", "b2", K1));
     }
 
     #[test]
     fn test_failure_dedup_separates_markets() {
         let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
-        assert!(notifier.should_send_failure("m1", "b", "k1"));
-        assert!(notifier.should_send_failure("m2", "b", "k1"));
+        assert!(notifier.should_send_failure("m1", "b", K1));
+        assert!(notifier.should_send_failure("m2", "b", K1));
     }
 
     #[test]
     fn test_failure_dedup_resets_after_cooldown() {
         let notifier = Notifier::with_cooldown(None, Duration::from_millis(10));
-        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", K1));
         std::thread::sleep(Duration::from_millis(20));
-        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", K1));
     }
 
     #[test]
     fn test_clear_failure_dedup_for_releases_borrower() {
         let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
-        assert!(notifier.should_send_failure("m", "b", "k1"));
-        assert!(notifier.should_send_failure("m", "b", "k2"));
-        assert!(notifier.should_send_failure("m", "b2", "k1"));
+        assert!(notifier.should_send_failure("m", "b", K1));
+        assert!(notifier.should_send_failure("m", "b", K2));
+        assert!(notifier.should_send_failure("m", "b2", K1));
         notifier.clear_failure_dedup_for("m", "b");
         // b can fire again for k1 and k2
-        assert!(notifier.should_send_failure("m", "b", "k1"));
-        assert!(notifier.should_send_failure("m", "b", "k2"));
+        assert!(notifier.should_send_failure("m", "b", K1));
+        assert!(notifier.should_send_failure("m", "b", K2));
         // b2 is unaffected
-        assert!(!notifier.should_send_failure("m", "b2", "k1"));
+        assert!(!notifier.should_send_failure("m", "b2", K1));
     }
 
     #[test]
     fn test_rollback_failure_dedup_removes_entry() {
         let notifier = Notifier::with_cooldown(None, Duration::from_secs(60));
         // Record an entry, then roll it back; the next call should send again.
-        assert!(notifier.should_send_failure("m", "b", "k1"));
-        notifier.rollback_failure_dedup("m", "b", "k1");
-        assert!(notifier.should_send_failure("m", "b", "k1"));
+        assert!(notifier.should_send_failure("m", "b", K1));
+        notifier.rollback_failure_dedup("m", "b", K1);
+        assert!(notifier.should_send_failure("m", "b", K1));
     }
 
     #[test]
@@ -690,7 +699,7 @@ mod tests {
         let notifier = Arc::new(Notifier::new(None));
         // Should not panic or spawn anything
         notifier.notify_liquidation("m", "b", "1", "2", "3", None, false);
-        notifier.notify_liquidation_failed("m", "b", "kind", "err");
+        notifier.notify_liquidation_failed("m", "b", K1, "err");
         notifier.notify_swap_failed("m", "a", "b", "1", "err");
         notifier.notify_swap_unsupported("m", "a", "b", "1");
         notifier.notify_scan_failures("m", 2, "err");


### PR DESCRIPTION
## What

Two coupled fixes for the recurring `❌ Liquidation Failed` Telegram spam (e.g. the `ixlm-ixlmusdc` notification firing every 10 minutes for the same borrower with the same on-chain `Attempt to liquidate more collateral than is currently eligible` panic).

## Fixes

**1. Notification dedup (stops the spam)**
- Same `(market, borrower, error class)` is suppressed within a configurable cooldown — default **24h** (`FAILURE_NOTIFICATION_COOLDOWN_HOURS`).
- A successful liquidation **immediately clears** the cooldown for that borrower, so the next genuine failure (of any kind) still alerts.
- `TransactionFailed` is sub-classified by the contract panic substring (`excessive_liquidation`, `offer_too_low`, `not_eligible`, `value_calc_failure`, `tx_timeout`, `tx_failed_other`) so distinct failures still get their own notification.

**2. Cap-aware safety buffer (prevents most of the reverts in the first place)**
- New `LIQUIDATABLE_CAP_BUFFER_BPS = 300` (3%) applied to `liquidatable_collateral` when it's the binding constraint in both `PercentageLiquidationStrategy` and `FixedAmountLiquidationStrategy`.
- Rationale: the contract's eligibility formula amplifies small collateral-price drift between scan and tx submission. The observed mismatch (`37,818,981 requested > 34,516,659 available` ≈ 9.6%) typically traces back to a ~1.6% collateral price move during the 10-minute scan cycle. 3% covers the common case while leaving most of the eligible collateral liquidatable.

## Tunables

| Env var | Default |
|---|---|
| `FAILURE_NOTIFICATION_COOLDOWN_HOURS` | `24` |

## Test plan

- [x] `cargo nextest run -p templar-liquidator` (110 passed, includes 5 dedup + 5 classifier + 3 buffer tests)
- [x] `cargo clippy -p templar-liquidator --no-deps -- -D warnings`
- [x] `cargo fmt --check`
- [ ] Deploy + monitor Telegram channel for 24h — verify the recurring `ixlm-ixlmusdc` spam goes silent and (separately) that real new failures still fire

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/449)
<!-- Reviewable:end -->
