### PR TITLE
fix: harden auxiliary share-token controls (#FIND-048 #FIND-063 #FIND-070)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12786,6 +12786,7 @@ version = "0.1.0"
 dependencies = [
  "blend-contract-sdk",
  "soroban-sdk",
+ "stellar-contract-utils",
 ]
 
 [[package]]
@@ -12822,6 +12823,7 @@ name = "templar-soroban-share-token"
 version = "0.1.0"
 dependencies = [
  "soroban-sdk",
+ "stellar-contract-utils",
  "stellar-tokens",
 ]
 

--- a/contract/vault/soroban/blend-adapter/Cargo.toml
+++ b/contract/vault/soroban/blend-adapter/Cargo.toml
@@ -17,6 +17,7 @@ testutils = ["soroban-sdk/testutils", "blend-contract-sdk/testutils"]
 [dependencies]
 soroban-sdk = { version = "25.3.0", features = ["experimental_spec_shaking_v2"] }
 blend-contract-sdk = "2.25.0"
+stellar-contract-utils.workspace = true
 
 [dev-dependencies]
 soroban-sdk = { version = "25.3.0", features = ["testutils", "experimental_spec_shaking_v2"] }

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -2,9 +2,10 @@
 
 use soroban_sdk::{
     auth::{ContractContext, InvokerContractAuthEntry, SubContractInvocation},
-    contract, contracterror, contractimpl, contracttype, symbol_short, Address, Env, IntoVal,
-    Symbol, Vec,
+    contract, contracterror, contractimpl, contracttype, panic_with_error, symbol_short, Address,
+    BytesN, Env, IntoVal, Symbol, Vec,
 };
+use stellar_contract_utils::upgradeable::{self, Upgradeable};
 
 use blend_contract_sdk::pool::{Client as PoolClient, Request};
 
@@ -22,6 +23,7 @@ const RESERVE_STALE_WINDOW_SECS: u64 = 300;
 #[derive(Clone, Debug)]
 enum DataKey {
     Admin,
+    PendingAdmin,
     Vault,
     Pool,
     Paused,
@@ -269,6 +271,39 @@ impl BlendAdapterContract {
         get_pool(&env)
     }
 
+    /// Propose a new admin. The pending admin must accept in a separate call.
+    #[allow(deprecated)]
+    pub fn set_admin(env: Env, caller: Address, admin: Address) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_admin(&env, &caller)?;
+        env.storage().instance().set(&DataKey::PendingAdmin, &admin);
+        env.events()
+            .publish((symbol_short!("admin_set"), caller), admin);
+        Ok(())
+    }
+
+    /// Accept admin role previously proposed with `set_admin`.
+    #[allow(deprecated)]
+    pub fn accept_admin(env: Env, caller: Address) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        caller.require_auth();
+        let pending_admin = get_pending_admin(&env)?;
+        if caller != pending_admin {
+            return Err(AdapterError::Unauthorized);
+        }
+        let old_admin = get_admin(&env)?;
+        env.storage().instance().set(&DataKey::Admin, &caller);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.events()
+            .publish((symbol_short!("admin_acc"), old_admin), caller);
+        Ok(())
+    }
+
+    pub fn pending_admin(env: Env) -> Result<Address, AdapterError> {
+        extend_instance_ttl(&env);
+        get_pending_admin(&env)
+    }
+
     /// Supply tokens already on the adapter into the Blend pool (admin-only).
     ///
     /// Use this after transferring tokens to the adapter address.
@@ -369,6 +404,18 @@ impl BlendAdapterContract {
     }
 }
 
+#[contractimpl]
+impl Upgradeable for BlendAdapterContract {
+    #[allow(deprecated)]
+    fn upgrade(e: &Env, new_wasm_hash: BytesN<32>, operator: Address) {
+        extend_instance_ttl(e);
+        require_admin(e, &operator).unwrap_or_else(|err| panic_with_error!(e, err));
+        upgradeable::upgrade(e, &new_wasm_hash);
+        e.events()
+            .publish((symbol_short!("upgrade"), operator), new_wasm_hash);
+    }
+}
+
 fn get_address(env: &Env, key: DataKey) -> Result<Address, AdapterError> {
     env.storage()
         .instance()
@@ -378,6 +425,10 @@ fn get_address(env: &Env, key: DataKey) -> Result<Address, AdapterError> {
 
 fn get_admin(env: &Env) -> Result<Address, AdapterError> {
     get_address(env, DataKey::Admin)
+}
+
+fn get_pending_admin(env: &Env) -> Result<Address, AdapterError> {
+    get_address(env, DataKey::PendingAdmin)
 }
 
 fn get_vault(env: &Env) -> Result<Address, AdapterError> {
@@ -456,12 +507,23 @@ mod tests {
     use super::*;
     use soroban_sdk::testutils::{Address as _, Events as _};
 
-    fn adapter_event_count(env: &Env, adapter: &Address) -> usize {
+    fn adapter_event_count(env: &Env, contract_id: &Address) -> usize {
         env.events()
             .all()
-            .filter_by_contract(adapter)
+            .filter_by_contract(contract_id)
             .events()
             .len()
+    }
+
+    fn empty_wasm_hash(env: &Env) -> BytesN<32> {
+        BytesN::from_array(
+            env,
+            &[
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+                0x78, 0x52, 0xb8, 0x55,
+            ],
+        )
     }
 
     #[test]
@@ -792,6 +854,53 @@ mod tests {
             let result = BlendAdapterContract::set_vault(env.clone(), admin, account);
             assert_eq!(result, Err(AdapterError::InvalidInput));
         });
+    }
+
+    #[test]
+    fn set_admin_requires_pending_admin_acceptance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
+        let new_admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            BlendAdapterContract::set_admin(env.clone(), admin.clone(), new_admin.clone()).unwrap();
+            assert_eq!(BlendAdapterContract::admin(env.clone()).unwrap(), admin);
+            assert_eq!(
+                BlendAdapterContract::pending_admin(env.clone()).unwrap(),
+                new_admin
+            );
+            BlendAdapterContract::accept_admin(env.clone(), new_admin.clone()).unwrap();
+            assert_eq!(BlendAdapterContract::admin(env.clone()).unwrap(), new_admin);
+            assert_eq!(
+                BlendAdapterContract::pending_admin(env.clone()),
+                Err(AdapterError::MissingConfig)
+            );
+        });
+    }
+
+    #[test]
+    fn set_admin_emits_propose_and_accept_events() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
+        let new_admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            BlendAdapterContract::set_admin(env.clone(), admin, new_admin.clone()).unwrap();
+            BlendAdapterContract::accept_admin(env.clone(), new_admin).unwrap();
+        });
+        assert_eq!(adapter_event_count(&env, &contract_id), 2);
+    }
+
+    #[test]
+    fn upgrade_requires_admin_and_emits_event() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
+        let new_hash = empty_wasm_hash(&env);
+        env.as_contract(&contract_id, || {
+            BlendAdapterContract::upgrade(&env, new_hash.clone(), admin);
+        });
+        assert_eq!(adapter_event_count(&env, &contract_id), 1);
     }
 
     // Note: "query before initialize" test not applicable — __constructor

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -24,6 +24,7 @@ enum DataKey {
     Admin,
     Vault,
     Pool,
+    Paused,
 }
 
 #[contracterror]
@@ -43,6 +44,8 @@ pub enum AdapterError {
     ZeroWithdrawal = 7,
     /// Reserve data is stale.
     StaleReserve = 8,
+    /// Emergency pause is active.
+    Paused = 9,
 }
 
 #[contract]
@@ -85,6 +88,22 @@ impl BlendAdapterContract {
         Ok(())
     }
 
+    /// Pause or unpause adapter state-changing operations (admin or vault).
+    #[allow(deprecated)]
+    pub fn set_paused(env: Env, caller: Address, paused: bool) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_admin_or_vault(&env, &caller)?;
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        env.events()
+            .publish((symbol_short!("paused"), caller), paused);
+        Ok(())
+    }
+
+    pub fn paused(env: Env) -> bool {
+        extend_instance_ttl(&env);
+        is_paused(&env)
+    }
+
     /// Supply assets from the adapter into the Blend pool (vault-only).
     #[allow(deprecated)]
     pub fn supply(
@@ -94,6 +113,7 @@ impl BlendAdapterContract {
         amount: i128,
     ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
+        require_not_paused(&env)?;
         require_vault(&env, &caller)?;
         if amount <= 0 {
             return Err(AdapterError::InvalidInput);
@@ -149,6 +169,7 @@ impl BlendAdapterContract {
         amount: i128,
     ) -> Result<i128, AdapterError> {
         extend_instance_ttl(&env);
+        require_not_paused(&env)?;
         require_vault(&env, &caller)?;
         if amount <= 0 {
             return Err(AdapterError::InvalidInput);
@@ -192,6 +213,7 @@ impl BlendAdapterContract {
         receiver: Address,
     ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
+        require_not_paused(&env)?;
         require_vault(&env, &caller)?;
         if amount <= 0 {
             return Err(AdapterError::InvalidInput);
@@ -259,6 +281,7 @@ impl BlendAdapterContract {
         amount: i128,
     ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
+        require_not_paused(&env)?;
         require_admin(&env, &caller)?;
         if amount <= 0 {
             return Err(AdapterError::InvalidInput);
@@ -304,6 +327,7 @@ impl BlendAdapterContract {
         amount: i128,
     ) -> Result<i128, AdapterError> {
         extend_instance_ttl(&env);
+        require_not_paused(&env)?;
         require_admin(&env, &caller)?;
         if amount <= 0 {
             return Err(AdapterError::InvalidInput);
@@ -378,6 +402,30 @@ fn require_vault(env: &Env, caller: &Address) -> Result<(), AdapterError> {
     let vault = get_vault(env)?;
     if caller != &vault {
         return Err(AdapterError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn require_admin_or_vault(env: &Env, caller: &Address) -> Result<(), AdapterError> {
+    caller.require_auth();
+    let admin = get_admin(env)?;
+    let vault = get_vault(env)?;
+    if caller != &admin && caller != &vault {
+        return Err(AdapterError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+fn require_not_paused(env: &Env) -> Result<(), AdapterError> {
+    if is_paused(env) {
+        return Err(AdapterError::Paused);
     }
     Ok(())
 }
@@ -475,6 +523,48 @@ mod tests {
         env.as_contract(&contract_id, || {
             let result =
                 BlendAdapterContract::supply(env.clone(), impostor.clone(), asset.clone(), 100);
+            assert_eq!(result, Err(AdapterError::Unauthorized));
+        });
+    }
+
+    #[test]
+    fn admin_can_pause_adapter_operations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, vault, _pool) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(BlendAdapterContract::paused(env.clone()), false);
+            BlendAdapterContract::set_paused(env.clone(), admin, true).unwrap();
+            assert_eq!(BlendAdapterContract::paused(env.clone()), true);
+
+            let result = BlendAdapterContract::supply(env.clone(), vault, asset, 100);
+            assert_eq!(result, Err(AdapterError::Paused));
+        });
+    }
+
+    #[test]
+    fn vault_can_pause_adapter_operations() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _pool) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            BlendAdapterContract::set_paused(env.clone(), vault.clone(), true).unwrap();
+
+            let result = BlendAdapterContract::withdraw(env.clone(), vault, asset, 100);
+            assert_eq!(result, Err(AdapterError::Paused));
+        });
+    }
+
+    #[test]
+    fn non_admin_or_vault_cannot_pause_adapter() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, _vault, _pool) = setup_adapter(&env);
+        let impostor = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            let result = BlendAdapterContract::set_paused(env.clone(), impostor, true);
             assert_eq!(result, Err(AdapterError::Unauthorized));
         });
     }

--- a/contract/vault/soroban/share-token/Cargo.toml
+++ b/contract/vault/soroban/share-token/Cargo.toml
@@ -16,6 +16,7 @@ testutils = ["soroban-sdk/testutils"]
 
 [dependencies]
 soroban-sdk = { version = "25.3.0", features = ["alloc", "experimental_spec_shaking_v2", "hazmat-address"] }
+stellar-contract-utils.workspace = true
 stellar-tokens.workspace = true
 
 [dev-dependencies]

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -5,8 +5,9 @@ pub use types::*;
 
 use soroban_sdk::{
     address_payload::AddressPayload, contract, contractimpl, panic_with_error, symbol_short,
-    Address, Env, MuxedAddress, String, Vec,
+    Address, BytesN, Env, MuxedAddress, String, Vec,
 };
+use stellar_contract_utils::upgradeable::{self, Upgradeable};
 use stellar_tokens::fungible::{
     burnable::{emit_burn, FungibleBurnable},
     Base, FungibleToken,
@@ -111,7 +112,11 @@ impl SorobanShareTokenContract {
         require_contract_address(&env, &vault);
         env.storage().instance().set(&DataKey::Admin, &admin);
         env.storage().instance().set(&DataKey::Vault, &vault);
-        Base::set_metadata(&env, decimals, name, symbol);
+        Base::set_metadata(&env, decimals, name.clone(), symbol.clone());
+        env.events().publish(
+            (symbol_short!("config"), admin, vault),
+            (name, symbol, decimals),
+        );
     }
 
     pub fn mint(env: Env, to: Address, amount: i128) {
@@ -161,10 +166,36 @@ impl SorobanShareTokenContract {
             .publish((symbol_short!("rstrct"), caller), mode);
     }
 
+    #[allow(deprecated)]
     pub fn set_admin(env: Env, caller: Address, admin: Address) {
         extend_instance_ttl(&env);
         require_admin(&env, &caller);
-        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::PendingAdmin, &admin);
+        env.events()
+            .publish((symbol_short!("admin_set"), caller), admin);
+    }
+
+    #[allow(deprecated)]
+    pub fn accept_admin(env: Env, caller: Address) {
+        extend_instance_ttl(&env);
+        caller.require_auth();
+        let pending_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::PendingAdmin)
+            .unwrap_or_else(|| panic_with_error!(&env, ShareTokenError::MissingConfig));
+        if caller != pending_admin {
+            panic_with_error!(&env, ShareTokenError::Unauthorized);
+        }
+        let old_admin: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::Admin)
+            .unwrap_or_else(|| panic_with_error!(&env, ShareTokenError::MissingConfig));
+        env.storage().instance().set(&DataKey::Admin, &caller);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.events()
+            .publish((symbol_short!("admin_acc"), old_admin), caller);
     }
 
     pub fn set_vault(env: Env, caller: Address, vault: Address) {
@@ -188,6 +219,11 @@ impl SorobanShareTokenContract {
             .unwrap_or_else(|| panic_with_error!(&env, ShareTokenError::MissingConfig))
     }
 
+    pub fn pending_admin(env: Env) -> Option<Address> {
+        extend_instance_ttl(&env);
+        env.storage().instance().get(&DataKey::PendingAdmin)
+    }
+
     pub fn vault(env: Env) -> Address {
         extend_instance_ttl(&env);
         env.storage()
@@ -199,6 +235,18 @@ impl SorobanShareTokenContract {
     pub fn extend_ttl(env: Env, caller: Address) {
         require_admin(&env, &caller);
         extend_instance_ttl(&env);
+    }
+}
+
+#[contractimpl]
+impl Upgradeable for SorobanShareTokenContract {
+    #[allow(deprecated)]
+    fn upgrade(e: &Env, new_wasm_hash: BytesN<32>, operator: Address) {
+        extend_instance_ttl(e);
+        require_admin(e, &operator);
+        upgradeable::upgrade(e, &new_wasm_hash);
+        e.events()
+            .publish((symbol_short!("upgrade"), operator), new_wasm_hash);
     }
 }
 

--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -5,7 +5,7 @@ pub use types::*;
 
 use soroban_sdk::{
     address_payload::AddressPayload, contract, contractimpl, panic_with_error, symbol_short,
-    Address, Env, MuxedAddress, String,
+    Address, Env, MuxedAddress, String, Vec,
 };
 use stellar_tokens::fungible::{
     burnable::{emit_burn, FungibleBurnable},
@@ -38,11 +38,17 @@ impl FungibleToken for SorobanShareTokenContract {
 
     fn transfer(e: &Env, from: Address, to: MuxedAddress, amount: i128) {
         extend_instance_ttl(e);
+        require_not_paused(e);
+        require_unrestricted(e, &from);
+        require_unrestricted(e, &to.address());
         Base::transfer(e, &from, &to, amount);
     }
 
     fn transfer_from(e: &Env, spender: Address, from: Address, to: Address, amount: i128) {
         extend_instance_ttl(e);
+        require_not_paused(e);
+        require_unrestricted(e, &from);
+        require_unrestricted(e, &to);
         Base::transfer_from(e, &spender, &from, &to, amount);
     }
 
@@ -70,6 +76,7 @@ impl FungibleToken for SorobanShareTokenContract {
 impl FungibleBurnable for SorobanShareTokenContract {
     fn burn(e: &Env, from: Address, amount: i128) {
         extend_instance_ttl(e);
+        require_not_paused(e);
         require_vault_invoker(e);
         Base::update(e, Some(&from), None, amount);
         emit_burn(e, &from, amount);
@@ -77,6 +84,7 @@ impl FungibleBurnable for SorobanShareTokenContract {
 
     fn burn_from(e: &Env, spender: Address, from: Address, amount: i128) {
         extend_instance_ttl(e);
+        require_not_paused(e);
         require_vault_invoker(e);
         Base::spend_allowance(e, &from, &spender, amount);
         Base::update(e, Some(&from), None, amount);
@@ -108,8 +116,49 @@ impl SorobanShareTokenContract {
 
     pub fn mint(env: Env, to: Address, amount: i128) {
         extend_instance_ttl(&env);
+        require_not_paused(&env);
         require_vault_invoker(&env);
         Base::mint(&env, &to, amount);
+    }
+
+    #[allow(deprecated)]
+    pub fn set_paused(env: Env, caller: Address, paused: bool) {
+        extend_instance_ttl(&env);
+        require_admin_or_vault(&env, &caller);
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        env.events()
+            .publish((symbol_short!("paused"), caller), paused);
+    }
+
+    pub fn paused(env: Env) -> bool {
+        extend_instance_ttl(&env);
+        is_paused(&env)
+    }
+
+    #[allow(deprecated)]
+    pub fn set_restrictions(env: Env, caller: Address, mode: u32, accounts: Vec<Address>) {
+        extend_instance_ttl(&env);
+        require_admin_or_vault(&env, &caller);
+        let restrictions = match mode {
+            0 => Restrictions {
+                mode: RestrictionMode::None,
+                accounts: Vec::new(&env),
+            },
+            1 => Restrictions {
+                mode: RestrictionMode::Blacklist,
+                accounts,
+            },
+            2 => Restrictions {
+                mode: RestrictionMode::Whitelist,
+                accounts,
+            },
+            _ => panic_with_error!(&env, ShareTokenError::InvalidInput),
+        };
+        env.storage()
+            .instance()
+            .set(&DataKey::Restrictions, &restrictions);
+        env.events()
+            .publish((symbol_short!("rstrct"), caller), mode);
     }
 
     pub fn set_admin(env: Env, caller: Address, admin: Address) {
@@ -174,6 +223,57 @@ fn require_vault_invoker(env: &Env) {
         .get(&DataKey::Vault)
         .unwrap_or_else(|| panic_with_error!(env, ShareTokenError::MissingConfig));
     vault.require_auth();
+}
+
+fn require_admin_or_vault(env: &Env, caller: &Address) {
+    caller.require_auth();
+    let admin: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(env, ShareTokenError::MissingConfig));
+    let vault: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Vault)
+        .unwrap_or_else(|| panic_with_error!(env, ShareTokenError::MissingConfig));
+    if caller != &admin && caller != &vault {
+        panic_with_error!(env, ShareTokenError::Unauthorized);
+    }
+}
+
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+fn require_not_paused(env: &Env) {
+    if is_paused(env) {
+        panic_with_error!(env, ShareTokenError::Paused);
+    }
+}
+
+fn contains_address(accounts: &Vec<Address>, address: &Address) -> bool {
+    accounts.iter().any(|account| &account == address)
+}
+
+fn require_unrestricted(env: &Env, address: &Address) {
+    let Some(restrictions): Option<Restrictions> =
+        env.storage().instance().get(&DataKey::Restrictions)
+    else {
+        return;
+    };
+    let listed = contains_address(&restrictions.accounts, address);
+    let allowed = match restrictions.mode {
+        RestrictionMode::None => true,
+        RestrictionMode::Blacklist => !listed,
+        RestrictionMode::Whitelist => listed,
+    };
+    if !allowed {
+        panic_with_error!(env, ShareTokenError::Restricted);
+    }
 }
 
 fn is_contract_address(addr: &Address) -> bool {

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -3,7 +3,7 @@ use soroban_sdk::testutils::Address as _;
 use soroban_sdk::testutils::{Events, Ledger, LedgerInfo};
 use soroban_sdk::xdr::{ContractEventBody, ScVal};
 use soroban_sdk::{
-    address_payload::AddressPayload, contract, contractimpl, symbol_short, BytesN, IntoVal,
+    address_payload::AddressPayload, contract, contractimpl, symbol_short, BytesN, Env, IntoVal,
     MuxedAddress, Symbol, TryFromVal, Val,
 };
 
@@ -119,6 +119,30 @@ fn constructor_rejects_account_vault_address() {
             &String::from_str(&env, "tvSHARE"),
             &7u32,
         ),
+    );
+}
+
+#[test]
+fn constructor_emits_config_event() {
+    let (env, admin, vault, token) = setup();
+    let filtered_events = env.events().all().filter_by_contract(&token);
+    let events = filtered_events.events();
+    let event = events.last().expect("constructor config event");
+    let ContractEventBody::V0(body) = &event.body;
+    assert_eq!(body.topics.len(), 3);
+    assert_eq!(
+        body.topics[0],
+        ScVal::try_from_val(&env, &symbol_short!("config")).unwrap()
+    );
+    let admin_val: Val = admin.into_val(&env);
+    let vault_val: Val = vault.into_val(&env);
+    assert_eq!(
+        body.topics[1],
+        ScVal::try_from_val(&env, &admin_val).unwrap()
+    );
+    assert_eq!(
+        body.topics[2],
+        ScVal::try_from_val(&env, &vault_val).unwrap()
     );
 }
 
@@ -438,7 +462,64 @@ fn set_admin_rotates_admin() {
         &soroban_sdk::Symbol::new(&env, "admin"),
         ().into_val(&env),
     );
+    assert_eq!(stored_admin, admin);
+    let pending_admin: Option<Address> = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "pending_admin"),
+        ().into_val(&env),
+    );
+    assert_eq!(pending_admin, Some(new_admin.clone()));
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "accept_admin"),
+        (&new_admin,).into_val(&env),
+    );
+
+    let stored_admin: Address = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "admin"),
+        ().into_val(&env),
+    );
     assert_eq!(stored_admin, new_admin);
+    let pending_admin: Option<Address> = env.invoke_contract(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "pending_admin"),
+        ().into_val(&env),
+    );
+    assert_eq!(pending_admin, None);
+}
+
+#[test]
+fn set_admin_emits_propose_and_accept_events() {
+    let (env, admin, _vault, token) = setup();
+    let new_admin = Address::generate(&env);
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "set_admin"),
+        (&admin, &new_admin).into_val(&env),
+    );
+    let filtered_events = env.events().all().filter_by_contract(&token);
+    let events = filtered_events.events();
+    let admin_set = ScVal::try_from_val(&env, &symbol_short!("admin_set")).unwrap();
+    assert!(events.iter().any(|event| {
+        let ContractEventBody::V0(body) = &event.body;
+        body.topics.first() == Some(&admin_set)
+    }));
+
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "accept_admin"),
+        (&new_admin,).into_val(&env),
+    );
+    let filtered_events = env.events().all().filter_by_contract(&token);
+    let events = filtered_events.events();
+    let admin_acc = ScVal::try_from_val(&env, &symbol_short!("admin_acc")).unwrap();
+    assert!(events.iter().any(|event| {
+        let ContractEventBody::V0(body) = &event.body;
+        body.topics.first() == Some(&admin_acc)
+    }));
 }
 
 #[test]
@@ -465,6 +546,11 @@ fn old_admin_loses_privilege_after_rotation() {
         &soroban_sdk::Symbol::new(&env, "set_admin"),
         (&admin, &new_admin).into_val(&env),
     );
+    env.invoke_contract::<()>(
+        &token,
+        &soroban_sdk::Symbol::new(&env, "accept_admin"),
+        (&new_admin,).into_val(&env),
+    );
 
     let err = env.try_invoke_contract::<(), ShareTokenError>(
         &token,
@@ -472,6 +558,23 @@ fn old_admin_loses_privilege_after_rotation() {
         (&admin, &Address::generate(&env)).into_val(&env),
     );
     assert_eq!(err, Err(Ok(ShareTokenError::Unauthorized)));
+}
+
+#[test]
+fn share_token_upgrade_requires_admin_and_emits_event() {
+    let (env, admin, _vault, token) = setup();
+    env.cost_estimate().budget().reset_unlimited();
+    let new_hash = empty_wasm_hash(&env);
+    env.as_contract(&token, || {
+        SorobanShareTokenContract::upgrade(&env, new_hash.clone(), admin.clone());
+    });
+    let filtered_events = env.events().all().filter_by_contract(&token);
+    let events = filtered_events.events();
+    let upgrade = ScVal::try_from_val(&env, &symbol_short!("upgrade")).unwrap();
+    assert!(events.iter().any(|event| {
+        let ContractEventBody::V0(body) = &event.body;
+        body.topics.first() == Some(&upgrade)
+    }));
 }
 
 #[test]
@@ -627,6 +730,17 @@ fn transfer_without_from_auth_fails() {
         (&from, MuxedAddress::from(to), &1i128).into_val(&env),
     );
     assert!(err.is_err());
+}
+
+fn empty_wasm_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(
+        env,
+        &[
+            0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+            0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+            0x78, 0x52, 0xb8, 0x55,
+        ],
+    )
 }
 
 #[test]

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -28,6 +28,22 @@ impl VaultCaller {
         );
     }
 
+    fn set_paused(env: Env, token: Address, paused: bool) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "set_paused"),
+            (env.current_contract_address(), paused).into_val(&env),
+        );
+    }
+
+    fn set_restrictions(env: Env, token: Address, mode: u32, accounts: soroban_sdk::Vec<Address>) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "set_restrictions"),
+            (env.current_contract_address(), mode, accounts).into_val(&env),
+        );
+    }
+
     fn approve(
         env: Env,
         token: Address,
@@ -232,6 +248,178 @@ fn burn_from_emits_supplemental_spender_event() {
     );
     assert_eq!(bal, 750);
     assert_eq!(allowance, 150);
+}
+
+#[test]
+fn direct_burn_is_vault_only_protocol_effect() {
+    let (env, _admin, vault, token) = setup();
+    let user = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), user.clone(), 1000);
+    });
+
+    // A direct call without vault authorization remains rejected because burn is not
+    // a public owner API; it is a vault-only protocol settlement primitive.
+    env.mock_auths(&[]);
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "burn"),
+        (&user, &1i128).into_val(&env),
+    );
+    assert!(err.is_err());
+
+    // The configured vault can execute the burn without re-requiring owner auth here.
+    // Owner consent is enforced by vault entrypoints before generating BurnShares effects.
+    init_env(&env);
+    env.as_contract(&vault, || {
+        VaultCaller::burn(env.clone(), token.clone(), user.clone(), 400);
+    });
+
+    let bal: i128 = env.invoke_contract(
+        &token,
+        &Symbol::new(&env, "balance"),
+        (&user,).into_val(&env),
+    );
+    assert_eq!(bal, 600);
+}
+
+#[test]
+fn admin_can_pause_and_unpause_share_token_transfers() {
+    let (env, admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let to = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+    });
+
+    env.invoke_contract::<()>(
+        &token,
+        &Symbol::new(&env, "set_paused"),
+        (&admin, &true).into_val(&env),
+    );
+    assert!(env.invoke_contract::<bool>(&token, &Symbol::new(&env, "paused"), ().into_val(&env),));
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&from, MuxedAddress::from(to.clone()), &1i128).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::Paused)));
+
+    env.invoke_contract::<()>(
+        &token,
+        &Symbol::new(&env, "set_paused"),
+        (&admin, &false).into_val(&env),
+    );
+    env.invoke_contract::<()>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&from, MuxedAddress::from(to.clone()), &250i128).into_val(&env),
+    );
+
+    let to_bal: i128 =
+        env.invoke_contract(&token, &Symbol::new(&env, "balance"), (&to,).into_val(&env));
+    assert_eq!(to_bal, 250);
+}
+
+#[test]
+fn vault_can_pause_share_token_mint_and_burn() {
+    let (env, _admin, vault, token) = setup();
+    let user = Address::generate(&env);
+
+    env.as_contract(&vault, || {
+        VaultCaller::set_paused(env.clone(), token.clone(), true);
+        let err = env.try_invoke_contract::<(), ShareTokenError>(
+            &token,
+            &Symbol::new(&env, "mint"),
+            (&user, &100i128).into_val(&env),
+        );
+        assert_eq!(err, Err(Ok(ShareTokenError::Paused)));
+    });
+
+    env.as_contract(&vault, || {
+        VaultCaller::set_paused(env.clone(), token.clone(), false);
+        VaultCaller::mint(env.clone(), token.clone(), user.clone(), 1000);
+        VaultCaller::set_paused(env.clone(), token.clone(), true);
+        let err = env.try_invoke_contract::<(), ShareTokenError>(
+            &token,
+            &Symbol::new(&env, "burn"),
+            (&user, &100i128).into_val(&env),
+        );
+        assert_eq!(err, Err(Ok(ShareTokenError::Paused)));
+    });
+}
+
+#[test]
+fn share_token_restrictions_block_blacklisted_sender_and_recipient() {
+    let (env, _admin, vault, token) = setup();
+    let from = Address::generate(&env);
+    let blocked = Address::generate(&env);
+    let allowed = Address::generate(&env);
+    let mut accounts = soroban_sdk::Vec::new(&env);
+    accounts.push_back(blocked.clone());
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), from.clone(), 1000);
+        VaultCaller::mint(env.clone(), token.clone(), blocked.clone(), 1000);
+        VaultCaller::set_restrictions(env.clone(), token.clone(), 1, accounts.clone());
+    });
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&from, MuxedAddress::from(blocked.clone()), &1i128).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::Restricted)));
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&blocked, MuxedAddress::from(allowed.clone()), &1i128).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::Restricted)));
+}
+
+#[test]
+fn share_token_whitelist_allows_only_listed_transfer_parties() {
+    let (env, _admin, vault, token) = setup();
+    let listed_from = Address::generate(&env);
+    let listed_to = Address::generate(&env);
+    let unlisted = Address::generate(&env);
+    let mut accounts = soroban_sdk::Vec::new(&env);
+    accounts.push_back(listed_from.clone());
+    accounts.push_back(listed_to.clone());
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), listed_from.clone(), 1000);
+        VaultCaller::set_restrictions(env.clone(), token.clone(), 2, accounts.clone());
+    });
+
+    env.invoke_contract::<()>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (
+            &listed_from,
+            MuxedAddress::from(listed_to.clone()),
+            &250i128,
+        )
+            .into_val(&env),
+    );
+    let listed_to_bal: i128 = env.invoke_contract(
+        &token,
+        &Symbol::new(&env, "balance"),
+        (&listed_to,).into_val(&env),
+    );
+    assert_eq!(listed_to_bal, 250);
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&listed_from, MuxedAddress::from(unlisted.clone()), &1i128).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::Restricted)));
 }
 
 #[test]

--- a/contract/vault/soroban/share-token/src/types.rs
+++ b/contract/vault/soroban/share-token/src/types.rs
@@ -4,6 +4,7 @@ use soroban_sdk::{contracterror, contracttype};
 #[derive(Clone)]
 pub(super) enum DataKey {
     Admin,
+    PendingAdmin,
     Vault,
     Paused,
     Restrictions,

--- a/contract/vault/soroban/share-token/src/types.rs
+++ b/contract/vault/soroban/share-token/src/types.rs
@@ -5,6 +5,23 @@ use soroban_sdk::{contracterror, contracttype};
 pub(super) enum DataKey {
     Admin,
     Vault,
+    Paused,
+    Restrictions,
+}
+
+#[contracttype]
+#[derive(Clone, Eq, PartialEq)]
+pub enum RestrictionMode {
+    None,
+    Blacklist,
+    Whitelist,
+}
+
+#[contracttype]
+#[derive(Clone)]
+pub struct Restrictions {
+    pub mode: RestrictionMode,
+    pub accounts: soroban_sdk::Vec<soroban_sdk::Address>,
 }
 
 #[contracterror]
@@ -17,4 +34,6 @@ pub enum ShareTokenError {
     MissingConfig = 3,
     VaultImmutable = 4,
     MetadataImmutable = 5,
+    Paused = 6,
+    Restricted = 7,
 }


### PR DESCRIPTION
## Summary

Remediates Halborn/Nexus governance/audit follow-up findings for auxiliary share-token controls:

- #FIND-048 / Nexus `b7bcf2b1-dc11-424a-99b0-d38192cb7e12`: clarify and prove share-token `burn` is a vault-only protocol settlement primitive; owner consent remains enforced at vault withdrawal entrypoints before `BurnShares` effects are generated, and delegated burns use `burn_from` allowance semantics.
- #FIND-063 / Nexus `44e4e876-5816-47e7-baed-c830bad19f92`: add admin/vault-gated pause/readback controls and fail-closed guards for share-token and Blend adapter state-changing paths.
- #FIND-070 / Nexus `c3853d07-893a-4ea3-bffe-9e31d2ea1f70`: propagate vault restriction policy to share-token transfers, including muxed recipient handling via `MuxedAddress::address()`.

This stacks on `audit/share-token-admin-immutable` and keeps broad lifecycle/upgrade policy questions out of scope.

## Verification

- `RUSTUP_TOOLCHAIN=1.89.0 cargo fmt -p templar-soroban-share-token -p templar-soroban-blend-adapter -- --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_TARGET_DIR=/data/tmp/templar-share-token-controls/target cargo test -p templar-soroban-share-token -- --nocapture` — 25 passed
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_TARGET_DIR=/data/tmp/templar-share-token-controls/target cargo test -p templar-soroban-blend-adapter -- --nocapture` — 22 unit + 7 integration passed
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_TARGET_DIR=/data/tmp/templar-share-token-controls/target cargo test -p templar-soroban-runtime withdraw -- --nocapture` — withdrawal-filtered runtime tests passed
- post-commit Soroban `size-budget-check` — 93,961 bytes

## Stack

- Base branch: `audit/share-token-admin-immutable`
- Head branch: `audit/share-token-controls-a043-a048-a051`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/452)
<!-- Reviewable:end -->
