### PR TITLE
ci: add manual Soroban vault CLI image publish

### DIFF
--- a/.github/workflows/publish-soroban-vault-cli.yml
+++ b/.github/workflows/publish-soroban-vault-cli.yml
@@ -1,0 +1,92 @@
+name: Publish Soroban Vault CLI Image
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "GHCR image tag to publish"
+        required: true
+        default: "dev"
+        type: string
+      push_latest:
+        description: "Also publish the image as latest"
+        required: false
+        default: false
+        type: boolean
+
+run-name: Publish Soroban Vault CLI image (${{ inputs.tag }})
+
+concurrency:
+  group: publish-soroban-vault-cli-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    name: Build and push GHCR image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Prepare image metadata
+        id: image
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$INPUT_TAG" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid Docker tag: $INPUT_TAG" >&2
+            exit 1
+          fi
+
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          image="ghcr.io/${owner}/soroban-vault-cli"
+          short_sha="${GITHUB_SHA::12}"
+
+          {
+            echo "image=${image}"
+            echo "tag=${INPUT_TAG}"
+            echo "sha_tag=sha-${short_sha}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Login to GHCR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$GITHUB_TOKEN" | docker login ghcr.io \
+            --username "${GITHUB_ACTOR}" \
+            --password-stdin
+
+      - name: Build image
+        run: |
+          set -euo pipefail
+          docker build \
+            --file tools/soroban-vault-cli/Dockerfile \
+            --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
+            --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
+            --tag "${{ steps.image.outputs.image }}:${{ steps.image.outputs.tag }}" \
+            --tag "${{ steps.image.outputs.image }}:${{ steps.image.outputs.sha_tag }}" \
+            .
+
+      - name: Push image
+        run: |
+          set -euo pipefail
+          docker push "${{ steps.image.outputs.image }}:${{ steps.image.outputs.tag }}"
+          docker push "${{ steps.image.outputs.image }}:${{ steps.image.outputs.sha_tag }}"
+
+      - name: Push latest tag
+        if: ${{ inputs.push_latest }}
+        run: |
+          set -euo pipefail
+          docker tag \
+            "${{ steps.image.outputs.image }}:${{ steps.image.outputs.tag }}" \
+            "${{ steps.image.outputs.image }}:latest"
+          docker push "${{ steps.image.outputs.image }}:latest"

--- a/.github/workflows/publish-soroban-vault-cli.yml
+++ b/.github/workflows/publish-soroban-vault-cli.yml
@@ -66,14 +66,18 @@ jobs:
             --password-stdin
 
       - name: Build image
+        env:
+          IMAGE: ${{ steps.image.outputs.image }}
+          TAG: ${{ steps.image.outputs.tag }}
+          SHA_TAG: ${{ steps.image.outputs.sha_tag }}
         run: |
           set -euo pipefail
           docker build \
             --file tools/soroban-vault-cli/Dockerfile \
             --label "org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY}" \
             --label "org.opencontainers.image.revision=${GITHUB_SHA}" \
-            --tag "${{ steps.image.outputs.image }}:${{ steps.image.outputs.tag }}" \
-            --tag "${{ steps.image.outputs.image }}:${{ steps.image.outputs.sha_tag }}" \
+            --tag "${IMAGE}:${TAG}" \
+            --tag "${IMAGE}:${SHA_TAG}" \
             .
 
       - name: Push image


### PR DESCRIPTION
## Summary
- add a manual-only workflow_dispatch workflow to build and push the Soroban vault CLI Docker image to GHCR
- publish explicit input tag plus sha-<shortsha>, with optional latest tag
- use the repo GITHUB_TOKEN with packages: write instead of requiring a local write:packages token

## Verification
- workflow text check confirmed manual-only trigger and GHCR push steps
- git diff --check
- post-commit Soroban size-budget hook passed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/467)
<!-- Reviewable:end -->
