### PR TITLE
chore: version proxy-oracle crates independently (NEAR contract 0.2.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12923,7 +12923,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-contract"
-version = "1.2.1"
+version = "0.2.0"
 dependencies = [
  "getrandom 0.2.17",
  "hex-literal",
@@ -12940,7 +12940,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-common"
-version = "1.2.1"
+version = "0.1.0"
 dependencies = [
  "near-sdk",
  "rstest",
@@ -12953,7 +12953,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-contract"
-version = "1.2.1"
+version = "0.1.0"
 dependencies = [
  "getrandom 0.2.17",
  "near-sdk",

--- a/contract/proxy-oracle/near/contract/Cargo.toml
+++ b/contract/proxy-oracle/near/contract/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-contract"
 repository.workspace = true
-version.workspace = true
+version = "0.2.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/near/governance-common/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-common/Cargo.toml
@@ -3,7 +3,7 @@ name = "templar-proxy-oracle-near-governance-common"
 license.workspace = true
 repository.workspace = true
 edition.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [dependencies]
 templar-common.workspace = true

--- a/contract/proxy-oracle/near/governance-contract/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-contract/Cargo.toml
@@ -3,7 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-governance-contract"
 repository.workspace = true
-version.workspace = true
+version = "0.1.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
## What

Give each `contract/proxy-oracle/near/*` crate its own version instead of inheriting the workspace version (`1.2.1`), and bump the NEAR proxy-oracle **contract** to `0.2.0`.

- `near/contract` → **0.2.0**
- `near/governance-common` → 0.1.0
- `near/governance-contract` → 0.1.0

(`near/lst-contract` is legacy and intentionally left untouched.)

## Why

These crates inherited `version.workspace = true`, so the NEP-330 `contract_source_metadata.version` they report was the workspace version (`1.2.1`) rather than anything indicative of the actual contract. That made it impossible to distinguish the new kernelized proxy-oracle from the legacy contract by version.

The legacy contract still deployed in production reports `0.1.0` (verified on mainnet — `proxy-oracle-iethhemibtc-iethusdc.v1.tmplr.near` → `"version": "0.1.0"`). Bumping the new contract to `0.2.0` makes `0.2.0` a clean, ground-truth cutover boundary: everything currently live is `< 0.2.0`, the kernelized contract is `>= 0.2.0`.

This unblocks the blockchain gateway detecting v0 vs v1 proxy oracles via the same standard NEP-330 `version::<T>()` path already used for markets and the registry.

## Notes

- Versioning metadata only — no contract logic changes. State-schema `VERSION` constants (`0`/`1`) are a separate axis and are untouched.
- No code or tests pin these crate versions, so nothing downstream breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/471)
<!-- Reviewable:end -->
