### PR TITLE
Fix governance policy wire canonicality

### DIFF
--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -299,6 +299,18 @@ fn governance_restrictions(
     }
 }
 
+fn ensure_none<T>(value: &Option<T>) -> Result<(), ContractError> {
+    if value.is_some() {
+        Err(ContractError::InvalidInput)
+    } else {
+        Ok(())
+    }
+}
+
+fn ensure_some<T>(value: Option<T>) -> Result<T, ContractError> {
+    value.ok_or(ContractError::InvalidInput)
+}
+
 fn apply_group_policy(
     env: &Env,
     caller_kernel: Address,
@@ -665,45 +677,90 @@ fn set_governance_policy_impl(
     };
     match kind {
         GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE => {
+            ensure_none(&mode)?;
+            ensure_none(&accounts)?;
+            ensure_none(&market_id)?;
+            ensure_none(&cap_group_id)?;
+            ensure_none(&value)?;
+            ensure_none(&value_b)?;
+            ensure_none(&value_c)?;
             let caller_kernel = governance_kernel()?;
             apply_supply_queue_policy(
                 env,
                 caller_kernel,
-                target_ids.ok_or(ContractError::InvalidInput)?,
+                ensure_some(target_ids)?,
                 caller_preauthorized,
             )
         }
-        GOVERNANCE_POLICY_KIND_CAP => apply_cap_policy(
-            env,
-            governance_kernel()?,
-            market_id.ok_or(ContractError::InvalidInput)?,
-            required_i128(value)?,
-            caller_preauthorized,
-        ),
-        GOVERNANCE_POLICY_KIND_REMOVE_MARKET => apply_remove_market_policy(
-            env,
-            governance_kernel()?,
-            market_id.ok_or(ContractError::InvalidInput)?,
-            caller_preauthorized,
-        ),
-        GOVERNANCE_POLICY_KIND_RESTRICTIONS => apply_restrictions_policy(
-            env,
-            caller,
-            mode.ok_or(ContractError::InvalidInput)?,
-            accounts.ok_or(ContractError::InvalidInput)?,
-            caller_preauthorized,
-        ),
-        GOVERNANCE_POLICY_KIND_GROUP => apply_group_policy(
-            env,
-            governance_kernel()?,
-            mode.ok_or(ContractError::InvalidInput)?,
-            market_id,
-            cap_group_id,
-            value,
-            caller_preauthorized,
-        ),
+        GOVERNANCE_POLICY_KIND_CAP => {
+            ensure_none(&target_ids)?;
+            ensure_none(&mode)?;
+            ensure_none(&accounts)?;
+            ensure_none(&cap_group_id)?;
+            ensure_none(&value_b)?;
+            ensure_none(&value_c)?;
+            apply_cap_policy(
+                env,
+                governance_kernel()?,
+                ensure_some(market_id)?,
+                ensure_some(value)?,
+                caller_preauthorized,
+            )
+        }
+        GOVERNANCE_POLICY_KIND_REMOVE_MARKET => {
+            ensure_none(&target_ids)?;
+            ensure_none(&mode)?;
+            ensure_none(&accounts)?;
+            ensure_none(&cap_group_id)?;
+            ensure_none(&value)?;
+            ensure_none(&value_b)?;
+            ensure_none(&value_c)?;
+            apply_remove_market_policy(
+                env,
+                governance_kernel()?,
+                ensure_some(market_id)?,
+                caller_preauthorized,
+            )
+        }
+        GOVERNANCE_POLICY_KIND_RESTRICTIONS => {
+            ensure_none(&target_ids)?;
+            ensure_none(&market_id)?;
+            ensure_none(&cap_group_id)?;
+            ensure_none(&value)?;
+            ensure_none(&value_b)?;
+            ensure_none(&value_c)?;
+            apply_restrictions_policy(
+                env,
+                caller,
+                ensure_some(mode)?,
+                ensure_some(accounts)?,
+                caller_preauthorized,
+            )
+        }
+        GOVERNANCE_POLICY_KIND_GROUP => {
+            ensure_none(&target_ids)?;
+            ensure_none(&accounts)?;
+            ensure_none(&value_b)?;
+            ensure_none(&value_c)?;
+            apply_group_policy(
+                env,
+                governance_kernel()?,
+                ensure_some(mode)?,
+                market_id,
+                cap_group_id,
+                value,
+                caller_preauthorized,
+            )
+        }
         GOVERNANCE_POLICY_KIND_PAUSED => {
-            let paused = match mode.ok_or(ContractError::InvalidInput)? {
+            ensure_none(&target_ids)?;
+            ensure_none(&accounts)?;
+            ensure_none(&market_id)?;
+            ensure_none(&cap_group_id)?;
+            ensure_none(&value)?;
+            ensure_none(&value_b)?;
+            ensure_none(&value_c)?;
+            let paused = match ensure_some(mode)? {
                 0 => false,
                 1 => true,
                 _ => return Err(ContractError::InvalidInput),
@@ -711,12 +768,16 @@ fn set_governance_policy_impl(
             apply_paused_policy(env, caller, paused, caller_preauthorized)
         }
         GOVERNANCE_POLICY_KIND_FEES => {
+            ensure_none(&target_ids)?;
+            ensure_none(&mode)?;
+            ensure_none(&market_id)?;
+            ensure_none(&cap_group_id)?;
             ensure_governance()?;
             apply_fees_policy(
                 env,
-                accounts.ok_or(ContractError::InvalidInput)?,
-                required_i128(value)?,
-                required_i128(value_b)?,
+                ensure_some(accounts)?,
+                ensure_some(value)?,
+                ensure_some(value_b)?,
                 value_c,
             )
         }

--- a/contract/vault/soroban/tests/integration_tests.rs
+++ b/contract/vault/soroban/tests/integration_tests.rs
@@ -24,6 +24,7 @@ use templar_soroban_shared_types::{
     GovernanceCommand, VaultCommand, VaultCommandResult, GOVERNANCE_CONFIG_KIND_ALLOCATORS,
     GOVERNANCE_CONFIG_KIND_CURATOR, GOVERNANCE_CONFIG_KIND_GUARDIANS,
     GOVERNANCE_CONFIG_KIND_SENTINEL, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
+    GOVERNANCE_POLICY_KIND_CAP, GOVERNANCE_POLICY_KIND_PAUSED, GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
 };
 use templar_vault_kernel::state::queue::DEFAULT_COOLDOWN_NS;
 use templar_vault_kernel::{
@@ -291,6 +292,63 @@ fn runtime_governance_config_rejects_sac_role_addresses(
             value_a: None,
             value_b: None,
         };
+        assert_eq!(
+            proxy.execute_governance_unit(&governance, &command),
+            Err(templar_soroban_runtime::ContractError::InvalidInput)
+        );
+    });
+}
+
+#[rstest]
+#[case(
+    GovernanceCommand::SetGovernancePolicy {
+        kind: GOVERNANCE_POLICY_KIND_SUPPLY_QUEUE,
+        target_ids: Some(vec![0]),
+        mode: Some(0),
+        accounts: None,
+        market_id: None,
+        cap_group_id: None,
+        value: None,
+        value_b: None,
+        value_c: None,
+    }
+)]
+#[case(
+    GovernanceCommand::SetGovernancePolicy {
+        kind: GOVERNANCE_POLICY_KIND_CAP,
+        target_ids: None,
+        mode: None,
+        accounts: None,
+        market_id: Some(0),
+        cap_group_id: None,
+        value: Some(1_000),
+        value_b: Some(1),
+        value_c: None,
+    }
+)]
+#[case(
+    GovernanceCommand::SetGovernancePolicy {
+        kind: GOVERNANCE_POLICY_KIND_PAUSED,
+        target_ids: None,
+        mode: Some(1),
+        accounts: None,
+        market_id: Some(0),
+        cap_group_id: None,
+        value: None,
+        value_b: None,
+        value_c: None,
+    }
+)]
+fn runtime_governance_policy_rejects_irrelevant_fields(
+    #[case] command: GovernanceCommand,
+    soroban_contract_fixture: SorobanContractFixture,
+) {
+    let env = soroban_contract_fixture.env;
+    let contract_id = soroban_contract_fixture.contract_id;
+    let proxy = VaultProxy::new(&env);
+
+    env.as_contract(&contract_id, || {
+        let governance = proxy.governance().unwrap();
         assert_eq!(
             proxy.execute_governance_unit(&governance, &command),
             Err(templar_soroban_runtime::ContractError::InvalidInput)
@@ -1842,7 +1900,11 @@ fn soroban_contract_resync_idle_balance_fixes_donation_accounting() {
     env.mock_all_auths();
 
     let contract_id = env.register(SorobanVaultContract, ());
-    let governance = soroban_sdk::Address::generate(&env);
+    let curator = soroban_sdk::Address::generate(&env);
+    let governance = env.register(
+        SorobanVaultGovernanceContract,
+        (&curator, &contract_id, &(0u64)),
+    );
     let asset_admin = soroban_sdk::Address::generate(&env);
     let asset_sac = env.register_stellar_asset_contract_v2(asset_admin.clone());
     let asset_token = asset_sac.address();


### PR DESCRIPTION
## Summary
- Reject `SetGovernancePolicy` payloads that carry fields irrelevant to the selected policy kind.
- Adds regression coverage proving sparse governance policy actions no longer have multiple accepted wire encodings for the same effective action.
- Updates an existing integration test to use a registered governance contract, matching the branch's production topology validation.

## Findings
- #FIND-092 / Nexus `28360a4f-b33c-45fd-bef9-67a7acbf0dc0`
- #FIND-090 / Nexus `109dc6ff-46cf-4974-bec7-089886e8560c` is triaged as not requiring a code change: shared-types already exposes distinct `CodecError` variants and enforces strict cursor exhaustion; the public contract boundary intentionally maps malformed client payloads to compact `InvalidInput`.

## Verification
- `cargo test -p templar-soroban-runtime runtime_governance_policy_rejects_irrelevant_fields --test integration_tests -- --nocapture`
- `cargo test -p templar-soroban-runtime --test integration_tests -- --nocapture`
- post-commit Soroban `size-budget-check` hook passed: `97270` bytes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/455)
<!-- Reviewable:end -->
