### PR TITLE
fix(liquidator): bump Dockerfile rust to 1.86 to match toolchain

### DIFF
--- a/service/liquidator/Dockerfile
+++ b/service/liquidator/Dockerfile
@@ -3,7 +3,7 @@
 # ============================================
 # Build Stage
 # ============================================
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.86-bookworm AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## Summary
- Bump liquidator Docker base image from `rust:1.85-bookworm` to `rust:1.86-bookworm`
- Workspace `rust-toolchain.toml` already pins `1.86.0`; recent dep update (#404) bumped `near-sdk` to 5.25.0, which requires rustc >= 1.86
- Without this, `docker build` fails at the cargo build step with `package requires rustc 1.86`

## Test plan
- [x] `docker build -f service/liquidator/Dockerfile -t templar-liquidator:test .` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/450)
<!-- Reviewable:end -->
