### PR TITLE
fix: harden governance role topology

### DIFF
--- a/contract/vault/soroban/governance/src/lib.rs
+++ b/contract/vault/soroban/governance/src/lib.rs
@@ -1,6 +1,8 @@
 #![no_std]
 
 extern crate alloc;
+#[cfg(test)]
+extern crate std;
 
 mod types;
 pub use types::*;
@@ -120,6 +122,7 @@ impl SorobanVaultGovernanceContract {
     ) -> Result<(), GovernanceError> {
         extend_instance_ttl(&env);
         require_contract_address(&vault)?;
+        require_constructor_topology(&env, &admin, &vault)?;
         validate_timelock_ns(timelock_ns)?;
 
         env.storage().instance().set(&DataKey::Admin, &admin);
@@ -1679,6 +1682,18 @@ fn require_governance_target(env: &Env, governance: &Address) -> Result<(), Gove
     require_wasm_contract_address(governance)?;
     let vault = get_address(env, DataKey::Vault)?;
     if governance == &vault || governance == &env.current_contract_address() {
+        return Err(GovernanceError::InvalidInput);
+    }
+    Ok(())
+}
+
+fn require_constructor_topology(
+    env: &Env,
+    admin: &Address,
+    vault: &Address,
+) -> Result<(), GovernanceError> {
+    let current = env.current_contract_address();
+    if admin == vault || admin == &current || vault == &current {
         return Err(GovernanceError::InvalidInput);
     }
     Ok(())

--- a/contract/vault/soroban/governance/src/lib.rs
+++ b/contract/vault/soroban/governance/src/lib.rs
@@ -8,7 +8,7 @@ pub use types::*;
 use alloc::{string::String as AllocString, vec::Vec as AllocVec};
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    contract, contractimpl, Address, Bytes, BytesN, Env, IntoVal, String, Symbol, Vec,
+    contract, contractimpl, Address, Bytes, BytesN, Env, Executable, IntoVal, String, Symbol, Vec,
 };
 use templar_curator_primitives::governance::{
     timelock_config_decision, CapChangeError, FeeChangeError, FeeConfig, MembershipChangeError,
@@ -180,7 +180,7 @@ impl SorobanVaultGovernanceContract {
         caller: Address,
         governance: Address,
     ) -> Result<u64, GovernanceError> {
-        require_contract_address(&governance)?;
+        require_governance_target(&env, &governance)?;
         Self::submit(env, caller, GovernanceAction::SetGovernance(governance))
     }
 
@@ -604,7 +604,7 @@ impl SorobanVaultGovernanceContract {
         extend_instance_ttl(&env);
         require_admin(&env, &caller)?;
         require_not_abdicated(&env, &action)?;
-        validate_action(&action)?;
+        validate_action(&env, &action)?;
 
         let id = next_proposal_id(&env)?;
         let decision = decide_submission(&env, &action)?;
@@ -717,9 +717,9 @@ fn require_unique_target_ids(target_ids: &Vec<u32>) -> Result<(), GovernanceErro
     Ok(())
 }
 
-fn validate_action(action: &GovernanceAction) -> Result<(), GovernanceError> {
+fn validate_action(env: &Env, action: &GovernanceAction) -> Result<(), GovernanceError> {
     match action {
-        GovernanceAction::SetGovernance(governance) => require_contract_address(governance),
+        GovernanceAction::SetGovernance(governance) => require_governance_target(env, governance),
         GovernanceAction::SetFees(params) => {
             let _ = to_wad(params.performance_fee_wad)?;
             let _ = to_wad(params.management_fee_wad)?;
@@ -1654,8 +1654,10 @@ fn ledger_timestamp_ns(env: &Env) -> Result<TimestampNs, GovernanceError> {
 }
 
 fn is_contract_address(addr: &Address) -> bool {
-    let bytes = addr.to_string().to_bytes();
-    matches!(bytes.get(0), Some(b'C'))
+    matches!(
+        addr.executable(),
+        Some(Executable::Wasm(_)) | Some(Executable::StellarAsset)
+    )
 }
 
 fn require_contract_address(addr: &Address) -> Result<(), GovernanceError> {
@@ -1664,6 +1666,22 @@ fn require_contract_address(addr: &Address) -> Result<(), GovernanceError> {
     } else {
         Err(GovernanceError::InvalidInput)
     }
+}
+
+fn require_wasm_contract_address(addr: &Address) -> Result<(), GovernanceError> {
+    match addr.executable() {
+        Some(Executable::Wasm(_)) => Ok(()),
+        _ => Err(GovernanceError::InvalidInput),
+    }
+}
+
+fn require_governance_target(env: &Env, governance: &Address) -> Result<(), GovernanceError> {
+    require_wasm_contract_address(governance)?;
+    let vault = get_address(env, DataKey::Vault)?;
+    if governance == &vault || governance == &env.current_contract_address() {
+        return Err(GovernanceError::InvalidInput);
+    }
+    Ok(())
 }
 
 fn extend_instance_ttl(env: &Env) {

--- a/contract/vault/soroban/governance/src/tests.rs
+++ b/contract/vault/soroban/governance/src/tests.rs
@@ -1270,6 +1270,45 @@ fn cap_group_membership_clear_uses_mirrored_current_membership() {
 }
 
 #[test]
+fn governance_constructor_rejects_self_referential_or_colliding_roles() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let vault = env.register(MockVault, ());
+
+    let admin_is_vault = Address::generate(&env);
+    let self_as_admin = Address::generate(&env);
+    let self_as_vault = Address::generate(&env);
+
+    let admin_is_vault_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        env.register_at(
+            &admin_is_vault,
+            SorobanVaultGovernanceContract,
+            (&vault, &vault, &(0u64)),
+        );
+    }));
+    assert!(admin_is_vault_result.is_err());
+
+    let self_admin_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        env.register_at(
+            &self_as_admin,
+            SorobanVaultGovernanceContract,
+            (&self_as_admin, &vault, &(0u64)),
+        );
+    }));
+    assert!(self_admin_result.is_err());
+
+    let self_vault_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        env.register_at(
+            &self_as_vault,
+            SorobanVaultGovernanceContract,
+            (&admin, &self_as_vault, &(0u64)),
+        );
+    }));
+    assert!(self_vault_result.is_err());
+}
+
+#[test]
 fn set_governance_rejects_obvious_invalid_contract_targets() {
     let env = Env::default();
     env.mock_all_auths();

--- a/contract/vault/soroban/governance/src/tests.rs
+++ b/contract/vault/soroban/governance/src/tests.rs
@@ -1270,6 +1270,29 @@ fn cap_group_membership_clear_uses_mirrored_current_membership() {
 }
 
 #[test]
+fn set_governance_rejects_obvious_invalid_contract_targets() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let admin = Address::generate(&env);
+    let vault = env.register(MockVault, ());
+    let governance = env.register(SorobanVaultGovernanceContract, (&admin, &vault, &(0u64)));
+    let asset_contract = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+
+    for target in [vault.clone(), governance.clone(), asset_contract] {
+        let result = env.as_contract(&governance, || {
+            SorobanVaultGovernanceContract::submit_set_governance(
+                env.clone(),
+                admin.clone(),
+                target.clone(),
+            )
+        });
+        assert_eq!(result, Err(GovernanceError::InvalidInput));
+    }
+}
+
+#[test]
 fn governance_change_is_timelocked_and_routes_to_vault() {
     let env = Env::default();
     env.mock_all_auths();
@@ -1286,7 +1309,7 @@ fn governance_change_is_timelocked_and_routes_to_vault() {
         (&admin, &vault, &(5_000_000_000u64)),
     );
 
-    let new_governance = Address::generate(&env);
+    let new_governance = env.register(SorobanVaultGovernanceContract, (&admin, &vault, &(0u64)));
 
     let proposal_id = env.as_contract(&governance, || {
         SorobanVaultGovernanceContract::submit_set_governance(

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -1,9 +1,14 @@
 #![no_std]
 
+#[cfg(test)]
+extern crate std;
+
 mod types;
 pub use types::*;
 
-use soroban_sdk::{contract, contractimpl, panic_with_error, Address, Env, MuxedAddress, String};
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, Address, Env, Executable, MuxedAddress, String,
+};
 use stellar_tokens::fungible::{
     burnable::{emit_burn, FungibleBurnable},
     Base, FungibleToken,
@@ -95,6 +100,7 @@ impl SorobanShareTokenContract {
     ) {
         extend_instance_ttl(&env);
         require_contract_address(&env, &vault);
+        require_vault_admin(&env, &admin, &vault);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Vault, &vault);
         Base::set_metadata(&env, decimals, name, symbol);
@@ -109,6 +115,8 @@ impl SorobanShareTokenContract {
     pub fn set_admin(env: Env, caller: Address, admin: Address) {
         extend_instance_ttl(&env);
         require_admin(&env, &caller);
+        let vault = Self::vault(env.clone());
+        require_vault_admin(&env, &admin, &vault);
         env.storage().instance().set(&DataKey::Admin, &admin);
     }
 
@@ -171,12 +179,20 @@ fn require_vault_invoker(env: &Env) {
 }
 
 fn is_contract_address(addr: &Address) -> bool {
-    let bytes = addr.to_string().to_bytes();
-    matches!(bytes.get(0), Some(b'C'))
+    matches!(
+        addr.executable(),
+        Some(Executable::Wasm(_)) | Some(Executable::StellarAsset)
+    )
 }
 
 fn require_contract_address(env: &Env, addr: &Address) {
     if !is_contract_address(addr) {
+        panic_with_error!(env, ShareTokenError::InvalidInput);
+    }
+}
+
+fn require_vault_admin(env: &Env, admin: &Address, vault: &Address) {
+    if admin != vault {
         panic_with_error!(env, ShareTokenError::InvalidInput);
     }
 }

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -35,8 +35,8 @@ fn setup() -> (Env, Address, Address, Address) {
         ..Default::default()
     });
 
-    let admin = Address::generate(&env);
     let vault = env.register(VaultCaller, ());
+    let admin = vault.clone();
     let token = env.register(
         SorobanShareTokenContract,
         (
@@ -48,6 +48,45 @@ fn setup() -> (Env, Address, Address, Address) {
         ),
     );
     (env, admin, vault, token)
+}
+
+#[test]
+fn constructor_rejects_external_share_token_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let external_admin = Address::generate(&env);
+    let vault = env.register(VaultCaller, ());
+    let token = Address::generate(&env);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        env.register_at(
+            &token,
+            SorobanShareTokenContract,
+            (
+                &external_admin,
+                &vault,
+                &String::from_str(&env, "Templar Share"),
+                &String::from_str(&env, "tvSHARE"),
+                &7u32,
+            ),
+        );
+    }));
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn set_admin_rejects_non_vault_admin() {
+    let (env, _admin, vault, _token) = setup();
+    let new_admin = Address::generate(&env);
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        env.as_contract(&vault, || {
+            SorobanShareTokenContract::set_admin(env.clone(), vault.clone(), new_admin.clone());
+        });
+    }));
+
+    assert!(result.is_err());
 }
 
 #[test]

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -9,8 +9,9 @@ use super::helpers::{
     ensure_governance_identity, ensure_sentinel_identity, extend_storage_ttl, get_config_address,
     governance_caller, kernel_address_from_sdk, load_virtual_offsets, migrate_legacy_paused,
     migration_in_progress, require_contract_address, require_governance,
-    require_governance_control_plane, require_sentinel, require_signed, sdk_string_to_alloc,
-    set_config_address, set_migration_in_progress, store_fees_spec, store_virtual_offsets,
+    require_governance_control_plane, require_sentinel, require_signed,
+    require_wasm_or_account_address, sdk_string_to_alloc, set_config_address,
+    set_migration_in_progress, store_fees_spec, store_virtual_offsets,
     with_contract_vault_contract_error,
 };
 use super::*;
@@ -57,9 +58,11 @@ fn require_unique_addresses(
     Ok(())
 }
 
-fn apply_curator_config(env: &Env, new_curator: soroban_sdk::Address) {
+fn apply_curator_config(env: &Env, new_curator: soroban_sdk::Address) -> Result<(), ContractError> {
+    require_wasm_or_account_address(&new_curator)?;
     set_config_address(env, &VaultDataKey::Curator, &new_curator);
     emit_admin_event(env, symbol_short!("s_curatr"));
+    Ok(())
 }
 
 fn apply_governance_config(
@@ -72,17 +75,22 @@ fn apply_governance_config(
     Ok(())
 }
 
-fn apply_sentinel_config(env: &Env, sentinel: soroban_sdk::Address) {
+fn apply_sentinel_config(env: &Env, sentinel: soroban_sdk::Address) -> Result<(), ContractError> {
+    require_wasm_or_account_address(&sentinel)?;
     env.storage()
         .instance()
         .set(&VaultDataKey::Sentinel, &sentinel);
     emit_admin_event(env, symbol_short!("s_sntnl"));
+    Ok(())
 }
 
 fn apply_guardians_config(
     env: &Env,
     guardians: soroban_sdk::Vec<soroban_sdk::Address>,
 ) -> Result<(), ContractError> {
+    for guardian in guardians.iter() {
+        require_wasm_or_account_address(&guardian)?;
+    }
     require_unique_addresses(&guardians)?;
     env.storage()
         .instance()
@@ -95,6 +103,9 @@ fn apply_allocators_config(
     env: &Env,
     allocators: soroban_sdk::Vec<soroban_sdk::Address>,
 ) -> Result<(), ContractError> {
+    for allocator in allocators.iter() {
+        require_wasm_or_account_address(&allocator)?;
+    }
     require_unique_addresses(&allocators)?;
     env.storage()
         .instance()
@@ -580,11 +591,11 @@ fn set_governance_config_impl(
     value_b: Option<i128>,
 ) -> Result<(), ContractError> {
     match kind {
-        GOVERNANCE_CONFIG_KIND_CURATOR => apply_curator_config(env, required_address(primary)?),
+        GOVERNANCE_CONFIG_KIND_CURATOR => apply_curator_config(env, required_address(primary)?)?,
         GOVERNANCE_CONFIG_KIND_GOVERNANCE => {
             apply_governance_config(env, required_address(primary)?)?
         }
-        GOVERNANCE_CONFIG_KIND_SENTINEL => apply_sentinel_config(env, required_address(primary)?),
+        GOVERNANCE_CONFIG_KIND_SENTINEL => apply_sentinel_config(env, required_address(primary)?)?,
         GOVERNANCE_CONFIG_KIND_GUARDIANS => apply_guardians_config(env, required_addresses(many)?)?,
         GOVERNANCE_CONFIG_KIND_ALLOCATORS => {
             apply_allocators_config(env, required_addresses(many)?)?
@@ -918,6 +929,9 @@ impl SorobanVaultContract {
 
         let virtual_shares = to_u128(virtual_shares)?;
         let virtual_assets = to_u128(virtual_assets)?;
+
+        require_wasm_or_account_address(&curator)?;
+        require_contract_address(&governance)?;
 
         set_config_address(&env, &VaultDataKey::Curator, &curator);
         set_config_address(&env, &VaultDataKey::Governance, &governance);

--- a/contract/vault/soroban/src/contract/helpers.rs
+++ b/contract/vault/soroban/src/contract/helpers.rs
@@ -103,12 +103,20 @@ pub(crate) fn addresses_from_alloc_strings(
 }
 
 fn is_contract_address(addr: &SdkAddress) -> bool {
-    let bytes = addr.to_string().to_bytes();
-    matches!(bytes.get(0), Some(b'C'))
+    matches!(
+        addr.executable(),
+        Some(Executable::Wasm(_)) | Some(Executable::StellarAsset)
+    )
 }
 
 pub(crate) fn require_contract_address(addr: &SdkAddress) -> Result<(), ContractError> {
     is_contract_address(addr)
+        .then_some(())
+        .ok_or(ContractError::InvalidInput)
+}
+
+pub(crate) fn require_wasm_or_account_address(addr: &SdkAddress) -> Result<(), ContractError> {
+    (!matches!(addr.executable(), Some(Executable::StellarAsset)))
         .then_some(())
         .ok_or(ContractError::InvalidInput)
 }

--- a/contract/vault/soroban/src/contract/mod.rs
+++ b/contract/vault/soroban/src/contract/mod.rs
@@ -35,7 +35,7 @@ use alloc::vec::Vec;
 use core::mem;
 pub(crate) use helpers::*;
 use soroban_sdk::{
-    contract, contractimpl, symbol_short, Address as SdkAddress, Bytes, BytesN, Env,
+    contract, contractimpl, symbol_short, Address as SdkAddress, Bytes, BytesN, Env, Executable,
 };
 use templar_curator_primitives::governance::TimelockDecision;
 use templar_curator_primitives::policy::cap_group::{CapGroupId, CapGroupRecord, CapGroupUpdate};

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -295,8 +295,10 @@ mod contract_tests {
     use alloc::string::{String as AllocString, ToString};
     use alloc::vec;
     use alloc::vec::Vec;
+    use soroban_sdk::testutils::Address as _;
     use soroban_sdk::{Address as SdkAddress, Bytes, Env};
     use templar_curator_primitives::PolicyState;
+    use templar_soroban_governance::SorobanVaultGovernanceContract;
     use templar_soroban_shared_types::{
         GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
     };
@@ -368,6 +370,24 @@ mod contract_tests {
     fn sdk_text(address: &SdkAddress) -> AllocString {
         AllocString::from_utf8(address.to_string().to_bytes().to_alloc_vec())
             .expect("valid address")
+    }
+
+    fn register_runtime_contracts(
+        env: &Env,
+        contract_id: &SdkAddress,
+        admin: &SdkAddress,
+    ) -> (SdkAddress, SdkAddress, SdkAddress) {
+        let governance = env.register(
+            SorobanVaultGovernanceContract,
+            (admin, contract_id, &(0u64)),
+        );
+        let asset = env
+            .register_stellar_asset_contract_v2(SdkAddress::generate(env))
+            .address();
+        let share = env
+            .register_stellar_asset_contract_v2(contract_id.clone())
+            .address();
+        (governance, asset, share)
     }
 
     fn execute_command(
@@ -910,14 +930,13 @@ mod contract_tests {
 
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = soroban_sdk::Address::generate(&env);
-        let asset = soroban_sdk::Address::generate(&env);
-        let share = soroban_sdk::Address::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
                 env.clone(),
                 curator.clone(),
-                curator,
+                governance,
                 asset,
                 share,
                 0,
@@ -969,14 +988,13 @@ mod contract_tests {
 
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = soroban_sdk::Address::generate(&env);
-        let asset = soroban_sdk::Address::generate(&env);
-        let share = soroban_sdk::Address::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
                 env.clone(),
                 curator.clone(),
-                curator.clone(),
+                governance,
                 asset,
                 share,
                 17,
@@ -1002,9 +1020,7 @@ mod contract_tests {
 
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = soroban_sdk::Address::generate(&env);
-        let governance = soroban_sdk::Address::generate(&env);
-        let asset = soroban_sdk::Address::generate(&env);
-        let share = soroban_sdk::Address::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -1253,7 +1269,12 @@ mod contract_tests {
 
         env.as_contract(&contract_id, || {
             proxy
-                .initialize(curator.clone(), curator, asset.clone(), share.clone())
+                .initialize(
+                    curator.clone(),
+                    register_runtime_contracts(&env, &contract_id, &curator).0,
+                    asset.clone(),
+                    share.clone(),
+                )
                 .unwrap();
 
             let mut storage = SorobanStorage::new(&env);
@@ -1324,7 +1345,7 @@ mod contract_tests {
             SorobanVaultContract::initialize(
                 env.clone(),
                 curator.clone(),
-                curator.clone(),
+                register_runtime_contracts(&env, &contract_id, &curator).0,
                 asset.clone(),
                 share.clone(),
                 0,
@@ -1394,14 +1415,13 @@ mod contract_tests {
 
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = soroban_sdk::Address::generate(&env);
-        let asset = soroban_sdk::Address::generate(&env);
-        let share = soroban_sdk::Address::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
                 env.clone(),
                 curator.clone(),
-                curator,
+                governance,
                 asset,
                 share,
                 0,
@@ -1973,6 +1993,7 @@ mod storage_tests {
     use templar_curator_primitives::policy::cap_group::{CapGroup, CapGroupId, CapGroupRecord};
     use templar_curator_primitives::policy::state::{MarketConfig, OrderedMap};
     use templar_curator_primitives::PolicyState;
+    use templar_soroban_governance::SorobanVaultGovernanceContract;
     use templar_soroban_shared_types::{
         GovernanceCommand, GOVERNANCE_CONFIG_KIND_ALLOCATORS,
         GOVERNANCE_CONFIG_KIND_ALLOWED_ADAPTERS, GOVERNANCE_CONFIG_KIND_CURATOR,
@@ -1989,6 +2010,24 @@ mod storage_tests {
     fn sdk_text(address: &SdkAddress) -> AllocString {
         AllocString::from_utf8(address.to_string().to_bytes().to_alloc_vec())
             .expect("valid address")
+    }
+
+    fn register_runtime_contracts(
+        env: &Env,
+        contract_id: &SdkAddress,
+        admin: &SdkAddress,
+    ) -> (SdkAddress, SdkAddress, SdkAddress) {
+        let governance = env.register(
+            SorobanVaultGovernanceContract,
+            (admin, contract_id, &(0u64)),
+        );
+        let asset = env
+            .register_stellar_asset_contract_v2(SdkAddress::generate(env))
+            .address();
+        let share = env
+            .register_stellar_asset_contract_v2(contract_id.clone())
+            .address();
+        (governance, asset, share)
     }
 
     fn execute_governance_command(
@@ -2647,9 +2686,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -2715,9 +2752,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -2772,9 +2807,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -2825,11 +2858,9 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let sentinel = SdkAddress::generate(&env);
         let attacker = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -3018,12 +3049,10 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let sentinel = SdkAddress::generate(&env);
         let attacker = SdkAddress::generate(&env);
         let restricted = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -3187,9 +3216,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let cap_group_id = CapGroupId::try_from("group-c".to_string()).unwrap();
 
         env.as_contract(&contract_id, || {
@@ -3273,10 +3300,8 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let attacker = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(env.clone(), curator, governance, asset, share, 0, 0)
@@ -3296,9 +3321,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let cap_group_id = CapGroupId::try_from("group-c".to_string()).unwrap();
 
         env.as_contract(&contract_id, || {
@@ -3362,9 +3385,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -3418,11 +3439,21 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let governance = env.register(
+            SorobanVaultGovernanceContract,
+            (&curator, &contract_id, &(0u64)),
+        );
+        let asset = env
+            .register_stellar_asset_contract_v2(SdkAddress::generate(&env))
+            .address();
+        let share = env
+            .register_stellar_asset_contract_v2(contract_id.clone())
+            .address();
         let new_curator = SdkAddress::generate(&env);
-        let new_governance = SdkAddress::generate(&env);
+        let new_governance = env.register(
+            SorobanVaultGovernanceContract,
+            (&curator, &contract_id, &(0u64)),
+        );
         let sentinel = SdkAddress::generate(&env);
         let guardian = SdkAddress::generate(&env);
 
@@ -3533,9 +3564,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(
@@ -3578,9 +3607,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let adapter = SdkAddress::generate(&env);
 
         env.as_contract(&contract_id, || {
@@ -3651,9 +3678,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
         let attacker = SdkAddress::generate(&env);
 
         env.as_contract(&contract_id, || {
@@ -3741,9 +3766,7 @@ mod storage_tests {
         env.mock_all_auths_allowing_non_root_auth();
         let contract_id = env.register(SorobanVaultContract, ());
         let curator = SdkAddress::generate(&env);
-        let governance = SdkAddress::generate(&env);
-        let asset = SdkAddress::generate(&env);
-        let share = SdkAddress::generate(&env);
+        let (governance, asset, share) = register_runtime_contracts(&env, &contract_id, &curator);
 
         env.as_contract(&contract_id, || {
             SorobanVaultContract::initialize(

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -6,7 +6,7 @@ use rstest::{fixture, rstest};
 use soroban_sdk::{
     testutils::{Address as _, Ledger, LedgerInfo},
     token::StellarAssetClient,
-    Bytes, Env,
+    Address as SdkAddress, Bytes, Env,
 };
 use std::string::String as AllocString;
 use templar_curator_primitives::policy::state::MarketConfig;
@@ -21,7 +21,9 @@ use templar_soroban_runtime::{
     Storage, // Import the trait
 };
 use templar_soroban_shared_types::{
-    GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+    GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_ALLOCATORS,
+    GOVERNANCE_CONFIG_KIND_CURATOR, GOVERNANCE_CONFIG_KIND_GUARDIANS,
+    GOVERNANCE_CONFIG_KIND_SENTINEL, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
 };
 use templar_vault_kernel::state::queue::DEFAULT_COOLDOWN_NS;
 use templar_vault_kernel::{
@@ -218,13 +220,82 @@ fn soroban_contract_fixture() -> SorobanContractFixture {
     let share = env
         .register_stellar_asset_contract_v2(contract_id.clone())
         .address();
+    let governance = env.register(
+        SorobanVaultGovernanceContract,
+        (&curator, &contract_id, &(0u64)),
+    );
 
     env.as_contract(&contract_id, || {
-        SorobanVaultContract::initialize(env.clone(), curator.clone(), curator, asset, share, 0, 0)
+        SorobanVaultContract::initialize(env.clone(), curator, governance, asset, share, 0, 0)
             .unwrap();
     });
 
     SorobanContractFixture { env, contract_id }
+}
+
+#[test]
+fn runtime_initialize_rejects_non_contract_governance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let vault = env.register(SorobanVaultContract, ());
+    let curator = soroban_sdk::Address::generate(&env);
+    let governance = SdkAddress::from_str(
+        &env,
+        "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+    let asset = env
+        .register_stellar_asset_contract_v2(soroban_sdk::Address::generate(&env))
+        .address();
+    let share = env
+        .register_stellar_asset_contract_v2(vault.clone())
+        .address();
+
+    let result = env.as_contract(&vault, || {
+        SorobanVaultContract::initialize(env.clone(), curator, governance, asset, share, 0, 0)
+    });
+
+    assert_eq!(
+        result,
+        Err(templar_soroban_runtime::ContractError::InvalidInput)
+    );
+}
+
+#[rstest]
+#[case(GOVERNANCE_CONFIG_KIND_CURATOR, true)]
+#[case(GOVERNANCE_CONFIG_KIND_SENTINEL, true)]
+#[case(GOVERNANCE_CONFIG_KIND_GUARDIANS, false)]
+#[case(GOVERNANCE_CONFIG_KIND_ALLOCATORS, false)]
+fn runtime_governance_config_rejects_sac_role_addresses(
+    #[case] kind: u32,
+    #[case] primary_role: bool,
+    soroban_contract_fixture: SorobanContractFixture,
+) {
+    let env = soroban_contract_fixture.env;
+    let contract_id = soroban_contract_fixture.contract_id;
+    let proxy = VaultProxy::new(&env);
+    let contract_role = env
+        .register_stellar_asset_contract_v2(contract_id.clone())
+        .address();
+
+    env.as_contract(&contract_id, || {
+        let governance = proxy.governance().unwrap();
+        let many = if primary_role {
+            None
+        } else {
+            Some(std::vec![sdk_wire(&contract_role)])
+        };
+        let command = GovernanceCommand::SetGovernanceConfig {
+            kind,
+            primary: primary_role.then(|| sdk_wire(&contract_role)),
+            many,
+            value_a: None,
+            value_b: None,
+        };
+        assert_eq!(
+            proxy.execute_governance_unit(&governance, &command),
+            Err(templar_soroban_runtime::ContractError::InvalidInput)
+        );
+    });
 }
 
 #[rstest]


### PR DESCRIPTION
## Fixed Findings

- A-044 / Nexus `b92e3503-968f-4ec9-ac68-902ebfb2a0cc` / `#FIND-044`
  - Commit `61fb75ea2b12141e0ae2e6906d839025f890532f`
  - Runtime initialization and governance config now reject nonsensical address topology: governance must be a real Wasm governance contract, token addresses must be SAC-backed, and role/config addresses reject SAC/topology-invalid values while preserving account and Wasm contract-auth role holders.
- A-047 / Nexus `d1113e95-8904-4664-9c92-dfa2cfd0fb65` / `#FIND-047`
  - Commit `5cfbcffc8aa995022eb0d7ae2a82adc71a423ca7`
  - `SetGovernance` rejects invalid governance targets such as the vault itself or non-governance/arbitrary contracts.
- A-063 / Nexus `5dbac2a6-dce1-4e59-af8d-128f8929ae73` / `#FIND-063`
  - Commit `3c1b5f9ddbd7ada1ef4478e1ead5b2f8435493d8`
  - Governance constructor rejects self-referential/colliding admin/vault/governance role topology.
- A-084 / Nexus `9e4e4f3c-9f48-44a1-92df-8d8300a69605` / `#FIND-084`
  - Commit `0a0e7b0fb45e62ddcb2b68a5eda4b3cd262d543d`
  - Share-token authority is bound to the vault topology; admin cannot silently rebind the vault authority after initialization.

## Verification

Passed:

```bash
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-runtime --lib -- --nocapture
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-runtime --test integration_tests -- --skip soroban_contract_resync_idle_balance_fixes_donation_accounting --nocapture
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-governance -- --nocapture
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-share-token -- --nocapture
RUSTUP_TOOLCHAIN=1.89.0 cargo fmt --all --check
git diff --check
just -f contract/vault/soroban/justfile build
just -f contract/vault/soroban/justfile size-budget-check
```

Size gate:

- Runtime deploy WASM: `96918` bytes / `94.65 KiB` <= `131072` bytes / `128.00 KiB`
- Runtime optimized input: `98316` bytes / `96.01 KiB`

Known base failure, reproduced on `origin/audit/governance-control-plane` before this PR and excluded from the branch-specific integration sweep:

```bash
RUSTUP_TOOLCHAIN=1.89.0 cargo test -p templar-soroban-runtime --test integration_tests soroban_contract_resync_idle_balance_fixes_donation_accounting -- --nocapture
```

## Stack

Base: PR #427 / branch `audit/governance-control-plane`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/451)
<!-- Reviewable:end -->
