### PR TITLE
fix: allow vault escrow under share-token whitelist

### DIFF
--- a/contract/vault/soroban/share-token/src/lib.rs
+++ b/contract/vault/soroban/share-token/src/lib.rs
@@ -46,8 +46,8 @@ impl FungibleToken for SorobanShareTokenContract {
     fn transfer(e: &Env, from: Address, to: MuxedAddress, amount: i128) {
         extend_instance_ttl(e);
         require_not_paused(e);
-        require_unrestricted(e, &from);
-        require_unrestricted(e, &to.address());
+        require_unrestricted_or_vault(e, &from);
+        require_unrestricted_or_vault(e, &to.address());
         Base::transfer(e, &from, &to, amount);
     }
 
@@ -323,19 +323,39 @@ fn contains_address(accounts: &Vec<Address>, address: &Address) -> bool {
 }
 
 fn require_unrestricted(env: &Env, address: &Address) {
+    if is_unrestricted(env, address) {
+        return;
+    }
+    panic_with_error!(env, ShareTokenError::Restricted);
+}
+
+fn require_unrestricted_or_vault(env: &Env, address: &Address) {
+    if is_unrestricted(env, address) {
+        return;
+    }
+    let vault: Address = env
+        .storage()
+        .instance()
+        .get(&DataKey::Vault)
+        .unwrap_or_else(|| panic_with_error!(env, ShareTokenError::MissingConfig));
+    if address == &vault {
+        vault.require_auth();
+        return;
+    }
+    panic_with_error!(env, ShareTokenError::Restricted);
+}
+
+fn is_unrestricted(env: &Env, address: &Address) -> bool {
     let Some(restrictions): Option<Restrictions> =
         env.storage().instance().get(&DataKey::Restrictions)
     else {
-        return;
+        return true;
     };
     let listed = contains_address(&restrictions.accounts, address);
-    let allowed = match restrictions.mode {
+    match restrictions.mode {
         RestrictionMode::None => true,
         RestrictionMode::Blacklist => !listed,
         RestrictionMode::Whitelist => listed,
-    };
-    if !allowed {
-        panic_with_error!(env, ShareTokenError::Restricted);
     }
 }
 

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -502,6 +502,21 @@ fn share_token_whitelist_allows_vault_authorized_escrow_to_vault() {
     accounts.push_back(listed_owner.clone());
 
     env.as_contract(&vault, || {
+        VaultCaller::set_restrictions(env.clone(), token.clone(), 2, accounts.clone());
+    });
+    env.mock_auths(&[]);
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&listed_owner, MuxedAddress::from(vault.clone()), &1i128).into_val(&env),
+    );
+    assert!(
+        matches!(err, Err(Err(_))),
+        "direct transfer without vault authorization must fail, got {err:?}"
+    );
+
+    env.mock_all_auths_allowing_non_root_auth();
+    env.as_contract(&vault, || {
         VaultCaller::mint(env.clone(), token.clone(), listed_owner.clone(), 1000);
         VaultCaller::set_restrictions(env.clone(), token.clone(), 2, accounts.clone());
         VaultCaller::transfer(

--- a/contract/vault/soroban/share-token/src/tests.rs
+++ b/contract/vault/soroban/share-token/src/tests.rs
@@ -67,6 +67,14 @@ impl VaultCaller {
             (spender, from, amount).into_val(&env),
         );
     }
+
+    fn transfer(env: Env, token: Address, from: Address, to: MuxedAddress, amount: i128) {
+        env.invoke_contract::<()>(
+            &token,
+            &soroban_sdk::Symbol::new(&env, "transfer"),
+            (from, to, amount).into_val(&env),
+        );
+    }
 }
 
 fn setup() -> (Env, Address, Address, Address) {
@@ -481,6 +489,54 @@ fn share_token_whitelist_allows_only_listed_transfer_parties() {
         &token,
         &Symbol::new(&env, "transfer"),
         (&listed_from, MuxedAddress::from(unlisted.clone()), &1i128).into_val(&env),
+    );
+    assert_eq!(err, Err(Ok(ShareTokenError::Restricted)));
+}
+
+#[test]
+fn share_token_whitelist_allows_vault_authorized_escrow_to_vault() {
+    let (env, _admin, vault, token) = setup();
+    let listed_owner = Address::generate(&env);
+    let unlisted = Address::generate(&env);
+    let mut accounts = soroban_sdk::Vec::new(&env);
+    accounts.push_back(listed_owner.clone());
+
+    env.as_contract(&vault, || {
+        VaultCaller::mint(env.clone(), token.clone(), listed_owner.clone(), 1000);
+        VaultCaller::set_restrictions(env.clone(), token.clone(), 2, accounts.clone());
+        VaultCaller::transfer(
+            env.clone(),
+            token.clone(),
+            listed_owner.clone(),
+            MuxedAddress::from(vault.clone()),
+            250,
+        );
+        VaultCaller::transfer(
+            env.clone(),
+            token.clone(),
+            vault.clone(),
+            MuxedAddress::from(listed_owner.clone()),
+            100,
+        );
+    });
+
+    let vault_balance: i128 = env.invoke_contract(
+        &token,
+        &Symbol::new(&env, "balance"),
+        (&vault,).into_val(&env),
+    );
+    assert_eq!(vault_balance, 150);
+    let owner_balance: i128 = env.invoke_contract(
+        &token,
+        &Symbol::new(&env, "balance"),
+        (&listed_owner,).into_val(&env),
+    );
+    assert_eq!(owner_balance, 850);
+
+    let err = env.try_invoke_contract::<(), ShareTokenError>(
+        &token,
+        &Symbol::new(&env, "transfer"),
+        (&listed_owner, MuxedAddress::from(unlisted.clone()), &1i128).into_val(&env),
     );
     assert_eq!(err, Err(Ok(ShareTokenError::Restricted)));
 }


### PR DESCRIPTION
## Summary
- allow configured-vault share-token transfers to bypass whitelist/blacklist checks only when the vault authorizes the transfer
- keep ordinary unlisted transfer recipients blocked
- add a regression for whitelist mode where a listed user escrows shares to the vault and the vault refunds shares without the vault address being whitelisted

## Verification
- `cargo fmt -p templar-soroban-share-token -- --check`
- `git diff --check`
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-share-token-vault-whitelist-escrow/target cargo test -p templar-soroban-share-token share_token_whitelist_allows_vault_authorized_escrow_to_vault -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-share-token-vault-whitelist-escrow/target cargo test -p templar-soroban-share-token -- --nocapture`
- post-commit Soroban size-budget-check passed: `128894` bytes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/468)
<!-- Reviewable:end -->
