### PR TITLE
Add Soroban custodial market adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12739,6 +12739,7 @@ dependencies = [
  "primitive-types 0.14.0",
  "templar-common",
  "templar-curator-primitives",
+ "templar-soroban-custodial-adapter",
  "templar-soroban-runtime",
  "templar-vault-kernel",
 ]
@@ -13119,6 +13120,15 @@ name = "templar-soroban-blend-adapter"
 version = "0.1.0"
 dependencies = [
  "blend-contract-sdk",
+ "soroban-sdk",
+ "stellar-contract-utils",
+]
+
+[[package]]
+name = "templar-soroban-custodial-adapter"
+version = "0.1.0"
+dependencies = [
+ "proptest",
  "soroban-sdk",
  "stellar-contract-utils",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "contract/vault/soroban",
     "contract/vault/soroban/shared-types",
     "contract/vault/soroban/blend-adapter",
+    "contract/vault/soroban/custodial-adapter",
     "contract/vault/soroban/governance",
     "contract/vault/soroban/share-token",
     "fuzz",

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -294,6 +294,32 @@ Use recipes in [contract/vault/soroban/justfile](./justfile):
 
 After deployment, register the adapter as a vault market before allocation.
 
+## Custodial Adapter
+
+The custodial adapter lives in `contract/vault/soroban/custodial-adapter` and is intended for an
+offchain-managed market route. It forwards allocated assets from the adapter to a configured
+custodian or multisig address. Offchain infrastructure is then responsible for bridging, depositing,
+unwinding, and returning liquidity to the adapter.
+
+Withdrawal settlement is deliberately narrow: `progress_withdrawal` only releases assets already
+returned to the adapter on Stellar. It does not initiate or prove a market exit. The adapter's
+`total_assets(asset)` value is explicit reported accounting, updated by vault allocation flow or by
+`set_reported_assets(caller, asset, amount)` from the configured admin, vault, or custodian.
+Returned idle balances are not auto-counted as NAV because the adapter cannot prove their offchain
+source.
+
+Use recipes in [contract/vault/soroban/justfile](./justfile):
+
+- `just build-custodial-adapter`
+- `just deploy-custodial-adapter <CUSTODIAN_OR_MULTISIG_ADDRESS>`
+- `just deploy-all-with-custodial <CUSTODIAN_OR_MULTISIG_ADDRESS>`
+- `just custodial-adapter-status`
+- `just custodial-adapter-set-reported-assets <CALLER_ADDRESS> <ASSET_ADDRESS> <RAW_AMOUNT>`
+
+After deployment, allow-list the adapter and configure the vault supply queue through governance
+before allocation. Treat the custodian and its offchain operating process as part of the vault's
+trust boundary.
+
 ## Deployment Artifact
 
 The Soroban justfile deploys the optimized runtime artifact directly:

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -307,7 +307,9 @@ returned to the adapter on Stellar. It does not initiate or prove a market exit.
 `set_reported_assets(caller, asset, expected_current, amount, report_nonce)` from the configured
 admin, vault, or custodian.
 Returned idle balances are not auto-counted as NAV because the adapter cannot prove their offchain
-source.
+source. When the adapter is paused, vault and custodian reports are blocked, but the adapter admin
+can still submit reported-NAV corrections for incident recovery. The `report_nonce` is an exact
+NAV revision and must increase by one from the current value.
 
 Use recipes in [contract/vault/soroban/justfile](./justfile):
 
@@ -316,6 +318,13 @@ Use recipes in [contract/vault/soroban/justfile](./justfile):
 - `just deploy-all-with-custodial <CUSTODIAN_OR_MULTISIG_ADDRESS>`
 - `just custodial-adapter-status`
 - `just custodial-adapter-set-reported-assets <CALLER_ADDRESS> <ASSET_ADDRESS> <EXPECTED_CURRENT> <RAW_AMOUNT> <REPORT_NONCE>`
+
+### Custodial Runbook Checks
+
+Before production deployment, operators must verify the offchain custodial runbook because this
+route intentionally depends on custodian operations outside the vault contract. Confirm custodian
+key controls and signer recovery, the NAV reporting cadence and approval set, and the delayed
+liquidity incident procedure for cases where returned liquidity is slower than queued withdrawals.
 
 After deployment, allow-list the adapter and configure the vault supply queue through governance
 before allocation. Treat the custodian and its offchain operating process as part of the vault's

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -304,7 +304,8 @@ unwinding, and returning liquidity to the adapter.
 Withdrawal settlement is deliberately narrow: `progress_withdrawal` only releases assets already
 returned to the adapter on Stellar. It does not initiate or prove a market exit. The adapter's
 `total_assets(asset)` value is explicit reported accounting, updated by vault allocation flow or by
-`set_reported_assets(caller, asset, amount)` from the configured admin, vault, or custodian.
+`set_reported_assets(caller, asset, expected_current, amount, report_nonce)` from the configured
+admin, vault, or custodian.
 Returned idle balances are not auto-counted as NAV because the adapter cannot prove their offchain
 source.
 
@@ -314,7 +315,7 @@ Use recipes in [contract/vault/soroban/justfile](./justfile):
 - `just deploy-custodial-adapter <CUSTODIAN_OR_MULTISIG_ADDRESS>`
 - `just deploy-all-with-custodial <CUSTODIAN_OR_MULTISIG_ADDRESS>`
 - `just custodial-adapter-status`
-- `just custodial-adapter-set-reported-assets <CALLER_ADDRESS> <ASSET_ADDRESS> <RAW_AMOUNT>`
+- `just custodial-adapter-set-reported-assets <CALLER_ADDRESS> <ASSET_ADDRESS> <EXPECTED_CURRENT> <RAW_AMOUNT> <REPORT_NONCE>`
 
 After deployment, allow-list the adapter and configure the vault supply queue through governance
 before allocation. Treat the custodian and its offchain operating process as part of the vault's

--- a/contract/vault/soroban/custodial-adapter/Cargo.toml
+++ b/contract/vault/soroban/custodial-adapter/Cargo.toml
@@ -14,6 +14,9 @@ doctest = false
 default = []
 testutils = ["soroban-sdk/testutils"]
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }
+
 [dependencies]
 soroban-sdk = { version = "25.3.0", features = ["experimental_spec_shaking_v2", "hazmat-address"] }
 stellar-contract-utils.workspace = true

--- a/contract/vault/soroban/custodial-adapter/Cargo.toml
+++ b/contract/vault/soroban/custodial-adapter/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "templar-soroban-custodial-adapter"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+description = "Soroban custodial market adapter for offchain-managed vault allocations"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+path = "src/lib.rs"
+doctest = false
+
+[features]
+default = []
+testutils = ["soroban-sdk/testutils"]
+
+[dependencies]
+soroban-sdk = { version = "25.3.0", features = ["experimental_spec_shaking_v2", "hazmat-address"] }
+stellar-contract-utils.workspace = true
+
+[dev-dependencies]
+proptest = "1.4"
+soroban-sdk = { version = "25.3.0", features = ["testutils", "experimental_spec_shaking_v2"] }

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -21,6 +21,7 @@ enum DataKey {
     PendingAdmin,
     Vault,
     Custodian,
+    Asset,
     Paused,
     ReportedAssets(Address),
 }
@@ -53,11 +54,18 @@ impl CustodialAdapterContract {
         admin: Address,
         vault: Address,
         custodian: Address,
+        asset: Address,
     ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
         require_contract_address(&vault, AdapterError::InvalidInput)?;
+        require_contract_address(&asset, AdapterError::InvalidInput)?;
         let adapter = env.current_contract_address();
-        if custodian == vault || custodian == adapter {
+        if admin == adapter
+            || vault == adapter
+            || asset == adapter
+            || custodian == vault
+            || custodian == adapter
+        {
             return Err(AdapterError::InvalidInput);
         }
 
@@ -66,10 +74,11 @@ impl CustodialAdapterContract {
         env.storage()
             .instance()
             .set(&DataKey::Custodian, &custodian);
+        env.storage().instance().set(&DataKey::Asset, &asset);
         Ok(())
     }
 
-    /// Pause or unpause vault allocation and withdrawal operations.
+    /// Pause or unpause new vault allocation and reported-NAV update operations.
     #[allow(deprecated)]
     pub fn set_paused(env: Env, caller: Address, paused: bool) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
@@ -86,7 +95,11 @@ impl CustodialAdapterContract {
     }
 
     /// Forward allocated funds to the configured custodian and increase the
-    /// adapter's reported market assets by `amount`.
+    /// adapter's reported route NAV by `amount`.
+    ///
+    /// Reported route NAV is the amount attributed to this adapter that has not
+    /// yet been released back to the vault. It includes both offchain position
+    /// value and any returned idle liquidity still held by this adapter.
     #[allow(deprecated)]
     pub fn supply(
         env: Env,
@@ -98,16 +111,17 @@ impl CustodialAdapterContract {
         require_not_paused(&env)?;
         require_vault(&env, &caller)?;
         require_positive(amount)?;
-
-        let adapter = env.current_contract_address();
-        let custodian = get_custodian(&env)?;
-        let token = soroban_sdk::token::Client::new(&env, &asset);
-        token.transfer(&adapter, &custodian, &amount);
+        require_asset(&env, &asset)?;
 
         let reported = load_reported_assets(&env, &asset);
         let next = reported
             .checked_add(amount)
             .ok_or(AdapterError::ArithmeticOverflow)?;
+        let adapter = env.current_contract_address();
+        let custodian = get_custodian(&env)?;
+        let token = soroban_sdk::token::Client::new(&env, &asset);
+        token.transfer(&adapter, &custodian, &amount);
+
         store_reported_assets(&env, &asset, next);
 
         env.events()
@@ -115,7 +129,13 @@ impl CustodialAdapterContract {
         Ok(())
     }
 
-    /// Withdraw returned idle liquidity from the adapter to the vault.
+    /// Withdraw exactly `amount` of returned idle liquidity to the vault.
+    ///
+    /// This compatibility method is exact-only because it does not return the
+    /// realized amount. Use `progress_withdrawal` when partial settlement is
+    /// acceptable and the caller can account for the amount actually released.
+    /// Settlement remains available while paused so already returned liquidity
+    /// can be recovered during an incident.
     #[allow(deprecated)]
     pub fn withdraw(
         env: Env,
@@ -123,11 +143,28 @@ impl CustodialAdapterContract {
         asset: Address,
         amount: i128,
     ) -> Result<(), AdapterError> {
-        Self::progress_withdrawal(env, caller, asset, amount).map(|_| ())
+        extend_instance_ttl(&env);
+        require_vault(&env, &caller)?;
+        require_positive(amount)?;
+        require_asset(&env, &asset)?;
+
+        let adapter = env.current_contract_address();
+        let token = soroban_sdk::token::Client::new(&env, &asset);
+        let idle_balance = token.balance(&adapter);
+        let reported = load_reported_assets(&env, &asset);
+        let next_reported = exact_withdrawal_result(reported, idle_balance, amount)?;
+        let vault = get_vault(&env)?;
+        token.transfer(&adapter, &vault, &amount);
+        store_reported_assets(&env, &asset, next_reported);
+
+        env.events()
+            .publish((symbol_short!("withdraw"), asset), amount);
+        Ok(())
     }
 
     /// Progress a vault withdrawal using only assets already returned to this
-    /// adapter. This method does not initiate any offchain market exit.
+    /// adapter. This method does not initiate any offchain market exit, and
+    /// remains available while paused so returned liquidity can be recovered.
     #[allow(deprecated)]
     pub fn progress_withdrawal(
         env: Env,
@@ -136,9 +173,9 @@ impl CustodialAdapterContract {
         amount: i128,
     ) -> Result<i128, AdapterError> {
         extend_instance_ttl(&env);
-        require_not_paused(&env)?;
         require_vault(&env, &caller)?;
         require_positive(amount)?;
+        require_asset(&env, &asset)?;
 
         let adapter = env.current_contract_address();
         let token = soroban_sdk::token::Client::new(&env, &asset);
@@ -154,22 +191,27 @@ impl CustodialAdapterContract {
         Ok(actual)
     }
 
-    /// Return the adapter's reported assets for `asset`.
+    /// Return the adapter's reported route NAV for `asset`.
     ///
-    /// Returned idle balance is intentionally not auto-added here. The custodian
-    /// address may return principal or yield, but this adapter cannot prove the
-    /// offchain source of funds. Operators should use `set_reported_assets` for
-    /// explicit NAV updates when needed.
+    /// Returned idle balance is intentionally not auto-added here because
+    /// reported route NAV already includes liquidity that has returned to this
+    /// adapter but has not yet been released to the vault. Operators should use
+    /// `set_reported_assets` for explicit NAV updates when offchain route value
+    /// changes, and should avoid reporting only the offchain remainder while
+    /// returned liquidity is still pending on this adapter.
     pub fn total_assets(env: Env, asset: Address) -> i128 {
         extend_instance_ttl(&env);
+        require_asset(&env, &asset).unwrap_or_else(|err| panic_with_error!(&env, err));
         load_reported_assets(&env, &asset)
     }
 
-    /// Explicitly set reported market assets for `asset`.
+    /// Explicitly set reported route NAV for `asset`.
     ///
     /// The configured custodian is allowed to report NAV because custody of the
     /// offchain position is already part of this adapter's trust boundary. This
-    /// keeps reporting usable when the admin is a governance contract.
+    /// keeps reporting usable when the admin is a governance contract. The
+    /// amount must represent total route NAV not yet released to the vault, not
+    /// only the offchain remainder when returned idle liquidity is pending.
     #[allow(deprecated)]
     pub fn set_reported_assets(
         env: Env,
@@ -180,6 +222,7 @@ impl CustodialAdapterContract {
         extend_instance_ttl(&env);
         require_not_paused(&env)?;
         require_reporter(&env, &caller)?;
+        require_asset(&env, &asset)?;
         if amount < 0 {
             return Err(AdapterError::InvalidInput);
         }
@@ -207,6 +250,11 @@ impl CustodialAdapterContract {
     pub fn custodian(env: Env) -> Result<Address, AdapterError> {
         extend_instance_ttl(&env);
         get_custodian(&env)
+    }
+
+    pub fn asset(env: Env) -> Result<Address, AdapterError> {
+        extend_instance_ttl(&env);
+        get_asset(&env)
     }
 
     /// Propose a new admin. The pending admin must accept in a separate call.
@@ -285,6 +333,23 @@ fn withdrawal_result(
     Ok((actual, next_reported))
 }
 
+fn exact_withdrawal_result(
+    reported: i128,
+    idle_balance: i128,
+    requested: i128,
+) -> Result<i128, AdapterError> {
+    require_positive(requested)?;
+    if reported < 0 || idle_balance < 0 {
+        return Err(AdapterError::InvalidInput);
+    }
+    if reported < requested || idle_balance < requested {
+        return Err(AdapterError::InsufficientReturnedLiquidity);
+    }
+    reported
+        .checked_sub(requested)
+        .ok_or(AdapterError::ArithmeticUnderflow)
+}
+
 fn min_i128(a: i128, b: i128) -> i128 {
     if a < b {
         a
@@ -324,6 +389,18 @@ fn get_custodian(env: &Env) -> Result<Address, AdapterError> {
     get_address(env, DataKey::Custodian)
 }
 
+fn get_asset(env: &Env) -> Result<Address, AdapterError> {
+    get_address(env, DataKey::Asset)
+}
+
+fn require_asset(env: &Env, asset: &Address) -> Result<(), AdapterError> {
+    let configured = get_asset(env)?;
+    if asset != &configured {
+        return Err(AdapterError::InvalidInput);
+    }
+    Ok(())
+}
+
 fn load_reported_assets(env: &Env, asset: &Address) -> i128 {
     env.storage()
         .instance()
@@ -332,9 +409,12 @@ fn load_reported_assets(env: &Env, asset: &Address) -> i128 {
 }
 
 fn store_reported_assets(env: &Env, asset: &Address, amount: i128) {
-    env.storage()
-        .instance()
-        .set(&DataKey::ReportedAssets(asset.clone()), &amount);
+    let key = DataKey::ReportedAssets(asset.clone());
+    if amount == 0 {
+        env.storage().instance().remove(&key);
+    } else {
+        env.storage().instance().set(&key, &amount);
+    }
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), AdapterError> {
@@ -411,6 +491,38 @@ fn extend_instance_ttl(env: &Env) {
         .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
 }
 
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+
+    #[kani::proof]
+    fn withdrawal_result_conserves_reported_assets() {
+        let reported: i128 = kani::any();
+        let idle: i128 = kani::any();
+        let requested: i128 = kani::any();
+        let result = withdrawal_result(reported, idle, requested);
+
+        if requested <= 0 || reported < 0 || idle < 0 {
+            assert_eq!(result, Err(AdapterError::InvalidInput));
+        } else {
+            let expected_actual = min_i128(min_i128(reported, idle), requested);
+            if expected_actual == 0 {
+                assert_eq!(result, Err(AdapterError::InsufficientReturnedLiquidity));
+            } else {
+                let (actual, next_reported) = result.unwrap();
+                assert_eq!(actual, expected_actual);
+                assert!(actual > 0);
+                assert!(actual <= reported);
+                assert!(actual <= idle);
+                assert!(actual <= requested);
+                assert_eq!(next_reported, reported - actual);
+                assert_eq!(actual + next_reported, reported);
+                assert!(next_reported >= 0);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -437,16 +549,48 @@ mod tests {
         )
     }
 
-    fn setup_adapter(env: &Env) -> (Address, Address, Address, Address) {
+    fn setup_adapter(env: &Env) -> (Address, Address, Address, Address, Address) {
         let admin = account_address(env);
         let vault = register_dummy_contract(env);
         let custodian = Address::generate(env);
-        let contract_id = env.register(CustodialAdapterContract, (&admin, &vault, &custodian));
-        (contract_id, admin, vault, custodian)
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(env));
+        let asset = asset_sac.address();
+        let contract_id = env.register(
+            CustodialAdapterContract,
+            (&admin, &vault, &custodian, &asset),
+        );
+        (contract_id, admin, vault, custodian, asset)
     }
 
     fn token_balance(env: &Env, token: &Address, account: &Address) -> i128 {
         soroban_sdk::token::Client::new(env, token).balance(account)
+    }
+
+    fn reported_assets(env: &Env, contract_id: &Address, asset: &Address) -> i128 {
+        env.as_contract(contract_id, || {
+            CustodialAdapterContract::total_assets(env.clone(), asset.clone())
+        })
+    }
+
+    fn has_reported_assets_key(env: &Env, contract_id: &Address, asset: &Address) -> bool {
+        env.as_contract(contract_id, || {
+            env.storage()
+                .instance()
+                .has(&DataKey::ReportedAssets(asset.clone()))
+        })
+    }
+
+    fn set_reported_assets_for(
+        env: &Env,
+        contract_id: &Address,
+        caller: Address,
+        asset: Address,
+        amount: i128,
+    ) {
+        env.as_contract(contract_id, || {
+            CustodialAdapterContract::set_reported_assets(env.clone(), caller, asset, amount)
+                .unwrap();
+        });
     }
 
     fn adapter_event_count(env: &Env, contract_id: &Address) -> usize {
@@ -471,7 +615,7 @@ mod tests {
     #[test]
     fn constructor_sets_config_and_allows_account_custodian() {
         let env = Env::default();
-        let (contract_id, admin, vault, custodian) = setup_adapter(&env);
+        let (contract_id, admin, vault, custodian, asset) = setup_adapter(&env);
         env.as_contract(&contract_id, || {
             assert_eq!(CustodialAdapterContract::admin(env.clone()).unwrap(), admin);
             assert_eq!(CustodialAdapterContract::vault(env.clone()).unwrap(), vault);
@@ -479,6 +623,7 @@ mod tests {
                 CustodialAdapterContract::custodian(env.clone()).unwrap(),
                 custodian
             );
+            assert_eq!(CustodialAdapterContract::asset(env.clone()).unwrap(), asset);
         });
     }
 
@@ -489,7 +634,25 @@ mod tests {
         let admin = account_address(&env);
         let vault = account_address(&env);
         let custodian = Address::generate(&env);
-        env.register(CustodialAdapterContract, (&admin, &vault, &custodian));
+        let asset = register_dummy_contract(&env);
+        env.register(
+            CustodialAdapterContract,
+            (&admin, &vault, &custodian, &asset),
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_asset() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let vault = register_dummy_contract(&env);
+        let custodian = Address::generate(&env);
+        let asset = account_address(&env);
+        env.register(
+            CustodialAdapterContract,
+            (&admin, &vault, &custodian, &asset),
+        );
     }
 
     #[test]
@@ -498,16 +661,91 @@ mod tests {
         let env = Env::default();
         let admin = account_address(&env);
         let vault = register_dummy_contract(&env);
-        env.register(CustodialAdapterContract, (&admin, &vault, &vault));
+        let asset = register_dummy_contract(&env);
+        env.register(CustodialAdapterContract, (&admin, &vault, &vault, &asset));
+    }
+
+    #[test]
+    fn constructor_rejects_custodian_equal_to_adapter() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let vault = register_dummy_contract(&env);
+        let adapter = Address::generate(&env);
+        let asset = register_dummy_contract(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            env.register_at(
+                &adapter,
+                CustodialAdapterContract,
+                (&admin, &vault, &adapter, &asset),
+            );
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn constructor_rejects_admin_equal_to_adapter() {
+        let env = Env::default();
+        let adapter = Address::generate(&env);
+        let vault = register_dummy_contract(&env);
+        let custodian = Address::generate(&env);
+        let asset = register_dummy_contract(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            env.register_at(
+                &adapter,
+                CustodialAdapterContract,
+                (&adapter, &vault, &custodian, &asset),
+            );
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn constructor_rejects_vault_equal_to_adapter() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let adapter = Address::generate(&env);
+        let custodian = Address::generate(&env);
+        let asset = register_dummy_contract(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            env.register_at(
+                &adapter,
+                CustodialAdapterContract,
+                (&admin, &adapter, &custodian, &asset),
+            );
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn constructor_rejects_asset_equal_to_adapter() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let adapter = Address::generate(&env);
+        let vault = register_dummy_contract(&env);
+        let custodian = Address::generate(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            env.register_at(
+                &adapter,
+                CustodialAdapterContract,
+                (&admin, &vault, &custodian, &adapter),
+            );
+        }));
+
+        assert!(result.is_err());
     }
 
     #[test]
     fn supply_forwards_funds_and_reports_assets() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, custodian) = setup_adapter(&env);
-        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-        let asset = asset_sac.address();
+        let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &1_000);
 
@@ -527,8 +765,7 @@ mod tests {
     fn supply_requires_configured_vault() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, _vault, _custodian) = setup_adapter(&env);
-        let asset = Address::generate(&env);
+        let (contract_id, _admin, _vault, _custodian, asset) = setup_adapter(&env);
         let impostor = Address::generate(&env);
 
         env.as_contract(&contract_id, || {
@@ -543,9 +780,7 @@ mod tests {
     fn supply_with_exact_vault_auth_transfers_adapter_funds() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, custodian) = setup_adapter(&env);
-        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-        let asset = asset_sac.address();
+        let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &1_000);
 
@@ -573,9 +808,7 @@ mod tests {
     fn withdrawal_releases_only_returned_liquidity() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, custodian) = setup_adapter(&env);
-        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-        let asset = asset_sac.address();
+        let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &1_000);
 
@@ -589,6 +822,7 @@ mod tests {
         token
             .mock_all_auths()
             .transfer(&custodian, &contract_id, &400);
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 1_000);
 
         env.as_contract(&contract_id, || {
             let actual = CustodialAdapterContract::progress_withdrawal(
@@ -609,11 +843,46 @@ mod tests {
     }
 
     #[test]
+    fn withdraw_requires_exact_returned_liquidity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &1_000);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 1_000)
+                .unwrap();
+        });
+        asset_admin.mint(&custodian, &400);
+        soroban_sdk::token::Client::new(&env, &asset)
+            .mock_all_auths()
+            .transfer(&custodian, &contract_id, &400);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::withdraw(env.clone(), vault.clone(), asset.clone(), 700),
+                Err(AdapterError::InsufficientReturnedLiquidity)
+            );
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 1_000);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 400);
+        assert_eq!(token_balance(&env, &asset, &vault), 0);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::withdraw(env.clone(), vault.clone(), asset.clone(), 400)
+                .unwrap();
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 600);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 0);
+        assert_eq!(token_balance(&env, &asset, &vault), 400);
+    }
+
+    #[test]
     fn withdrawal_requires_configured_vault() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, _vault, _custodian) = setup_adapter(&env);
-        let asset = Address::generate(&env);
+        let (contract_id, _admin, _vault, _custodian, asset) = setup_adapter(&env);
         let impostor = Address::generate(&env);
 
         env.as_contract(&contract_id, || {
@@ -628,9 +897,7 @@ mod tests {
     fn withdrawal_with_exact_vault_auth_transfers_adapter_funds() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
-        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-        let asset = asset_sac.address();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &500);
         env.as_contract(&contract_id, || {
@@ -673,9 +940,7 @@ mod tests {
     fn withdrawal_fails_when_no_liquidity_has_returned() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
-        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-        let asset = asset_sac.address();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
 
         env.as_contract(&contract_id, || {
             CustodialAdapterContract::set_reported_assets(
@@ -697,9 +962,7 @@ mod tests {
     fn withdrawal_does_not_exceed_reported_assets() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
-        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
-        let asset = asset_sac.address();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &1_000);
 
@@ -734,8 +997,7 @@ mod tests {
     fn set_reported_assets_requires_admin_vault_or_custodian() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, admin, vault, custodian) = setup_adapter(&env);
-        let asset = Address::generate(&env);
+        let (contract_id, admin, vault, custodian, asset) = setup_adapter(&env);
         let impostor = Address::generate(&env);
         env.as_contract(&contract_id, || {
             assert_eq!(
@@ -761,11 +1023,25 @@ mod tests {
     }
 
     #[test]
+    fn zero_reported_assets_removes_storage_key() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 7);
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 7);
+        assert!(has_reported_assets_key(&env, &contract_id, &asset));
+
+        set_reported_assets_for(&env, &contract_id, vault, asset.clone(), 0);
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 0);
+        assert!(!has_reported_assets_key(&env, &contract_id, &asset));
+    }
+
+    #[test]
     fn negative_or_zero_amounts_are_rejected() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
-        let asset = Address::generate(&env);
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
         env.as_contract(&contract_id, || {
             assert_eq!(
                 CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 0),
@@ -792,20 +1068,86 @@ mod tests {
     }
 
     #[test]
-    fn pause_blocks_supply_withdraw_and_report_updates() {
+    fn failed_operations_leave_reported_assets_unchanged() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, admin, vault, _custodian) = setup_adapter(&env);
-        let asset = Address::generate(&env);
+        let (contract_id, admin, vault, _custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &10);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 100);
+
         env.as_contract(&contract_id, || {
-            CustodialAdapterContract::set_paused(env.clone(), admin, true).unwrap();
-            assert!(CustodialAdapterContract::paused(env.clone()));
+            assert_eq!(
+                CustodialAdapterContract::supply(
+                    env.clone(),
+                    Address::generate(&env),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    Address::generate(&env),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    Address::generate(&env),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 100);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 0),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::withdraw(env.clone(), vault.clone(), asset.clone(), -1),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    -1
+                ),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 100);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_paused(env.clone(), admin.clone(), true).unwrap();
+        });
+        env.as_contract(&contract_id, || {
             assert_eq!(
                 CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 1),
                 Err(AdapterError::Paused)
             );
+        });
+        env.as_contract(&contract_id, || {
             assert_eq!(
-                CustodialAdapterContract::progress_withdrawal(
+                CustodialAdapterContract::set_reported_assets(
                     env.clone(),
                     vault.clone(),
                     asset.clone(),
@@ -813,18 +1155,386 @@ mod tests {
                 ),
                 Err(AdapterError::Paused)
             );
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_paused(env.clone(), admin.clone(), false).unwrap();
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 100);
+    }
+
+    #[test]
+    fn supply_overflow_fails_before_transfer_or_accounting_change() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &1);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), i128::MAX);
+
+        env.as_contract(&contract_id, || {
             assert_eq!(
-                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, 1),
+                CustodialAdapterContract::supply(env.clone(), vault, asset.clone(), 1),
+                Err(AdapterError::ArithmeticOverflow)
+            );
+        });
+
+        assert_eq!(reported_assets(&env, &contract_id, &asset), i128::MAX);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 1);
+        assert_eq!(token_balance(&env, &asset, &custodian), 0);
+    }
+
+    #[test]
+    fn withdrawal_accounting_matches_transferred_amount_for_each_bound() {
+        for (reported, idle, requested, expected_actual) in [
+            (1_000, 600, 400, 400),
+            (300, 600, 400, 300),
+            (1_000, 250, 400, 250),
+        ] {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+            let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+            asset_admin.mint(&contract_id, &idle);
+            set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), reported);
+
+            let actual = env.as_contract(&contract_id, || {
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    requested,
+                )
+                .unwrap()
+            });
+
+            assert_eq!(actual, expected_actual);
+            assert_eq!(
+                reported_assets(&env, &contract_id, &asset),
+                reported - expected_actual
+            );
+            assert_eq!(token_balance(&env, &asset, &vault), expected_actual);
+            assert_eq!(
+                token_balance(&env, &asset, &contract_id),
+                idle - expected_actual
+            );
+        }
+    }
+
+    #[test]
+    fn unsupported_assets_are_rejected_without_accounting_change() {
+        {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+            let unsupported_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+            let unsupported = unsupported_sac.address();
+            set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 10);
+            env.as_contract(&contract_id, || {
+                assert_eq!(
+                    CustodialAdapterContract::set_reported_assets(
+                        env.clone(),
+                        vault.clone(),
+                        unsupported.clone(),
+                        200
+                    ),
+                    Err(AdapterError::InvalidInput)
+                );
+            });
+            assert_eq!(reported_assets(&env, &contract_id, &asset), 10);
+            assert!(!has_reported_assets_key(&env, &contract_id, &unsupported));
+        }
+
+        {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
+            let unsupported_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+            let unsupported = unsupported_sac.address();
+            soroban_sdk::token::StellarAssetClient::new(&env, &asset).mint(&contract_id, &100);
+            set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 10);
+            env.as_contract(&contract_id, || {
+                assert_eq!(
+                    CustodialAdapterContract::supply(
+                        env.clone(),
+                        vault.clone(),
+                        unsupported.clone(),
+                        40
+                    ),
+                    Err(AdapterError::InvalidInput)
+                );
+            });
+            assert_eq!(reported_assets(&env, &contract_id, &asset), 10);
+            assert!(!has_reported_assets_key(&env, &contract_id, &unsupported));
+            assert_eq!(token_balance(&env, &unsupported, &custodian), 0);
+        }
+
+        {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+            let unsupported_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+            let unsupported = unsupported_sac.address();
+            set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 10);
+            env.as_contract(&contract_id, || {
+                assert_eq!(
+                    CustodialAdapterContract::progress_withdrawal(
+                        env.clone(),
+                        vault.clone(),
+                        unsupported.clone(),
+                        25
+                    ),
+                    Err(AdapterError::InvalidInput)
+                );
+            });
+            assert_eq!(reported_assets(&env, &contract_id, &asset), 10);
+            assert!(!has_reported_assets_key(&env, &contract_id, &unsupported));
+            assert_eq!(token_balance(&env, &unsupported, &vault), 0);
+        }
+
+        {
+            let env = Env::default();
+            env.mock_all_auths();
+            let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+            let unsupported_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+            let unsupported = unsupported_sac.address();
+            set_reported_assets_for(&env, &contract_id, vault, asset.clone(), 10);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                env.as_contract(&contract_id, || {
+                    CustodialAdapterContract::total_assets(env.clone(), unsupported.clone());
+                });
+            }));
+            assert!(result.is_err());
+            assert_eq!(reported_assets(&env, &contract_id, &asset), 10);
+            assert_eq!(
+                has_reported_assets_key(&env, &contract_id, &unsupported),
+                false
+            );
+        }
+    }
+
+    #[test]
+    fn total_assets_is_reported_nav_not_idle_balance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 100);
+        asset_admin.mint(&contract_id, &50);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 50);
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 100);
+
+        env.as_contract(&contract_id, || {
+            let actual = CustodialAdapterContract::progress_withdrawal(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                40,
+            )
+            .unwrap();
+            assert_eq!(actual, 40);
+        });
+        assert_eq!(token_balance(&env, &asset, &contract_id), 10);
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 60);
+    }
+
+    #[test]
+    fn pause_blocks_new_exposure_but_allows_returned_liquidity_settlement() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, vault, _custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &50);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 50);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_paused(env.clone(), admin.clone(), true).unwrap();
+            assert!(CustodialAdapterContract::paused(env.clone()));
+            assert_eq!(
+                CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 1),
+                Err(AdapterError::Paused)
+            );
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    60
+                ),
+                Err(AdapterError::Paused)
+            );
+        });
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    20
+                )
+                .unwrap(),
+                20
+            );
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 30);
+        assert_eq!(token_balance(&env, &asset, &vault), 20);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::withdraw(env.clone(), vault.clone(), asset.clone(), 10)
+                .unwrap();
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 20);
+        assert_eq!(token_balance(&env, &asset, &vault), 30);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, 30),
                 Err(AdapterError::Paused)
             );
         });
     }
 
     #[test]
+    fn pause_does_not_block_admin_recovery_or_ttl_extension() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, _vault, _custodian, _asset) = setup_adapter(&env);
+        let new_admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_paused(env.clone(), admin.clone(), true).unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_admin(env.clone(), admin.clone(), new_admin.clone())
+                .unwrap();
+            assert_eq!(CustodialAdapterContract::admin(env.clone()).unwrap(), admin);
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::accept_admin(env.clone(), new_admin.clone()).unwrap();
+            assert_eq!(
+                CustodialAdapterContract::admin(env.clone()).unwrap(),
+                new_admin
+            );
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::extend_ttl(env.clone(), new_admin).unwrap();
+        });
+    }
+
+    #[test]
+    fn authorization_matrix_rejects_untrusted_callers() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, vault, _custodian, asset) = setup_adapter(&env);
+        let impostor = Address::generate(&env);
+        let new_admin = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_paused(env.clone(), impostor.clone(), true),
+                Err(AdapterError::Unauthorized)
+            );
+            CustodialAdapterContract::set_paused(env.clone(), admin.clone(), true).unwrap();
+            CustodialAdapterContract::set_paused(env.clone(), vault.clone(), false).unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::supply(
+                    env.clone(),
+                    Address::generate(&env),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    Address::generate(&env),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    Address::generate(&env),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_admin(
+                    env.clone(),
+                    Address::generate(&env),
+                    new_admin.clone()
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::extend_ttl(env.clone(), Address::generate(&env)),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_admin(env.clone(), admin, new_admin.clone()).unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::accept_admin(env.clone(), impostor),
+                Err(AdapterError::Unauthorized)
+            );
+            assert_eq!(
+                CustodialAdapterContract::admin(env.clone()).unwrap(),
+                account_address(&env)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::accept_admin(env.clone(), new_admin.clone()).unwrap();
+            assert_eq!(
+                CustodialAdapterContract::admin(env.clone()).unwrap(),
+                new_admin
+            );
+            assert_eq!(
+                CustodialAdapterContract::pending_admin(env.clone()),
+                Err(AdapterError::MissingConfig)
+            );
+        });
+    }
+
+    #[test]
+    fn upgrade_requires_admin() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, _vault, _custodian, _asset) = setup_adapter(&env);
+        let impostor = Address::generate(&env);
+        let new_hash = empty_wasm_hash(&env);
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            env.as_contract(&contract_id, || {
+                CustodialAdapterContract::upgrade(&env, new_hash, impostor);
+            });
+        }));
+
+        assert!(result.is_err());
+    }
+
+    #[test]
     fn set_admin_requires_pending_admin_acceptance() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, admin, _vault, _custodian) = setup_adapter(&env);
+        let (contract_id, admin, _vault, _custodian, _asset) = setup_adapter(&env);
         let new_admin = Address::generate(&env);
         env.as_contract(&contract_id, || {
             CustodialAdapterContract::set_admin(env.clone(), admin.clone(), new_admin.clone())
@@ -850,7 +1560,7 @@ mod tests {
     fn admin_events_and_upgrade_emit() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, admin, _vault, _custodian) = setup_adapter(&env);
+        let (contract_id, admin, _vault, _custodian, _asset) = setup_adapter(&env);
         let new_admin = Address::generate(&env);
         let new_hash = empty_wasm_hash(&env);
         env.as_contract(&contract_id, || {
@@ -874,21 +1584,29 @@ mod tests {
 
     proptest! {
         #[test]
-        fn withdrawal_model_never_overdraws(
-            reported in 0i128..=1_000_000_000_000i128,
-            idle in 0i128..=1_000_000_000_000i128,
-            requested in 1i128..=1_000_000_000_000i128,
+        fn withdrawal_result_matches_conservation_model(
+            reported in any::<i128>(),
+            idle in any::<i128>(),
+            requested in any::<i128>(),
         ) {
             let result = simulate_progress_withdrawal(reported, idle, requested);
-            if reported == 0 || idle == 0 {
+
+            if requested <= 0 || reported < 0 || idle < 0 {
+                prop_assert_eq!(result, Err(AdapterError::InvalidInput));
+            } else if min_i128(min_i128(reported, idle), requested) == 0 {
                 prop_assert_eq!(result, Err(AdapterError::InsufficientReturnedLiquidity));
             } else {
-                let (actual, next_reported) = result.expect("positive reported and idle should withdraw");
+                let expected_actual = min_i128(min_i128(reported, idle), requested);
+                let (actual, next_reported) =
+                    result.expect("positive reported, idle, and request should withdraw");
+                prop_assert_eq!(actual, expected_actual);
                 prop_assert!(actual > 0);
                 prop_assert!(actual <= reported);
                 prop_assert!(actual <= idle);
                 prop_assert!(actual <= requested);
                 prop_assert_eq!(next_reported, reported - actual);
+                prop_assert_eq!(actual + next_reported, reported);
+                prop_assert!(next_reported >= 0);
             }
         }
 

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -24,6 +24,7 @@ enum DataKey {
     Asset,
     Paused,
     ReportedAssets(Address),
+    ReportNonce(Address),
 }
 
 #[contracterror]
@@ -63,6 +64,9 @@ impl CustodialAdapterContract {
         if admin == adapter
             || vault == adapter
             || asset == adapter
+            || asset == admin
+            || asset == vault
+            || asset == custodian
             || custodian == vault
             || custodian == adapter
         {
@@ -120,7 +124,7 @@ impl CustodialAdapterContract {
         let adapter = env.current_contract_address();
         let custodian = get_custodian(&env)?;
         let token = soroban_sdk::token::Client::new(&env, &asset);
-        token.transfer(&adapter, &custodian, &amount);
+        transfer_exact(&token, &adapter, &custodian, amount)?;
 
         store_reported_assets(&env, &asset, next);
 
@@ -154,7 +158,7 @@ impl CustodialAdapterContract {
         let reported = load_reported_assets(&env, &asset);
         let next_reported = exact_withdrawal_result(reported, idle_balance, amount)?;
         let vault = get_vault(&env)?;
-        token.transfer(&adapter, &vault, &amount);
+        transfer_exact(&token, &adapter, &vault, amount)?;
         store_reported_assets(&env, &asset, next_reported);
 
         env.events()
@@ -183,7 +187,7 @@ impl CustodialAdapterContract {
         let reported = load_reported_assets(&env, &asset);
         let (actual, next_reported) = withdrawal_result(reported, idle_balance, amount)?;
         let vault = get_vault(&env)?;
-        token.transfer(&adapter, &vault, &actual);
+        transfer_exact(&token, &adapter, &vault, actual)?;
         store_reported_assets(&env, &asset, next_reported);
 
         env.events()
@@ -217,16 +221,24 @@ impl CustodialAdapterContract {
         env: Env,
         caller: Address,
         asset: Address,
+        expected_current: i128,
         amount: i128,
+        report_nonce: u64,
     ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
-        require_not_paused(&env)?;
-        require_reporter(&env, &caller)?;
+        require_report_update_authority(&env, &caller)?;
         require_asset(&env, &asset)?;
-        if amount < 0 {
+        if expected_current < 0 || amount < 0 {
+            return Err(AdapterError::InvalidInput);
+        }
+        if load_reported_assets(&env, &asset) != expected_current {
+            return Err(AdapterError::InvalidInput);
+        }
+        if report_nonce <= load_report_nonce(&env, &asset) {
             return Err(AdapterError::InvalidInput);
         }
         store_reported_assets(&env, &asset, amount);
+        store_report_nonce(&env, &asset, report_nonce);
         env.events()
             .publish((symbol_short!("report"), caller, asset), amount);
         Ok(())
@@ -255,6 +267,12 @@ impl CustodialAdapterContract {
     pub fn asset(env: Env) -> Result<Address, AdapterError> {
         extend_instance_ttl(&env);
         get_asset(&env)
+    }
+
+    pub fn report_nonce(env: Env, asset: Address) -> Result<u64, AdapterError> {
+        extend_instance_ttl(&env);
+        require_asset(&env, &asset)?;
+        Ok(load_report_nonce(&env, &asset))
     }
 
     /// Propose a new admin. The pending admin must accept in a separate call.
@@ -366,6 +384,29 @@ fn require_positive(amount: i128) -> Result<(), AdapterError> {
     }
 }
 
+fn transfer_exact(
+    token: &soroban_sdk::token::Client<'_>,
+    from: &Address,
+    to: &Address,
+    amount: i128,
+) -> Result<(), AdapterError> {
+    let from_before = token.balance(from);
+    let to_before = token.balance(to);
+    token.transfer(from, to, &amount);
+    let from_after = token.balance(from);
+    let to_after = token.balance(to);
+    let debited = from_before
+        .checked_sub(from_after)
+        .ok_or(AdapterError::InvalidInput)?;
+    let credited = to_after
+        .checked_sub(to_before)
+        .ok_or(AdapterError::InvalidInput)?;
+    if debited != amount || credited != amount {
+        return Err(AdapterError::InvalidInput);
+    }
+    Ok(())
+}
+
 fn get_address(env: &Env, key: DataKey) -> Result<Address, AdapterError> {
     env.storage()
         .instance()
@@ -408,6 +449,13 @@ fn load_reported_assets(env: &Env, asset: &Address) -> i128 {
         .unwrap_or(0)
 }
 
+fn load_report_nonce(env: &Env, asset: &Address) -> u64 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReportNonce(asset.clone()))
+        .unwrap_or(0)
+}
+
 fn store_reported_assets(env: &Env, asset: &Address, amount: i128) {
     let key = DataKey::ReportedAssets(asset.clone());
     if amount == 0 {
@@ -415,6 +463,12 @@ fn store_reported_assets(env: &Env, asset: &Address, amount: i128) {
     } else {
         env.storage().instance().set(&key, &amount);
     }
+}
+
+fn store_report_nonce(env: &Env, asset: &Address, nonce: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReportNonce(asset.clone()), &nonce);
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), AdapterError> {
@@ -445,12 +499,18 @@ fn require_admin_or_vault(env: &Env, caller: &Address) -> Result<(), AdapterErro
     Ok(())
 }
 
-fn require_reporter(env: &Env, caller: &Address) -> Result<(), AdapterError> {
+fn require_report_update_authority(env: &Env, caller: &Address) -> Result<(), AdapterError> {
     caller.require_auth();
     let admin = get_admin(env)?;
+    if caller == &admin {
+        return Ok(());
+    }
+    if is_paused(env) {
+        return Err(AdapterError::Paused);
+    }
     let vault = get_vault(env)?;
     let custodian = get_custodian(env)?;
-    if caller != &admin && caller != &vault && caller != &custodian {
+    if caller != &vault && caller != &custodian {
         return Err(AdapterError::Unauthorized);
     }
     Ok(())
@@ -538,8 +598,45 @@ mod tests {
     #[contractimpl]
     impl DummyContract {}
 
+    #[contract]
+    struct FeeToken;
+
+    #[contractimpl]
+    impl FeeToken {
+        pub fn mint(env: Env, to: Address, amount: i128) {
+            let current = Self::balance(env.clone(), to.clone());
+            env.storage()
+                .instance()
+                .set(&DataKey::ReportedAssets(to), &(current + amount));
+        }
+
+        pub fn balance(env: Env, id: Address) -> i128 {
+            env.storage()
+                .instance()
+                .get(&DataKey::ReportedAssets(id))
+                .unwrap_or(0)
+        }
+
+        pub fn transfer(env: Env, from: Address, to: Address, amount: i128) {
+            from.require_auth();
+            let from_balance = Self::balance(env.clone(), from.clone());
+            let to_balance = Self::balance(env.clone(), to.clone());
+            let credited = amount.saturating_sub(1);
+            env.storage()
+                .instance()
+                .set(&DataKey::ReportedAssets(from), &(from_balance - amount));
+            env.storage()
+                .instance()
+                .set(&DataKey::ReportedAssets(to), &(to_balance + credited));
+        }
+    }
+
     fn register_dummy_contract(env: &Env) -> Address {
         env.register(DummyContract, ())
+    }
+
+    fn register_fee_token(env: &Env) -> Address {
+        env.register(FeeToken, ())
     }
 
     fn account_address(env: &Env) -> Address {
@@ -555,11 +652,18 @@ mod tests {
         let custodian = Address::generate(env);
         let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(env));
         let asset = asset_sac.address();
-        let contract_id = env.register(
-            CustodialAdapterContract,
-            (&admin, &vault, &custodian, &asset),
-        );
+        let contract_id = setup_adapter_with(env, &admin, &vault, &custodian, &asset);
         (contract_id, admin, vault, custodian, asset)
+    }
+
+    fn setup_adapter_with(
+        env: &Env,
+        admin: &Address,
+        vault: &Address,
+        custodian: &Address,
+        asset: &Address,
+    ) -> Address {
+        env.register(CustodialAdapterContract, (admin, vault, custodian, asset))
     }
 
     fn token_balance(env: &Env, token: &Address, account: &Address) -> i128 {
@@ -569,6 +673,12 @@ mod tests {
     fn reported_assets(env: &Env, contract_id: &Address, asset: &Address) -> i128 {
         env.as_contract(contract_id, || {
             CustodialAdapterContract::total_assets(env.clone(), asset.clone())
+        })
+    }
+
+    fn report_nonce(env: &Env, contract_id: &Address, asset: &Address) -> u64 {
+        env.as_contract(contract_id, || {
+            CustodialAdapterContract::report_nonce(env.clone(), asset.clone()).unwrap()
         })
     }
 
@@ -587,9 +697,18 @@ mod tests {
         asset: Address,
         amount: i128,
     ) {
+        let expected_current = reported_assets(env, contract_id, &asset);
+        let report_nonce = report_nonce(env, contract_id, &asset) + 1;
         env.as_contract(contract_id, || {
-            CustodialAdapterContract::set_reported_assets(env.clone(), caller, asset, amount)
-                .unwrap();
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                caller,
+                asset,
+                expected_current,
+                amount,
+                report_nonce,
+            )
+            .unwrap();
         });
     }
 
@@ -739,6 +858,30 @@ mod tests {
         }));
 
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn constructor_rejects_asset_equal_to_role_addresses() {
+        let env = Env::default();
+        let admin = register_dummy_contract(&env);
+        let vault = register_dummy_contract(&env);
+        let custodian = register_dummy_contract(&env);
+        let asset = register_dummy_contract(&env);
+
+        for invalid_asset in [&admin, &vault, &custodian] {
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                env.register(
+                    CustodialAdapterContract,
+                    (&admin, &vault, &custodian, invalid_asset),
+                );
+            }));
+            assert!(result.is_err());
+        }
+
+        env.register(
+            CustodialAdapterContract,
+            (&admin, &vault, &custodian, &asset),
+        );
     }
 
     #[test]
@@ -900,15 +1043,7 @@ mod tests {
         let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &500);
-        env.as_contract(&contract_id, || {
-            CustodialAdapterContract::set_reported_assets(
-                env.clone(),
-                vault.clone(),
-                asset.clone(),
-                500,
-            )
-            .unwrap();
-        });
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 500);
 
         let args: soroban_sdk::Vec<soroban_sdk::Val> = (&vault, &asset, &300i128).into_val(&env);
         env.mock_auths(&[MockAuth {
@@ -942,15 +1077,7 @@ mod tests {
         env.mock_all_auths();
         let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
 
-        env.as_contract(&contract_id, || {
-            CustodialAdapterContract::set_reported_assets(
-                env.clone(),
-                vault.clone(),
-                asset.clone(),
-                1_000,
-            )
-            .unwrap();
-        });
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 1_000);
         env.as_contract(&contract_id, || {
             let result =
                 CustodialAdapterContract::progress_withdrawal(env.clone(), vault, asset, 100);
@@ -966,15 +1093,7 @@ mod tests {
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &1_000);
 
-        env.as_contract(&contract_id, || {
-            CustodialAdapterContract::set_reported_assets(
-                env.clone(),
-                vault.clone(),
-                asset.clone(),
-                250,
-            )
-            .unwrap();
-        });
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 250);
         env.as_contract(&contract_id, || {
             let actual = CustodialAdapterContract::progress_withdrawal(
                 env.clone(),
@@ -1005,16 +1124,39 @@ mod tests {
                     env.clone(),
                     impostor,
                     asset.clone(),
+                    0,
+                    1,
                     1
                 ),
                 Err(AdapterError::Unauthorized)
             );
-            CustodialAdapterContract::set_reported_assets(env.clone(), admin, asset.clone(), 9)
-                .unwrap();
-            CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset.clone(), 7)
-                .unwrap();
-            CustodialAdapterContract::set_reported_assets(env.clone(), custodian, asset.clone(), 5)
-                .unwrap();
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                admin,
+                asset.clone(),
+                0,
+                9,
+                1,
+            )
+            .unwrap();
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                vault,
+                asset.clone(),
+                9,
+                7,
+                2,
+            )
+            .unwrap();
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                custodian,
+                asset.clone(),
+                7,
+                5,
+                3,
+            )
+            .unwrap();
             assert_eq!(
                 CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
                 5
@@ -1061,7 +1203,7 @@ mod tests {
         });
         env.as_contract(&contract_id, || {
             assert_eq!(
-                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, -1),
+                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, 0, -1, 1),
                 Err(AdapterError::InvalidInput)
             );
         });
@@ -1104,6 +1246,8 @@ mod tests {
                     env.clone(),
                     Address::generate(&env),
                     asset.clone(),
+                    100,
+                    1,
                     1
                 ),
                 Err(AdapterError::Unauthorized)
@@ -1129,7 +1273,9 @@ mod tests {
                     env.clone(),
                     vault.clone(),
                     asset.clone(),
-                    -1
+                    100,
+                    -1,
+                    2
                 ),
                 Err(AdapterError::InvalidInput)
             );
@@ -1151,7 +1297,9 @@ mod tests {
                     env.clone(),
                     vault.clone(),
                     asset.clone(),
-                    1
+                    100,
+                    1,
+                    2
                 ),
                 Err(AdapterError::Paused)
             );
@@ -1235,7 +1383,9 @@ mod tests {
                         env.clone(),
                         vault.clone(),
                         unsupported.clone(),
-                        200
+                        0,
+                        200,
+                        1,
                     ),
                     Err(AdapterError::InvalidInput)
                 );
@@ -1313,6 +1463,31 @@ mod tests {
     }
 
     #[test]
+    fn fee_on_transfer_asset_is_rejected_without_accounting_change() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let admin = account_address(&env);
+        let vault = register_dummy_contract(&env);
+        let custodian = Address::generate(&env);
+        let asset = register_fee_token(&env);
+        let contract_id = setup_adapter_with(&env, &admin, &vault, &custodian, &asset);
+
+        env.as_contract(&asset, || {
+            FeeToken::mint(env.clone(), contract_id.clone(), 100);
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::supply(env.clone(), vault, asset.clone(), 40),
+                Err(AdapterError::InvalidInput)
+            );
+            assert_eq!(
+                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
+                0
+            );
+        });
+    }
+
+    #[test]
     fn total_assets_is_reported_nav_not_idle_balance() {
         let env = Env::default();
         env.mock_all_auths();
@@ -1342,7 +1517,7 @@ mod tests {
     fn pause_blocks_new_exposure_but_allows_returned_liquidity_settlement() {
         let env = Env::default();
         env.mock_all_auths();
-        let (contract_id, admin, vault, _custodian, asset) = setup_adapter(&env);
+        let (contract_id, admin, vault, custodian, asset) = setup_adapter(&env);
         let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
         asset_admin.mint(&contract_id, &50);
         set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 50);
@@ -1359,7 +1534,20 @@ mod tests {
                     env.clone(),
                     vault.clone(),
                     asset.clone(),
-                    60
+                    50,
+                    60,
+                    2,
+                ),
+                Err(AdapterError::Paused)
+            );
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    custodian.clone(),
+                    asset.clone(),
+                    50,
+                    60,
+                    2,
                 ),
                 Err(AdapterError::Paused)
             );
@@ -1389,10 +1577,84 @@ mod tests {
 
         env.as_contract(&contract_id, || {
             assert_eq!(
-                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, 30),
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    20,
+                    30,
+                    2,
+                ),
                 Err(AdapterError::Paused)
             );
         });
+        set_reported_assets_for(&env, &contract_id, admin, asset.clone(), 30);
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 30);
+    }
+
+    #[test]
+    fn stale_or_replayed_absolute_reports_are_rejected_after_withdrawal() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &400);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 1_000);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 1);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    400,
+                )
+                .unwrap(),
+                400
+            );
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 600);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    1_000,
+                    1_000,
+                    2,
+                ),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    600,
+                    650,
+                    1,
+                ),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                600,
+                650,
+                2,
+            )
+            .unwrap();
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 650);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 2);
     }
 
     #[test]
@@ -1466,6 +1728,8 @@ mod tests {
                     env.clone(),
                     Address::generate(&env),
                     asset.clone(),
+                    0,
+                    1,
                     1
                 ),
                 Err(AdapterError::Unauthorized)

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -83,6 +83,9 @@ impl CustodialAdapterContract {
     }
 
     /// Pause or unpause new vault allocation and reported-NAV update operations.
+    ///
+    /// While paused, vault and custodian report updates are blocked. The admin
+    /// may still call `set_reported_assets` to correct NAV during recovery.
     #[allow(deprecated)]
     pub fn set_paused(env: Env, caller: Address, paused: bool) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
@@ -116,6 +119,7 @@ impl CustodialAdapterContract {
         require_vault(&env, &caller)?;
         require_positive(amount)?;
         require_asset(&env, &asset)?;
+        let next_report_nonce = next_report_nonce(&env, &asset)?;
 
         let reported = load_reported_assets(&env, &asset);
         let next = reported
@@ -127,6 +131,7 @@ impl CustodialAdapterContract {
         transfer_exact(&token, &adapter, &custodian, amount)?;
 
         store_reported_assets(&env, &asset, next);
+        store_report_nonce(&env, &asset, next_report_nonce);
 
         env.events()
             .publish((symbol_short!("supply"), asset, custodian), amount);
@@ -151,6 +156,7 @@ impl CustodialAdapterContract {
         require_vault(&env, &caller)?;
         require_positive(amount)?;
         require_asset(&env, &asset)?;
+        let next_report_nonce = next_report_nonce(&env, &asset)?;
 
         let adapter = env.current_contract_address();
         let token = soroban_sdk::token::Client::new(&env, &asset);
@@ -160,6 +166,7 @@ impl CustodialAdapterContract {
         let vault = get_vault(&env)?;
         transfer_exact(&token, &adapter, &vault, amount)?;
         store_reported_assets(&env, &asset, next_reported);
+        store_report_nonce(&env, &asset, next_report_nonce);
 
         env.events()
             .publish((symbol_short!("withdraw"), asset), amount);
@@ -180,6 +187,7 @@ impl CustodialAdapterContract {
         require_vault(&env, &caller)?;
         require_positive(amount)?;
         require_asset(&env, &asset)?;
+        let next_report_nonce = next_report_nonce(&env, &asset)?;
 
         let adapter = env.current_contract_address();
         let token = soroban_sdk::token::Client::new(&env, &asset);
@@ -189,6 +197,7 @@ impl CustodialAdapterContract {
         let vault = get_vault(&env)?;
         transfer_exact(&token, &adapter, &vault, actual)?;
         store_reported_assets(&env, &asset, next_reported);
+        store_report_nonce(&env, &asset, next_report_nonce);
 
         env.events()
             .publish((symbol_short!("withdraw"), asset), actual);
@@ -216,6 +225,11 @@ impl CustodialAdapterContract {
     /// keeps reporting usable when the admin is a governance contract. The
     /// amount must represent total route NAV not yet released to the vault, not
     /// only the offchain remainder when returned idle liquidity is pending.
+    /// `report_nonce` must be exactly one greater than the current report
+    /// nonce; every successful NAV mutation advances this same revision.
+    ///
+    /// Pause blocks vault and custodian reporting, but intentionally leaves an
+    /// admin recovery path for emergency NAV correction.
     #[allow(deprecated)]
     pub fn set_reported_assets(
         env: Env,
@@ -234,7 +248,8 @@ impl CustodialAdapterContract {
         if load_reported_assets(&env, &asset) != expected_current {
             return Err(AdapterError::InvalidInput);
         }
-        if report_nonce <= load_report_nonce(&env, &asset) {
+        let next_report_nonce = next_report_nonce(&env, &asset)?;
+        if report_nonce != next_report_nonce {
             return Err(AdapterError::InvalidInput);
         }
         store_reported_assets(&env, &asset, amount);
@@ -454,6 +469,12 @@ fn load_report_nonce(env: &Env, asset: &Address) -> u64 {
         .instance()
         .get(&DataKey::ReportNonce(asset.clone()))
         .unwrap_or(0)
+}
+
+fn next_report_nonce(env: &Env, asset: &Address) -> Result<u64, AdapterError> {
+    load_report_nonce(env, asset)
+        .checked_add(1)
+        .ok_or(AdapterError::ArithmeticOverflow)
 }
 
 fn store_reported_assets(env: &Env, asset: &Address, amount: i128) {
@@ -1113,6 +1134,49 @@ mod tests {
     }
 
     #[test]
+    fn nav_mutations_advance_report_nonce_exactly_once() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &100);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 0);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 100)
+                .unwrap();
+        });
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 1);
+
+        asset_admin.mint(&custodian, &50);
+        soroban_sdk::token::Client::new(&env, &asset)
+            .mock_all_auths()
+            .transfer(&custodian, &contract_id, &50);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    20,
+                )
+                .unwrap(),
+                20
+            );
+        });
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 2);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::withdraw(env.clone(), vault.clone(), asset.clone(), 10)
+                .unwrap();
+        });
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 3);
+
+        set_reported_assets_for(&env, &contract_id, vault, asset.clone(), 80);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 4);
+    }
+
+    #[test]
     fn set_reported_assets_requires_admin_vault_or_custodian() {
         let env = Env::default();
         env.mock_all_auths();
@@ -1475,16 +1539,20 @@ mod tests {
         env.as_contract(&asset, || {
             FeeToken::mint(env.clone(), contract_id.clone(), 100);
         });
-        env.as_contract(&contract_id, || {
-            assert_eq!(
-                CustodialAdapterContract::supply(env.clone(), vault, asset.clone(), 40),
-                Err(AdapterError::InvalidInput)
-            );
-            assert_eq!(
-                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
-                0
-            );
-        });
+        assert_eq!(token_balance(&env, &asset, &contract_id), 100);
+        assert_eq!(token_balance(&env, &asset, &custodian), 0);
+
+        let args: soroban_sdk::Vec<soroban_sdk::Val> = (&vault, &asset, &40i128).into_val(&env);
+        let result = env.try_invoke_contract::<(), AdapterError>(
+            &contract_id,
+            &Symbol::new(&env, "supply"),
+            args,
+        );
+        assert_eq!(result, Err(Ok(AdapterError::InvalidInput)));
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 0);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 100);
+        assert_eq!(token_balance(&env, &asset, &custodian), 0);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 0);
     }
 
     #[test]
@@ -1615,6 +1683,7 @@ mod tests {
             );
         });
         assert_eq!(reported_assets(&env, &contract_id, &asset), 600);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 2);
 
         env.as_contract(&contract_id, || {
             assert_eq!(
@@ -1643,18 +1712,31 @@ mod tests {
             );
         });
         env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    600,
+                    650,
+                    u64::MAX,
+                ),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
             CustodialAdapterContract::set_reported_assets(
                 env.clone(),
                 vault.clone(),
                 asset.clone(),
                 600,
                 650,
-                2,
+                3,
             )
             .unwrap();
         });
         assert_eq!(reported_assets(&env, &contract_id, &asset), 650);
-        assert_eq!(report_nonce(&env, &contract_id, &asset), 2);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 3);
     }
 
     #[test]

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -1,0 +1,913 @@
+#![no_std]
+
+#[cfg(any(test, feature = "testutils"))]
+extern crate std;
+
+use soroban_sdk::{
+    address_payload::AddressPayload, contract, contracterror, contractimpl, contracttype,
+    panic_with_error, symbol_short, Address, BytesN, Env,
+};
+use stellar_contract_utils::upgradeable::{self, Upgradeable};
+
+/// Re-extend instance TTL when remaining TTL drops below ~30 days.
+const INSTANCE_TTL_THRESHOLD: u32 = 518_400;
+/// Extend instance TTL to the Soroban maximum (~6 months).
+const INSTANCE_TTL_EXTEND_TO: u32 = 3_110_400;
+
+#[contracttype]
+#[derive(Clone, Debug)]
+enum DataKey {
+    Admin,
+    PendingAdmin,
+    Vault,
+    Custodian,
+    Paused,
+    ReportedAssets(Address),
+}
+
+#[contracterror]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum AdapterError {
+    Unauthorized = 1,
+    InvalidInput = 2,
+    MissingConfig = 3,
+    ArithmeticOverflow = 4,
+    ArithmeticUnderflow = 5,
+    InsufficientReturnedLiquidity = 6,
+    Paused = 7,
+}
+
+#[contract]
+pub struct CustodialAdapterContract;
+
+#[contractimpl]
+impl CustodialAdapterContract {
+    /// Configure the adapter.
+    ///
+    /// The `custodian` may be either an account or contract address. It is the
+    /// operational address that receives allocated funds and is expected to
+    /// return assets to this adapter before vault withdrawals are progressed.
+    pub fn __constructor(
+        env: Env,
+        admin: Address,
+        vault: Address,
+        custodian: Address,
+    ) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_contract_address(&vault, AdapterError::InvalidInput)?;
+        let adapter = env.current_contract_address();
+        if custodian == vault || custodian == adapter {
+            return Err(AdapterError::InvalidInput);
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage().instance().set(&DataKey::Vault, &vault);
+        env.storage()
+            .instance()
+            .set(&DataKey::Custodian, &custodian);
+        Ok(())
+    }
+
+    /// Pause or unpause vault allocation and withdrawal operations.
+    #[allow(deprecated)]
+    pub fn set_paused(env: Env, caller: Address, paused: bool) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_admin_or_vault(&env, &caller)?;
+        env.storage().instance().set(&DataKey::Paused, &paused);
+        env.events()
+            .publish((symbol_short!("paused"), caller), paused);
+        Ok(())
+    }
+
+    pub fn paused(env: Env) -> bool {
+        extend_instance_ttl(&env);
+        is_paused(&env)
+    }
+
+    /// Forward allocated funds to the configured custodian and increase the
+    /// adapter's reported market assets by `amount`.
+    #[allow(deprecated)]
+    pub fn supply(
+        env: Env,
+        caller: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_not_paused(&env)?;
+        require_vault(&env, &caller)?;
+        require_positive(amount)?;
+
+        let adapter = env.current_contract_address();
+        let custodian = get_custodian(&env)?;
+        let token = soroban_sdk::token::Client::new(&env, &asset);
+        token.transfer(&adapter, &custodian, &amount);
+
+        let reported = load_reported_assets(&env, &asset);
+        let next = reported
+            .checked_add(amount)
+            .ok_or(AdapterError::ArithmeticOverflow)?;
+        store_reported_assets(&env, &asset, next);
+
+        env.events()
+            .publish((symbol_short!("supply"), asset, custodian), amount);
+        Ok(())
+    }
+
+    /// Withdraw returned idle liquidity from the adapter to the vault.
+    #[allow(deprecated)]
+    pub fn withdraw(
+        env: Env,
+        caller: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<(), AdapterError> {
+        Self::progress_withdrawal(env, caller, asset, amount).map(|_| ())
+    }
+
+    /// Progress a vault withdrawal using only assets already returned to this
+    /// adapter. This method does not initiate any offchain market exit.
+    #[allow(deprecated)]
+    pub fn progress_withdrawal(
+        env: Env,
+        caller: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<i128, AdapterError> {
+        extend_instance_ttl(&env);
+        require_not_paused(&env)?;
+        require_vault(&env, &caller)?;
+        require_positive(amount)?;
+
+        let adapter = env.current_contract_address();
+        let token = soroban_sdk::token::Client::new(&env, &asset);
+        let idle_balance = token.balance(&adapter);
+        let reported = load_reported_assets(&env, &asset);
+        let (actual, next_reported) = withdrawal_result(reported, idle_balance, amount)?;
+        let vault = get_vault(&env)?;
+        token.transfer(&adapter, &vault, &actual);
+        store_reported_assets(&env, &asset, next_reported);
+
+        env.events()
+            .publish((symbol_short!("withdraw"), asset), actual);
+        Ok(actual)
+    }
+
+    /// Return the adapter's reported assets for `asset`.
+    ///
+    /// Returned idle balance is intentionally not auto-added here. The custodian
+    /// address may return principal or yield, but this adapter cannot prove the
+    /// offchain source of funds. Operators should use `set_reported_assets` for
+    /// explicit NAV updates when needed.
+    pub fn total_assets(env: Env, asset: Address) -> i128 {
+        extend_instance_ttl(&env);
+        load_reported_assets(&env, &asset)
+    }
+
+    /// Explicitly set reported market assets for `asset`.
+    ///
+    /// The configured custodian is allowed to report NAV because custody of the
+    /// offchain position is already part of this adapter's trust boundary. This
+    /// keeps reporting usable when the admin is a governance contract.
+    #[allow(deprecated)]
+    pub fn set_reported_assets(
+        env: Env,
+        caller: Address,
+        asset: Address,
+        amount: i128,
+    ) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_not_paused(&env)?;
+        require_reporter(&env, &caller)?;
+        if amount < 0 {
+            return Err(AdapterError::InvalidInput);
+        }
+        store_reported_assets(&env, &asset, amount);
+        env.events()
+            .publish((symbol_short!("report"), caller, asset), amount);
+        Ok(())
+    }
+
+    pub fn admin(env: Env) -> Result<Address, AdapterError> {
+        extend_instance_ttl(&env);
+        get_admin(&env)
+    }
+
+    pub fn pending_admin(env: Env) -> Result<Address, AdapterError> {
+        extend_instance_ttl(&env);
+        get_pending_admin(&env)
+    }
+
+    pub fn vault(env: Env) -> Result<Address, AdapterError> {
+        extend_instance_ttl(&env);
+        get_vault(&env)
+    }
+
+    pub fn custodian(env: Env) -> Result<Address, AdapterError> {
+        extend_instance_ttl(&env);
+        get_custodian(&env)
+    }
+
+    /// Propose a new admin. The pending admin must accept in a separate call.
+    #[allow(deprecated)]
+    pub fn set_admin(env: Env, caller: Address, admin: Address) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_admin(&env, &caller)?;
+        env.storage().instance().set(&DataKey::PendingAdmin, &admin);
+        env.events()
+            .publish((symbol_short!("admin_set"), caller), admin);
+        Ok(())
+    }
+
+    /// Accept admin role previously proposed with `set_admin`.
+    #[allow(deprecated)]
+    pub fn accept_admin(env: Env, caller: Address) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        caller.require_auth();
+        let pending_admin = get_pending_admin(&env)?;
+        if caller != pending_admin {
+            return Err(AdapterError::Unauthorized);
+        }
+        let old_admin = get_admin(&env)?;
+        env.storage().instance().set(&DataKey::Admin, &caller);
+        env.storage().instance().remove(&DataKey::PendingAdmin);
+        env.events()
+            .publish((symbol_short!("admin_acc"), old_admin), caller);
+        Ok(())
+    }
+
+    /// Extend instance storage TTL (admin-only).
+    pub fn extend_ttl(env: Env, caller: Address) -> Result<(), AdapterError> {
+        extend_instance_ttl(&env);
+        require_admin(&env, &caller)?;
+        Ok(())
+    }
+}
+
+#[contractimpl]
+impl Upgradeable for CustodialAdapterContract {
+    #[allow(deprecated)]
+    fn upgrade(e: &Env, new_wasm_hash: BytesN<32>, operator: Address) {
+        extend_instance_ttl(e);
+        require_admin(e, &operator).unwrap_or_else(|err| panic_with_error!(e, err));
+        upgradeable::upgrade(e, &new_wasm_hash);
+        e.events()
+            .publish((symbol_short!("upgrade"), operator), new_wasm_hash);
+    }
+}
+
+#[cfg(any(test, feature = "testutils"))]
+pub fn simulate_progress_withdrawal(
+    reported: i128,
+    idle_balance: i128,
+    requested: i128,
+) -> Result<(i128, i128), AdapterError> {
+    withdrawal_result(reported, idle_balance, requested)
+}
+
+fn withdrawal_result(
+    reported: i128,
+    idle_balance: i128,
+    requested: i128,
+) -> Result<(i128, i128), AdapterError> {
+    require_positive(requested)?;
+    if reported < 0 || idle_balance < 0 {
+        return Err(AdapterError::InvalidInput);
+    }
+    let actual = min_i128(min_i128(reported, idle_balance), requested);
+    if actual <= 0 {
+        return Err(AdapterError::InsufficientReturnedLiquidity);
+    }
+    let next_reported = reported
+        .checked_sub(actual)
+        .ok_or(AdapterError::ArithmeticUnderflow)?;
+    Ok((actual, next_reported))
+}
+
+fn min_i128(a: i128, b: i128) -> i128 {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
+fn require_positive(amount: i128) -> Result<(), AdapterError> {
+    if amount <= 0 {
+        Err(AdapterError::InvalidInput)
+    } else {
+        Ok(())
+    }
+}
+
+fn get_address(env: &Env, key: DataKey) -> Result<Address, AdapterError> {
+    env.storage()
+        .instance()
+        .get(&key)
+        .ok_or(AdapterError::MissingConfig)
+}
+
+fn get_admin(env: &Env) -> Result<Address, AdapterError> {
+    get_address(env, DataKey::Admin)
+}
+
+fn get_pending_admin(env: &Env) -> Result<Address, AdapterError> {
+    get_address(env, DataKey::PendingAdmin)
+}
+
+fn get_vault(env: &Env) -> Result<Address, AdapterError> {
+    get_address(env, DataKey::Vault)
+}
+
+fn get_custodian(env: &Env) -> Result<Address, AdapterError> {
+    get_address(env, DataKey::Custodian)
+}
+
+fn load_reported_assets(env: &Env, asset: &Address) -> i128 {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReportedAssets(asset.clone()))
+        .unwrap_or(0)
+}
+
+fn store_reported_assets(env: &Env, asset: &Address, amount: i128) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReportedAssets(asset.clone()), &amount);
+}
+
+fn require_admin(env: &Env, caller: &Address) -> Result<(), AdapterError> {
+    caller.require_auth();
+    let admin = get_admin(env)?;
+    if caller != &admin {
+        return Err(AdapterError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn require_vault(env: &Env, caller: &Address) -> Result<(), AdapterError> {
+    caller.require_auth();
+    let vault = get_vault(env)?;
+    if caller != &vault {
+        return Err(AdapterError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn require_admin_or_vault(env: &Env, caller: &Address) -> Result<(), AdapterError> {
+    caller.require_auth();
+    let admin = get_admin(env)?;
+    let vault = get_vault(env)?;
+    if caller != &admin && caller != &vault {
+        return Err(AdapterError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn require_reporter(env: &Env, caller: &Address) -> Result<(), AdapterError> {
+    caller.require_auth();
+    let admin = get_admin(env)?;
+    let vault = get_vault(env)?;
+    let custodian = get_custodian(env)?;
+    if caller != &admin && caller != &vault && caller != &custodian {
+        return Err(AdapterError::Unauthorized);
+    }
+    Ok(())
+}
+
+fn is_paused(env: &Env) -> bool {
+    env.storage()
+        .instance()
+        .get(&DataKey::Paused)
+        .unwrap_or(false)
+}
+
+fn require_not_paused(env: &Env) -> Result<(), AdapterError> {
+    if is_paused(env) {
+        return Err(AdapterError::Paused);
+    }
+    Ok(())
+}
+
+fn is_contract_address(addr: &Address) -> bool {
+    matches!(
+        AddressPayload::from_address(addr),
+        Some(AddressPayload::ContractIdHash(_))
+    )
+}
+
+fn require_contract_address(addr: &Address, err: AdapterError) -> Result<(), AdapterError> {
+    if is_contract_address(addr) {
+        Ok(())
+    } else {
+        Err(err)
+    }
+}
+
+fn extend_instance_ttl(env: &Env) {
+    env.storage()
+        .instance()
+        .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_TTL_EXTEND_TO);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
+    use soroban_sdk::{contract, contractimpl, IntoVal, Symbol};
+
+    const ADAPTER_SOURCE: &str = include_str!("lib.rs");
+
+    #[contract]
+    struct DummyContract;
+
+    #[contractimpl]
+    impl DummyContract {}
+
+    fn register_dummy_contract(env: &Env) -> Address {
+        env.register(DummyContract, ())
+    }
+
+    fn account_address(env: &Env) -> Address {
+        Address::from_str(
+            env,
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        )
+    }
+
+    fn setup_adapter(env: &Env) -> (Address, Address, Address, Address) {
+        let admin = account_address(env);
+        let vault = register_dummy_contract(env);
+        let custodian = Address::generate(env);
+        let contract_id = env.register(CustodialAdapterContract, (&admin, &vault, &custodian));
+        (contract_id, admin, vault, custodian)
+    }
+
+    fn token_balance(env: &Env, token: &Address, account: &Address) -> i128 {
+        soroban_sdk::token::Client::new(env, token).balance(account)
+    }
+
+    fn adapter_event_count(env: &Env, contract_id: &Address) -> usize {
+        env.events()
+            .all()
+            .filter_by_contract(contract_id)
+            .events()
+            .len()
+    }
+
+    fn empty_wasm_hash(env: &Env) -> BytesN<32> {
+        BytesN::from_array(
+            env,
+            &[
+                0xe3, 0xb0, 0xc4, 0x42, 0x98, 0xfc, 0x1c, 0x14, 0x9a, 0xfb, 0xf4, 0xc8, 0x99, 0x6f,
+                0xb9, 0x24, 0x27, 0xae, 0x41, 0xe4, 0x64, 0x9b, 0x93, 0x4c, 0xa4, 0x95, 0x99, 0x1b,
+                0x78, 0x52, 0xb8, 0x55,
+            ],
+        )
+    }
+
+    #[test]
+    fn constructor_sets_config_and_allows_account_custodian() {
+        let env = Env::default();
+        let (contract_id, admin, vault, custodian) = setup_adapter(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(CustodialAdapterContract::admin(env.clone()).unwrap(), admin);
+            assert_eq!(CustodialAdapterContract::vault(env.clone()).unwrap(), vault);
+            assert_eq!(
+                CustodialAdapterContract::custodian(env.clone()).unwrap(),
+                custodian
+            );
+        });
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_non_contract_vault() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let vault = account_address(&env);
+        let custodian = Address::generate(&env);
+        env.register(CustodialAdapterContract, (&admin, &vault, &custodian));
+    }
+
+    #[test]
+    #[should_panic(expected = "Error(Contract, #2)")]
+    fn constructor_rejects_custodian_equal_to_vault() {
+        let env = Env::default();
+        let admin = account_address(&env);
+        let vault = register_dummy_contract(&env);
+        env.register(CustodialAdapterContract, (&admin, &vault, &vault));
+    }
+
+    #[test]
+    fn supply_forwards_funds_and_reports_assets() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, custodian) = setup_adapter(&env);
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let asset = asset_sac.address();
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &1_000);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::supply(env.clone(), vault, asset.clone(), 750).unwrap();
+            assert_eq!(
+                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
+                750
+            );
+        });
+
+        assert_eq!(token_balance(&env, &asset, &custodian), 750);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 250);
+    }
+
+    #[test]
+    fn supply_requires_configured_vault() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, _vault, _custodian) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        let impostor = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::supply(env.clone(), impostor, asset, 1),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+    }
+
+    #[test]
+    fn supply_with_exact_vault_auth_transfers_adapter_funds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, custodian) = setup_adapter(&env);
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let asset = asset_sac.address();
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &1_000);
+
+        let args: soroban_sdk::Vec<soroban_sdk::Val> = (&vault, &asset, &750i128).into_val(&env);
+        env.mock_auths(&[MockAuth {
+            address: &vault,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "supply",
+                args: args.clone(),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = env.try_invoke_contract::<(), AdapterError>(
+            &contract_id,
+            &Symbol::new(&env, "supply"),
+            args,
+        );
+
+        assert_eq!(result, Ok(Ok(())));
+        assert_eq!(token_balance(&env, &asset, &custodian), 750);
+    }
+
+    #[test]
+    fn withdrawal_releases_only_returned_liquidity() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, custodian) = setup_adapter(&env);
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let asset = asset_sac.address();
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &1_000);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 1_000)
+                .unwrap();
+        });
+
+        asset_admin.mint(&custodian, &400);
+        let token = soroban_sdk::token::Client::new(&env, &asset);
+        token
+            .mock_all_auths()
+            .transfer(&custodian, &contract_id, &400);
+
+        env.as_contract(&contract_id, || {
+            let actual = CustodialAdapterContract::progress_withdrawal(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                700,
+            )
+            .unwrap();
+            assert_eq!(actual, 400);
+            assert_eq!(
+                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
+                600
+            );
+        });
+        assert_eq!(token_balance(&env, &asset, &vault), 400);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 0);
+    }
+
+    #[test]
+    fn withdrawal_requires_configured_vault() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, _vault, _custodian) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        let impostor = Address::generate(&env);
+
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(env.clone(), impostor, asset, 1),
+                Err(AdapterError::Unauthorized)
+            );
+        });
+    }
+
+    #[test]
+    fn withdrawal_with_exact_vault_auth_transfers_adapter_funds() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let asset = asset_sac.address();
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &500);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                500,
+            )
+            .unwrap();
+        });
+
+        let args: soroban_sdk::Vec<soroban_sdk::Val> = (&vault, &asset, &300i128).into_val(&env);
+        env.mock_auths(&[MockAuth {
+            address: &vault,
+            invoke: &MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "progress_withdrawal",
+                args: args.clone(),
+                sub_invokes: &[],
+            },
+        }]);
+        let result = env.try_invoke_contract::<i128, AdapterError>(
+            &contract_id,
+            &Symbol::new(&env, "progress_withdrawal"),
+            args,
+        );
+
+        assert_eq!(result, Ok(Ok(300)));
+        assert_eq!(token_balance(&env, &asset, &vault), 300);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
+                200
+            );
+        });
+    }
+
+    #[test]
+    fn withdrawal_fails_when_no_liquidity_has_returned() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let asset = asset_sac.address();
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                1_000,
+            )
+            .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            let result =
+                CustodialAdapterContract::progress_withdrawal(env.clone(), vault, asset, 100);
+            assert_eq!(result, Err(AdapterError::InsufficientReturnedLiquidity));
+        });
+    }
+
+    #[test]
+    fn withdrawal_does_not_exceed_reported_assets() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
+        let asset_sac = env.register_stellar_asset_contract_v2(Address::generate(&env));
+        let asset = asset_sac.address();
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+        asset_admin.mint(&contract_id, &1_000);
+
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_reported_assets(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                250,
+            )
+            .unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            let actual = CustodialAdapterContract::progress_withdrawal(
+                env.clone(),
+                vault.clone(),
+                asset.clone(),
+                500,
+            )
+            .unwrap();
+            assert_eq!(actual, 250);
+            assert_eq!(
+                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
+                0
+            );
+        });
+        assert_eq!(token_balance(&env, &asset, &vault), 250);
+        assert_eq!(token_balance(&env, &asset, &contract_id), 750);
+    }
+
+    #[test]
+    fn set_reported_assets_requires_admin_vault_or_custodian() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, vault, custodian) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        let impostor = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    impostor,
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Unauthorized)
+            );
+            CustodialAdapterContract::set_reported_assets(env.clone(), admin, asset.clone(), 9)
+                .unwrap();
+            CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset.clone(), 7)
+                .unwrap();
+            CustodialAdapterContract::set_reported_assets(env.clone(), custodian, asset.clone(), 5)
+                .unwrap();
+            assert_eq!(
+                CustodialAdapterContract::total_assets(env.clone(), asset.clone()),
+                5
+            );
+        });
+    }
+
+    #[test]
+    fn negative_or_zero_amounts_are_rejected() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 0),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    -1
+                ),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, -1),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+    }
+
+    #[test]
+    fn pause_blocks_supply_withdraw_and_report_updates() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, vault, _custodian) = setup_adapter(&env);
+        let asset = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_paused(env.clone(), admin, true).unwrap();
+            assert!(CustodialAdapterContract::paused(env.clone()));
+            assert_eq!(
+                CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 1),
+                Err(AdapterError::Paused)
+            );
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    1
+                ),
+                Err(AdapterError::Paused)
+            );
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(env.clone(), vault, asset, 1),
+                Err(AdapterError::Paused)
+            );
+        });
+    }
+
+    #[test]
+    fn set_admin_requires_pending_admin_acceptance() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, _vault, _custodian) = setup_adapter(&env);
+        let new_admin = Address::generate(&env);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_admin(env.clone(), admin.clone(), new_admin.clone())
+                .unwrap();
+            assert_eq!(CustodialAdapterContract::admin(env.clone()).unwrap(), admin);
+            assert_eq!(
+                CustodialAdapterContract::pending_admin(env.clone()).unwrap(),
+                new_admin
+            );
+            CustodialAdapterContract::accept_admin(env.clone(), new_admin.clone()).unwrap();
+            assert_eq!(
+                CustodialAdapterContract::admin(env.clone()).unwrap(),
+                new_admin
+            );
+            assert_eq!(
+                CustodialAdapterContract::pending_admin(env.clone()),
+                Err(AdapterError::MissingConfig)
+            );
+        });
+    }
+
+    #[test]
+    fn admin_events_and_upgrade_emit() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, admin, _vault, _custodian) = setup_adapter(&env);
+        let new_admin = Address::generate(&env);
+        let new_hash = empty_wasm_hash(&env);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::set_admin(env.clone(), admin.clone(), new_admin.clone())
+                .unwrap();
+            CustodialAdapterContract::accept_admin(env.clone(), new_admin.clone()).unwrap();
+        });
+        assert_eq!(adapter_event_count(&env, &contract_id), 2);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::upgrade(&env, new_hash, new_admin);
+        });
+        assert_eq!(adapter_event_count(&env, &contract_id), 1);
+    }
+
+    #[test]
+    fn no_public_custody_or_vault_retarget_entrypoints() {
+        assert!(!ADAPTER_SOURCE.contains(concat!("pub fn ", "set_custodian")));
+        assert!(!ADAPTER_SOURCE.contains(concat!("pub fn ", "set_vault")));
+        assert!(!ADAPTER_SOURCE.contains(concat!("pub fn ", "rescue")));
+    }
+
+    proptest! {
+        #[test]
+        fn withdrawal_model_never_overdraws(
+            reported in 0i128..=1_000_000_000_000i128,
+            idle in 0i128..=1_000_000_000_000i128,
+            requested in 1i128..=1_000_000_000_000i128,
+        ) {
+            let result = simulate_progress_withdrawal(reported, idle, requested);
+            if reported == 0 || idle == 0 {
+                prop_assert_eq!(result, Err(AdapterError::InsufficientReturnedLiquidity));
+            } else {
+                let (actual, next_reported) = result.expect("positive reported and idle should withdraw");
+                prop_assert!(actual > 0);
+                prop_assert!(actual <= reported);
+                prop_assert!(actual <= idle);
+                prop_assert!(actual <= requested);
+                prop_assert_eq!(next_reported, reported - actual);
+            }
+        }
+
+        #[test]
+        fn supply_then_withdraw_model_preserves_non_negative_report(
+            initial_reported in 0i128..=1_000_000_000i128,
+            supplied in 1i128..=1_000_000_000i128,
+            returned in 0i128..=1_000_000_000i128,
+            requested in 1i128..=1_000_000_000i128,
+        ) {
+            let reported = initial_reported + supplied;
+            let result = simulate_progress_withdrawal(reported, returned, requested);
+            if returned == 0 {
+                prop_assert_eq!(result, Err(AdapterError::InsufficientReturnedLiquidity));
+            } else {
+                let (actual, next_reported) = result.expect("returned liquidity should withdraw");
+                prop_assert_eq!(next_reported + actual, reported);
+                prop_assert!(next_reported >= 0);
+            }
+        }
+    }
+}

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -1519,10 +1519,7 @@ mod tests {
             }));
             assert!(result.is_err());
             assert_eq!(reported_assets(&env, &contract_id, &asset), 10);
-            assert_eq!(
-                has_reported_assets_key(&env, &contract_id, &unsupported),
-                false
-            );
+            assert!(!has_reported_assets_key(&env, &contract_id, &unsupported));
         }
     }
 

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -574,6 +574,11 @@ deploy-custodial-adapter custodian:
 		echo "Error: Vault not deployed. Run 'just deploy' first."; \
 		exit 1; \
 	fi; \
+	asset_token="${SOROBAN_ASSET_TOKEN:-$(cat {{state_dir}}/asset_token_id 2>/dev/null)}"; \
+	if [ -z "$asset_token" ]; then \
+		echo "Error: No asset token. Run 'just deploy-test-token' first or set SOROBAN_ASSET_TOKEN"; \
+		exit 1; \
+	fi; \
 	admin="${SOROBAN_ADAPTER_ADMIN:-$(cat {{state_dir}}/governance_id 2>/dev/null)}"; \
 	if [ -z "$admin" ]; then \
 		admin="$vault_id"; \
@@ -584,6 +589,7 @@ deploy-custodial-adapter custodian:
 	echo "  Admin:     $admin"; \
 	echo "  Vault:     $vault_id"; \
 	echo "  Custodian: {{custodian}}"; \
+	echo "  Asset:     $asset_token"; \
 	adapter_id=$(stellar contract deploy \
 		--wasm "$wasm" \
 		--network "$network" \
@@ -591,7 +597,8 @@ deploy-custodial-adapter custodian:
 		-- \
 		--admin "$admin" \
 		--vault "$vault_id" \
-		--custodian "{{custodian}}"); \
+		--custodian "{{custodian}}" \
+		--asset "$asset_token"); \
 	if [ -z "$adapter_id" ]; then \
 		echo "Error: deploy failed — no adapter ID returned"; \
 		exit 1; \

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -34,7 +34,9 @@ set dotenv-load := false
 #   SOROBAN_VIRTUAL_ASSETS   Initial virtual assets offset (default: 0)
 #   BLEND_ADAPTER_ID         Deployed Blend adapter contract ID
 #   BLEND_POOL_ID            Blend pool address
-#   SOROBAN_ADAPTER_ADMIN    Blend adapter admin contract (default: governance, then vault)
+#   SOROBAN_ADAPTER_ADMIN    Adapter admin contract/address (default: governance, then vault)
+#   CUSTODIAL_ADAPTER_ID     Deployed custodial adapter contract ID
+#   CUSTODIAL_ADDRESS        Custodian/multisig receiving allocated funds
 #
 # =============================================================================
 
@@ -49,6 +51,7 @@ remap_rustflags := "--remap-path-prefix " + root + "=/workspace --remap-path-pre
 soroban_rust_toolchain := env_var_or_default("SOROBAN_RUST_TOOLCHAIN", "1.89.0")
 default_wasm := optimized_wasm
 blend_adapter_wasm := wasm_dir + "/templar_soroban_blend_adapter.wasm"
+custodial_adapter_wasm := wasm_dir + "/templar_soroban_custodial_adapter.wasm"
 governance_wasm := wasm_dir + "/templar_soroban_governance.wasm"
 share_token_wasm := wasm_dir + "/templar_soroban_share_token.wasm"
 payload_script := justfile_directory() + "/scripts/vault_payload.py"
@@ -82,6 +85,7 @@ deploy-all: _ensure-setup build deploy-test-token deploy deploy-share-token depl
 	@echo ""
 	@echo "Run: just demo-deposit"
 	@echo "For Blend integration: just deploy-blend-adapter"
+	@echo "For custodial integration: just deploy-custodial-adapter <custodian>"
 
 # Deploy everything including Blend adapter for yield strategies.
 # NOTE: Blend integration requires allowed-adapter and supply-queue governance after deployment.
@@ -89,6 +93,15 @@ deploy-all-with-blend pool_address: _ensure-setup build build-blend-adapter depl
 	@just deploy-blend-adapter "{{pool_address}}"
 	@echo ""
 	@echo "✓ Full deployment with Blend adapter complete!"
+	@echo "NOTE: Run set-allowed-adapters and set-supply-queue before allocation."
+	@just status
+
+# Deploy everything including custodial adapter for offchain-managed market routing.
+# NOTE: Custodial integration requires allowed-adapter and supply-queue governance after deployment.
+deploy-all-with-custodial custodian: _ensure-setup build build-custodial-adapter deploy-test-token deploy deploy-share-token deploy-governance init
+	@just deploy-custodial-adapter "{{custodian}}"
+	@echo ""
+	@echo "✓ Full deployment with custodial adapter complete!"
 	@echo "NOTE: Run set-allowed-adapters and set-supply-queue before allocation."
 	@just status
 
@@ -132,6 +145,12 @@ build-blend-adapter:
 	@just -f "{{justfile_directory()}}/justfile" _optimize-wasm templar-soroban-blend-adapter "{{wasm_dir}}/templar_soroban_blend_adapter.wasm"
 	@echo "✓ Built: {{blend_adapter_wasm}}"
 
+# Build and optimize the custodial adapter WASM.
+build-custodial-adapter:
+	@echo "Building custodial adapter WASM..."
+	@just -f "{{justfile_directory()}}/justfile" _optimize-wasm templar-soroban-custodial-adapter "{{wasm_dir}}/templar_soroban_custodial_adapter.wasm"
+	@echo "✓ Built: {{custodial_adapter_wasm}}"
+
 # Check the Soroban ERC-4626 proxy crate.
 check-4626-proxy:
 	@echo "Checking Soroban ERC-4626 proxy crate..."
@@ -141,8 +160,8 @@ check-4626-proxy:
 		-p templar-4626-proxy-soroban
 	@echo "✓ Checked: templar-4626-proxy-soroban"
 
-# Build all WASMs (vault + governance + share token + blend adapter).
-build-all: build build-blend-adapter
+# Build all WASMs (vault + governance + share token + adapters).
+build-all: build build-blend-adapter build-custodial-adapter
 	@echo "✓ All contracts built"
 
 # Build debug WASM, emit twiggy reports, and print them.
@@ -204,6 +223,10 @@ deploy-wasm-path:
 # Print the Blend adapter WASM path.
 blend-adapter-wasm-path:
 	@echo "{{blend_adapter_wasm}}"
+
+# Print the custodial adapter WASM path.
+custodial-adapter-wasm-path:
+	@echo "{{custodial_adapter_wasm}}"
 
 # Print the governance WASM path.
 governance-wasm-path:
@@ -536,6 +559,101 @@ deploy-blend-adapter pool_address:
 	mkdir -p "{{state_dir}}"; \
 	echo "$adapter_id" > "{{state_dir}}/blend_adapter_id"; \
 	echo "{{pool_address}}" > "{{state_dir}}/blend_pool_id"
+
+# Deploy the custodial adapter contract.
+# Requires: vault must be deployed first, custodian is the multisig/address receiving allocated funds.
+deploy-custodial-adapter custodian:
+	@wasm="${CUSTODIAL_ADAPTER_WASM:-{{custodial_adapter_wasm}}}"; \
+	if [ ! -f "$wasm" ]; then \
+		echo "Error: custodial adapter WASM not found at $wasm"; \
+		echo "Run: just build-custodial-adapter"; \
+		exit 1; \
+	fi; \
+	vault_id="${SOROBAN_CONTRACT_ID:-$(cat {{state_dir}}/vault_id 2>/dev/null)}"; \
+	if [ -z "$vault_id" ]; then \
+		echo "Error: Vault not deployed. Run 'just deploy' first."; \
+		exit 1; \
+	fi; \
+	admin="${SOROBAN_ADAPTER_ADMIN:-$(cat {{state_dir}}/governance_id 2>/dev/null)}"; \
+	if [ -z "$admin" ]; then \
+		admin="$vault_id"; \
+	fi; \
+	network="${SOROBAN_NETWORK:-{{default_network}}}"; \
+	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
+	echo "Deploying custodial adapter..."; \
+	echo "  Admin:     $admin"; \
+	echo "  Vault:     $vault_id"; \
+	echo "  Custodian: {{custodian}}"; \
+	adapter_id=$(stellar contract deploy \
+		--wasm "$wasm" \
+		--network "$network" \
+		--source-account "$source" \
+		-- \
+		--admin "$admin" \
+		--vault "$vault_id" \
+		--custodian "{{custodian}}"); \
+	if [ -z "$adapter_id" ]; then \
+		echo "Error: deploy failed — no adapter ID returned"; \
+		exit 1; \
+	fi; \
+	echo "✓ Custodial adapter deployed: $adapter_id"; \
+	mkdir -p "{{state_dir}}"; \
+	echo "$adapter_id" > "{{state_dir}}/custodial_adapter_id"; \
+	echo "{{custodian}}" > "{{state_dir}}/custodial_address"
+
+# Invoke a function on the custodial adapter contract.
+custodial-invoke *args:
+	@adapter_id="${CUSTODIAL_ADAPTER_ID:-$(cat {{state_dir}}/custodial_adapter_id 2>/dev/null)}"; \
+	if [ -z "$adapter_id" ]; then \
+		echo "Error: custodial adapter not deployed."; \
+		exit 1; \
+	fi; \
+	network="${SOROBAN_NETWORK:-{{default_network}}}"; \
+	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
+	stellar contract invoke \
+		--id "$adapter_id" \
+		--network "$network" \
+		--source-account "$source" \
+		-- {{args}}
+
+# Get custodial adapter admin.
+custodial-adapter-admin:
+	@just custodial-invoke admin
+
+# Get custodial adapter's configured vault.
+custodial-adapter-vault:
+	@just custodial-invoke vault
+
+# Get custodial adapter's configured custodian.
+custodial-adapter-custodian:
+	@just custodial-invoke custodian
+
+# Get reported assets for the underlying asset token via custodial adapter.
+custodial-adapter-total-assets asset_address:
+	@just custodial-invoke total_assets --asset "{{asset_address}}"
+
+# Set reported assets for an offchain-managed position.
+# caller must be the configured admin, vault, or custodian and must authorize the call.
+custodial-adapter-set-reported-assets caller asset_address amount:
+	@just custodial-invoke set_reported_assets \
+		--caller "{{caller}}" \
+		--asset "{{asset_address}}" \
+		--amount "{{amount}}"
+
+# Show custodial adapter status.
+custodial-adapter-status:
+	@echo "=== Custodial Adapter Status ==="
+	@adapter_id="$(cat {{state_dir}}/custodial_adapter_id 2>/dev/null || echo 'not deployed')"; \
+	echo "Adapter ID: $adapter_id"
+	@if [ -f "{{state_dir}}/custodial_adapter_id" ]; then \
+		echo "Admin:     $(just custodial-invoke admin 2>/dev/null || echo 'error')"; \
+		echo "Vault:     $(just custodial-invoke vault 2>/dev/null || echo 'error')"; \
+		echo "Custodian: $(just custodial-invoke custodian 2>/dev/null || echo 'error')"; \
+		asset="${SOROBAN_ASSET_TOKEN:-$(cat {{state_dir}}/asset_token_id 2>/dev/null)}"; \
+		if [ -n "$asset" ]; then \
+			echo "Reported:  $(just custodial-invoke total_assets --asset "$asset" 2>/dev/null || echo 'error')"; \
+		fi; \
+	fi
 
 # Invoke a function on the Blend adapter contract.
 blend-invoke *args:
@@ -1096,6 +1214,8 @@ status:
 	@echo "Admin:         $(cat {{state_dir}}/admin_address 2>/dev/null || echo 'not set')"
 	@echo "Blend Adapter: $(cat {{state_dir}}/blend_adapter_id 2>/dev/null || echo 'not deployed')"
 	@echo "Blend Pool:    $(cat {{state_dir}}/blend_pool_id 2>/dev/null || echo 'not set')"
+	@echo "Custodial Adapter: $(cat {{state_dir}}/custodial_adapter_id 2>/dev/null || echo 'not deployed')"
+	@echo "Custodian:     $(cat {{state_dir}}/custodial_address 2>/dev/null || echo 'not set')"
 	@echo ""
 	@if [ -f "{{state_dir}}/vault_id" ]; then \
 		echo "Vault state:"; \
@@ -1128,6 +1248,8 @@ export-env:
 	@echo "SOROBAN_ADMIN=$(cat {{state_dir}}/admin_address 2>/dev/null || echo '')"
 	@echo "BLEND_ADAPTER_ID=$(cat {{state_dir}}/blend_adapter_id 2>/dev/null || echo '')"
 	@echo "BLEND_POOL_ID=$(cat {{state_dir}}/blend_pool_id 2>/dev/null || echo '')"
+	@echo "CUSTODIAL_ADAPTER_ID=$(cat {{state_dir}}/custodial_adapter_id 2>/dev/null || echo '')"
+	@echo "CUSTODIAL_ADDRESS=$(cat {{state_dir}}/custodial_address 2>/dev/null || echo '')"
 
 # Internal: Ensure setup is complete.
 _ensure-setup:
@@ -1150,6 +1272,7 @@ help:
 	@echo "  just setup                    Full setup (build, network, keys, fund)"
 	@echo "  just deploy-all               Deploy vault + share token + governance + test token, initialize"
 	@echo "  just deploy-all-with-blend <pool>  Deploy with Blend adapter"
+	@echo "  just deploy-all-with-custodial <custodian>  Deploy with custodial adapter"
 	@echo "  just demo-deposit             Run deposit demonstration"
 	@echo "  just demo-withdraw            Run withdrawal demonstration"
 	@echo "  just demo-e2e-full            Run full e2e flow"
@@ -1157,6 +1280,7 @@ help:
 	@echo "BUILD:"
 	@echo "  just build                    Build vault WASM"
 	@echo "  just build-blend-adapter      Build Blend adapter WASM"
+	@echo "  just build-custodial-adapter  Build custodial adapter WASM"
 	@echo "  just build-all                Build all WASMs"
 	@echo "  just wasm-analyze [rows]      Generate twiggy analysis reports"
 	@echo "  just wasm-analyze-print [report] [lines]  Print analysis reports"
@@ -1184,6 +1308,12 @@ help:
 	@echo "  just fund-adapter <amount>       Transfer tokens to adapter (manual)"
 	@echo "  just blend-adapter-set-admin <admin_contract>"
 	@echo "  just demo-e2e-blend              Full Blend integration e2e"
+	@echo ""
+	@echo "CUSTODIAL ADAPTER:"
+	@echo "  just deploy-custodial-adapter <custodian>  Deploy adapter for offchain custody route"
+	@echo "  just custodial-adapter-status              Show adapter status"
+	@echo "  just custodial-adapter-total-assets <asset>  Query reported position"
+	@echo "  just custodial-adapter-set-reported-assets <caller> <asset> <amount>"
 	@echo ""
 	@echo "DEPOSITS:"
 	@echo "  just deposit <owner> <receiver> <assets> [min_shares]"

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -634,11 +634,13 @@ custodial-adapter-total-assets asset_address:
 
 # Set reported assets for an offchain-managed position.
 # caller must be the configured admin, vault, or custodian and must authorize the call.
-custodial-adapter-set-reported-assets caller asset_address amount:
+custodial-adapter-set-reported-assets caller asset_address expected_current amount report_nonce:
 	@just custodial-invoke set_reported_assets \
 		--caller "{{caller}}" \
 		--asset "{{asset_address}}" \
-		--amount "{{amount}}"
+		--expected_current "{{expected_current}}" \
+		--amount "{{amount}}" \
+		--report_nonce "{{report_nonce}}"
 
 # Show custodial adapter status.
 custodial-adapter-status:
@@ -1313,7 +1315,7 @@ help:
 	@echo "  just deploy-custodial-adapter <custodian>  Deploy adapter for offchain custody route"
 	@echo "  just custodial-adapter-status              Show adapter status"
 	@echo "  just custodial-adapter-total-assets <asset>  Query reported position"
-	@echo "  just custodial-adapter-set-reported-assets <caller> <asset> <amount>"
+	@echo "  just custodial-adapter-set-reported-assets <caller> <asset> <expected_current> <amount> <report_nonce>"
 	@echo ""
 	@echo "DEPOSITS:"
 	@echo "  just deposit <owner> <receiver> <assets> [min_shares]"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ templar-common = { workspace = true, features = ["non-contract-usage"] }
 templar-vault-kernel = { path = "../contract/vault/kernel", features = ["postcard", "soroban"] }
 templar-curator-primitives = { path = "../contract/vault/curator-primitives", features = ["postcard"] }
 templar-soroban-runtime = { path = "../contract/vault/soroban", features = ["testutils"] }
+templar-soroban-custodial-adapter = { path = "../contract/vault/soroban/custodial-adapter", features = ["testutils"] }
 
 [lints]
 workspace = true
@@ -144,5 +145,11 @@ bench = false
 [[bin]]
 name = "fuzz_snapshot"
 path = "fuzz_targets/fuzz_snapshot.rs"
+test = false
+bench = false
+
+[[bin]]
+name = "fuzz_soroban_custodial_adapter"
+path = "fuzz_targets/fuzz_soroban_custodial_adapter.rs"
 test = false
 bench = false

--- a/fuzz/fuzz_targets/fuzz_soroban_custodial_adapter.rs
+++ b/fuzz/fuzz_targets/fuzz_soroban_custodial_adapter.rs
@@ -1,0 +1,41 @@
+#![no_main]
+
+use arbitrary::Arbitrary;
+use libfuzzer_sys::fuzz_target;
+use templar_soroban_custodial_adapter::{simulate_progress_withdrawal, AdapterError};
+
+#[derive(Arbitrary, Debug)]
+struct CustodialAdapterInput {
+    reported: i128,
+    idle_balance: i128,
+    requested: i128,
+}
+
+fn bounded_non_negative(value: i128) -> i128 {
+    value.saturating_abs() % 1_000_000_000_000_000_000
+}
+
+fuzz_target!(|input: CustodialAdapterInput| {
+    let reported = bounded_non_negative(input.reported);
+    let idle_balance = bounded_non_negative(input.idle_balance);
+    let requested = bounded_non_negative(input.requested);
+    let result = simulate_progress_withdrawal(reported, idle_balance, requested);
+
+    if requested == 0 {
+        assert_eq!(result, Err(AdapterError::InvalidInput));
+        return;
+    }
+
+    if reported == 0 || idle_balance == 0 {
+        assert_eq!(result, Err(AdapterError::InsufficientReturnedLiquidity));
+        return;
+    }
+
+    let (actual, next_reported) = result.expect("positive inputs should withdraw");
+    assert!(actual > 0);
+    assert!(actual <= reported);
+    assert!(actual <= idle_balance);
+    assert!(actual <= requested);
+    assert_eq!(next_reported + actual, reported);
+    assert!(next_reported >= 0);
+});

--- a/fuzz/fuzz_targets/fuzz_soroban_custodial_adapter.rs
+++ b/fuzz/fuzz_targets/fuzz_soroban_custodial_adapter.rs
@@ -11,17 +11,17 @@ struct CustodialAdapterInput {
     requested: i128,
 }
 
-fn bounded_non_negative(value: i128) -> i128 {
-    value.saturating_abs() % 1_000_000_000_000_000_000
+fn bounded(value: i128) -> i128 {
+    value % 1_000_000_000_000_000_000
 }
 
 fuzz_target!(|input: CustodialAdapterInput| {
-    let reported = bounded_non_negative(input.reported);
-    let idle_balance = bounded_non_negative(input.idle_balance);
-    let requested = bounded_non_negative(input.requested);
+    let reported = bounded(input.reported);
+    let idle_balance = bounded(input.idle_balance);
+    let requested = bounded(input.requested);
     let result = simulate_progress_withdrawal(reported, idle_balance, requested);
 
-    if requested == 0 {
+    if requested <= 0 || reported < 0 || idle_balance < 0 {
         assert_eq!(result, Err(AdapterError::InvalidInput));
         return;
     }

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -356,7 +356,9 @@ stellar contract invoke \
 For custodial adapters, use `deploy adapters --custodian <address>` to append custodial routes,
 then allow the deployed adapter and add it to the supply queue before allocating to it. Each
 custodial adapter is bound to the manifest asset token at deployment and rejects calls for any
-other asset. The custodian, adapter admin, or vault can explicitly report route NAV on the adapter:
+other asset. The custodian, adapter admin, or vault can explicitly report route NAV on the adapter.
+Reports include the current stored NAV and a monotonically increasing nonce so stale heartbeats
+cannot re-add assets that have already been released back to the vault:
 
 ```sh
 stellar contract invoke \
@@ -365,7 +367,9 @@ stellar contract invoke \
   -- set_reported_assets \
   --caller GCUSTODIAN... \
   --asset CASSET... \
-  --amount 1000000000
+  --expected_current 800000000 \
+  --amount 1000000000 \
+  --report_nonce 42
 ```
 
 ## Safety

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -540,10 +540,14 @@ tmplr-soroban-vault export-env
 `export-env` emits `BLEND_ADAPTER_ID` for the first adapter for compatibility, plus indexed
 `BLEND_ADAPTER_0_ID`, `BLEND_ADAPTER_1_ID`, and matching `BLEND_POOL_0_ID` values when pool
 constructor args are known. Custodial adapters use the same pattern with `CUSTODIAL_ADAPTER_ID`,
-`CUSTODIAL_ADAPTER_0_ID`, matching `CUSTODIAL_ADDRESS` / `CUSTODIAL_0_ADDRESS`, and
-`CUSTODIAL_0_ASSET` values when constructor args are known.
+`CUSTODIAL_ADAPTER_0_ID`, matching indexed `CUSTODIAL_0_ADDRESS`, and `CUSTODIAL_0_ASSET` values
+when constructor args are known. The unindexed `CUSTODIAL_ADDRESS` name is reserved for explicit
+deploy input and is not emitted by `export-env`.
 
 `extend-ttl` runs the vault compact `ExtendTtl` command, governance `extend_ttl`, ERC-4626 proxy
 `extend_ttl`, curator proxy `extend_ttl`, share-token `extend_ttl --caller`, and each Blend adapter
-or custodial adapter `extend_ttl --caller`. Manifest contracts without an explicit deployment-wide
-TTL entrypoint, such as the asset token, are reported as skipped.
+`extend_ttl --caller`. Custodial adapters are extended only when the selected caller matches the
+recorded adapter admin; governance-admin custodial adapters are reported as skipped because the
+current governance contract does not expose an adapter TTL forwarding entrypoint. Manifest contracts
+without an explicit deployment-wide TTL entrypoint, such as the asset token, are reported as
+skipped.

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -62,25 +62,30 @@ and RPC later reports success, the CLI treats the transaction as confirmed and r
 Pass `--blend-pool` once per Blend pool to deploy one adapter per pool. The manifest stores these
 as `blend_adapter_0`, `blend_adapter_1`, and so on. On an existing deployment, new pools are
 appended and pools already present in the manifest are left unchanged unless `--force-new` is set.
+Pass `--custodian` once per custodian or multisig address to deploy custodial adapters in the same
+flow. The manifest stores these as `custodial_adapter_0`, `custodial_adapter_1`, and so on, with
+the `admin`, `vault`, and `custodian` constructor args recorded for reconciliation and status.
 
 ```sh
 tmplr-soroban-vault deploy stack \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
-  --blend-pool CPOOL2...
+  --blend-pool CPOOL2... \
+  --custodian G...
 ```
 
 To add adapters later without redeploying the stack, use `deploy adapters`. If the manifest already
-contains `vault` and `governance`, only the Blend adapter WASM and new adapter instances are touched.
-For imported deployments, pass the existing contract ids once and the CLI records them in the
-manifest before appending adapters.
+contains `vault` and `governance`, only the requested adapter WASM and new adapter instances are
+touched. For imported deployments, pass the existing contract ids once and the CLI records them in
+the manifest before appending adapters.
 
 ```sh
 tmplr-soroban-vault deploy adapters \
   --vault CVAULT... \
   --governance CGOV... \
   --asset-token CASSET... \
-  --blend-pool CPOOL...
+  --blend-pool CPOOL... \
+  --custodian G...
 ```
 
 Use `deploy plan` to inspect reuse, upload, deploy, and manifest decisions without network writes or
@@ -89,12 +94,14 @@ manifest changes:
 ```sh
 tmplr-soroban-vault deploy plan stack \
   --governance-timelock-ns 86400000000000 \
-  --blend-pool CPOOL...
+  --blend-pool CPOOL... \
+  --custodian G...
 
 tmplr-soroban-vault deploy plan adapters \
   --vault CVAULT... \
   --governance CGOV... \
-  --blend-pool CPOOL...
+  --blend-pool CPOOL... \
+  --custodian G...
 ```
 
 Recover an interrupted deployment by reconciling first, then resuming if the repair plan reports
@@ -106,7 +113,8 @@ tmplr-soroban-vault reconcile --skip-view-verification --json
 tmplr-soroban-vault deploy repair --json
 tmplr-soroban-vault deploy resume \
   --governance-timelock-ns 86400000000000 \
-  --blend-pool CPOOL...
+  --blend-pool CPOOL... \
+  --custodian G...
 ```
 
 The CLI validates Soroban account and contract addresses at parse time for operational commands.
@@ -279,9 +287,11 @@ tmplr-soroban-vault export-env
 
 `export-env` emits `BLEND_ADAPTER_ID` for the first adapter for compatibility, plus indexed
 `BLEND_ADAPTER_0_ID`, `BLEND_ADAPTER_1_ID`, and matching `BLEND_POOL_0_ID` values when pool
+constructor args are known. Custodial adapters use the same pattern with `CUSTODIAL_ADAPTER_ID`,
+`CUSTODIAL_ADAPTER_0_ID`, and matching `CUSTODIAL_ADDRESS` / `CUSTODIAL_0_ADDRESS` values when
 constructor args are known.
 
 `extend-ttl` runs the vault compact `ExtendTtl` command, governance `extend_ttl`, ERC-4626 proxy
 `extend_ttl`, curator proxy `extend_ttl`, share-token `extend_ttl --caller`, and each Blend adapter
-`extend_ttl --caller`. Manifest contracts without an explicit deployment-wide TTL entrypoint, such
-as the asset token, are reported as skipped.
+or custodial adapter `extend_ttl --caller`. Manifest contracts without an explicit deployment-wide
+TTL entrypoint, such as the asset token, are reported as skipped.

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -64,7 +64,9 @@ as `blend_adapter_0`, `blend_adapter_1`, and so on. On an existing deployment, n
 appended and pools already present in the manifest are left unchanged unless `--force-new` is set.
 Pass `--custodian` once per custodian or multisig address to deploy custodial adapters in the same
 flow. The manifest stores these as `custodial_adapter_0`, `custodial_adapter_1`, and so on, with
-the `admin`, `vault`, and `custodian` constructor args recorded for reconciliation and status.
+the `admin`, `vault`, `custodian`, and bound `asset` constructor args recorded for reconciliation
+and status. Custodial adapters are single-asset; `deploy adapters --custodian ...` requires
+`asset_token` in the manifest or `--asset-token`.
 
 ```sh
 tmplr-soroban-vault deploy stack \
@@ -352,8 +354,9 @@ stellar contract invoke \
 ```
 
 For custodial adapters, use `deploy adapters --custodian <address>` to append custodial routes,
-then allow the deployed adapter and add it to the supply queue before allocating to it. The
-custodian, adapter admin, or vault can explicitly report market NAV on the adapter:
+then allow the deployed adapter and add it to the supply queue before allocating to it. Each
+custodial adapter is bound to the manifest asset token at deployment and rejects calls for any
+other asset. The custodian, adapter admin, or vault can explicitly report route NAV on the adapter:
 
 ```sh
 stellar contract invoke \
@@ -533,8 +536,8 @@ tmplr-soroban-vault export-env
 `export-env` emits `BLEND_ADAPTER_ID` for the first adapter for compatibility, plus indexed
 `BLEND_ADAPTER_0_ID`, `BLEND_ADAPTER_1_ID`, and matching `BLEND_POOL_0_ID` values when pool
 constructor args are known. Custodial adapters use the same pattern with `CUSTODIAL_ADAPTER_ID`,
-`CUSTODIAL_ADAPTER_0_ID`, and matching `CUSTODIAL_ADDRESS` / `CUSTODIAL_0_ADDRESS` values when
-constructor args are known.
+`CUSTODIAL_ADAPTER_0_ID`, matching `CUSTODIAL_ADDRESS` / `CUSTODIAL_0_ADDRESS`, and
+`CUSTODIAL_0_ASSET` values when constructor args are known.
 
 `extend-ttl` runs the vault compact `ExtendTtl` command, governance `extend_ttl`, ERC-4626 proxy
 `extend_ttl`, curator proxy `extend_ttl`, share-token `extend_ttl --caller`, and each Blend adapter

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -120,6 +120,251 @@ tmplr-soroban-vault deploy resume \
 The CLI validates Soroban account and contract addresses at parse time for operational commands.
 WASM hashes accepted by governance upgrade commands must be 32-byte hex values.
 
+## Curator Role Models
+
+The CLI uses the contract name `governance admin` for the address that controls the governance
+contract, but operationally that address can represent several curator models. It can be a single
+operator key, a multisig contract, or a governance contract controlled by an external process. A new
+stack uses `--admin` as both the governance admin and the initial vault curator. After deployment,
+governance proposals can split that into separate curator, sentinel, and allocator identities.
+
+Common role terms:
+
+- `governance admin`: the address passed as `--admin` on governance commands. It submits and accepts
+  governance proposals. For multisig governance, this is the multisig contract address.
+- `vault curator`: the runtime curator address. It starts as the deployment `--admin` and can be
+  changed with `governance submit-set-curator`.
+- `sentinel`: an emergency backstop configured with `governance submit-set-sentinel`. It can only
+  take protective actions such as pausing or tightening restrictions; governance admin is still
+  required to relax or unpause.
+- `allocator`: one or more addresses configured with `governance submit-set-allocators`. Allocators
+  run market allocation and refresh operations. The vault curator is always authorized as an
+  allocator too.
+- `adapter`: a market route such as a Blend adapter or custodial adapter. The governance admin must
+  allow adapters and place them into the typed supply queue before allocations can route through
+  them.
+
+For timelocked deployments, submit commands create proposals and `accept-ready` accepts them only
+after the relevant timelock has elapsed. Use `governance queue` and `governance explain` to inspect
+pending proposal ids and readiness.
+
+### Single Curator
+
+Use this model when one operational address controls governance and day-to-day allocation. This is
+the simplest testnet or custodial setup.
+
+```sh
+tmplr-soroban-vault deploy stack \
+  --admin GCURATOR... \
+  --governance-timelock-ns 86400000000000 \
+  --blend-pool CPOOL...
+
+tmplr-soroban-vault governance submit-set-allowed-adapters \
+  --admin GCURATOR... \
+  --adapters CBLENDADAPTER...
+tmplr-soroban-vault governance accept-ready --admin GCURATOR... --kind allowed-adapters
+
+tmplr-soroban-vault governance submit-set-supply-queue \
+  --admin GCURATOR... \
+  --entry 0:CBLENDADAPTER...
+tmplr-soroban-vault governance accept-ready --admin GCURATOR... --kind supply-queue
+
+tmplr-soroban-vault curator allocate-supply \
+  --caller GCURATOR... \
+  --market 0 \
+  --amount 1.25 \
+  --asset-decimals 7
+```
+
+For zero-timelock local deployments, the curator convenience commands can submit and immediately
+accept adapter setup:
+
+```sh
+tmplr-soroban-vault curator set-allowed-adapters \
+  --admin GCURATOR... \
+  --adapters CBLENDADAPTER... \
+  --auto-accept
+tmplr-soroban-vault curator set-supply-queue \
+  --admin GCURATOR... \
+  --entry 0:CBLENDADAPTER... \
+  --auto-accept
+```
+
+### Multisig Governance Curator
+
+Use this model when the curator is decentralized and governance actions are controlled by a multisig
+or governance contract. Deploy with the multisig as `--admin`; the CLI treats that address as the
+governance caller, while the Stellar source account supplies the transaction envelope.
+
+```sh
+tmplr-soroban-vault deploy stack \
+  --admin CMULTISIG... \
+  --governance-timelock-ns 86400000000000 \
+  --blend-pool CPOOL...
+
+tmplr-soroban-vault governance plan-submit-set-supply-queue \
+  --admin CMULTISIG... \
+  --entry 0:CBLENDADAPTER...
+```
+
+When the multisig can authorize the child invocation directly, submit and accept through the CLI:
+
+```sh
+tmplr-soroban-vault governance submit-set-allowed-adapters \
+  --admin CMULTISIG... \
+  --adapters CBLENDADAPTER...
+tmplr-soroban-vault governance queue --kind allowed-adapters
+tmplr-soroban-vault governance accept-ready --admin CMULTISIG... --kind allowed-adapters
+```
+
+If the multisig requires a separate proposal flow, use the `plan-*`, `queue`, `explain`, and
+`pending` commands to prepare and audit the intended action, then submit the equivalent invocation
+through the multisig workflow.
+
+### Curator With Sentinel
+
+Use this model when a separate emergency key or contract can pause the vault or tighten transfer
+restrictions, while normal governance remains with the governance admin.
+
+```sh
+tmplr-soroban-vault governance submit-set-sentinel \
+  --admin GCURATOR_OR_MULTISIG... \
+  --sentinel GSENTINEL...
+tmplr-soroban-vault governance accept-ready --admin GCURATOR_OR_MULTISIG... --kind sentinel
+```
+
+Governance-admin pause and restriction changes use the normal timelocked proposal path:
+
+```sh
+tmplr-soroban-vault governance submit-set-paused \
+  --admin GCURATOR_OR_MULTISIG... \
+  --paused true
+tmplr-soroban-vault governance submit-set-restrictions \
+  --admin GCURATOR_OR_MULTISIG... \
+  --mode blacklist \
+  --accounts GACCOUNT...
+```
+
+Sentinel emergency actions are immediate governance-contract entrypoints. They bypass the proposal
+queue and are intentionally one-way: the sentinel can pause or tighten restrictions, but cannot
+unpause or relax restrictions. Use `stellar contract invoke` with the same network/profile
+environment as the vault CLI:
+
+```sh
+stellar contract invoke \
+  --id "$SOROBAN_GOVERNANCE" \
+  --source-account sentinel \
+  -- set_paused \
+  --caller GSENTINEL... \
+  --paused true
+
+stellar contract invoke \
+  --id "$SOROBAN_GOVERNANCE" \
+  --source-account sentinel \
+  -- set_restrictions \
+  --caller GSENTINEL... \
+  --mode 1 \
+  --accounts '["GACCOUNT..."]'
+```
+
+The governance admin restores normal operation:
+
+```sh
+tmplr-soroban-vault governance submit-set-paused \
+  --admin GCURATOR_OR_MULTISIG... \
+  --paused false
+tmplr-soroban-vault governance accept-ready --admin GCURATOR_OR_MULTISIG... --kind pause
+```
+
+### Curator With Allocators
+
+Use this model when governance is retained by the curator or multisig, but allocation execution is
+delegated to one or more hot or automated addresses. Configure allocators through governance, then
+use the allocator address as the `--caller` for market operations.
+
+```sh
+tmplr-soroban-vault governance submit-set-allocators \
+  --admin GCURATOR_OR_MULTISIG... \
+  --allocators GALLOCATOR1...,GALLOCATOR2...
+tmplr-soroban-vault governance accept-ready --admin GCURATOR_OR_MULTISIG... --kind allocators
+
+tmplr-soroban-vault curator refresh-markets \
+  --caller GALLOCATOR1... \
+  --markets 0,1
+tmplr-soroban-vault curator allocate-supply \
+  --caller GALLOCATOR1... \
+  --market 0 \
+  --amount 100 \
+  --asset-decimals 7
+tmplr-soroban-vault curator allocate-withdraw \
+  --caller GALLOCATOR1... \
+  --market 0 \
+  --amount 25 \
+  --asset-decimals 7
+```
+
+### Curator With Sentinel And Allocators
+
+Use this model for a more separated production setup: governance admin or multisig controls policy,
+allocator keys execute routine market operations, and a sentinel key or contract handles emergency
+pause/restriction tightening.
+
+```sh
+tmplr-soroban-vault deploy stack \
+  --admin GCURATOR_OR_MULTISIG... \
+  --governance-timelock-ns 86400000000000 \
+  --blend-pool CPOOL... \
+  --custodian GCUSTODIAN...
+
+tmplr-soroban-vault governance submit-set-sentinel \
+  --admin GCURATOR_OR_MULTISIG... \
+  --sentinel GSENTINEL...
+tmplr-soroban-vault governance submit-set-allocators \
+  --admin GCURATOR_OR_MULTISIG... \
+  --allocators GALLOCATOR1...,GALLOCATOR2...
+tmplr-soroban-vault governance submit-set-allowed-adapters \
+  --admin GCURATOR_OR_MULTISIG... \
+  --adapters CBLENDADAPTER...,CCUSTODIALADAPTER...
+tmplr-soroban-vault governance submit-set-supply-queue \
+  --admin GCURATOR_OR_MULTISIG... \
+  --entry 0:CBLENDADAPTER... \
+  --entry 1:CCUSTODIALADAPTER...
+
+tmplr-soroban-vault governance queue
+tmplr-soroban-vault governance accept-ready --admin GCURATOR_OR_MULTISIG...
+```
+
+After setup, allocators operate the supply queue and sentinel handles emergencies:
+
+```sh
+tmplr-soroban-vault curator allocate-supply \
+  --caller GALLOCATOR1... \
+  --market 1 \
+  --amount 1000 \
+  --asset-decimals 7
+
+stellar contract invoke \
+  --id "$SOROBAN_GOVERNANCE" \
+  --source-account sentinel \
+  -- set_paused \
+  --caller GSENTINEL... \
+  --paused true
+```
+
+For custodial adapters, use `deploy adapters --custodian <address>` to append custodial routes,
+then allow the deployed adapter and add it to the supply queue before allocating to it. The
+custodian, adapter admin, or vault can explicitly report market NAV on the adapter:
+
+```sh
+stellar contract invoke \
+  --id "$CUSTODIAL_ADAPTER_ID" \
+  --source-account custodian \
+  -- set_reported_assets \
+  --caller GCUSTODIAN... \
+  --asset CASSET... \
+  --amount 1000000000
+```
+
 ## Safety
 
 - Mainnet write commands require `--allow-mainnet-write`.

--- a/tools/soroban-vault-cli/src/artifacts.rs
+++ b/tools/soroban-vault-cli/src/artifacts.rs
@@ -27,12 +27,13 @@ impl ArtifactSpec {
             ArtifactName::Governance => Self::governance(),
             ArtifactName::ShareToken => Self::share_token(),
             ArtifactName::BlendAdapter => Self::blend_adapter(),
+            ArtifactName::CustodialAdapter => Self::custodial_adapter(),
             ArtifactName::Proxy4626 => Self::proxy_4626(),
             ArtifactName::CuratorProxy => Self::curator_proxy(),
         }
     }
 
-    pub fn stack_artifacts(include_blend: bool) -> Vec<Self> {
+    pub fn stack_artifacts(include_blend: bool, include_custodial: bool) -> Vec<Self> {
         let mut artifacts = vec![
             Self::vault(),
             Self::governance(),
@@ -42,6 +43,9 @@ impl ArtifactSpec {
         ];
         if include_blend {
             artifacts.push(Self::blend_adapter());
+        }
+        if include_custodial {
+            artifacts.push(Self::custodial_adapter());
         }
         artifacts
     }
@@ -82,6 +86,16 @@ impl ArtifactSpec {
             package: "templar-soroban-blend-adapter",
             wasm_relative_path:
                 "target/wasm32-unknown-unknown/release-soroban/templar_soroban_blend_adapter.wasm",
+            build_output_dir: "target/wasm32-unknown-unknown/release-soroban",
+        }
+    }
+
+    const fn custodial_adapter() -> Self {
+        Self {
+            key: "custodial_adapter",
+            package: "templar-soroban-custodial-adapter",
+            wasm_relative_path:
+                "target/wasm32-unknown-unknown/release-soroban/templar_soroban_custodial_adapter.wasm",
             build_output_dir: "target/wasm32-unknown-unknown/release-soroban",
         }
     }

--- a/tools/soroban-vault-cli/src/cli.rs
+++ b/tools/soroban-vault-cli/src/cli.rs
@@ -1140,6 +1140,39 @@ mod tests {
     }
 
     #[test]
+    fn parses_comma_delimited_custodians() {
+        let cli = Cli::try_parse_from([
+            "tmplr-soroban-vault",
+            "deploy",
+            "stack",
+            "--admin",
+            ADMIN,
+            "--custodian",
+            &format!("{ADMIN},{POOL}"),
+        ])
+        .expect("parse cli");
+
+        match cli.command {
+            Commands::Deploy(args) => match args.command {
+                DeployCommand::Stack(stack) => {
+                    let custodians = stack
+                        .custodians
+                        .iter()
+                        .map(ToString::to_string)
+                        .collect::<Vec<_>>();
+                    assert_eq!(custodians, vec![ADMIN, POOL]);
+                }
+                DeployCommand::Plan(_)
+                | DeployCommand::Resume(_)
+                | DeployCommand::Repair(_)
+                | DeployCommand::Adapters(_)
+                | DeployCommand::Wasm(_) => panic!("expected deploy stack"),
+            },
+            _ => panic!("expected deploy command"),
+        }
+    }
+
+    #[test]
     fn parses_additive_adapter_deploy_flags() {
         let cli = Cli::try_parse_from([
             "tmplr-soroban-vault",

--- a/tools/soroban-vault-cli/src/cli.rs
+++ b/tools/soroban-vault-cli/src/cli.rs
@@ -202,7 +202,7 @@ pub enum DeployCommand {
     Resume(Box<DeployStackArgs>),
     /// Print the safe repair/resume plan for the current manifest
     Repair(ReconcileArgs),
-    /// Add Blend adapters to an existing or imported vault deployment
+    /// Add Blend or custodial adapters to an existing or imported vault deployment
     Adapters(DeployAdaptersArgs),
     /// Upload or verify a single WASM artifact
     Wasm(DeployWasmArgs),
@@ -224,7 +224,7 @@ pub struct DeployPlanArgs {
 pub enum DeployPlanCommand {
     /// Plan a full vault stack deployment or reuse flow
     Stack(Box<DeployStackArgs>),
-    /// Plan appending Blend adapters to an existing or imported deployment
+    /// Plan appending Blend or custodial adapters to an existing or imported deployment
     Adapters(DeployAdaptersArgs),
 }
 
@@ -270,6 +270,10 @@ pub struct DeployStackArgs {
     #[arg(long = "blend-pool", env = "BLEND_POOL_ID", value_delimiter = ',')]
     pub blend_pools: Vec<AddressStr>,
 
+    /// Custodian or multisig address. Repeat the flag, or provide comma-separated CUSTODIAL_ADDRESS values, to deploy custodial adapters.
+    #[arg(long = "custodian", env = "CUSTODIAL_ADDRESS", value_delimiter = ',')]
+    pub custodians: Vec<AddressStr>,
+
     /// Rebuild missing artifacts before upload/deploy
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub build: bool,
@@ -297,7 +301,11 @@ pub struct DeployAdaptersArgs {
     #[arg(long = "blend-pool", env = "BLEND_POOL_ID", value_delimiter = ',')]
     pub blend_pools: Vec<AddressStr>,
 
-    /// Rebuild the Blend adapter artifact before upload/deploy
+    /// Custodian or multisig address. Repeat the flag, or provide comma-separated CUSTODIAL_ADDRESS values, to append multiple custodial adapters.
+    #[arg(long = "custodian", env = "CUSTODIAL_ADDRESS", value_delimiter = ',')]
+    pub custodians: Vec<AddressStr>,
+
+    /// Rebuild adapter artifacts before upload/deploy
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub build: bool,
 
@@ -323,6 +331,7 @@ pub enum ArtifactName {
     Governance,
     ShareToken,
     BlendAdapter,
+    CustodialAdapter,
     Proxy4626,
     CuratorProxy,
 }
@@ -1104,6 +1113,8 @@ mod tests {
             POOL,
             "--blend-pool",
             POOL,
+            "--custodian",
+            ADMIN,
         ])
         .expect("parse cli");
 
@@ -1116,6 +1127,7 @@ mod tests {
                     );
                     assert_eq!(stack.governance_timelock_ns, Some(1000));
                     assert_eq!(stack.blend_pools.len(), 2);
+                    assert_eq!(stack.custodians.len(), 1);
                 }
                 DeployCommand::Plan(_)
                 | DeployCommand::Resume(_)
@@ -1141,6 +1153,8 @@ mod tests {
             POOL,
             "--blend-pool",
             POOL,
+            "--custodian",
+            ADMIN,
         ])
         .expect("parse cli");
 
@@ -1152,6 +1166,7 @@ mod tests {
                         Some(POOL)
                     );
                     assert_eq!(args.blend_pools.len(), 1);
+                    assert_eq!(args.custodians.len(), 1);
                 }
                 DeployCommand::Plan(_)
                 | DeployCommand::Stack(_)

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -445,7 +445,7 @@ fn manifest_writable_check(path: &Path) -> DoctorCheck {
 
 fn artifact_doctor_checks(cli: &Cli) -> Vec<DoctorCheck> {
     let workspace_manifest = cli.workspace_path.join("Cargo.toml");
-    ArtifactSpec::stack_artifacts(true)
+    ArtifactSpec::stack_artifacts(true, true)
         .into_iter()
         .map(|spec| {
             let wasm_path = spec.wasm_path(&cli.workspace_path);
@@ -593,9 +593,17 @@ impl DeploymentProgress {
     }
 }
 
-fn stack_progress_steps(include_blend: bool, blend_pool_count: usize) -> u64 {
-    let artifact_steps = ArtifactSpec::stack_artifacts(include_blend).len();
-    u64::try_from(artifact_steps + 9 + usize::from(blend_pool_count > 0)).unwrap_or(u64::MAX)
+fn stack_progress_steps(
+    include_blend: bool,
+    include_custodial: bool,
+    blend_pool_count: usize,
+    custodian_count: usize,
+) -> u64 {
+    let artifact_steps = ArtifactSpec::stack_artifacts(include_blend, include_custodial).len();
+    u64::try_from(
+        artifact_steps + 9 + usize::from(blend_pool_count > 0) + usize::from(custodian_count > 0),
+    )
+    .unwrap_or(u64::MAX)
 }
 
 #[allow(
@@ -618,12 +626,18 @@ fn deploy_stack<E: CommandExecutor>(
     };
 
     let include_blend = !args.blend_pools.is_empty();
+    let include_custodial = !args.custodians.is_empty();
     let progress = DeploymentProgress::stack(
         cli,
-        stack_progress_steps(include_blend, args.blend_pools.len()),
+        stack_progress_steps(
+            include_blend,
+            include_custodial,
+            args.blend_pools.len(),
+            args.custodians.len(),
+        ),
     );
     let mut wasm_hashes = BTreeMap::new();
-    for spec in ArtifactSpec::stack_artifacts(include_blend) {
+    for spec in ArtifactSpec::stack_artifacts(include_blend, include_custodial) {
         let hash = progress.step(format!("WASM {} upload/reuse", spec.key), || {
             let hash = ensure_uploaded(stellar, manifest, &cli.workspace_path, spec, args.build)?;
             checkpoint_manifest(cli, manifest)?;
@@ -823,6 +837,22 @@ fn deploy_stack<E: CommandExecutor>(
             )
         })?
     };
+    let custodial_adapters = if args.custodians.is_empty() {
+        custodial_adapter_statuses(manifest)
+    } else {
+        progress.step("Custodial adapters deploy/reuse", || {
+            append_custodial_adapters(
+                cli,
+                stellar,
+                manifest,
+                &wasm_hashes["custodial_adapter"],
+                &governance,
+                &vault,
+                &args.custodians,
+                args.force_new,
+            )
+        })?
+    };
     progress.finish();
 
     Ok(Response::Status(StatusResponse {
@@ -834,6 +864,7 @@ fn deploy_stack<E: CommandExecutor>(
         proxy_4626: Some(proxy_4626),
         curator_proxy: Some(curator_proxy),
         blend_adapters,
+        custodial_adapters,
     }))
 }
 
@@ -1192,6 +1223,30 @@ fn verify_component_wiring<E: CommandExecutor>(
                 )?);
             }
         }
+        key if key.starts_with("custodial_adapter") => {
+            checks.push(view_equals_check(
+                stellar,
+                &record.contract_id,
+                "vault",
+                contract_id(manifest, "vault"),
+            )?);
+            if let Some(custodian) = record.constructor_args.get("custodian") {
+                checks.push(view_equals_check(
+                    stellar,
+                    &record.contract_id,
+                    "custodian",
+                    Some(custodian),
+                )?);
+            }
+            if let Some(admin) = record.constructor_args.get("admin") {
+                checks.push(view_equals_check(
+                    stellar,
+                    &record.contract_id,
+                    "admin",
+                    Some(admin),
+                )?);
+            }
+        }
         _ => {}
     }
     Ok(checks)
@@ -1249,8 +1304,8 @@ fn deploy_adapters<E: CommandExecutor>(
     args: &crate::cli::DeployAdaptersArgs,
 ) -> anyhow::Result<Response> {
     anyhow::ensure!(
-        !args.blend_pools.is_empty(),
-        "deploy adapters requires at least one --blend-pool"
+        !args.blend_pools.is_empty() || !args.custodians.is_empty(),
+        "deploy adapters requires at least one --blend-pool or --custodian"
     );
 
     record_imported_contract_if_provided(cli, manifest, "vault", args.vault.as_ref())?;
@@ -1264,24 +1319,50 @@ fn deploy_adapters<E: CommandExecutor>(
 
     let vault = required_contract(manifest, "vault")?.to_string();
     let governance = required_contract(manifest, "governance")?.to_string();
-    let wasm_hash = ensure_uploaded(
-        stellar,
-        manifest,
-        &cli.workspace_path,
-        ArtifactSpec::from_name(crate::cli::ArtifactName::BlendAdapter),
-        args.build,
-    )?;
-    checkpoint_manifest(cli, manifest)?;
-    let blend_adapters = append_blend_adapters(
-        cli,
-        stellar,
-        manifest,
-        &wasm_hash,
-        &governance,
-        &vault,
-        &args.blend_pools,
-        args.force_new,
-    )?;
+    let blend_adapters = if args.blend_pools.is_empty() {
+        blend_adapter_statuses(manifest)
+    } else {
+        let wasm_hash = ensure_uploaded(
+            stellar,
+            manifest,
+            &cli.workspace_path,
+            ArtifactSpec::from_name(crate::cli::ArtifactName::BlendAdapter),
+            args.build,
+        )?;
+        checkpoint_manifest(cli, manifest)?;
+        append_blend_adapters(
+            cli,
+            stellar,
+            manifest,
+            &wasm_hash,
+            &governance,
+            &vault,
+            &args.blend_pools,
+            args.force_new,
+        )?
+    };
+    let custodial_adapters = if args.custodians.is_empty() {
+        custodial_adapter_statuses(manifest)
+    } else {
+        let wasm_hash = ensure_uploaded(
+            stellar,
+            manifest,
+            &cli.workspace_path,
+            ArtifactSpec::from_name(crate::cli::ArtifactName::CustodialAdapter),
+            args.build,
+        )?;
+        checkpoint_manifest(cli, manifest)?;
+        append_custodial_adapters(
+            cli,
+            stellar,
+            manifest,
+            &wasm_hash,
+            &governance,
+            &vault,
+            &args.custodians,
+            args.force_new,
+        )?
+    };
 
     Ok(Response::Status(StatusResponse {
         network: manifest.network.clone(),
@@ -1292,6 +1373,7 @@ fn deploy_adapters<E: CommandExecutor>(
         proxy_4626: contract_id(manifest, "proxy_4626").map(ToString::to_string),
         curator_proxy: contract_id(manifest, "curator_proxy").map(ToString::to_string),
         blend_adapters,
+        custodial_adapters,
     }))
 }
 
@@ -1325,7 +1407,8 @@ fn deploy_stack_plan(
     );
 
     let include_blend = !args.blend_pools.is_empty();
-    for spec in ArtifactSpec::stack_artifacts(include_blend) {
+    let include_custodial = !args.custodians.is_empty();
+    for spec in ArtifactSpec::stack_artifacts(include_blend, include_custodial) {
         plan.wasm.push(wasm_plan(cli, manifest, spec, args.build)?);
     }
 
@@ -1385,6 +1468,29 @@ fn deploy_stack_plan(
             ));
         }
     }
+    for custodian in &args.custodians {
+        if !args.force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
+            plan.contracts_to_reuse.push(PlanContract {
+                key: format!("custodial adapter for custodian {custodian}"),
+                contract_id: custodial_adapter_by_custodian(manifest, custodian)
+                    .map(ToString::to_string),
+                reason: "adapter for custodian is already recorded in manifest".to_string(),
+            });
+        } else {
+            plan.contracts_to_deploy.push(PlanContract {
+                key: next_custodial_adapter_key(manifest),
+                contract_id: None,
+                reason: format!("new adapter for custodian {custodian}"),
+            });
+            plan.manifest_mutations.push(format!(
+                "record new custodial adapter for custodian {custodian}"
+            ));
+            plan.stellar_commands.push(stellar_command_shape(
+                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian>",
+                true,
+            ));
+        }
+    }
     plan.manifest_mutations
         .push("mark initialized contracts after successful initialize calls".to_string());
     Ok(plan)
@@ -1397,12 +1503,22 @@ fn deploy_adapters_plan(
 ) -> anyhow::Result<PlanResponse> {
     let mut plan = PlanResponse::new("deploy adapters", &cli.network);
     plan.required_signers.push(default_source_label());
-    plan.wasm.push(wasm_plan(
-        cli,
-        manifest,
-        ArtifactSpec::from_name(crate::cli::ArtifactName::BlendAdapter),
-        args.build,
-    )?);
+    if !args.blend_pools.is_empty() {
+        plan.wasm.push(wasm_plan(
+            cli,
+            manifest,
+            ArtifactSpec::from_name(crate::cli::ArtifactName::BlendAdapter),
+            args.build,
+        )?);
+    }
+    if !args.custodians.is_empty() {
+        plan.wasm.push(wasm_plan(
+            cli,
+            manifest,
+            ArtifactSpec::from_name(crate::cli::ArtifactName::CustodialAdapter),
+            args.build,
+        )?);
+    }
 
     for (key, provided) in [
         ("vault", args.vault.as_ref()),
@@ -1442,6 +1558,29 @@ fn deploy_adapters_plan(
                 .push(format!("record new Blend adapter for pool {pool}"));
             plan.stellar_commands.push(stellar_command_shape(
                 "contract deploy --wasm-hash <blend_adapter_hash> -- --admin <governance> --vault <vault> --pool <pool>",
+                true,
+            ));
+        }
+    }
+    for custodian in &args.custodians {
+        if !args.force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
+            plan.contracts_to_reuse.push(PlanContract {
+                key: format!("custodial adapter for custodian {custodian}"),
+                contract_id: custodial_adapter_by_custodian(manifest, custodian)
+                    .map(ToString::to_string),
+                reason: "adapter for custodian is already recorded in manifest".to_string(),
+            });
+        } else {
+            plan.contracts_to_deploy.push(PlanContract {
+                key: next_custodial_adapter_key(manifest),
+                contract_id: None,
+                reason: format!("new adapter for custodian {custodian}"),
+            });
+            plan.manifest_mutations.push(format!(
+                "record new custodial adapter for custodian {custodian}"
+            ));
+            plan.stellar_commands.push(stellar_command_shape(
+                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian>",
                 true,
             ));
         }
@@ -1619,6 +1758,54 @@ fn append_blend_adapters<E: CommandExecutor>(
         checkpoint_manifest(cli, manifest)?;
     }
     Ok(blend_adapter_statuses(manifest))
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "adapter deployment needs both manifest checkpoint context and constructor inputs"
+)]
+fn append_custodial_adapters<E: CommandExecutor>(
+    cli: &Cli,
+    stellar: &Stellar<'_, E>,
+    manifest: &mut Manifest,
+    wasm_hash: &str,
+    governance: &str,
+    vault: &str,
+    custodians: &[AddressStr],
+    force_new: bool,
+) -> anyhow::Result<Vec<CustodialAdapterStatus>> {
+    for custodian in custodians {
+        if !force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
+            continue;
+        }
+        let key = next_custodial_adapter_key(manifest);
+        let adapter = deploy_contract_if_needed(
+            cli,
+            stellar,
+            manifest,
+            &key,
+            wasm_hash,
+            vec![
+                "--admin".to_string(),
+                governance.to_string(),
+                "--vault".to_string(),
+                vault.to_string(),
+                "--custodian".to_string(),
+                custodian.to_string(),
+            ],
+            map_args([
+                ("admin", governance),
+                ("vault", vault),
+                ("custodian", custodian.as_str()),
+            ]),
+            force_new,
+        )?;
+        if let Some(record) = manifest.contracts.get_mut(&key) {
+            record.contract_id = adapter;
+        }
+        checkpoint_manifest(cli, manifest)?;
+    }
+    Ok(custodial_adapter_statuses(manifest))
 }
 
 fn record_imported_contract_if_provided(
@@ -3067,6 +3254,7 @@ fn run_extend_ttl<E: CommandExecutor>(
 
     let caller = if contract_id(manifest, "share_token").is_some()
         || !blend_adapter_statuses(manifest).is_empty()
+        || !custodial_adapter_statuses(manifest).is_empty()
     {
         Some(resolve_extend_ttl_caller(stellar, ttl_args)?)
     } else {
@@ -3084,6 +3272,21 @@ fn run_extend_ttl<E: CommandExecutor>(
     let adapters = blend_adapter_statuses(manifest);
     if adapters.is_empty() {
         skipped.push("blend_adapters".to_string());
+    } else {
+        let caller = caller.as_ref().context("missing TTL caller")?;
+        for adapter in adapters {
+            stellar.invoke(
+                &adapter.contract_id,
+                "extend_ttl",
+                args([("--caller", caller.as_str())]),
+            )?;
+            extended.push(adapter.key);
+        }
+    }
+
+    let adapters = custodial_adapter_statuses(manifest);
+    if adapters.is_empty() {
+        skipped.push("custodial_adapters".to_string());
     } else {
         let caller = caller.as_ref().context("missing TTL caller")?;
         for adapter in adapters {
@@ -3250,6 +3453,46 @@ fn blend_adapter_by_pool<'a>(manifest: &'a Manifest, pool: &AddressStr) -> Optio
         .map(|(_, record)| record.contract_id.as_str())
 }
 
+fn custodial_adapter_key(index: usize) -> String {
+    format!("custodial_adapter_{index}")
+}
+
+fn next_custodial_adapter_key(manifest: &Manifest) -> String {
+    custodial_adapter_key(next_custodial_adapter_index(manifest))
+}
+
+fn next_custodial_adapter_index(manifest: &Manifest) -> usize {
+    let highest_index = manifest
+        .contracts
+        .keys()
+        .filter_map(|key| {
+            if key == "custodial_adapter" {
+                Some(0)
+            } else {
+                custodial_adapter_index(key)
+            }
+        })
+        .max();
+    highest_index.map_or(0, |index| index + 1)
+}
+
+fn custodial_adapter_by_custodian<'a>(
+    manifest: &'a Manifest,
+    custodian: &AddressStr,
+) -> Option<&'a str> {
+    manifest
+        .contracts
+        .iter()
+        .find(|(key, record)| {
+            is_custodial_adapter_key(key)
+                && record
+                    .constructor_args
+                    .get("custodian")
+                    .is_some_and(|value| value == custodian.as_str())
+        })
+        .map(|(_, record)| record.contract_id.as_str())
+}
+
 fn selected_blend_adapter<'a>(
     manifest: &'a Manifest,
     args: &AdapterArgs,
@@ -3280,6 +3523,14 @@ fn is_blend_adapter_key(key: &str) -> bool {
 
 fn blend_adapter_index(key: &str) -> Option<usize> {
     key.strip_prefix("blend_adapter_")?.parse().ok()
+}
+
+fn is_custodial_adapter_key(key: &str) -> bool {
+    key == "custodial_adapter" || custodial_adapter_index(key).is_some()
+}
+
+fn custodial_adapter_index(key: &str) -> Option<usize> {
+    key.strip_prefix("custodial_adapter_")?.parse().ok()
 }
 
 fn args<const N: usize>(items: [(&str, &str); N]) -> Vec<String> {
@@ -3326,6 +3577,7 @@ fn status_response(manifest: &Manifest) -> StatusResponse {
         proxy_4626: contract_id(manifest, "proxy_4626").map(ToString::to_string),
         curator_proxy: contract_id(manifest, "curator_proxy").map(ToString::to_string),
         blend_adapters: blend_adapter_statuses(manifest),
+        custodial_adapters: custodial_adapter_statuses(manifest),
     }
 }
 
@@ -3362,6 +3614,39 @@ fn blend_adapter_statuses(manifest: &Manifest) -> Vec<BlendAdapterStatus> {
     adapters
 }
 
+fn custodial_adapter_statuses(manifest: &Manifest) -> Vec<CustodialAdapterStatus> {
+    let mut adapters = manifest
+        .contracts
+        .iter()
+        .filter_map(|(key, record)| {
+            let index = custodial_adapter_index(key)?;
+            Some((
+                index,
+                CustodialAdapterStatus {
+                    key: key.clone(),
+                    contract_id: record.contract_id.clone(),
+                    custodian: record.constructor_args.get("custodian").cloned(),
+                },
+            ))
+        })
+        .collect::<Vec<_>>();
+    adapters.sort_by_key(|(index, _)| *index);
+    let mut adapters = adapters
+        .into_iter()
+        .map(|(_, status)| status)
+        .collect::<Vec<_>>();
+    if adapters.is_empty() {
+        if let Some(record) = manifest.contracts.get("custodial_adapter") {
+            adapters.push(CustodialAdapterStatus {
+                key: "custodial_adapter".to_string(),
+                contract_id: record.contract_id.clone(),
+                custodian: record.constructor_args.get("custodian").cloned(),
+            });
+        }
+    }
+    adapters
+}
+
 fn export_env(manifest: &Manifest) -> Vec<(String, String)> {
     let mut values = vec![("SOROBAN_NETWORK".to_string(), manifest.network.clone())];
     for (env, key) in [
@@ -3386,6 +3671,24 @@ fn export_env(manifest: &Manifest) -> Vec<(String, String)> {
         ));
         if let Some(pool) = adapter.pool {
             values.push((format!("BLEND_POOL_{index}_ID"), pool));
+        }
+    }
+    for (index, adapter) in custodial_adapter_statuses(manifest).into_iter().enumerate() {
+        if index == 0 {
+            values.push((
+                "CUSTODIAL_ADAPTER_ID".to_string(),
+                adapter.contract_id.clone(),
+            ));
+        }
+        values.push((
+            format!("CUSTODIAL_ADAPTER_{index}_ID"),
+            adapter.contract_id.clone(),
+        ));
+        if let Some(custodian) = adapter.custodian {
+            if index == 0 {
+                values.push(("CUSTODIAL_ADDRESS".to_string(), custodian.clone()));
+            }
+            values.push((format!("CUSTODIAL_{index}_ADDRESS"), custodian));
         }
     }
     values
@@ -3433,6 +3736,23 @@ fn print_response(response: &Response, cli: &Cli) -> anyhow::Result<()> {
                             .pool
                             .as_ref()
                             .map_or_else(String::new, |pool| format!(" (pool {pool})"))
+                    );
+                }
+            }
+            if status.custodial_adapters.is_empty() {
+                println!("Custodial Adapters: not deployed");
+            } else {
+                for adapter in &status.custodial_adapters {
+                    println!(
+                        "Custodial Adapter {}: {}{}",
+                        adapter.key,
+                        adapter.contract_id,
+                        adapter
+                            .custodian
+                            .as_ref()
+                            .map_or_else(String::new, |custodian| {
+                                format!(" (custodian {custodian})")
+                            })
                     );
                 }
             }
@@ -3844,6 +4164,7 @@ struct StatusResponse {
     proxy_4626: Option<String>,
     curator_proxy: Option<String>,
     blend_adapters: Vec<BlendAdapterStatus>,
+    custodial_adapters: Vec<CustodialAdapterStatus>,
 }
 
 #[derive(Debug, Serialize)]
@@ -3851,6 +4172,13 @@ struct BlendAdapterStatus {
     key: String,
     contract_id: String,
     pool: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct CustodialAdapterStatus {
+    key: String,
+    contract_id: String,
+    custodian: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -4585,6 +4913,7 @@ mod tests {
                         CONTRACT.parse().expect("existing pool"),
                         ACCOUNT.parse().expect("new pool"),
                     ],
+                    custodians: Vec::new(),
                     build: false,
                     force_new: false,
                 }),
@@ -4615,6 +4944,68 @@ mod tests {
     }
 
     #[test]
+    fn deploy_adapters_appends_custodial_adapter_to_existing_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_custodial_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("vault".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("governance".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("asset_token".to_string(), imported_record(CONTRACT));
+        manifest.save(&state).expect("save manifest");
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::Adapters(crate::cli::DeployAdaptersArgs {
+                    vault: None,
+                    governance: None,
+                    asset_token: None,
+                    blend_pools: Vec::new(),
+                    custodians: vec![ACCOUNT.parse().expect("custodian")],
+                    build: false,
+                    force_new: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = RecordingExecutor::new();
+
+        run(&cli, &executor).expect("deploy custodial adapter");
+
+        let loaded = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        let adapter = loaded
+            .contracts
+            .get("custodial_adapter_0")
+            .expect("appended custodial adapter");
+        assert_eq!(
+            adapter
+                .constructor_args
+                .get("custodian")
+                .map(String::as_str),
+            Some(ACCOUNT)
+        );
+        assert_eq!(
+            adapter.constructor_args.get("vault").map(String::as_str),
+            Some(CONTRACT)
+        );
+        assert_eq!(
+            adapter.constructor_args.get("admin").map(String::as_str),
+            Some(CONTRACT)
+        );
+        let adapter_deploys = submitted_calls(&executor.calls())
+            .iter()
+            .filter(|(_, args)| args.iter().any(|arg| arg == "--custodian"))
+            .count();
+        assert_eq!(adapter_deploys, 1);
+    }
+
+    #[test]
     fn dry_run_deploy_adapters_does_not_execute_or_write_manifest() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_fake_blend_wasm(dir.path());
@@ -4630,6 +5021,7 @@ mod tests {
                     governance: None,
                     asset_token: None,
                     blend_pools: vec![CONTRACT.parse().expect("pool")],
+                    custodians: Vec::new(),
                     build: false,
                     force_new: false,
                 }),
@@ -4666,6 +5058,7 @@ mod tests {
                         share_symbol: "tvSHARE".to_string(),
                         share_decimals: 7,
                         blend_pools: vec![CONTRACT.parse().expect("pool")],
+                        custodians: Vec::new(),
                         build: false,
                         force_new: false,
                     })),
@@ -4702,6 +5095,10 @@ mod tests {
         manifest
             .contracts
             .insert("blend_adapter_0".to_string(), imported_record("CADAPTER0"));
+        manifest.contracts.insert(
+            "custodial_adapter_0".to_string(),
+            imported_record("CCUSTODIAL0"),
+        );
         manifest.save(&state).expect("save manifest");
         let cli = base_cli(
             state,
@@ -4714,7 +5111,7 @@ mod tests {
         run(&cli, &executor).expect("extend ttl");
 
         let calls = submitted_calls(&executor.calls());
-        assert_eq!(calls.len(), 6);
+        assert_eq!(calls.len(), 7);
         assert!(calls.iter().any(|(_, args)| args
             .windows(2)
             .any(|pair| pair == ["--id", "CVAULT"])
@@ -4725,6 +5122,7 @@ mod tests {
             "CCURATORPROXY",
             "CSHARE",
             "CADAPTER0",
+            "CCUSTODIAL0",
         ] {
             assert!(calls.iter().any(|(_, args)| args
                 .windows(2)
@@ -4982,6 +5380,7 @@ mod tests {
                         CONTRACT.parse().expect("first pool"),
                         ACCOUNT.parse().expect("second pool"),
                     ],
+                    custodians: Vec::new(),
                     build: false,
                     force_new: false,
                 })),
@@ -4998,6 +5397,60 @@ mod tests {
             .filter(|(_, args)| args.iter().any(|arg| arg == "--pool"))
             .count();
         assert_eq!(adapter_deploys, 2);
+    }
+
+    #[test]
+    fn deploy_stack_deploys_one_custodial_adapter_per_custodian() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_stack_wasms(dir.path());
+        let state = dir.path().join("manifest.json");
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("vault".to_string(), imported_record(CONTRACT));
+        manifest.save(&state).expect("save manifest");
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::Stack(Box::new(DeployStackArgs {
+                    admin: Some(ACCOUNT.parse().expect("admin")),
+                    asset_token: Some(CONTRACT.parse().expect("asset token")),
+                    governance_timelock_ns: Some(1_000),
+                    virtual_shares: 0,
+                    virtual_assets: 0,
+                    share_name: "Templar Vault Share".to_string(),
+                    share_symbol: "tvSHARE".to_string(),
+                    share_decimals: 7,
+                    blend_pools: Vec::new(),
+                    custodians: vec![ACCOUNT.parse().expect("custodian")],
+                    build: false,
+                    force_new: false,
+                })),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = RecordingExecutor::new();
+
+        run(&cli, &executor).expect("deploy stack");
+
+        let calls = submitted_calls(&executor.calls());
+        let adapter_deploys = calls
+            .iter()
+            .filter(|(_, args)| args.iter().any(|arg| arg == "--custodian"))
+            .count();
+        assert_eq!(adapter_deploys, 1);
+
+        let loaded = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        assert_eq!(
+            loaded
+                .contracts
+                .get("custodial_adapter_0")
+                .expect("custodial adapter")
+                .constructor_args
+                .get("custodian")
+                .map(String::as_str),
+            Some(ACCOUNT)
+        );
     }
 
     #[test]
@@ -5018,6 +5471,7 @@ mod tests {
                     share_symbol: "tvSHARE".to_string(),
                     share_decimals: 7,
                     blend_pools: Vec::new(),
+                    custodians: Vec::new(),
                     build: false,
                     force_new: false,
                 })),
@@ -5174,6 +5628,7 @@ mod tests {
                     share_symbol: "tvSHARE".to_string(),
                     share_decimals: 7,
                     blend_pools: Vec::new(),
+                    custodians: Vec::new(),
                     build: false,
                     force_new: false,
                 })),
@@ -5294,6 +5749,7 @@ mod tests {
             ArtifactName::Governance,
             ArtifactName::ShareToken,
             ArtifactName::BlendAdapter,
+            ArtifactName::CustodialAdapter,
             ArtifactName::Proxy4626,
             ArtifactName::CuratorProxy,
         ] {
@@ -5307,5 +5763,11 @@ mod tests {
         let path = ArtifactSpec::from_name(ArtifactName::BlendAdapter).wasm_path(root);
         fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
         fs::write(path, "blend").expect("write wasm");
+    }
+
+    fn write_fake_custodial_wasm(root: &std::path::Path) {
+        let path = ArtifactSpec::from_name(ArtifactName::CustodialAdapter).wasm_path(root);
+        fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        fs::write(path, "custodial").expect("write wasm");
     }
 }

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -848,6 +848,7 @@ fn deploy_stack<E: CommandExecutor>(
                 &wasm_hashes["custodial_adapter"],
                 &governance,
                 &vault,
+                &asset_token,
                 &args.custodians,
                 args.force_new,
             )
@@ -1230,6 +1231,12 @@ fn verify_component_wiring<E: CommandExecutor>(
                 "vault",
                 contract_id(manifest, "vault"),
             )?);
+            checks.push(view_equals_check(
+                stellar,
+                &record.contract_id,
+                "asset",
+                contract_id(manifest, "asset_token"),
+            )?);
             if let Some(custodian) = record.constructor_args.get("custodian") {
                 checks.push(view_equals_check(
                     stellar,
@@ -1319,6 +1326,11 @@ fn deploy_adapters<E: CommandExecutor>(
 
     let vault = required_contract(manifest, "vault")?.to_string();
     let governance = required_contract(manifest, "governance")?.to_string();
+    let asset_token = if args.custodians.is_empty() {
+        contract_id(manifest, "asset_token").map(ToString::to_string)
+    } else {
+        Some(required_contract(manifest, "asset_token")?.to_string())
+    };
     let blend_adapters = if args.blend_pools.is_empty() {
         blend_adapter_statuses(manifest)
     } else {
@@ -1359,6 +1371,9 @@ fn deploy_adapters<E: CommandExecutor>(
             &wasm_hash,
             &governance,
             &vault,
+            asset_token
+                .as_deref()
+                .context("custodial adapters require asset_token in manifest or --asset-token")?,
             &args.custodians,
             args.force_new,
         )?
@@ -1369,7 +1384,7 @@ fn deploy_adapters<E: CommandExecutor>(
         vault: Some(vault),
         share_token: contract_id(manifest, "share_token").map(ToString::to_string),
         governance: Some(governance),
-        asset_token: contract_id(manifest, "asset_token").map(ToString::to_string),
+        asset_token,
         proxy_4626: contract_id(manifest, "proxy_4626").map(ToString::to_string),
         curator_proxy: contract_id(manifest, "curator_proxy").map(ToString::to_string),
         blend_adapters,
@@ -1486,7 +1501,7 @@ fn deploy_stack_plan(
                 "record new custodial adapter for custodian {custodian}"
             ));
             plan.stellar_commands.push(stellar_command_shape(
-                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian>",
+                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian> --asset <asset_token>",
                 true,
             ));
         }
@@ -1538,6 +1553,11 @@ fn deploy_adapters_plan(
             plan.warnings.push(format!(
                 "{key} is missing from manifest and must be passed for deploy adapters"
             ));
+        } else if !args.custodians.is_empty() {
+            plan.warnings.push(
+                "asset_token is missing from manifest and must be passed for custodial adapters"
+                    .to_string(),
+            );
         }
     }
 
@@ -1580,7 +1600,7 @@ fn deploy_adapters_plan(
                 "record new custodial adapter for custodian {custodian}"
             ));
             plan.stellar_commands.push(stellar_command_shape(
-                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian>",
+                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian> --asset <asset_token>",
                 true,
             ));
         }
@@ -1771,6 +1791,7 @@ fn append_custodial_adapters<E: CommandExecutor>(
     wasm_hash: &str,
     governance: &str,
     vault: &str,
+    asset_token: &str,
     custodians: &[AddressStr],
     force_new: bool,
 ) -> anyhow::Result<Vec<CustodialAdapterStatus>> {
@@ -1792,11 +1813,14 @@ fn append_custodial_adapters<E: CommandExecutor>(
                 vault.to_string(),
                 "--custodian".to_string(),
                 custodian.to_string(),
+                "--asset".to_string(),
+                asset_token.to_string(),
             ],
             map_args([
                 ("admin", governance),
                 ("vault", vault),
                 ("custodian", custodian.as_str()),
+                ("asset", asset_token),
             ]),
             force_new,
         )?;
@@ -3626,6 +3650,7 @@ fn custodial_adapter_statuses(manifest: &Manifest) -> Vec<CustodialAdapterStatus
                     key: key.clone(),
                     contract_id: record.contract_id.clone(),
                     custodian: record.constructor_args.get("custodian").cloned(),
+                    asset: record.constructor_args.get("asset").cloned(),
                 },
             ))
         })
@@ -3641,6 +3666,7 @@ fn custodial_adapter_statuses(manifest: &Manifest) -> Vec<CustodialAdapterStatus
                 key: "custodial_adapter".to_string(),
                 contract_id: record.contract_id.clone(),
                 custodian: record.constructor_args.get("custodian").cloned(),
+                asset: record.constructor_args.get("asset").cloned(),
             });
         }
     }
@@ -3689,6 +3715,9 @@ fn export_env(manifest: &Manifest) -> Vec<(String, String)> {
                 values.push(("CUSTODIAL_ADDRESS".to_string(), custodian.clone()));
             }
             values.push((format!("CUSTODIAL_{index}_ADDRESS"), custodian));
+        }
+        if let Some(asset) = adapter.asset {
+            values.push((format!("CUSTODIAL_{index}_ASSET"), asset));
         }
     }
     values
@@ -3744,7 +3773,7 @@ fn print_response(response: &Response, cli: &Cli) -> anyhow::Result<()> {
             } else {
                 for adapter in &status.custodial_adapters {
                     println!(
-                        "Custodial Adapter {}: {}{}",
+                        "Custodial Adapter {}: {}{}{}",
                         adapter.key,
                         adapter.contract_id,
                         adapter
@@ -3752,7 +3781,11 @@ fn print_response(response: &Response, cli: &Cli) -> anyhow::Result<()> {
                             .as_ref()
                             .map_or_else(String::new, |custodian| {
                                 format!(" (custodian {custodian})")
-                            })
+                            }),
+                        adapter
+                            .asset
+                            .as_ref()
+                            .map_or_else(String::new, |asset| format!(" (asset {asset})"))
                     );
                 }
             }
@@ -4179,6 +4212,7 @@ struct CustodialAdapterStatus {
     key: String,
     contract_id: String,
     custodian: Option<String>,
+    asset: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -4998,11 +5032,19 @@ mod tests {
             adapter.constructor_args.get("admin").map(String::as_str),
             Some(CONTRACT)
         );
-        let adapter_deploys = submitted_calls(&executor.calls())
+        assert_eq!(
+            adapter.constructor_args.get("asset").map(String::as_str),
+            Some(CONTRACT)
+        );
+        let calls = submitted_calls(&executor.calls());
+        let adapter_deploys = calls
             .iter()
             .filter(|(_, args)| args.iter().any(|arg| arg == "--custodian"))
             .count();
         assert_eq!(adapter_deploys, 1);
+        assert!(calls.iter().any(|(_, args)| args
+            .windows(2)
+            .any(|window| window[0] == "--asset" && window[1] == CONTRACT)));
     }
 
     #[test]
@@ -5451,6 +5493,19 @@ mod tests {
                 .map(String::as_str),
             Some(ACCOUNT)
         );
+        assert_eq!(
+            loaded
+                .contracts
+                .get("custodial_adapter_0")
+                .expect("custodial adapter")
+                .constructor_args
+                .get("asset")
+                .map(String::as_str),
+            Some(CONTRACT)
+        );
+        assert!(calls.iter().any(|(_, args)| args
+            .windows(2)
+            .any(|window| window[0] == "--asset" && window[1] == CONTRACT)));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -1224,7 +1224,7 @@ fn verify_component_wiring<E: CommandExecutor>(
                 )?);
             }
         }
-        key if key.starts_with("custodial_adapter") => {
+        key if is_custodial_adapter_key(key) => {
             checks.push(view_equals_check(
                 stellar,
                 &record.contract_id,
@@ -3505,13 +3505,7 @@ fn next_custodial_adapter_index(manifest: &Manifest) -> usize {
     let highest_index = manifest
         .contracts
         .keys()
-        .filter_map(|key| {
-            if key == "custodial_adapter" {
-                Some(0)
-            } else {
-                custodial_adapter_index(key)
-            }
-        })
+        .filter_map(|key| custodial_adapter_index(key))
         .max();
     highest_index.map_or(0, |index| index + 1)
 }
@@ -3573,7 +3567,7 @@ fn blend_adapter_index(key: &str) -> Option<usize> {
 }
 
 fn is_custodial_adapter_key(key: &str) -> bool {
-    key == "custodial_adapter" || custodial_adapter_index(key).is_some()
+    custodial_adapter_index(key).is_some()
 }
 
 fn custodial_adapter_index(key: &str) -> Option<usize> {
@@ -3679,21 +3673,10 @@ fn custodial_adapter_statuses(manifest: &Manifest) -> Vec<CustodialAdapterStatus
         })
         .collect::<Vec<_>>();
     adapters.sort_by_key(|(index, _)| *index);
-    let mut adapters = adapters
+    adapters
         .into_iter()
         .map(|(_, status)| status)
-        .collect::<Vec<_>>();
-    if adapters.is_empty() {
-        if let Some(record) = manifest.contracts.get("custodial_adapter") {
-            adapters.push(CustodialAdapterStatus {
-                key: "custodial_adapter".to_string(),
-                contract_id: record.contract_id.clone(),
-                custodian: record.constructor_args.get("custodian").cloned(),
-                asset: record.constructor_args.get("asset").cloned(),
-            });
-        }
-    }
-    adapters
+        .collect::<Vec<_>>()
 }
 
 fn export_env(manifest: &Manifest) -> Vec<(String, String)> {
@@ -4664,6 +4647,36 @@ mod tests {
         assert!(!export_env(&manifest)
             .iter()
             .any(|(key, _)| key == "CUSTODIAL_ADDRESS"));
+    }
+
+    #[test]
+    fn status_ignores_unindexed_custodial_adapter_record() {
+        let mut manifest = Manifest::new("testnet", None);
+        let mut unindexed = imported_record("CLEGACY");
+        unindexed.constructor_args = map_args([("custodian", ACCOUNT), ("asset", CONTRACT)]);
+        manifest
+            .contracts
+            .insert("custodial_adapter".to_string(), unindexed);
+
+        assert!(status_response(&manifest).custodial_adapters.is_empty());
+        assert!(!export_env(&manifest)
+            .iter()
+            .any(|(key, value)| key.starts_with("CUSTODIAL") || value == "CLEGACY"));
+
+        let mut indexed = imported_record("CCUSTODIAL0");
+        indexed.constructor_args = map_args([("custodian", ACCOUNT), ("asset", CONTRACT)]);
+        manifest
+            .contracts
+            .insert("custodial_adapter_0".to_string(), indexed);
+
+        let status = status_response(&manifest);
+        assert_eq!(status.custodial_adapters.len(), 1);
+        assert_eq!(status.custodial_adapters[0].key, "custodial_adapter_0");
+        assert_eq!(status.custodial_adapters[0].contract_id, "CCUSTODIAL0");
+        assert!(export_env(&manifest).contains(&(
+            "CUSTODIAL_ADAPTER_ID".to_string(),
+            "CCUSTODIAL0".to_string()
+        )));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -1483,29 +1483,7 @@ fn deploy_stack_plan(
             ));
         }
     }
-    for custodian in &args.custodians {
-        if !args.force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
-            plan.contracts_to_reuse.push(PlanContract {
-                key: format!("custodial adapter for custodian {custodian}"),
-                contract_id: custodial_adapter_by_custodian(manifest, custodian)
-                    .map(ToString::to_string),
-                reason: "adapter for custodian is already recorded in manifest".to_string(),
-            });
-        } else {
-            plan.contracts_to_deploy.push(PlanContract {
-                key: next_custodial_adapter_key(manifest),
-                contract_id: None,
-                reason: format!("new adapter for custodian {custodian}"),
-            });
-            plan.manifest_mutations.push(format!(
-                "record new custodial adapter for custodian {custodian}"
-            ));
-            plan.stellar_commands.push(stellar_command_shape(
-                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian> --asset <asset_token>",
-                true,
-            ));
-        }
-    }
+    plan_custodial_adapters(&mut plan, manifest, &args.custodians, args.force_new);
     plan.manifest_mutations
         .push("mark initialized contracts after successful initialize calls".to_string());
     Ok(plan)
@@ -1582,8 +1560,23 @@ fn deploy_adapters_plan(
             ));
         }
     }
-    for custodian in &args.custodians {
-        if !args.force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
+    plan_custodial_adapters(&mut plan, manifest, &args.custodians, args.force_new);
+    Ok(plan)
+}
+
+fn plan_custodial_adapters(
+    plan: &mut PlanResponse,
+    manifest: &Manifest,
+    custodians: &[AddressStr],
+    force_new: bool,
+) {
+    let mut next_custodial_index = next_custodial_adapter_index(manifest);
+    let mut planned_custodians = BTreeSet::new();
+    for custodian in custodians {
+        if !planned_custodians.insert(custodian.as_str().to_string()) {
+            continue;
+        }
+        if !force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
             plan.contracts_to_reuse.push(PlanContract {
                 key: format!("custodial adapter for custodian {custodian}"),
                 contract_id: custodial_adapter_by_custodian(manifest, custodian)
@@ -1592,10 +1585,11 @@ fn deploy_adapters_plan(
             });
         } else {
             plan.contracts_to_deploy.push(PlanContract {
-                key: next_custodial_adapter_key(manifest),
+                key: custodial_adapter_key(next_custodial_index),
                 contract_id: None,
                 reason: format!("new adapter for custodian {custodian}"),
             });
+            next_custodial_index += 1;
             plan.manifest_mutations.push(format!(
                 "record new custodial adapter for custodian {custodian}"
             ));
@@ -1605,7 +1599,6 @@ fn deploy_adapters_plan(
             ));
         }
     }
-    Ok(plan)
 }
 
 fn push_contract_plan(plan: &mut PlanResponse, manifest: &Manifest, key: &str, force_new: bool) {
@@ -1795,7 +1788,11 @@ fn append_custodial_adapters<E: CommandExecutor>(
     custodians: &[AddressStr],
     force_new: bool,
 ) -> anyhow::Result<Vec<CustodialAdapterStatus>> {
+    let mut planned_custodians = BTreeSet::new();
     for custodian in custodians {
+        if !planned_custodians.insert(custodian.as_str().to_string()) {
+            continue;
+        }
         if !force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
             continue;
         }
@@ -3314,6 +3311,12 @@ fn run_extend_ttl<E: CommandExecutor>(
     } else {
         let caller = caller.as_ref().context("missing TTL caller")?;
         for adapter in adapters {
+            if let Some(skip_reason) =
+                custodial_ttl_skip_reason(manifest, &adapter.key, caller.as_str())
+            {
+                skipped.push(skip_reason);
+                continue;
+            }
             stellar.invoke(
                 &adapter.contract_id,
                 "extend_ttl",
@@ -3330,6 +3333,19 @@ fn run_extend_ttl<E: CommandExecutor>(
     }
 
     Ok(Response::ExtendTtl(ExtendTtlResponse { extended, skipped }))
+}
+
+fn custodial_ttl_skip_reason(manifest: &Manifest, key: &str, caller: &str) -> Option<String> {
+    let admin = custodial_adapter_admin(manifest, key)?;
+    if contract_id(manifest, "governance").is_some_and(|governance| governance == admin) {
+        return Some(format!(
+            "{key}: admin is governance; no direct custodial adapter TTL authorization path"
+        ));
+    }
+    if admin != caller {
+        return Some(format!("{key}: caller is not custodial adapter admin"));
+    }
+    None
 }
 
 fn resolve_extend_ttl_caller<E: CommandExecutor>(
@@ -3515,6 +3531,13 @@ fn custodial_adapter_by_custodian<'a>(
                     .is_some_and(|value| value == custodian.as_str())
         })
         .map(|(_, record)| record.contract_id.as_str())
+}
+
+fn custodial_adapter_admin<'a>(manifest: &'a Manifest, key: &str) -> Option<&'a str> {
+    manifest
+        .contracts
+        .get(key)
+        .and_then(|record| record.constructor_args.get("admin").map(String::as_str))
 }
 
 fn selected_blend_adapter<'a>(
@@ -3711,9 +3734,6 @@ fn export_env(manifest: &Manifest) -> Vec<(String, String)> {
             adapter.contract_id.clone(),
         ));
         if let Some(custodian) = adapter.custodian {
-            if index == 0 {
-                values.push(("CUSTODIAL_ADDRESS".to_string(), custodian.clone()));
-            }
             values.push((format!("CUSTODIAL_{index}_ADDRESS"), custodian));
         }
         if let Some(asset) = adapter.asset {
@@ -4631,9 +4651,19 @@ mod tests {
                 initialized: true,
             },
         );
+        let mut custodial = imported_record("CCUSTODIAL0");
+        custodial.constructor_args = map_args([("custodian", ACCOUNT), ("asset", CONTRACT)]);
+        manifest
+            .contracts
+            .insert("custodial_adapter_0".to_string(), custodial);
         assert!(
             export_env(&manifest).contains(&("SOROBAN_CONTRACT_ID".to_string(), "CV".to_string()))
         );
+        assert!(export_env(&manifest)
+            .contains(&("CUSTODIAL_0_ADDRESS".to_string(), ACCOUNT.to_string())));
+        assert!(!export_env(&manifest)
+            .iter()
+            .any(|(key, _)| key == "CUSTODIAL_ADDRESS"));
     }
 
     #[test]
@@ -5001,7 +5031,10 @@ mod tests {
                     governance: None,
                     asset_token: None,
                     blend_pools: Vec::new(),
-                    custodians: vec![ACCOUNT.parse().expect("custodian")],
+                    custodians: vec![
+                        ACCOUNT.parse().expect("custodian"),
+                        ACCOUNT.parse().expect("duplicate custodian"),
+                    ],
                     build: false,
                     force_new: false,
                 }),
@@ -5013,6 +5046,7 @@ mod tests {
         run(&cli, &executor).expect("deploy custodial adapter");
 
         let loaded = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        assert!(!loaded.contracts.contains_key("custodial_adapter_1"));
         let adapter = loaded
             .contracts
             .get("custodial_adapter_0")
@@ -5118,6 +5152,56 @@ mod tests {
     }
 
     #[test]
+    fn deploy_plan_uses_unique_keys_for_multiple_custodians() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("manifest.json");
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("vault".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("governance".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("asset_token".to_string(), imported_record(CONTRACT));
+        let cli = base_cli(state, Commands::Status);
+        let plan = deploy_adapters_plan(
+            &cli,
+            &manifest,
+            &crate::cli::DeployAdaptersArgs {
+                vault: None,
+                governance: None,
+                asset_token: None,
+                blend_pools: Vec::new(),
+                custodians: vec![
+                    ACCOUNT.parse().expect("first custodian"),
+                    ACCOUNT.parse().expect("duplicate custodian"),
+                    CONTRACT.parse().expect("second custodian"),
+                ],
+                build: false,
+                force_new: false,
+            },
+        )
+        .expect("plan adapters");
+
+        let custodial_keys = plan
+            .contracts_to_deploy
+            .iter()
+            .filter_map(|contract| {
+                contract
+                    .key
+                    .starts_with("custodial_adapter_")
+                    .then_some(contract.key.as_str())
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            custodial_keys,
+            vec!["custodial_adapter_0", "custodial_adapter_1"]
+        );
+    }
+
+    #[test]
     fn extend_ttl_runs_for_entire_ttl_capable_deployment_set() {
         let dir = tempfile::tempdir().expect("tempdir");
         let state = dir.path().join("manifest.json");
@@ -5139,7 +5223,10 @@ mod tests {
             .insert("blend_adapter_0".to_string(), imported_record("CADAPTER0"));
         manifest.contracts.insert(
             "custodial_adapter_0".to_string(),
-            imported_record("CCUSTODIAL0"),
+            ContractRecord {
+                constructor_args: map_args([("admin", ACCOUNT)]),
+                ..imported_record("CCUSTODIAL0")
+            },
         );
         manifest.save(&state).expect("save manifest");
         let cli = base_cli(
@@ -5174,6 +5261,42 @@ mod tests {
         assert!(!calls
             .iter()
             .any(|(_, args)| args.windows(2).any(|pair| pair == ["--id", "CASSET"])));
+    }
+
+    #[test]
+    fn extend_ttl_skips_governance_admin_custodial_adapter() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("manifest.json");
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("governance".to_string(), imported_record("CGOVERNANCE"));
+        manifest.contracts.insert(
+            "custodial_adapter_0".to_string(),
+            ContractRecord {
+                constructor_args: map_args([("admin", "CGOVERNANCE")]),
+                ..imported_record("CCUSTODIAL0")
+            },
+        );
+        manifest.save(&state).expect("save manifest");
+        let cli = base_cli(
+            state,
+            Commands::ExtendTtl(ExtendTtlArgs {
+                caller: Some(ACCOUNT.parse().expect("caller")),
+            }),
+        );
+        let executor = RecordingExecutor::new();
+
+        run(&cli, &executor).expect("extend ttl");
+
+        let calls = submitted_calls(&executor.calls());
+        assert!(calls.iter().any(|(_, args)| args
+            .windows(2)
+            .any(|pair| pair == ["--id", "CGOVERNANCE"])
+            && args.iter().any(|arg| arg == "extend_ttl")));
+        assert!(!calls
+            .iter()
+            .any(|(_, args)| args.windows(2).any(|pair| pair == ["--id", "CCUSTODIAL0"])));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -3737,12 +3737,9 @@ fn print_response(response: &Response, cli: &Cli) -> anyhow::Result<()> {
     }
     match response {
         Response::Message { message } => println!("{message}"),
-        Response::Command { stdout, stderr } => {
+        Response::Command { stdout, stderr: _ } => {
             if !stdout.is_empty() {
                 println!("{stdout}");
-            }
-            if !stderr.is_empty() {
-                eprintln!("{stderr}");
             }
         }
         Response::Status(status) => {

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -3737,9 +3737,12 @@ fn print_response(response: &Response, cli: &Cli) -> anyhow::Result<()> {
     }
     match response {
         Response::Message { message } => println!("{message}"),
-        Response::Command { stdout, stderr: _ } => {
+        Response::Command { stdout, stderr } => {
             if !stdout.is_empty() {
                 println!("{stdout}");
+            }
+            if !stderr.is_empty() {
+                eprintln!("{stderr}");
             }
         }
         Response::Status(status) => {


### PR DESCRIPTION
## Summary

Adds a Soroban custodial market adapter for the offchain-managed Option 1 route.

- forwards allocated assets from the adapter to a configured custodian/multisig
- only releases withdrawals from liquidity already returned to the adapter
- keeps adapter NAV explicit via reported assets rather than auto-counting returned idle balance
- allows admin, vault, or custodian to update reported assets so governance can remain the admin while the operational custodian reports NAV
- adds justfile deployment/status/reporting recipes and README operator notes

## Trust model

This adapter intentionally does not initiate or prove an offchain market exit. The configured custodian and its operating process are part of the vault trust boundary. Offchain infra is responsible for bridging, depositing, unwinding, and returning Stellar-side liquidity before the vault can withdraw from the adapter.

## Validation

- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-soroban-custodial-adapter/target cargo test -p templar-soroban-custodial-adapter -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-soroban-custodial-adapter/target cargo test -p templar-fuzz --no-run --bin fuzz_soroban_custodial_adapter`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-soroban-custodial-adapter/target just -f contract/vault/soroban/justfile build-custodial-adapter`
- `RUSTUP_TOOLCHAIN=1.89.0 cargo fmt -- --check`
- `RUSTUP_TOOLCHAIN=1.89.0 CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/contracts-soroban-custodial-adapter/target cargo clippy -p templar-soroban-custodial-adapter --all-targets -- -D warnings`
- `git diff --check`
- post-commit hook: Soroban runtime `size-budget-check` passed at `128894` bytes

`cargo-fuzz` is not installed in this environment, so I compiled the new fuzz target but did not run `cargo fuzz run`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/470)
<!-- Reviewable:end -->
