### PR TITLE
Build Soroban crates on Rust 1.86 and unify the test toolchain

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,7 +12,7 @@ max-fail = 10
 # CI-specific profile balancing disk space and performance
 test-threads = 6
 retries = 1
-default-filter = "not package(templar-soroban-runtime) and not test(/^requires_network_/)"
+default-filter = "not test(/^requires_network_/)"
 
 # Fail fast to avoid wasting resources
 fail-fast = false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,51 +46,10 @@ jobs:
         env:
           SQLX_OFFLINE: true
         run: |
-          cargo clippy --all-features --workspace --tests \
-            --exclude templar-proxy-oracle-soroban-common \
-            --exclude templar-proxy-oracle-soroban-contract \
-            --exclude templar-proxy-oracle-soroban-governance-common \
-            --exclude templar-proxy-oracle-soroban-governance-contract \
-            --exclude templar-proxy-oracle-soroban-integration-tests \
-            --exclude templar-proxy-oracle-soroban-sep40-adapter-contract \
-            --exclude templar-soroban-blend-adapter \
-            --exclude templar-soroban-governance \
-            --exclude templar-soroban-runtime \
-            --exclude templar-soroban-share-token \
-            --exclude templar-soroban-shared-types \
-            -- -D warnings
-
-  soroban-code-linter:
-    name: Soroban Code Linter
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
-        with:
-          persist-credentials: false
-      - name: Install Soroban lint Rust toolchain
-        uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e
-        with:
-          targets: wasm32-unknown-unknown,wasm32v1-none
-          components: clippy
-      - name: Run Soroban cargo clippy
-        env:
-          RUSTUP_TOOLCHAIN: 1.89.0
-          SQLX_OFFLINE: true
-        run: |
-          cargo clippy --all-features --tests \
-            -p templar-proxy-oracle-soroban-common \
-            -p templar-proxy-oracle-soroban-contract \
-            -p templar-proxy-oracle-soroban-governance-common \
-            -p templar-proxy-oracle-soroban-governance-contract \
-            -p templar-proxy-oracle-soroban-integration-tests \
-            -p templar-proxy-oracle-soroban-sep40-adapter-contract \
-            -p templar-soroban-blend-adapter \
-            -p templar-soroban-governance \
-            -p templar-soroban-runtime \
-            -p templar-soroban-share-token \
-            -p templar-soroban-shared-types \
-            -- -D warnings
+          # The Soroban crates build on the default 1.86 toolchain via the
+          # stellar-contract-utils [patch.crates-io] (root Cargo.toml), so they
+          # are linted here with the rest of the workspace — no separate job.
+          cargo clippy --all-features --workspace --tests -- -D warnings
 
   soroban:
     name: Soroban
@@ -105,6 +64,11 @@ jobs:
         with:
           persist-credentials: false
 
+      # The Soroban toolchain is still required here: `stellar contract build`
+      # (size-budget checks) targets wasm32v1-none. Host unit tests for these
+      # crates now run in the main `test` job on 1.86 via the
+      # stellar-contract-utils [patch.crates-io], so there is no separate
+      # Soroban test/clippy pass.
       - name: Install Soroban Rust toolchain
         uses: dtolnay/rust-toolchain@193d6aa1dbbc28bd2c0a6b0e327cfdce68baaf6e
         with:
@@ -113,24 +77,7 @@ jobs:
       - name: Install tools
         uses: taiki-e/install-action@cde8c9e634f4a17bc06b61413ac0ef75450eac46
         with:
-          tool: just,nextest
-
-      - name: Run Soroban contract tests
-        env:
-          RUSTUP_TOOLCHAIN: 1.89.0
-          SQLX_OFFLINE: true
-        run: |
-          cargo nextest run \
-            -p templar-proxy-oracle-soroban-common \
-            -p templar-proxy-oracle-soroban-contract \
-            -p templar-proxy-oracle-soroban-governance-common \
-            -p templar-proxy-oracle-soroban-governance-contract \
-            -p templar-proxy-oracle-soroban-integration-tests \
-            -p templar-proxy-oracle-soroban-sep40-adapter-contract \
-            -p templar-soroban-runtime \
-            -p templar-soroban-governance \
-            -p templar-soroban-share-token \
-            -p templar-soroban-blend-adapter
+          tool: just
 
       - name: Install packages
         run: sudo apt-get install -y libdbus-1-dev libudev-dev pkg-config
@@ -307,20 +254,11 @@ jobs:
           CARGO_TERM_COLOR: always
           CARGO_INCREMENTAL: 0
         run: |
-          # Soroban crates require their dedicated toolchain and are tested in the
-          # Soroban job. Keep the default workspace test pass on rust-toolchain.toml.
-          ./script/test.sh --workspace \
-            --exclude templar-proxy-oracle-soroban-common \
-            --exclude templar-proxy-oracle-soroban-contract \
-            --exclude templar-proxy-oracle-soroban-governance-common \
-            --exclude templar-proxy-oracle-soroban-governance-contract \
-            --exclude templar-proxy-oracle-soroban-integration-tests \
-            --exclude templar-proxy-oracle-soroban-sep40-adapter-contract \
-            --exclude templar-soroban-blend-adapter \
-            --exclude templar-soroban-governance \
-            --exclude templar-soroban-runtime \
-            --exclude templar-soroban-share-token \
-            --exclude templar-soroban-shared-types
+          # The whole workspace — Soroban crates included — builds on the 1.86
+          # toolchain via the stellar-contract-utils [patch.crates-io], so the
+          # default test pass covers everything. (The Soroban job still builds
+          # the optimized wasm for size budgets on its own toolchain.)
+          ./script/test.sh --workspace
 
       - name: Cleanup Docker resources
         if: always()
@@ -385,20 +323,10 @@ jobs:
           CARGO_TERM_COLOR: always
         run: |
           # --lib: unit tests only (excludes slow WASM integration tests).
-          # Soroban crates are tested in the dedicated Soroban job with their
-          # newer toolchain; exclude them from the default 1.86 coverage build.
-          cargo llvm-cov nextest --workspace --lib --lcov --output-path coverage.lcov \
-            --exclude templar-proxy-oracle-soroban-common \
-            --exclude templar-proxy-oracle-soroban-contract \
-            --exclude templar-proxy-oracle-soroban-governance-common \
-            --exclude templar-proxy-oracle-soroban-governance-contract \
-            --exclude templar-proxy-oracle-soroban-integration-tests \
-            --exclude templar-proxy-oracle-soroban-sep40-adapter-contract \
-            --exclude templar-soroban-blend-adapter \
-            --exclude templar-soroban-governance \
-            --exclude templar-soroban-runtime \
-            --exclude templar-soroban-share-token \
-            --exclude templar-soroban-shared-types
+          # Soroban crates build on 1.86 via the stellar-contract-utils
+          # [patch.crates-io], so they are covered here with the rest of the
+          # workspace.
+          cargo llvm-cov nextest --workspace --lib --lcov --output-path coverage.lcov
 
           # Aggressive cleanup to free disk space
           echo "Cleaning up build artifacts..."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12238,8 +12238,7 @@ dependencies = [
 [[package]]
 name = "stellar-contract-utils"
 version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acd8001a84e189032af6d8d17355a923d98ea97917064d6e6003ff3e5accb0f5"
+source = "git+https://github.com/Templar-Protocol/stellar-contracts?rev=f9d7cee755ee09cd43f6978eecf7ea8156e32a86#f9d7cee755ee09cd43f6978eecf7ea8156e32a86"
 dependencies = [
  "soroban-sdk",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,17 @@ zeroize = "1.8.2"
 stellar-contract-utils = { version = "0.7.1", default-features = false }
 stellar-tokens = { version = "0.7.1", default-features = false }
 
+# Rust 1.86 compatibility shim. Upstream stellar-contract-utils 0.7.1 calls
+# `u32::is_multiple_of` (stabilized in Rust 1.87) in src/crypto/merkle.rs, which
+# fails to build on our pinned toolchain (1.86 — the ceiling NEAR's reproducible
+# builds support). This points at a one-commit fork of the upstream `v0.7.1` tag
+# that replaces the two call sites with the identical `% 2 == 0`. The redirect
+# applies transitively (e.g. stellar-tokens). Audit the delta with:
+#   git diff v0.7.1 f9d7cee  # on Templar-Protocol/stellar-contracts
+# Drop this once the change is upstreamed and released.
+[patch.crates-io]
+stellar-contract-utils = { git = "https://github.com/Templar-Protocol/stellar-contracts", rev = "f9d7cee755ee09cd43f6978eecf7ea8156e32a86" }
+
 [workspace.lints.clippy]
 pedantic = { level = "warn", priority = -1 }
 must_use_candidate = "allow"


### PR DESCRIPTION
## Problem

Plain `cargo test` failed to compile. The Soroban crates depend (transitively) on `stellar-contract-utils 0.7.1`, whose only Rust-1.87 API — `u32::is_multiple_of` in `src/crypto/merkle.rs` — cannot build on the workspace's pinned **1.86** toolchain (the ceiling NEAR's reproducible builds support). That single upstream line forced a two-toolchain split across the whole workspace: `--exclude` lists in every cargo invocation plus a dedicated Soroban CI job on 1.89.

## Fix

**1. Patch the one line.** `[patch.crates-io]` now points at a one-commit fork of the upstream **v0.7.1** tag that replaces the two `is_multiple_of(2)` call sites with the identical `% 2 == 0` (both operands are `u32`).

- Fork: `Templar-Protocol/stellar-contracts` @ `f9d7cee`, tag `contract-utils-0.7.1-rust1.86`, branched off OZ `v0.7.1`.
- `git diff v0.7.1 f9d7cee` is exactly those two lines — trivially auditable, full upstream history preserved.
- The redirect applies transitively (e.g. `stellar-tokens`).

The whole workspace — all Soroban crates included — now builds and tests on **1.86**.

**2. Collapse the now-unnecessary split (CI).**
- `code-linter`: drop the Soroban `--exclude` list — lints the whole workspace on 1.86.
- Remove the `soroban-code-linter` job (folded in).
- `soroban` job: drop the host `nextest` test step; keep the Soroban toolchain **only** for the `stellar contract build` wasm size-budget checks (those genuinely need `wasm32v1-none`).
- `tests` / `coverage`: drop the Soroban `--exclude` lists.
- nextest `ci` profile: stop filtering out `templar-soroban-runtime` tests.

## Verification

- `cargo check --workspace --tests` on 1.86 → clean.
- **612 Soroban tests pass on 1.86** (full set, incl. proxy-oracle integration tests).
- 1.86 clippy on all Soroban crates: clean with `-D warnings`.
- Reproducibility intact: the optimized vault wasm is path-free and byte-identical across builds (the git-source patch does not affect deployed artifacts).

## Note for reviewers / repo admins

The **"Soroban Code Linter"** status check no longer reports (job removed). If it's a **required check** on `dev`/`main`, drop it from branch protection or this PR (and future ones) will hang waiting on it. The `Soroban` job name is unchanged.

The patch is a temporary bridge; the endgame is to upstream the change to OpenZeppelin and drop the `[patch]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/469)
<!-- Reviewable:end -->
