### PR TITLE
feat(pyth-pro): Pyth Pro (Lazer) ed25519 oracle adapter for NEAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ contract/proxy-*-soroban/test_snapshots/
 contract/proxy-oracle/**/test_snapshots/
 contract/proxy-*-soroban/**/test_snapshots/
 
+# pyth pro payloads
+contract/pyth-pro/payloads
+
 # generated bindings
 client/vault/dist/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ Use this section as an execution checklist: read the local docs first, preserve 
   Minimum verification: run the narrowest relevant `cargo test -p templar-relayer ...`; if SQL changes, update prepared queries as documented in the README.
 - `contract/pyth-pro` (`templar-pyth-pro-verifier` / `templar-pyth-pro-adapter-contract`)
   Read first: `contract/pyth-pro/README.md`, `contract/pyth-pro/SPEC.md`, `contract/pyth-pro/TRUSTED_SIGNERS.md`.
-  Read/inspect: `contract/pyth-pro/verifier/src/verify.rs`, `contract/pyth-pro/contract/src/lib.rs`, `contract/pyth-pro/contract/src/views.rs`.
+  Read/inspect: `contract/pyth-pro/verifier/src/verify.rs`, `contract/pyth-pro/contract/src/lib.rs`, `contract/pyth-pro/contract/src/feed_map.rs`, `contract/pyth-pro/contract/src/views.rs`, `contract/pyth-pro/contract/src/events.rs`.
   Why it matters: a drop-in `pyth-oracle.near` price oracle — forged, stale, or mis-scaled prices flow straight into borrow accounting. The wire parser is a forked `pyth-lazer-protocol` pinned by exact rev; bumps are security-sensitive.
   Watch for: signer/trust/expiry + ed25519 checks, canonical-encoding (`NonCanonical`) rejection, the freshness window and per-feed monotonic anti-replay, confidence/EMA discipline, `SignerSet` invariants, and storage-fee/refund.
   Minimum verification: `cargo test -p templar-pyth-pro-verifier -p templar-pyth-pro-adapter-contract`; `cargo check --target wasm32-unknown-unknown -p templar-pyth-pro-adapter-contract`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ This repository is a Rust workspace for Templar Protocol smart contracts, servic
 ## Repository Layout
 
 - `common`: shared protocol logic used by contracts and tests
-- `contract`: deployable smart contracts (`market`, `registry`, `vault`, `universal-account`, `lst-oracle`)
+- `contract`: deployable smart contracts (`market`, `registry`, `vault`, `universal-account`, `lst-oracle`, `pyth-pro`)
 - `service`: standalone executables and off-chain services
 - `tools`: operator and developer CLIs
 - `test-utils`: shared test harness utilities
@@ -49,6 +49,12 @@ Use this section as an execution checklist: read the local docs first, preserve 
   Why it matters: this service is an operational security boundary for delegated actions and universal-account flows.
   Watch for: allowed-method changes, nonce handling, gas settings, SQL query changes, storage-deposit behavior, and universal-account deployment/execution integration.
   Minimum verification: run the narrowest relevant `cargo test -p templar-relayer ...`; if SQL changes, update prepared queries as documented in the README.
+- `contract/pyth-pro` (`templar-pyth-pro-verifier` / `templar-pyth-pro-adapter-contract`)
+  Read first: `contract/pyth-pro/README.md`, `contract/pyth-pro/SPEC.md`, `contract/pyth-pro/TRUSTED_SIGNERS.md`.
+  Read/inspect: `contract/pyth-pro/verifier/src/verify.rs`, `contract/pyth-pro/contract/src/lib.rs`, `contract/pyth-pro/contract/src/views.rs`.
+  Why it matters: a drop-in `pyth-oracle.near` price oracle — forged, stale, or mis-scaled prices flow straight into borrow accounting. The wire parser is a forked `pyth-lazer-protocol` pinned by exact rev; bumps are security-sensitive.
+  Watch for: signer/trust/expiry + ed25519 checks, canonical-encoding (`NonCanonical`) rejection, the freshness window and per-feed monotonic anti-replay, confidence/EMA discipline, `SignerSet` invariants, and storage-fee/refund.
+  Minimum verification: `cargo test -p templar-pyth-pro-verifier -p templar-pyth-pro-adapter-contract`; `cargo check --target wasm32-unknown-unknown -p templar-pyth-pro-adapter-contract`.
 
 ## Working Norms
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13102,6 +13102,7 @@ dependencies = [
  "near-sdk",
  "near-sdk-contract-tools",
  "pyth-lazer-protocol",
+ "schemars 0.8.22",
  "templar-common",
  "templar-pyth-pro-verifier",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2510,6 +2510,12 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "convert_case"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "convert_case"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb4a24b1aaf0fd0ce8b45161144d6f42cd91677fd5940fd431183eb023b3a2b8"
@@ -2971,6 +2977,19 @@ checksum = "67e77553c4162a157adbf834ebae5b415acbecbeafc7a74b0e886657506a7611"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
+dependencies = [
+ "convert_case 0.4.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version 0.4.1",
  "syn 2.0.117",
 ]
 
@@ -7381,6 +7400,21 @@ dependencies = [
  "bitflags 2.11.0",
  "memchr",
  "unicase",
+]
+
+[[package]]
+name = "pyth-lazer-protocol"
+version = "0.43.0"
+source = "git+https://github.com/Templar-Protocol/pyth-lazer-public?rev=10aebfd0075887e9784f9fb65ef28ddbadb57139#10aebfd0075887e9784f9fb65ef28ddbadb57139"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "derive_more 0.99.20",
+ "hex",
+ "rust_decimal",
+ "serde",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -12404,6 +12438,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12426,6 +12469,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.117",
 ]
 
@@ -13034,6 +13089,34 @@ dependencies = [
  "templar-proxy-oracle-soroban-common",
  "templar-proxy-oracle-soroban-contract",
  "templar-proxy-oracle-soroban-sep40-adapter-contract",
+]
+
+[[package]]
+name = "templar-pyth-pro-adapter-contract"
+version = "0.1.0"
+dependencies = [
+ "byteorder",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hex",
+ "near-sdk",
+ "near-sdk-contract-tools",
+ "pyth-lazer-protocol",
+ "templar-common",
+ "templar-pyth-pro-verifier",
+]
+
+[[package]]
+name = "templar-pyth-pro-verifier"
+version = "0.1.0"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "ed25519-dalek",
+ "pyth-lazer-protocol",
+ "rstest",
+ "templar-primitives",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ members = [
     "contract/proxy-oracle/soroban/common",
     "contract/proxy-oracle/soroban/integration-tests",
     "contract/proxy-oracle/soroban/sep40-adapter-contract",
+    "contract/pyth-pro/verifier",
+    "contract/pyth-pro/contract",
     "contract/redstone-adapter",
     "contract/registry",
     "contract/vault/macros",
@@ -87,6 +89,7 @@ near-sdk-contract-tools = "4.0.0"
 near-workspaces = { version = "0.22.1", features = ["unstable"] }
 p256 = "0.13.2"
 primitive-types = { version = "0.14.0", features = ["serde"] }
+pyth-lazer-protocol = { git = "https://github.com/Templar-Protocol/pyth-lazer-public", rev = "10aebfd0075887e9784f9fb65ef28ddbadb57139", default-features = false }
 redstone = { git = "https://github.com/redstone-finance/rust-sdk", tag = "3.1.0-pre1", default-features = false }
 reqwest = "0.12.28"
 rstest = { version = "0.24" }
@@ -105,6 +108,7 @@ templar-proxy-oracle-near-common = { path = "./contract/proxy-oracle/near/common
 templar-proxy-oracle-near-contract = { path = "./contract/proxy-oracle/near/contract" }
 templar-proxy-oracle-near-governance-common = { path = "./contract/proxy-oracle/near/governance-common" }
 templar-proxy-oracle-near-governance-contract = { path = "./contract/proxy-oracle/near/governance-contract" }
+templar-pyth-pro-verifier = { path = "./contract/pyth-pro/verifier" }
 templar-redstone-bridge = { path = "./service/redstone-bridge" }
 templar-tools-common = { path = "./tools/tools-common" }
 templar-universal-account = { path = "./universal-account" }

--- a/common/src/versioned_state/macros.rs
+++ b/common/src/versioned_state/macros.rs
@@ -34,6 +34,10 @@ macro_rules! impl_versioned_state {
             let args: $migrations = ::near_sdk::serde_json::from_slice(&input)
                 .unwrap_or_else(|e| env::panic_str(&e.to_string()));
 
+            // A contract may launch at its first state version with no migrations defined, making
+            // `$migrations` an uninhabited (empty) enum. The deserialize above then has type `!`
+            // (it can only panic), so this call is statically unreachable — expected, not a bug.
+            #[allow(unreachable_code)]
             $crate::versioned_state::Migrator::run(args);
         }
     };

--- a/contract/pyth-pro/README.md
+++ b/contract/pyth-pro/README.md
@@ -1,0 +1,63 @@
+# Pyth Pro oracle adapter
+
+A push-style NEAR oracle that ingests [Pyth Pro](https://docs.pyth.network/lazer) signed price
+payloads and re-serves them through the **same view ABI as `pyth-oracle.near`** — so it is a
+drop-in Pyth oracle for the market and proxy-oracle.
+
+> **Naming:** this adapter consumes **Pyth Pro** signed updates. Pyth Pro was formerly known as
+> **Pyth Lazer**; some upstream protocol crates and contract paths still use the `lazer` name (e.g.
+> `pyth-lazer-protocol`, the `lazer/contracts` reference paths). We use **Pyth Pro** for everything
+> this repo owns and keep **Lazer** only when quoting such an upstream/legacy identifier.
+
+This is intentionally a **storage oracle backed by Pyth Pro** (push → persist → serve the Pyth
+views), *not* a stateless verifier like Pyth's official EVM/Sui/Aptos Lazer contracts — the drop-in
+requirement needs stored, view-served prices. A read-only `verify_update` method adds the
+official-style stateless verify-and-return surface alongside it (see the contract README).
+
+Flow: a relayer submits a signed Pyth Pro payload (Pyth's **solana** / ed25519 format) → the adapter
+verifies it (ed25519 signature against a trusted, non-expired signer set; channel filter; freshness
+window; monotonic-per-feed timestamp for anti-replay) → stores the prices → consumers read them via
+the Pyth view methods.
+
+## Crates
+
+| Crate | Path | What |
+|-------|------|------|
+| `templar-pyth-pro-verifier` | `verifier/` | Chain-agnostic verify + parse. No `near-sdk`. |
+| `templar-pyth-pro-adapter-contract` | `contract/` | NEAR cdylib: storage, governance, Pyth views. |
+
+The verifier wraps a forked, slimmed [`pyth-lazer-protocol`](https://github.com/Templar-Protocol/pyth-lazer-public/tree/feat/protocol-slim-build)
+(pinned by `rev = "10aebfd0075887e9784f9fb65ef28ddbadb57139"` on the `feat/protocol-slim-build`
+branch, `default-features = false`) for the wire format and adds the trust checks an on-chain
+adapter needs.
+
+## Identifier spaces
+
+Pyth Pro keys feeds by a small `u32`; Pyth Core consumers use 32-byte `PriceIdentifier`s. The
+adapter stores by `u32` and translates at read time through one isolated module
+(`contract/src/feed_map.rs`). Map each consumer `PriceIdentifier` to its existing Pyth Core
+identifier (`admin_set_feed_mapping`) to stay drop-in. That module is the *only* coupling between
+the two spaces, so the mapping can later move to the proxy-oracle by deleting it alone.
+
+## Governance
+
+Single owner (`near_sdk_contract_tools::Owner`); all privileged methods are `admin_*`, each
+`#[payable]` + `assert_one_yocto`. `update_price_feeds` is permissionless — authenticity is
+cryptographic.
+
+## Integration
+
+No proxy-oracle changes: register the deployed account as `OracleType::Pyth(<account>)`.
+
+## Build & test
+
+```sh
+cargo test -p templar-pyth-pro-verifier -p templar-pyth-pro-adapter-contract
+cargo check --target wasm32-unknown-unknown -p templar-pyth-pro-adapter-contract
+```
+
+## Before mainnet
+
+Real Pyth Pro signer public key(s) + expiry for a `config_prod` helper (see
+[`TRUSTED_SIGNERS.md`](./TRUSTED_SIGNERS.md) for how to obtain/verify them on-chain); the channel to
+accept (`allowed_channel_id`); an off-chain `service/pyth-pro-bridge` to subscribe and push updates.

--- a/contract/pyth-pro/SPEC.md
+++ b/contract/pyth-pro/SPEC.md
@@ -1,0 +1,87 @@
+# Pyth Pro Adapter Spec
+
+Naming: **Pyth Pro** for everything this repo owns, **Lazer** only for upstream/legacy identifiers
+(see [`README.md`](./README.md)).
+
+## Scope
+
+- `templar-pyth-pro-verifier`: chain-agnostic payload verification/parsing.
+- `templar-pyth-pro-adapter-contract`: NEAR storage, governance, fees, feed mapping, events, and Pyth-compatible views.
+
+## Build Contract
+
+- The verifier is chain-agnostic logic with no `near-sdk` dependency. It may use `std`; the
+  upstream parser it wraps uses `std::io`, and the NEAR contract target provides `std`.
+- Contract must compile for `wasm32-unknown-unknown`.
+- Parser dependency changes must be pinned by exact revision and reviewed as security-sensitive.
+
+Required checks:
+
+```bash
+cargo check --target wasm32-unknown-unknown -p templar-pyth-pro-adapter-contract
+```
+
+## Type Contract
+
+- External Pyth Lazer protocol types are allowed at the parser boundary.
+- Internal adapter/verifier time values should use `templar_primitives::Nanoseconds`.
+- Raw timestamp `u64` values are allowed only when required by an external ABI or protocol type.
+- A `Nanoseconds` field that is serialized to JSON must carry an `_ns` suffix (the type is erased in
+  JSON, so the field name has to convey the unit), e.g. `FeedData.publish_time_ns`.
+- Price output must preserve Pyth semantics: `price`, `conf`, `expo`, and `publish_time`.
+
+## Verification Contract
+
+An accepted update must satisfy:
+
+- signed solana-format (ed25519) message decodes;
+- the public key carried in the envelope is configured and unexpired;
+- the ed25519 signature verifies over the payload under that public key;
+- channel is allowed;
+- package timestamp is within configured past/future bounds;
+- each stored feed has price, exponent, and explicit non-negative confidence;
+- EMA is stored only when EMA price and explicit non-negative EMA confidence are both present;
+- effective per-feed publish time strictly advances stored data;
+- age-gated reads reject stale and future-dated prices.
+
+## Storage Contract
+
+- Callers must pay newly consumed storage plus configured update fee.
+- Feed mapping is `PriceIdentifier -> Lazer feed id`.
+- Unmapping a price id does not delete retained feed data.
+- Policy for storing signed but unmapped feeds must be explicit.
+
+## Governance Contract
+
+- Owner controls config, signer set, feed mappings, and withdrawals.
+- Config updates must preserve signer-set and freshness-window invariants.
+- Signer updates must preserve signer uniqueness. This invariant is structural: `SignerSet` is
+  backed by a `BTreeMap<[u8; 32], u64>` (public key → `expires_at_s`), so duplicate keys cannot
+  exist and iteration order is deterministic. It serializes transparently as the `Vec<TrustedSigner>`
+  array, so the stored layout and `get_config` JSON shape are unchanged.
+- Accepted trade-off: the verifier and contract keep separate `TrustedSigner` representations (the
+  contract's carries JSON/Borsh serializers; the verifier's is plain), and verification builds a
+  fresh `Vec<verifier::TrustedSigner>` per call (`SignerSet::verifier_signers`). This duplication and
+  the per-update allocation are low-risk for a small (`SignerSet::MAX`) signer set and avoid
+  feature-gating serializers onto the verifier type.
+
+## View Contract
+
+- Pyth-compatible spot and EMA view names must remain stable.
+- Unsafe views may return latest stored data without age filtering.
+- Age-gated and default-window views must apply freshness checks.
+- EMA views must not fall back to spot prices.
+- `verify_update(payload)` is a read-only, stateless verify-and-return: it runs the full
+  verification (signer / ed25519 signature / channel / freshness) and returns the **complete** Lazer
+  data (all properties) without writing storage, charging a fee, or touching feed mappings. It is
+  the official-Lazer-contract-style parity surface, intended for off-chain RPC callers (and on-chain
+  async callers via cross-contract call + callback — NEAR has no synchronous read calls).
+
+## Model & parity (intentional scope)
+
+This adapter is a **`pyth-oracle.near`-compatible storage oracle** (push → persist → serve), not a
+stateless verifier like the official Lazer contracts — the firm drop-in requirement (rationale in
+[`README.md`](./README.md)). `verify_update` adds the stateless surface alongside it. Known
+narrowing: the verifier preserves every property as `Option` but does not distinguish "not
+requested" from "requested-but-missing" (the official EVM `triStateMap` does) — a possible future
+enrichment.

--- a/contract/pyth-pro/TRUSTED_SIGNERS.md
+++ b/contract/pyth-pro/TRUSTED_SIGNERS.md
@@ -1,0 +1,171 @@
+# Pyth Pro Trusted Signers
+
+How to obtain and verify the Ed25519/Solana signer public key(s) the adapter must trust
+(`Config.signers`). See [`SPEC.md`](./SPEC.md) for the verification contract.
+
+## Finding
+
+There is **no static list** of Pyth Pro signer keys in Pyth's docs. The canonical Solana signer set
+is on-chain state in the deployed Pyth Pro Solana program storage account. Signers **rotate and
+expire** — never treat a recovered/hardcoded value as permanent.
+
+- Solana program, from Pyth Pro contract-address docs:
+  `pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt`
+- Storage PDA, derived from seed `storage` under that program:
+  `3rdJbqfnagQ4yx9HXJViD4zc4xpiSqmFsKpPuSCQVyQL`
+- Upstream/local source shape:
+  - `Storage.trusted_signers: [TrustedSignerInfo<Pubkey>; 5]`
+  - `Storage.num_trusted_signers: u8`
+  - `TrustedSignerInfo { pubkey: Pubkey, expires_at: i64 }`
+
+## Current Value
+
+Read from real Pyth Pro Solana payloads:
+
+```text
+publicKey:    9gKEEcFzSd1PDYBKWAKZi4Sq4ZCUaVX5oTr8kEjdwsfR
+publicKeyHex: 80efc1f480c5615af3fb673d42287e993da9fbc3506b6e41dfa32950820c2e6c
+```
+
+The same key was present in the Solana storage account when checked on 2026-06-17:
+
+```text
+expiresAt:    2052483257
+expiresAtIso: 2035-01-15T14:14:17.000Z
+active:       true
+```
+
+This value is useful evidence and a regression fixture, but it is **not** a trust root by itself.
+Trust comes from checking the public key against live Solana program state.
+
+## Reproduce
+
+### A. Read the signer from a Solana-format payload
+
+The Solana Lazer envelope contains:
+
+- 4-byte little-endian Solana format magic
+- 64-byte Ed25519 signature
+- 32-byte Ed25519 public key
+- 2-byte little-endian payload length
+- little-endian Lazer payload bytes
+
+The public key is carried in the envelope (no recovery); inspect a captured payload and verify its
+signature:
+
+```sh
+node contract/pyth-pro/solana-payload-signer.mjs <BASE64_OR_HEX_PAYLOAD>
+printf '%s\n' '<BASE64_PAYLOAD>' | node contract/pyth-pro/solana-payload-signer.mjs
+```
+
+Expected shape:
+
+```json
+{
+  "publicKey": "9gKEEcFzSd1PDYBKWAKZi4Sq4ZCUaVX5oTr8kEjdwsfR",
+  "publicKeyHex": "80efc1f480c5615af3fb673d42287e993da9fbc3506b6e41dfa32950820c2e6c",
+  "signatureVerified": true,
+  "channel": 3,
+  "feedIds": [7, 8, 1, 27, 23]
+}
+```
+
+### B. Query the live trusted signer list on Solana
+
+Use the dependency-free storage decoder:
+
+```sh
+node contract/pyth-pro/query-solana-trusted-signers.mjs
+```
+
+Optional environment:
+
+```sh
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com \
+node contract/pyth-pro/query-solana-trusted-signers.mjs
+```
+
+Expected shape:
+
+```json
+{
+  "programId": "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt",
+  "storageAccount": "3rdJbqfnagQ4yx9HXJViD4zc4xpiSqmFsKpPuSCQVyQL",
+  "trustedSigners": [
+    {
+      "publicKey": "9gKEEcFzSd1PDYBKWAKZi4Sq4ZCUaVX5oTr8kEjdwsfR",
+      "publicKeyHex": "80efc1f480c5615af3fb673d42287e993da9fbc3506b6e41dfa32950820c2e6c",
+      "expiresAt": "2052483257",
+      "active": true
+    }
+  ]
+}
+```
+
+### C. Manual Storage Layout
+
+The helper decodes the Anchor account directly:
+
+```text
+0..8      Anchor discriminator
+8..40     top_authority Pubkey
+40..72    treasury Pubkey
+72..80    single_update_fee_in_lamports u64 LE
+80        num_trusted_signers u8
+81..281   trusted_signers[5], each:
+          pubkey Pubkey (32 bytes)
+          expires_at i64 LE
+281..381  unused by this adapter path
+```
+
+A Solana signer is currently valid only if it appears in `trusted_signers[0..num_trusted_signers]`
+and `expires_at > current_unix_timestamp_seconds`.
+
+## Rotating the adapter's trusted signers
+
+When Pyth rotates the Solana ed25519 signer, mirror it on the adapter with the owner-only,
+1-yoctoNEAR `admin_*` methods (no redeploy). Signers are 32-byte ed25519 keys passed as **64-char
+hex** — the Solana tools print base58, which is the same 32 bytes, so convert if needed. Always add
+the new key *before* removing the old one (overlap window); the contract rejects removing the last
+signer.
+
+1. **Read the live Solana set** (source of truth):
+   ```sh
+   node contract/pyth-pro/query-solana-trusted-signers.mjs   # pubkeys + expiries
+   ```
+2. **Add / refresh** a signer on the adapter (pass `expires_at_s` = unix seconds, ideally matching
+   Solana's `expiresAt`):
+   ```sh
+   near call <ADAPTER> admin_set_signer \
+     '{"public_key":"<64-hex>","expires_at_s":<unix>}' \
+     --accountId <OWNER> --depositYocto 1
+   ```
+   The same call with an existing key just refreshes its expiry.
+3. **Remove** a retired signer once its overlap window has passed by omitting `expires_at_s`
+   (rejected if it's the last one):
+   ```sh
+   near call <ADAPTER> admin_set_signer \
+     '{"public_key":"<64-hex>"}' \
+     --accountId <OWNER> --depositYocto 1
+   ```
+   Or replace the whole policy atomically (full set + windows + fee):
+   ```sh
+   near call <ADAPTER> admin_set_config '{"config":{ "signers":[...], ... }}' \
+     --accountId <OWNER> --depositYocto 1
+   ```
+4. **Confirm**:
+   ```sh
+   near view <ADAPTER> get_config
+   ```
+
+Behavior is covered by `contract/.../tests/test.rs`
+(`rotating_in_a_new_signer_accepts_its_updates`, `refreshing_signer_expiry_into_the_past_rejects_updates`,
+`admin_set_signer_cannot_remove_last`, `admin_methods_reject_non_owner`).
+
+## Before Mainnet
+
+Read the public key from a fresh Solana-format payload (A), enumerate live signers from Solana
+state (B), and set `Config.signers` to the current public key(s) with matching `expires_at_s`.
+
+A dedicated CLI / `service/pyth-pro-bridge` step (planned) should reconcile our signer set against the
+Solana storage account automatically so we track Pyth's rotations rather than updating by hand.

--- a/contract/pyth-pro/contract/Cargo.toml
+++ b/contract/pyth-pro/contract/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+edition.workspace = true
+license.workspace = true
+name = "templar-pyth-pro-adapter-contract"
+repository.workspace = true
+version = "0.1.0"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+# Pulled transitively and required for the `wasm32-unknown-unknown` build; the `custom` feature
+# (set in the workspace dep) provides the getrandom backend. Not used directly.
+getrandom.workspace = true
+hex.workspace = true
+near-sdk.workspace = true
+near-sdk-contract-tools.workspace = true
+templar-common.workspace = true
+templar-pyth-pro-verifier.workspace = true
+
+[dev-dependencies]
+byteorder = "1"
+ed25519-dalek.workspace = true
+near-sdk = { workspace = true, features = ["non-contract-usage", "unit-testing"] }
+pyth-lazer-protocol.workspace = true
+
+# fields to configure build with WASM reproducibility, according to specs
+# in https://github.com/near/NEPs/blob/master/neps/nep-0330.md
+[package.metadata.near.reproducible_build]
+# docker image, descriptor of build environment
+image = "sourcescan/cargo-near:0.17.0-rust-1.86.0"
+# tag after colon above serves only descriptive purpose; image is identified by digest
+image_digest = "sha256:1784ca6310f3496f0048356ce420921c8f5fdf71ee8124d43a2e1ceb1f70db8a"
+# build command inside of docker container
+container_build_command = [
+    "cargo",
+    "near",
+    "build",
+    "non-reproducible-wasm",
+    "--locked",
+]
+
+[lints]
+workspace = true

--- a/contract/pyth-pro/contract/Cargo.toml
+++ b/contract/pyth-pro/contract/Cargo.toml
@@ -15,6 +15,9 @@ getrandom.workspace = true
 hex.workspace = true
 near-sdk.workspace = true
 near-sdk-contract-tools.workspace = true
+# Direct (always-on, already in-tree via templar-common) so `SignerSet` can carry unconditional
+# `JsonSchema` impls — the contract's custom types need schemas under near-sdk's `abi` build.
+schemars.workspace = true
 templar-common.workspace = true
 templar-pyth-pro-verifier.workspace = true
 

--- a/contract/pyth-pro/contract/README.md
+++ b/contract/pyth-pro/contract/README.md
@@ -1,0 +1,62 @@
+# templar-pyth-pro-adapter-contract
+
+NEAR cdylib for the Pyth Pro adapter: stores verified prices and serves them through the
+`pyth-oracle.near` view ABI. Verification lives in `templar-pyth-pro-verifier`; see the
+[adapter overview](../README.md).
+
+## Methods
+
+Init / config:
+- `new(owner, config)` — `config`: `signers`, `max_timestamp_delay_s`, `max_timestamp_ahead_s`,
+  `allowed_channel_id`, `update_fee` (a `NearToken`, default `0`), `default_valid_time_period_s`
+  (staleness window for the non-suffixed views).
+- `get_config()`.
+
+Owner-only (`admin_*`, `#[payable]`, 1 yocto):
+- `admin_set_config(config)`.
+- `admin_set_signer(public_key: hex, expires_at_s: Option<u64>)` — add/refresh (`Some`) or remove
+  (`None`) a 32-byte ed25519 signer (64 hex chars).
+- `admin_set_feed_mapping(price_identifier, feed_id: Option<u32>)` — map/unmap. Unmapping removes
+  only the id→feed entry; `feeds[feed_id]` is retained, so remapping can resurface pre-existing data
+  via the `*_unsafe` views / `price_feed_exists` (the `*_no_older_than` views age-filter it). Re-push
+  an update after (re)mapping if that matters.
+- `admin_withdraw(amount: NearToken)` — send accrued fees/free balance to the owner (the runtime's
+  storage-staking guard blocks withdrawing below the staked requirement).
+
+Permissionless write (`#[payable]`):
+- `update_price_feeds(payload: Base64VecU8)` — verify and store; emits `UpdatePrices`. A feed is
+  stored only with both a price and an exponent, only if its effective per-feed publish timestamp
+  strictly advances (anti-replay) and is not too far in the future, and EMA is stored only when the
+  payload actually carried it (never derived from spot). The caller must attach a deposit covering
+  the newly consumed storage plus `config.update_fee`; the excess is refunded. Updates that only
+  overwrite known feeds consume no new storage, so with a zero fee they are effectively free.
+
+Storage policy: every verified feed is stored, **regardless of whether a consumer `PriceIdentifier`
+currently maps to it**. This is intentional — it keeps update correctness independent of the
+removable `feed_map` seam. The submitter funds the storage, and unmapped feeds are simply not
+queryable until an `admin_set_feed_mapping` exists. There is deliberately no mapped-only allowlist.
+
+Pyth views (drop-in for `pyth-oracle.near`): `price_feed_exists`; spot `get_price` /
+`get_price_unsafe` / `get_price_no_older_than` and the `list_prices*` forms; EMA `get_ema_price` /
+`get_ema_price_unsafe` / `get_ema_price_no_older_than` and the `list_ema_prices*` forms. The
+non-suffixed `get_price` / `get_ema_price` / `list_prices` / `list_ema_prices` apply
+`config.default_valid_time_period_s` as their staleness window. Plus `get_feed_mapping`,
+`list_feed_mappings`, and `get_feed_data(feed_id)` (debug).
+
+Stateless verify (read-only): `verify_update(payload) -> VerifiedUpdateView` runs the full
+verification and returns the **complete** Lazer data for every feed (all properties — not just the
+Pyth subset) **without** writing storage / charging a fee / touching mappings. It's the
+official-Lazer-style parity surface for off-chain RPC (`near view`) and async on-chain callers; it
+does not replace the store+serve path above (NEAR has no synchronous cross-contract reads).
+
+## Layout
+
+- `lib.rs` — state (`config`, `feeds: u32 -> FeedData`, `ids`), init, admin, write path.
+- `crypto.rs` — `Crypto` via `env::ed25519_verify`.
+- `feed_map.rs` — **removable** `PriceIdentifier ↔ u32` seam.
+- `views.rs` — Pyth read ABI.  `events.rs` — `UpdatePrices` event.
+
+## Build
+
+Build the deployable artifact with `--target wasm32-unknown-unknown`; run the integration tests on
+host with `cargo test`.

--- a/contract/pyth-pro/contract/README.md
+++ b/contract/pyth-pro/contract/README.md
@@ -23,6 +23,16 @@ Owner-only (`admin_*`, `#[payable]`, 1 yocto):
   an update after (re)mapping if that matters.
 - `admin_withdraw(amount: NearToken)` — send accrued fees/free balance to the owner (the runtime's
   storage-staking guard blocks withdrawing below the staked requirement).
+- `admin_upgrade(code: Base64VecU8, migrate_args: Base64VecU8)` — atomically deploy new contract
+  code and run its `migrate` in one receipt: a failed migration reverts the code deploy too.
+  `migrate_args` is the JSON-encoded migration selector. The contract launches at state version 1
+  with no migrations defined, so this is the seam for future version bumps; the batched `migrate` is
+  private (only the runtime, acting as this account, can call it).
+
+State versioning: persistent state is wrapped in `VersionedState` (launches at version 1). View
+helpers `get_stored_state_version()`, `get_target_state_version()`, and `needs_migration()` report
+the on-chain vs. code-target state version — `needs_migration()` is `false` on a fresh deploy and
+guards against accidental downgrades (a stored version newer than the code panics).
 
 Permissionless write (`#[payable]`):
 - `update_price_feeds(payload: Base64VecU8)` — verify and store; emits `UpdatePrices`. Bundles

--- a/contract/pyth-pro/contract/README.md
+++ b/contract/pyth-pro/contract/README.md
@@ -9,7 +9,8 @@ NEAR cdylib for the Pyth Pro adapter: stores verified prices and serves them thr
 Init / config:
 - `new(owner, config)` — `config`: `signers`, `max_timestamp_delay_s`, `max_timestamp_ahead_s`,
   `allowed_channel_id`, `update_fee` (a `NearToken`, default `0`), `default_valid_time_period_s`
-  (staleness window for the non-suffixed views).
+  (staleness window for the non-suffixed views), `max_feeds_per_update` (non-zero cap on feeds
+  accepted per `update_price_feeds` call, bounding the `UpdatePrices` event / log size).
 - `get_config()`.
 
 Owner-only (`admin_*`, `#[payable]`, 1 yocto):
@@ -24,10 +25,12 @@ Owner-only (`admin_*`, `#[payable]`, 1 yocto):
   storage-staking guard blocks withdrawing below the staked requirement).
 
 Permissionless write (`#[payable]`):
-- `update_price_feeds(payload: Base64VecU8)` — verify and store; emits `UpdatePrices`. A feed is
-  stored only with both a price and an exponent, only if its effective per-feed publish timestamp
-  strictly advances (anti-replay) and is not too far in the future, and EMA is stored only when the
-  payload actually carried it (never derived from spot). The caller must attach a deposit covering
+- `update_price_feeds(payload: Base64VecU8)` — verify and store; emits `UpdatePrices`. Bundles
+  carrying more than `config.max_feeds_per_update` feeds are rejected up front (keeps the emitted
+  event/log bounded). A feed is stored only with both a price and an exponent, only if its effective
+  per-feed publish timestamp strictly advances (anti-replay) and is not too far in the future, and
+  EMA is stored only when the payload actually carried it (never derived from spot). The caller must
+  attach a deposit covering
   the newly consumed storage plus `config.update_fee`; the excess is refunded. Updates that only
   overwrite known feeds consume no new storage, so with a zero fee they are effectively free.
 

--- a/contract/pyth-pro/contract/src/crypto.rs
+++ b/contract/pyth-pro/contract/src/crypto.rs
@@ -1,0 +1,11 @@
+use near_sdk::env;
+use templar_pyth_pro_verifier::Crypto;
+
+/// [`Crypto`] backed by NEAR's native `env::ed25519_verify` (ed25519 is NEAR's own scheme).
+pub struct EnvCrypto;
+
+impl Crypto for EnvCrypto {
+    fn ed25519_verify(&self, signature: &[u8; 64], message: &[u8], public_key: &[u8; 32]) -> bool {
+        env::ed25519_verify(signature, message, public_key)
+    }
+}

--- a/contract/pyth-pro/contract/src/events.rs
+++ b/contract/pyth-pro/contract/src/events.rs
@@ -1,0 +1,12 @@
+use near_sdk::near;
+
+use crate::FeedData;
+
+/// NEP-297 events emitted by the adapter.
+#[near(event_json(standard = "pyth-pro-adapter"))]
+pub enum PythProEvent {
+    /// Emitted after a successful `update_price_feeds`, listing the feeds that were written
+    /// (by Lazer feed id) together with their new data.
+    #[event_version("1.0.0")]
+    UpdatePrices { updated_feeds: Vec<(u32, FeedData)> },
+}

--- a/contract/pyth-pro/contract/src/feed_map.rs
+++ b/contract/pyth-pro/contract/src/feed_map.rs
@@ -1,0 +1,69 @@
+//! Feed-id mapping layer — the ONLY coupling between Pyth's 32-byte `PriceIdentifier` space and
+//! Lazer's `u32` feed-id space.
+//!
+//! Everything else in the contract (storage, the write path) is keyed by `u32`. If this mapping
+//! is later relocated to the proxy-oracle, deleting this module and the `Contract::ids` field —
+//! then exposing feed-id-keyed views — is all that's required; nothing else depends on it.
+
+use near_sdk::{assert_one_yocto, near};
+use near_sdk_contract_tools::owner::Owner;
+use templar_common::{contract::list, oracle::pyth::PriceIdentifier};
+
+use crate::{Contract, ContractExt};
+
+impl Contract {
+    /// Translate a consumer-facing price identifier into a Lazer feed id, if mapped.
+    pub(crate) fn resolve(&self, price_identifier: &PriceIdentifier) -> Option<u32> {
+        self.ids.get(price_identifier).copied()
+    }
+}
+
+#[near]
+impl Contract {
+    /// Map (`feed_id = Some`) or unmap (`feed_id = None`) a consumer `PriceIdentifier` to a Lazer
+    /// feed id. Map to the asset's existing Pyth Core identifier to make this a drop-in oracle.
+    ///
+    /// Unmapping removes only the `PriceIdentifier -> feed_id` entry; the stored `feeds[feed_id]`
+    /// data is intentionally retained (it is global, keyed by the Lazer id, and may be referenced
+    /// by other identifiers). Consequently, re-mapping a `PriceIdentifier` to a feed id that still
+    /// holds data makes `price_feed_exists` true and lets the `*_unsafe` views return that
+    /// pre-existing data immediately, before any fresh update. The age-gated `*_no_older_than`
+    /// views (which Templar consumers use) filter such stale data by `publish_time`, so this is an
+    /// operational caveat for `*_unsafe`/`price_feed_exists` callers during onboarding or feed
+    /// replacement — re-push an update (or query with a freshness bound) after (re)mapping.
+    #[payable]
+    pub fn admin_set_feed_mapping(
+        &mut self,
+        price_identifier: PriceIdentifier,
+        feed_id: Option<u32>,
+    ) {
+        assert_one_yocto();
+        Self::require_owner();
+        match feed_id {
+            Some(id) => {
+                self.ids.insert(price_identifier, id);
+            }
+            None => {
+                self.ids.remove(&price_identifier);
+            }
+        }
+    }
+
+    /// The Lazer feed id a `PriceIdentifier` resolves to, if any.
+    pub fn get_feed_mapping(&self, price_identifier: PriceIdentifier) -> Option<u32> {
+        self.resolve(&price_identifier)
+    }
+
+    /// Paginated list of all configured `(PriceIdentifier, feed_id)` mappings.
+    pub fn list_feed_mappings(
+        &self,
+        offset: Option<u32>,
+        count: Option<u32>,
+    ) -> Vec<(PriceIdentifier, u32)> {
+        list(
+            self.ids.iter().map(|(id, feed_id)| (*id, *feed_id)),
+            offset,
+            count,
+        )
+    }
+}

--- a/contract/pyth-pro/contract/src/lib.rs
+++ b/contract/pyth-pro/contract/src/lib.rs
@@ -175,6 +175,7 @@ pub struct ConfigArgs {
     pub allowed_channel_id: Option<u8>,
     pub update_fee: NearToken,
     pub default_valid_time_period_s: u64,
+    pub max_feeds_per_update: u32,
 }
 
 /// Validated verification policy for incoming payloads. Built only via `Config::try_from` a
@@ -198,6 +199,14 @@ pub struct Config {
     /// `pyth-oracle.near`'s `valid_time_period`. The `*_no_older_than` / `*_unsafe` variants are
     /// unaffected.
     pub default_valid_time_period_s: u64,
+    /// Upper bound (must be non-zero) on how many feeds a single `update_price_feeds` call may
+    /// store. The emitted NEP-297 `UpdatePrices` event carries the full `FeedData` for every
+    /// updated feed, so an oversized signed bundle could otherwise push the receipt's total log
+    /// length past NEAR's limit and abort the call *after* verification + storage writes. Capping
+    /// the accepted feed count keeps the event (and the per-call work) bounded. Bundle size is set
+    /// by a trusted signer, not the caller, so this is a robustness guard rather than an anti-abuse
+    /// control.
+    pub max_feeds_per_update: u32,
 }
 
 impl TryFrom<ConfigArgs> for Config {
@@ -210,6 +219,9 @@ impl TryFrom<ConfigArgs> for Config {
         if args.default_valid_time_period_s == 0 {
             return Err("config: default_valid_time_period_s must be non-zero");
         }
+        if args.max_feeds_per_update == 0 {
+            return Err("config: max_feeds_per_update must be non-zero");
+        }
         Ok(Self {
             signers: SignerSet::try_new(args.signers)?,
             max_timestamp_delay_s: args.max_timestamp_delay_s,
@@ -217,6 +229,7 @@ impl TryFrom<ConfigArgs> for Config {
             allowed_channel_id: args.allowed_channel_id,
             update_fee: args.update_fee,
             default_valid_time_period_s: args.default_valid_time_period_s,
+            max_feeds_per_update: args.max_feeds_per_update,
         })
     }
 }
@@ -462,6 +475,15 @@ impl Contract {
 
         let update = self.verify(&payload.0, now);
 
+        // Reject oversized bundles up front (before any storage write) so the eventual NEP-297
+        // `UpdatePrices` log — which carries full `FeedData` per feed — stays within NEAR's
+        // total-log-length limit. `updated_feeds` only ever shrinks relative to `update.feeds`
+        // (some feeds skip on intrinsic-invalidity or anti-replay), so bounding the bundle bounds
+        // the event.
+        if update.feeds.len() as u64 > u64::from(self.config.max_feeds_per_update) {
+            env::panic_str("too many feeds in a single update");
+        }
+
         let mut updated_feeds = Vec::new();
         for feed in &update.feeds {
             // Intrinsic validity lives in `from_parsed`; `None` skips. Timestamps are already
@@ -541,5 +563,10 @@ impl Contract {
 /// positive confidence — we reject the ambiguous/invalid case rather than mold it into a
 /// precise-looking zero.
 fn require_confidence(confidence: Option<i64>) -> Option<u64> {
-    confidence.and_then(|value| u64::try_from(value).ok())
+    // Defense-in-depth: keep only strictly-positive confidences. Upstream `Price` is `NonZeroI64`,
+    // so a literal `Some(0)` should never reach here, but the explicit `> 0` filter means this
+    // never stores a zero confidence even if that invariant changes on a parser rev bump.
+    confidence
+        .and_then(|value| u64::try_from(value).ok())
+        .filter(|&value| value > 0)
 }

--- a/contract/pyth-pro/contract/src/lib.rs
+++ b/contract/pyth-pro/contract/src/lib.rs
@@ -15,35 +15,28 @@
 mod crypto;
 mod events;
 mod feed_map;
+mod state;
 mod views;
 
 use std::collections::BTreeMap;
+use std::ops::{Deref, DerefMut};
 
 use near_sdk::{
-    assert_one_yocto,
-    borsh::BorshSerialize,
-    env,
+    assert_one_yocto, env,
     json_types::{Base64VecU8, I64, U64},
-    near,
-    store::IterableMap,
-    AccountId, BorshStorageKey, NearToken, PanicOnDefault, Promise,
+    near, AccountId, Gas, NearToken, PanicOnDefault, Promise,
 };
 use near_sdk_contract_tools::{owner::Owner, utils::apply_storage_fee_and_refund, Owner};
 use templar_common::{
-    oracle::pyth::{Price, PriceIdentifier, PythTimestamp},
+    oracle::pyth::{Price, PythTimestamp},
+    versioned_state::{impl_versioned_state, StateVersion, VersionedState},
     Nanoseconds, UnwrapReject,
 };
 use templar_pyth_pro_verifier as verifier;
 
 use crate::crypto::EnvCrypto;
 use crate::events::PythProEvent;
-
-#[derive(BorshSerialize, BorshStorageKey)]
-#[borsh(crate = "near_sdk::borsh")]
-enum StorageKey {
-    Feeds,
-    Ids,
-}
+use crate::state::State;
 
 /// A trusted Pyth Pro publisher: its 32-byte ed25519 public key (hex-encoded in JSON) and the
 /// unix-seconds instant after which its signatures are no longer accepted.
@@ -395,22 +388,39 @@ impl From<verifier::VerifiedUpdate> for VerifiedUpdateView {
 #[derive(Owner, PanicOnDefault)]
 #[near(contract_state)]
 pub struct Contract {
-    config: Config,
-    /// Latest data keyed by the natural Lazer `u32` feed id.
-    feeds: IterableMap<u32, FeedData>,
-    /// Mapping layer (see `feed_map`): consumer `PriceIdentifier` -> Lazer feed id.
-    ids: IterableMap<PriceIdentifier, u32>,
+    pub state: VersionedState<State>,
+}
+
+// Generates the private `migrate()` entrypoint (driven by `state::migration::Migration`) plus the
+// `get_stored_state_version` / `get_target_state_version` / `needs_migration` views.
+impl_versioned_state!(Contract, State, crate::state::migration::Migration);
+
+// The live fields (`config`, `feeds`, `ids`) live on `State`; deref so the rest of the contract can
+// keep reaching them as `self.config` / `self.feeds` / `self.ids`.
+impl Deref for Contract {
+    type Target = State;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl DerefMut for Contract {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
 }
 
 #[near]
 impl Contract {
+    /// Gas reserved for the batched `migrate` call in [`Self::admin_upgrade`].
+    pub const GAS_FOR_MIGRATE: Gas = Gas::from_tgas(250);
+
     #[init]
     pub fn new(owner: AccountId, config: ConfigArgs) -> Self {
         let config = Config::try_from(config).unwrap_or_else(|e| env::panic_str(e));
         let mut contract = Self {
-            config,
-            feeds: IterableMap::new(StorageKey::Feeds),
-            ids: IterableMap::new(StorageKey::Ids),
+            state: State::new(config),
         };
         Owner::init(&mut contract, &owner);
         contract
@@ -459,6 +469,25 @@ impl Contract {
         Self::require_owner();
         // `require_owner` guarantees the predecessor is the owner.
         Promise::new(env::predecessor_account_id()).transfer(amount)
+    }
+
+    /// Atomically deploy new contract code and run its `migrate` in a single receipt: a failed
+    /// migration reverts the code deployment too. `migrate_args` is the JSON-encoded
+    /// [`state::migration::Migration`] selecting the state transform to apply (none exist at v1, so
+    /// this is the seam for future upgrades). The batched `migrate` is private — the runtime calls
+    /// it as this account, so only the owner-gated path here can trigger it.
+    #[payable]
+    pub fn admin_upgrade(&mut self, code: Base64VecU8, migrate_args: Base64VecU8) -> Promise {
+        assert_one_yocto();
+        Self::require_owner();
+        Promise::new(env::current_account_id())
+            .deploy_contract(code.0)
+            .function_call(
+                "migrate".to_string(),
+                migrate_args.0,
+                NearToken::from_yoctonear(0),
+                Self::GAS_FOR_MIGRATE,
+            )
     }
 
     /// Verify a Pyth Pro solana-format (ed25519) signed payload and store its feeds. Permissionless:

--- a/contract/pyth-pro/contract/src/lib.rs
+++ b/contract/pyth-pro/contract/src/lib.rs
@@ -43,7 +43,10 @@ use crate::state::State;
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[near(serializers = [borsh, json])]
 pub struct TrustedSigner {
-    #[serde(with = "hex::serde")]
+    #[serde(
+        serialize_with = "hex::serde::serialize",
+        deserialize_with = "hex::serde::deserialize"
+    )]
     pub public_key: [u8; 32],
     pub expires_at_s: u64,
 }
@@ -155,6 +158,54 @@ impl<'de> near_sdk::serde::Deserialize<'de> for SignerSet {
     ) -> Result<Self, D::Error> {
         let signers = Vec::<TrustedSigner>::deserialize(deserializer)?;
         Self::try_new(signers).map_err(near_sdk::serde::de::Error::custom)
+    }
+}
+
+// ABI schemas. `SignerSet` has hand-written Borsh/serde impls (transparent over `Vec<TrustedSigner>`,
+// validated on the way in), so the `#[near]` macro can't derive its schemas — and the `#[near]`
+// schema on `Config` recurses into this field under near-sdk's `abi` build. These impls are
+// unconditional (matching `templar-common`'s `Wad`/`Number`): they describe the wire form via
+// always-available primitives, so they need neither an `abi` feature gate nor `TrustedSigner`'s own
+// (abi-only) schemas.
+impl near_sdk::borsh::BorshSchema for SignerSet {
+    fn add_definitions_recursively(
+        definitions: &mut std::collections::BTreeMap<
+            near_sdk::borsh::schema::Declaration,
+            near_sdk::borsh::schema::Definition,
+        >,
+    ) {
+        // A `TrustedSigner` (`[u8; 32]` then `u64`) is Borsh-identical to that tuple, so the set is
+        // byte-for-byte a `Vec<([u8; 32], u64)>`.
+        <Vec<([u8; 32], u64)> as near_sdk::borsh::BorshSchema>::add_definitions_recursively(
+            definitions,
+        );
+    }
+
+    fn declaration() -> near_sdk::borsh::schema::Declaration {
+        <Vec<([u8; 32], u64)> as near_sdk::borsh::BorshSchema>::declaration()
+    }
+}
+
+impl schemars::JsonSchema for SignerSet {
+    fn schema_name() -> String {
+        "SignerSet".to_string()
+    }
+
+    fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
+        // The JSON form is an array of `TrustedSigner` objects (`public_key` as a hex string). Mirror
+        // that with a schema-only DTO so this impl never needs `TrustedSigner: JsonSchema`.
+        #[derive(schemars::JsonSchema)]
+        #[allow(dead_code)]
+        struct TrustedSignerSchema {
+            #[schemars(with = "String")]
+            public_key: [u8; 32],
+            expires_at_s: u64,
+        }
+        <Vec<TrustedSignerSchema> as schemars::JsonSchema>::json_schema(generator)
+    }
+
+    fn is_referenceable() -> bool {
+        false
     }
 }
 
@@ -367,7 +418,10 @@ impl From<&verifier::ParsedFeed> for ParsedFeedView {
 #[near(serializers = [json])]
 pub struct VerifiedUpdateView {
     /// The trusted ed25519 signer public key (hex).
-    #[serde(with = "hex::serde")]
+    #[serde(
+        serialize_with = "hex::serde::serialize",
+        deserialize_with = "hex::serde::deserialize"
+    )]
     pub signer: [u8; 32],
     pub channel_id: u8,
     pub timestamp_ns: Nanoseconds,

--- a/contract/pyth-pro/contract/src/lib.rs
+++ b/contract/pyth-pro/contract/src/lib.rs
@@ -1,0 +1,545 @@
+#![allow(clippy::needless_pass_by_value)]
+//! Pyth Pro (formerly Pyth Lazer) oracle adapter for NEAR.
+//!
+//! A push-style adapter: anyone may relay a Pyth Pro signed price payload via
+//! [`Contract::update_price_feeds`]; the adapter verifies it (ed25519 signature against a
+//! trusted, non-expired signer set, channel filter, freshness window, and a monotonic-per-feed
+//! timestamp that blocks replays) and stores the prices. Consumers read those prices through the
+//! same view ABI as `pyth-oracle.near`, so the adapter is a drop-in Pyth oracle.
+//!
+//! Governance is intentionally minimal: a single owner (via [`near_sdk_contract_tools::Owner`])
+//! gates the `admin_*` methods. The `feed_map` module is the sole place that couples Pyth's
+//! 32-byte `PriceIdentifier` to Lazer's `u32` feed id, kept isolated so it can later move to the
+//! proxy-oracle without disturbing the rest of the contract.
+
+mod crypto;
+mod events;
+mod feed_map;
+mod views;
+
+use std::collections::BTreeMap;
+
+use near_sdk::{
+    assert_one_yocto,
+    borsh::BorshSerialize,
+    env,
+    json_types::{Base64VecU8, I64, U64},
+    near,
+    store::IterableMap,
+    AccountId, BorshStorageKey, NearToken, PanicOnDefault, Promise,
+};
+use near_sdk_contract_tools::{owner::Owner, utils::apply_storage_fee_and_refund, Owner};
+use templar_common::{
+    oracle::pyth::{Price, PriceIdentifier, PythTimestamp},
+    Nanoseconds, UnwrapReject,
+};
+use templar_pyth_pro_verifier as verifier;
+
+use crate::crypto::EnvCrypto;
+use crate::events::PythProEvent;
+
+#[derive(BorshSerialize, BorshStorageKey)]
+#[borsh(crate = "near_sdk::borsh")]
+enum StorageKey {
+    Feeds,
+    Ids,
+}
+
+/// A trusted Pyth Pro publisher: its 32-byte ed25519 public key (hex-encoded in JSON) and the
+/// unix-seconds instant after which its signatures are no longer accepted.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [borsh, json])]
+pub struct TrustedSigner {
+    #[serde(with = "hex::serde")]
+    pub public_key: [u8; 32],
+    pub expires_at_s: u64,
+}
+
+/// A validated set of trusted signers: non-empty, free of duplicate public keys, and bounded in
+/// size. Backed by a `BTreeMap<public_key, expires_at_s>`, so the "one expiry per key" uniqueness
+/// invariant is structural (enforced by the map) rather than re-checked on every mutation, and
+/// iteration order is deterministic (sorted by public key). Serializes transparently as the inner
+/// array of [`TrustedSigner`] for both Borsh and JSON, so the stored layout and `get_config` shape
+/// are unchanged (the array is just emitted in public-key order).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SignerSet(BTreeMap<[u8; 32], u64>);
+
+impl SignerSet {
+    /// Maximum number of trusted signers (Pyth Pro uses a small publisher set).
+    pub const MAX: usize = 32;
+
+    /// Validate a list of signers into the set.
+    fn try_new(signers: Vec<TrustedSigner>) -> Result<Self, &'static str> {
+        if signers.is_empty() {
+            return Err("config: signer set must not be empty");
+        }
+        if signers.len() > Self::MAX {
+            return Err("config: too many signers");
+        }
+        let mut map = BTreeMap::new();
+        for signer in signers {
+            // A duplicate key collides in the map; that's the uniqueness invariant made structural.
+            if map.insert(signer.public_key, signer.expires_at_s).is_some() {
+                return Err("config: duplicate signer public key");
+            }
+        }
+        Ok(Self(map))
+    }
+
+    /// Add a new signer, or refresh the expiry of an existing one (matched by public key).
+    fn upsert(&mut self, signer: TrustedSigner) -> Result<(), &'static str> {
+        if !self.0.contains_key(&signer.public_key) && self.0.len() >= Self::MAX {
+            return Err("config: too many signers");
+        }
+        self.0.insert(signer.public_key, signer.expires_at_s);
+        Ok(())
+    }
+
+    /// Remove the signer with `public_key`. Rejects removing the final signer (which would brick
+    /// verification); removing an absent key is a no-op.
+    fn remove(&mut self, public_key: &[u8; 32]) -> Result<(), &'static str> {
+        if self.0.len() == 1 && self.0.contains_key(public_key) {
+            return Err("config: cannot remove the last signer");
+        }
+        self.0.remove(public_key);
+        Ok(())
+    }
+
+    /// The trusted signers in the verifier's chain-agnostic representation.
+    fn verifier_signers(&self) -> Vec<verifier::TrustedSigner> {
+        self.0
+            .iter()
+            .map(|(&public_key, &expires_at_s)| verifier::TrustedSigner {
+                public_key,
+                expires_at_s,
+            })
+            .collect()
+    }
+
+    /// The signers as the public [`TrustedSigner`] DTO (the serialized form), in public-key order.
+    fn to_vec(&self) -> Vec<TrustedSigner> {
+        self.0
+            .iter()
+            .map(|(&public_key, &expires_at_s)| TrustedSigner {
+                public_key,
+                expires_at_s,
+            })
+            .collect()
+    }
+}
+
+// Serialize transparently as `Vec<TrustedSigner>` (in public-key order) and validate back through
+// `try_new` on the way in — the map is an internal representation detail, not a wire format.
+impl near_sdk::borsh::BorshSerialize for SignerSet {
+    fn serialize<W: near_sdk::borsh::io::Write>(
+        &self,
+        writer: &mut W,
+    ) -> near_sdk::borsh::io::Result<()> {
+        near_sdk::borsh::BorshSerialize::serialize(&self.to_vec(), writer)
+    }
+}
+
+impl near_sdk::borsh::BorshDeserialize for SignerSet {
+    fn deserialize_reader<R: near_sdk::borsh::io::Read>(
+        reader: &mut R,
+    ) -> near_sdk::borsh::io::Result<Self> {
+        let signers = Vec::<TrustedSigner>::deserialize_reader(reader)?;
+        Self::try_new(signers).map_err(|e| {
+            near_sdk::borsh::io::Error::new(near_sdk::borsh::io::ErrorKind::InvalidData, e)
+        })
+    }
+}
+
+impl near_sdk::serde::Serialize for SignerSet {
+    fn serialize<S: near_sdk::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        near_sdk::serde::Serialize::serialize(&self.to_vec(), serializer)
+    }
+}
+
+impl<'de> near_sdk::serde::Deserialize<'de> for SignerSet {
+    fn deserialize<D: near_sdk::serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Self, D::Error> {
+        let signers = Vec::<TrustedSigner>::deserialize(deserializer)?;
+        Self::try_new(signers).map_err(near_sdk::serde::de::Error::custom)
+    }
+}
+
+/// Caller-supplied verification policy, validated into a [`Config`] by `new` / `admin_set_config`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [json])]
+pub struct ConfigArgs {
+    pub signers: Vec<TrustedSigner>,
+    pub max_timestamp_delay_s: u64,
+    pub max_timestamp_ahead_s: u64,
+    pub allowed_channel_id: Option<u8>,
+    pub update_fee: NearToken,
+    pub default_valid_time_period_s: u64,
+}
+
+/// Validated verification policy for incoming payloads. Built only via `Config::try_from` a
+/// [`ConfigArgs`], so the invariants live here rather than in the callers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [borsh, json])]
+pub struct Config {
+    /// Accepted publisher signers (non-empty, deduplicated, bounded).
+    pub signers: SignerSet,
+    /// Reject payloads whose timestamp is older than this many seconds (must be non-zero).
+    pub max_timestamp_delay_s: u64,
+    /// Reject payloads more than this many seconds in the future (`0` = strict, no future).
+    pub max_timestamp_ahead_s: u64,
+    /// If set, only accept payloads on this Lazer channel id (e.g. 1 = real-time).
+    pub allowed_channel_id: Option<u8>,
+    /// Fee charged per `update_price_feeds` call, on top of the storage cost, and retained by the
+    /// contract. Defaults to zero (no fee).
+    pub update_fee: NearToken,
+    /// Default staleness window (seconds, non-zero) applied by the non-suffixed Pyth views
+    /// (`get_price`, `get_ema_price`, `list_prices`, `list_ema_prices`), mirroring
+    /// `pyth-oracle.near`'s `valid_time_period`. The `*_no_older_than` / `*_unsafe` variants are
+    /// unaffected.
+    pub default_valid_time_period_s: u64,
+}
+
+impl TryFrom<ConfigArgs> for Config {
+    type Error = &'static str;
+
+    fn try_from(args: ConfigArgs) -> Result<Self, Self::Error> {
+        if args.max_timestamp_delay_s == 0 {
+            return Err("config: max_timestamp_delay_s must be non-zero");
+        }
+        if args.default_valid_time_period_s == 0 {
+            return Err("config: default_valid_time_period_s must be non-zero");
+        }
+        Ok(Self {
+            signers: SignerSet::try_new(args.signers)?,
+            max_timestamp_delay_s: args.max_timestamp_delay_s,
+            max_timestamp_ahead_s: args.max_timestamp_ahead_s,
+            allowed_channel_id: args.allowed_channel_id,
+            update_fee: args.update_fee,
+            default_valid_time_period_s: args.default_valid_time_period_s,
+        })
+    }
+}
+
+/// EMA price/confidence for a feed, following the same fixed-point `expo` as the spot price.
+/// Present only when the signed payload actually carried an EMA price — never synthesized from
+/// spot data.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [borsh, json])]
+pub struct EmaData {
+    pub price: I64,
+    pub conf: U64,
+}
+
+/// The latest stored data for one Lazer feed. Prices/exponent follow the Pyth fixed-point
+/// convention (`value * 10^expo`); timestamps are stored as [`Nanoseconds`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [borsh, json])]
+pub struct FeedData {
+    pub price: I64,
+    pub conf: U64,
+    /// EMA data, present only when the payload carried it (no fallback to spot).
+    pub ema: Option<EmaData>,
+    pub expo: i32,
+    /// Per-feed publish time (Lazer `FeedUpdateTimestamp`, else the payload timestamp), in
+    /// nanoseconds. Drives both the served freshness and the monotonic anti-replay gate. The `_ns`
+    /// suffix marks the unit for JSON consumers (the `Nanoseconds` type is erased in JSON).
+    pub publish_time_ns: Nanoseconds,
+}
+
+impl FeedData {
+    /// Build a Pyth [`Price`] from a `(price, conf)` pair using this feed's exponent and publish
+    /// time. `None` if the publish time cannot be represented as a [`PythTimestamp`].
+    fn to_price(&self, price: I64, conf: U64) -> Option<Price> {
+        Some(Price {
+            price,
+            conf,
+            expo: self.expo,
+            publish_time: PythTimestamp::try_from_time(self.publish_time_ns)?,
+        })
+    }
+
+    /// EMA [`Price`] view (`list_ema_prices_*` / `get_ema_price_*`); `None` if no EMA was carried.
+    fn to_ema_price(&self) -> Option<Price> {
+        let ema = self.ema.as_ref()?;
+        self.to_price(ema.price, ema.conf)
+    }
+
+    /// Spot [`Price`] view (`list_prices_*` / `get_price_*`).
+    fn to_spot_price(&self) -> Option<Price> {
+        self.to_price(self.price, self.conf)
+    }
+
+    /// Fallibly build a storable feed from a parsed (wire) feed, owning every intrinsic validity
+    /// rule. Returns `None` when the feed must be skipped: missing price or exponent, missing or
+    /// invalid spot confidence, an `EmaPrice` without a valid `EmaConfidence`, or an effective
+    /// publish timestamp more than `max_ahead_s` seconds beyond `now`. (Anti-replay is relational
+    /// and handled by the caller.)
+    fn from_parsed(
+        parsed: &verifier::ParsedFeed,
+        package: Nanoseconds,
+        now: Nanoseconds,
+        max_ahead_s: u64,
+    ) -> Option<Self> {
+        let price = parsed.price?;
+        let exponent = parsed.exponent?;
+        let conf = require_confidence(parsed.confidence)?;
+
+        // Effective per-feed publish time: `FeedUpdateTimestamp` when present, else the payload's.
+        let publish_time_ns = parsed.feed_update_timestamp.unwrap_or(package);
+
+        // The verifier only bounds the package timestamp; reject a per-feed time too far ahead.
+        if publish_time_ns.as_secs() > now.as_secs().saturating_add(max_ahead_s) {
+            return None;
+        }
+
+        // EMA is stored only when the payload carried an EMA price *and* a valid EMA confidence;
+        // never fall back to spot. A half-specified EMA makes the whole feed malformed.
+        let ema = match parsed.ema_price {
+            Some(ema_price) => Some(EmaData {
+                price: I64(ema_price),
+                conf: U64(require_confidence(parsed.ema_confidence)?),
+            }),
+            None => None,
+        };
+
+        Some(Self {
+            price: I64(price),
+            conf: U64(conf),
+            ema,
+            expo: i32::from(exponent),
+            publish_time_ns,
+        })
+    }
+}
+
+/// JSON view of one verified feed returned by [`Contract::verify_update`] — the full Lazer property
+/// set (not just the Pyth-compatible subset). Price-like values are raw `i64` mantissas (interpret
+/// with `exponent`); `_ns` timestamps are nanoseconds. `None` = property absent.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [json])]
+pub struct ParsedFeedView {
+    pub feed_id: u32,
+    pub price: Option<I64>,
+    pub best_bid_price: Option<I64>,
+    pub best_ask_price: Option<I64>,
+    pub publisher_count: Option<u16>,
+    pub exponent: Option<i16>,
+    pub confidence: Option<I64>,
+    pub funding_rate: Option<I64>,
+    pub funding_timestamp_ns: Option<Nanoseconds>,
+    pub funding_rate_interval_ns: Option<Nanoseconds>,
+    pub market_session: Option<i16>,
+    pub ema_price: Option<I64>,
+    pub ema_confidence: Option<I64>,
+    pub feed_update_timestamp_ns: Option<Nanoseconds>,
+}
+
+impl From<&verifier::ParsedFeed> for ParsedFeedView {
+    fn from(f: &verifier::ParsedFeed) -> Self {
+        Self {
+            feed_id: f.feed_id,
+            price: f.price.map(I64),
+            best_bid_price: f.best_bid_price.map(I64),
+            best_ask_price: f.best_ask_price.map(I64),
+            publisher_count: f.publisher_count,
+            exponent: f.exponent,
+            confidence: f.confidence.map(I64),
+            funding_rate: f.funding_rate.map(I64),
+            funding_timestamp_ns: f.funding_timestamp,
+            funding_rate_interval_ns: f.funding_rate_interval,
+            market_session: f.market_session,
+            ema_price: f.ema_price.map(I64),
+            ema_confidence: f.ema_confidence.map(I64),
+            feed_update_timestamp_ns: f.feed_update_timestamp,
+        }
+    }
+}
+
+/// JSON view of a verified update returned by [`Contract::verify_update`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[near(serializers = [json])]
+pub struct VerifiedUpdateView {
+    /// The trusted ed25519 signer public key (hex).
+    #[serde(with = "hex::serde")]
+    pub signer: [u8; 32],
+    pub channel_id: u8,
+    pub timestamp_ns: Nanoseconds,
+    pub feeds: Vec<ParsedFeedView>,
+}
+
+impl From<verifier::VerifiedUpdate> for VerifiedUpdateView {
+    fn from(update: verifier::VerifiedUpdate) -> Self {
+        Self {
+            signer: update.signer,
+            channel_id: update.channel_id,
+            timestamp_ns: update.timestamp,
+            feeds: update.feeds.iter().map(ParsedFeedView::from).collect(),
+        }
+    }
+}
+
+#[derive(Owner, PanicOnDefault)]
+#[near(contract_state)]
+pub struct Contract {
+    config: Config,
+    /// Latest data keyed by the natural Lazer `u32` feed id.
+    feeds: IterableMap<u32, FeedData>,
+    /// Mapping layer (see `feed_map`): consumer `PriceIdentifier` -> Lazer feed id.
+    ids: IterableMap<PriceIdentifier, u32>,
+}
+
+#[near]
+impl Contract {
+    #[init]
+    pub fn new(owner: AccountId, config: ConfigArgs) -> Self {
+        let config = Config::try_from(config).unwrap_or_else(|e| env::panic_str(e));
+        let mut contract = Self {
+            config,
+            feeds: IterableMap::new(StorageKey::Feeds),
+            ids: IterableMap::new(StorageKey::Ids),
+        };
+        Owner::init(&mut contract, &owner);
+        contract
+    }
+
+    pub fn get_config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Replace the whole verification policy (validated before it is stored).
+    #[payable]
+    pub fn admin_set_config(&mut self, config: ConfigArgs) {
+        assert_one_yocto();
+        Self::require_owner();
+        self.config = Config::try_from(config).unwrap_or_else(|e| env::panic_str(e));
+    }
+
+    /// Add/refresh (`expires_at_s = Some`) or remove (`expires_at_s = None`) a trusted signer.
+    /// `public_key` is a 64-character hex ed25519 key (an optional `0x` prefix is accepted).
+    /// Removing the last signer is rejected; `SignerSet` upholds dedup and the size bound.
+    #[payable]
+    pub fn admin_set_signer(&mut self, public_key: String, expires_at_s: Option<u64>) {
+        assert_one_yocto();
+        Self::require_owner();
+
+        let mut bytes = [0u8; 32];
+        hex::decode_to_slice(public_key.trim_start_matches("0x"), &mut bytes)
+            .unwrap_or_else(|_| env::panic_str("invalid signer public key: expected 32-byte hex"));
+
+        let result = match expires_at_s {
+            Some(expires_at_s) => self.config.signers.upsert(TrustedSigner {
+                public_key: bytes,
+                expires_at_s,
+            }),
+            None => self.config.signers.remove(&bytes),
+        };
+        result.unwrap_or_else(|e| env::panic_str(e));
+    }
+
+    /// Withdraw `amount` of accrued fees (or any free balance) to the owner. The NEAR runtime's
+    /// storage-staking guard rejects any withdrawal that would drop the balance below the
+    /// contract's staked storage requirement.
+    #[payable]
+    pub fn admin_withdraw(&mut self, amount: NearToken) -> Promise {
+        assert_one_yocto();
+        Self::require_owner();
+        // `require_owner` guarantees the predecessor is the owner.
+        Promise::new(env::predecessor_account_id()).transfer(amount)
+    }
+
+    /// Verify a Pyth Pro solana-format (ed25519) signed payload and store its feeds. Permissionless:
+    /// authenticity is enforced cryptographically, and the per-feed monotonic timestamp check
+    /// prevents replays and out-of-order writes.
+    ///
+    /// The caller must attach a deposit covering the storage newly consumed by this call plus the
+    /// configured [`Config::update_fee`]; any excess is refunded. Updates that only overwrite
+    /// existing feeds consume no new storage, so (with a zero fee) they cost nothing.
+    #[payable]
+    pub fn update_price_feeds(&mut self, payload: Base64VecU8) {
+        let storage_before = env::storage_usage();
+        let now = Nanoseconds::near_timestamp();
+
+        let update = self.verify(&payload.0, now);
+
+        let mut updated_feeds = Vec::new();
+        for feed in &update.feeds {
+            // Intrinsic validity lives in `from_parsed`; `None` skips. Timestamps are already
+            // `Nanoseconds` (converted once in the verifier).
+            let Some(feed_data) = FeedData::from_parsed(
+                feed,
+                update.timestamp,
+                now,
+                self.config.max_timestamp_ahead_s,
+            ) else {
+                continue;
+            };
+
+            // Anti-replay (relational, so it stays here): the effective publish timestamp must
+            // strictly advance for this feed.
+            if let Some(existing) = self.feeds.get(&feed.feed_id) {
+                if feed_data.publish_time_ns <= existing.publish_time_ns {
+                    continue;
+                }
+            }
+
+            // Storage policy: every verified feed is stored regardless of whether a consumer
+            // `PriceIdentifier` currently maps to it. This keeps update correctness independent of
+            // the removable `feed_map` seam; the caller funds the storage (below), and unmapped
+            // feeds are simply not queryable until an `admin_set_feed_mapping` exists.
+            self.feeds.insert(feed.feed_id, feed_data.clone());
+            updated_feeds.push((feed.feed_id, feed_data));
+        }
+
+        // Commit pending writes so the storage delta reflects this call's insertions (the helper
+        // measures actual storage usage and does not see `store` collections' cached writes), then
+        // charge the submitter for the new storage plus the configured update fee and refund any
+        // excess.
+        self.feeds.flush();
+        let _refund =
+            apply_storage_fee_and_refund(storage_before, self.config.update_fee.as_yoctonear());
+
+        PythProEvent::UpdatePrices { updated_feeds }.emit();
+    }
+
+    /// Raw stored data for a Lazer feed id.
+    pub fn get_feed_data(&self, feed_id: u32) -> Option<FeedData> {
+        self.feeds.get(&feed_id).cloned()
+    }
+
+    /// Stateless verify-and-return (read-only): verify a Pyth Pro solana-format payload against
+    /// the configured signer set + freshness/channel policy and return the **full** verified update
+    /// (all Lazer properties), **without** writing storage, charging a fee, or touching feed
+    /// mappings. Panics if verification fails. This is the official-Lazer-style parity surface; on
+    /// NEAR it is most useful called directly via RPC (`near view`) by off-chain clients, or by
+    /// on-chain callers through a cross-contract call + callback (NEAR has no sync read calls).
+    pub fn verify_update(&self, payload: Base64VecU8) -> VerifiedUpdateView {
+        let now = Nanoseconds::near_timestamp();
+        VerifiedUpdateView::from(self.verify(&payload.0, now))
+    }
+
+    /// Shared verification: build the kernel signer slice from config and run the verifier (panics
+    /// on failure). Used by both the storing `update_price_feeds` and the read-only `verify_update`.
+    fn verify(&self, raw: &[u8], now: Nanoseconds) -> verifier::VerifiedUpdate {
+        let signers = self.config.signers.verifier_signers();
+
+        let params = verifier::VerifyParams {
+            trusted_signers: &signers,
+            now_s: now.as_secs(),
+            max_timestamp_delay_s: self.config.max_timestamp_delay_s,
+            max_timestamp_ahead_s: self.config.max_timestamp_ahead_s,
+            allowed_channel_id: self.config.allowed_channel_id,
+        };
+
+        verifier::verify_solana_update(&EnvCrypto, raw, &params).unwrap_or_reject()
+    }
+}
+
+/// A confidence is usable only when explicitly present and non-negative; absent or negative ⇒
+/// `None`, and the caller skips the feed. On the Lazer wire a `0` confidence is indistinguishable
+/// from "absent" (both deserialize to `None` upstream), so a stored feed always carries a genuine
+/// positive confidence — we reject the ambiguous/invalid case rather than mold it into a
+/// precise-looking zero.
+fn require_confidence(confidence: Option<i64>) -> Option<u64> {
+    confidence.and_then(|value| u64::try_from(value).ok())
+}

--- a/contract/pyth-pro/contract/src/state.rs
+++ b/contract/pyth-pro/contract/src/state.rs
@@ -1,0 +1,46 @@
+//! Versioned contract state. The live fields (config plus the feed/id maps) live here behind
+//! [`templar_common::versioned_state::VersionedState`], so an upgrade runs a typed,
+//! version-checked `migrate` (see [`migration`]) instead of an ad-hoc `state_read`. Adopting this
+//! from v1 — before the contract is deployed — avoids a later unversioned→versioned migration.
+
+pub mod migration;
+
+use near_sdk::{borsh::BorshSerialize, near, store::IterableMap, BorshStorageKey};
+use templar_common::{
+    oracle::pyth::PriceIdentifier,
+    versioned_state::{StateVersion, VersionedState},
+};
+
+use crate::{Config, FeedData};
+
+#[derive(BorshSerialize, BorshStorageKey)]
+#[borsh(crate = "near_sdk::borsh")]
+enum StorageKey {
+    Feeds,
+    Ids,
+}
+
+/// The adapter's persistent state (version 1). Its Borsh layout is the on-chain schema; any change
+/// requires bumping [`StateVersion::VERSION`] and adding a [`migration`] transformer for it.
+#[derive(Debug)]
+#[near(serializers = [borsh])]
+pub struct State {
+    pub(crate) config: Config,
+    /// Latest data keyed by the natural Lazer `u32` feed id.
+    pub(crate) feeds: IterableMap<u32, FeedData>,
+    /// Mapping layer (see `feed_map`): consumer `PriceIdentifier` -> Lazer feed id.
+    pub(crate) ids: IterableMap<PriceIdentifier, u32>,
+}
+
+impl StateVersion for State {
+    const VERSION: u32 = 1;
+    type NewArgs = Config;
+
+    fn new(config: Config) -> VersionedState<Self> {
+        VersionedState::new(Self {
+            config,
+            feeds: IterableMap::new(StorageKey::Feeds),
+            ids: IterableMap::new(StorageKey::Ids),
+        })
+    }
+}

--- a/contract/pyth-pro/contract/src/state/migration.rs
+++ b/contract/pyth-pro/contract/src/state/migration.rs
@@ -1,0 +1,25 @@
+//! State-version migrations for the adapter.
+//!
+//! The contract launches at [`crate::state::State`]`::VERSION == 1`, so there are no migrations
+//! yet — [`Migration`] is intentionally empty. When a future `State` layout (v2+) lands, add a
+//! `V1(V1ToV2)` variant backed by a [`templar_common::versioned_state::StateTransformer`] and
+//! dispatch it in [`Migrator::run`], mirroring
+//! `contract/proxy-oracle/near/common/src/state/migration`.
+
+use near_sdk::near;
+use templar_common::versioned_state::Migrator;
+
+/// JSON-tagged set of supported state migrations — empty at v1. `admin_upgrade` forwards the chosen
+/// variant as `migrate_args`; the macro-generated `migrate` entrypoint deserializes it into this
+/// type and runs it. With no variants, any `migrate` call fails to deserialize, which is correct:
+/// there is nothing to migrate to yet.
+#[derive(Clone, Debug)]
+#[near(serializers = [json])]
+#[serde(tag = "from_version", rename_all = "snake_case")]
+pub enum Migration {}
+
+impl Migrator for Migration {
+    fn run(self) {
+        match self {}
+    }
+}

--- a/contract/pyth-pro/contract/src/views.rs
+++ b/contract/pyth-pro/contract/src/views.rs
@@ -1,0 +1,152 @@
+//! Pyth-compatible read ABI. Method names and signatures mirror `pyth-oracle.near` so this
+//! adapter is a drop-in for existing consumers (the market and the proxy-oracle's `Pyth` source).
+
+use std::collections::HashMap;
+
+use near_sdk::near;
+use templar_common::{
+    oracle::pyth::{Price, PriceIdentifier},
+    Nanoseconds,
+};
+
+use crate::{Contract, ContractExt, FeedData};
+
+impl Contract {
+    /// Stored data for a consumer price id, via the feed-map seam.
+    fn feed_for(&self, price_identifier: &PriceIdentifier) -> Option<&FeedData> {
+        let feed_id = self.resolve(price_identifier)?;
+        self.feeds.get(&feed_id)
+    }
+
+    /// Whether `feed` is no older than `age_s` seconds relative to `now`. A future-dated
+    /// `publish_time_ns` (possible within the ingestion skew tolerance) is never fresh — fail
+    /// closed, matching the proxy-oracle cache.
+    fn is_fresh(feed: &FeedData, now: Nanoseconds, age_s: u64) -> bool {
+        feed.publish_time_ns <= now && now.saturating_sub(feed.publish_time_ns).as_secs() <= age_s
+    }
+
+    /// Project one feed to a [`Price`] via `project`, applying an optional freshness bound first.
+    fn read_one(
+        &self,
+        price_id: &PriceIdentifier,
+        age: Option<u64>,
+        project: impl Fn(&FeedData) -> Option<Price>,
+    ) -> Option<Price> {
+        let feed = self.feed_for(price_id)?;
+        if let Some(age) = age {
+            if !Self::is_fresh(feed, Nanoseconds::near_timestamp(), age) {
+                return None;
+            }
+        }
+        project(feed)
+    }
+
+    /// `read_one` over a list of ids (single `now` for the whole batch).
+    fn read_many(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+        age: Option<u64>,
+        project: impl Fn(&FeedData) -> Option<Price>,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        let now = Nanoseconds::near_timestamp();
+        price_ids
+            .into_iter()
+            .map(|id| {
+                let price = self.feed_for(&id).and_then(|feed| {
+                    if age.is_some_and(|age| !Self::is_fresh(feed, now, age)) {
+                        return None;
+                    }
+                    project(feed)
+                });
+                (id, price)
+            })
+            .collect()
+    }
+}
+
+#[near]
+impl Contract {
+    pub fn price_feed_exists(&self, price_identifier: PriceIdentifier) -> bool {
+        self.resolve(&price_identifier)
+            .is_some_and(|feed_id| self.feeds.contains_key(&feed_id))
+    }
+
+    // --- EMA prices (the variants Templar's market and proxy-oracle call) ---
+
+    pub fn list_ema_prices_unsafe(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        self.read_many(price_ids, None, FeedData::to_ema_price)
+    }
+
+    pub fn list_ema_prices_no_older_than(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+        age: u64,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        self.read_many(price_ids, Some(age), FeedData::to_ema_price)
+    }
+
+    pub fn get_ema_price_unsafe(&self, price_id: PriceIdentifier) -> Option<Price> {
+        self.read_one(&price_id, None, FeedData::to_ema_price)
+    }
+
+    pub fn get_ema_price_no_older_than(
+        &self,
+        price_id: PriceIdentifier,
+        age: u64,
+    ) -> Option<Price> {
+        self.read_one(&price_id, Some(age), FeedData::to_ema_price)
+    }
+
+    // --- Spot prices (fuller Pyth parity) ---
+
+    pub fn list_prices_unsafe(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        self.read_many(price_ids, None, FeedData::to_spot_price)
+    }
+
+    pub fn list_prices_no_older_than(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+        age: u64,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        self.read_many(price_ids, Some(age), FeedData::to_spot_price)
+    }
+
+    pub fn get_price_unsafe(&self, price_id: PriceIdentifier) -> Option<Price> {
+        self.read_one(&price_id, None, FeedData::to_spot_price)
+    }
+
+    pub fn get_price_no_older_than(&self, price_id: PriceIdentifier, age: u64) -> Option<Price> {
+        self.read_one(&price_id, Some(age), FeedData::to_spot_price)
+    }
+
+    // --- Non-suffixed variants: `pyth-oracle.near` exposes these as the `*_no_older_than` form with
+    //     the contract's configured default validity window (`config.default_valid_time_period_s`). ---
+
+    pub fn get_price(&self, price_id: PriceIdentifier) -> Option<Price> {
+        self.get_price_no_older_than(price_id, self.config.default_valid_time_period_s)
+    }
+
+    pub fn get_ema_price(&self, price_id: PriceIdentifier) -> Option<Price> {
+        self.get_ema_price_no_older_than(price_id, self.config.default_valid_time_period_s)
+    }
+
+    pub fn list_prices(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        self.list_prices_no_older_than(price_ids, self.config.default_valid_time_period_s)
+    }
+
+    pub fn list_ema_prices(
+        &self,
+        price_ids: Vec<PriceIdentifier>,
+    ) -> HashMap<PriceIdentifier, Option<Price>> {
+        self.list_ema_prices_no_older_than(price_ids, self.config.default_valid_time_period_s)
+    }
+}

--- a/contract/pyth-pro/contract/src/views.rs
+++ b/contract/pyth-pro/contract/src/views.rs
@@ -21,8 +21,14 @@ impl Contract {
     /// Whether `feed` is no older than `age_s` seconds relative to `now`. A future-dated
     /// `publish_time_ns` (possible within the ingestion skew tolerance) is never fresh — fail
     /// closed, matching the proxy-oracle cache.
+    ///
+    /// The age comparison runs at full nanosecond precision: `age_s` is widened to nanoseconds
+    /// rather than truncating the delta to whole seconds. Truncating would let a feed up to ~1s
+    /// older than `age_s` pass (e.g. a 1.9s-old feed against `age_s = 1`), silently serving stale
+    /// prices to consumers that rely on these views to enforce `price_maximum_age_s`.
     fn is_fresh(feed: &FeedData, now: Nanoseconds, age_s: u64) -> bool {
-        feed.publish_time_ns <= now && now.saturating_sub(feed.publish_time_ns).as_secs() <= age_s
+        feed.publish_time_ns <= now
+            && now.saturating_sub(feed.publish_time_ns) <= Nanoseconds::from_secs(age_s)
     }
 
     /// Project one feed to a [`Price`] via `project`, applying an optional freshness bound first.

--- a/contract/pyth-pro/contract/tests/test.rs
+++ b/contract/pyth-pro/contract/tests/test.rs
@@ -270,6 +270,41 @@ fn non_suffixed_views_apply_default_validity() {
 }
 
 #[test]
+fn no_older_than_does_not_truncate_subsecond_age() {
+    // A feed 1.9s old must fail a 1s freshness bound. Truncating the ns delta to whole seconds
+    // (1.9s -> 1s) would leak ~1s of staleness past `age_s` — and the market/proxy flows rely on
+    // these views to enforce `price_maximum_age_s`.
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // `now` is NOW_S * 1e9 (set by relayer_context); publish 1.9s earlier.
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000 - 1_900_000,
+        123_456,
+        123_000,
+        50,
+    )));
+
+    // 1s bound: a 1.9s-old feed is stale (no sub-second truncation).
+    assert!(contract.get_price_no_older_than(price_id(), 1).is_none());
+    assert!(contract
+        .list_ema_prices_no_older_than(vec![price_id()], 1)
+        .get(&price_id())
+        .unwrap()
+        .is_none());
+
+    // 2s bound: the same 1.9s-old feed is still fresh.
+    assert_eq!(
+        contract
+            .get_price_no_older_than(price_id(), 2)
+            .unwrap()
+            .price
+            .0,
+        123_456
+    );
+}
+
+#[test]
 fn stale_prices_are_filtered_by_age() {
     let mut contract = deploy_and_map();
 

--- a/contract/pyth-pro/contract/tests/test.rs
+++ b/contract/pyth-pro/contract/tests/test.rs
@@ -122,6 +122,7 @@ fn config() -> ConfigArgs {
         allowed_channel_id: Some(ChannelId::REAL_TIME.0),
         update_fee: NearToken::from_yoctonear(0),
         default_valid_time_period_s: 600,
+        max_feeds_per_update: 64,
     }
 }
 
@@ -487,6 +488,37 @@ fn duplicate_feed_id_in_payload_is_first_wins() {
 }
 
 #[test]
+#[should_panic(expected = "too many feeds in a single update")]
+fn update_exceeding_max_feeds_rejected() {
+    // A signed bundle carrying more feeds than `max_feeds_per_update` is rejected up front, before
+    // any storage write or event emission, so the NEP-297 `UpdatePrices` log stays bounded.
+    let mut contract = deploy_and_map_with(ConfigArgs {
+        max_feeds_per_update: 1,
+        ..config()
+    });
+
+    let feed = |id: u32, price: i64| PayloadFeedData {
+        feed_id: PriceFeedId(id),
+        properties: vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(price).unwrap())),
+            PayloadPropertyValue::Confidence(Some(Price::from_mantissa(1).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                NOW_S * 1_000_000,
+            ))),
+        ],
+    };
+    let payload = sign(&PayloadData {
+        timestamp_us: TimestampUs::from_micros(NOW_S * 1_000_000),
+        channel_id: ChannelId::REAL_TIME,
+        feeds: vec![feed(FEED_ID, 111), feed(FEED_ID + 1, 222)],
+    });
+
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(payload));
+}
+
+#[test]
 fn negative_confidence_skips_feed() {
     let mut contract = deploy_and_map();
 
@@ -741,6 +773,19 @@ fn zero_default_validity_rejected() {
         owner(),
         ConfigArgs {
             default_valid_time_period_s: 0,
+            ..config()
+        },
+    );
+}
+
+#[test]
+#[should_panic(expected = "max_feeds_per_update must be non-zero")]
+fn zero_max_feeds_per_update_rejected() {
+    set_owner_context();
+    let _ = Contract::new(
+        owner(),
+        ConfigArgs {
+            max_feeds_per_update: 0,
             ..config()
         },
     );

--- a/contract/pyth-pro/contract/tests/test.rs
+++ b/contract/pyth-pro/contract/tests/test.rs
@@ -1,0 +1,905 @@
+#![allow(clippy::unwrap_used)]
+
+use byteorder::LE;
+use ed25519_dalek::{Signer, SigningKey};
+use near_sdk::{
+    json_types::Base64VecU8,
+    mock::MockAction,
+    test_utils::{get_created_receipts, VMContextBuilder},
+    testing_env, AccountId, NearToken,
+};
+use pyth_lazer_protocol::message::SolanaMessage;
+use pyth_lazer_protocol::payload::{PayloadData, PayloadFeedData, PayloadPropertyValue};
+use pyth_lazer_protocol::time::TimestampUs;
+use pyth_lazer_protocol::{ChannelId, Price, PriceFeedId};
+use templar_common::oracle::pyth::PriceIdentifier;
+
+use templar_pyth_pro_adapter_contract::{ConfigArgs, Contract, TrustedSigner};
+
+const FEED_ID: u32 = 2;
+const NOW_S: u64 = 1_700_000_000;
+const EXPO: i16 = -8;
+
+fn signing_key() -> SigningKey {
+    SigningKey::from_bytes(&[7u8; 32])
+}
+
+fn signer_public_key() -> [u8; 32] {
+    signing_key().verifying_key().to_bytes()
+}
+
+/// Sign a solana-format (ed25519) Lazer message wrapping `data` with the default signer.
+fn sign(data: &PayloadData) -> Vec<u8> {
+    sign_with(&signing_key(), data)
+}
+
+/// Sign a solana-format (ed25519) Lazer message wrapping `data` with an arbitrary key (used to
+/// exercise signer rotation).
+fn sign_with(key: &SigningKey, data: &PayloadData) -> Vec<u8> {
+    let mut payload = Vec::new();
+    data.serialize::<LE>(&mut payload).unwrap();
+
+    let message = SolanaMessage {
+        signature: key.sign(&payload).to_bytes(),
+        public_key: key.verifying_key().to_bytes(),
+        payload,
+    };
+    let mut raw = Vec::new();
+    message.serialize(&mut raw).unwrap();
+    raw
+}
+
+/// A standard single-feed real-time payload signed by `key` (for rotation tests).
+fn real_time_signed_by(
+    key: &SigningKey,
+    timestamp_us: u64,
+    price: i64,
+    ema: i64,
+    conf: i64,
+) -> Vec<u8> {
+    sign_with(
+        key,
+        &PayloadData {
+            timestamp_us: TimestampUs::from_micros(timestamp_us),
+            channel_id: ChannelId(ChannelId::REAL_TIME.0),
+            feeds: vec![PayloadFeedData {
+                feed_id: PriceFeedId(FEED_ID),
+                properties: full_props(price, ema, conf, timestamp_us),
+            }],
+        },
+    )
+}
+
+/// Build a single-feed (FEED_ID) signed payload with arbitrary properties.
+fn build_payload(timestamp_us: u64, channel: u8, properties: Vec<PayloadPropertyValue>) -> Vec<u8> {
+    sign(&PayloadData {
+        timestamp_us: TimestampUs::from_micros(timestamp_us),
+        channel_id: ChannelId(channel),
+        feeds: vec![PayloadFeedData {
+            feed_id: PriceFeedId(FEED_ID),
+            properties,
+        }],
+    })
+}
+
+/// The standard property set: spot price + confidence + exponent + EMA price + per-feed timestamp.
+fn full_props(price: i64, ema: i64, conf: i64, timestamp_us: u64) -> Vec<PayloadPropertyValue> {
+    vec![
+        PayloadPropertyValue::Price(Some(Price::from_mantissa(price).unwrap())),
+        PayloadPropertyValue::Confidence(Some(Price::from_mantissa(conf).unwrap())),
+        PayloadPropertyValue::Exponent(EXPO),
+        PayloadPropertyValue::EmaPrice(Some(Price::from_mantissa(ema).unwrap())),
+        PayloadPropertyValue::EmaConfidence(Some(Price::from_mantissa(conf).unwrap())),
+        PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(timestamp_us))),
+    ]
+}
+
+/// A well-formed single-feed payload carrying spot, EMA, confidence and a per-feed timestamp.
+fn signed_payload(timestamp_us: u64, channel: u8, price: i64, ema: i64, conf: i64) -> Vec<u8> {
+    build_payload(
+        timestamp_us,
+        channel,
+        full_props(price, ema, conf, timestamp_us),
+    )
+}
+
+fn real_time(timestamp_us: u64, price: i64, ema: i64, conf: i64) -> Vec<u8> {
+    signed_payload(timestamp_us, ChannelId::REAL_TIME.0, price, ema, conf)
+}
+
+fn owner() -> AccountId {
+    "owner.near".parse().unwrap()
+}
+
+fn config() -> ConfigArgs {
+    ConfigArgs {
+        signers: vec![TrustedSigner {
+            public_key: signer_public_key(),
+            expires_at_s: NOW_S + 1_000_000,
+        }],
+        max_timestamp_delay_s: 600,
+        max_timestamp_ahead_s: 600,
+        allowed_channel_id: Some(ChannelId::REAL_TIME.0),
+        update_fee: NearToken::from_yoctonear(0),
+        default_valid_time_period_s: 600,
+    }
+}
+
+fn price_id() -> PriceIdentifier {
+    PriceIdentifier([0x11; 32])
+}
+
+/// Context as the owner, with 1 yocto attached (for `#[payable]` admin methods).
+fn set_owner_context() {
+    testing_env!(VMContextBuilder::new()
+        .predecessor_account_id(owner())
+        .attached_deposit(NearToken::from_yoctonear(1))
+        .block_timestamp(NOW_S * 1_000_000_000)
+        .build());
+}
+
+/// Context as an arbitrary relayer attaching `deposit` (for the permissionless update + views).
+fn relayer_context(deposit: NearToken) {
+    testing_env!(VMContextBuilder::new()
+        .predecessor_account_id("relayer.near".parse().unwrap())
+        .attached_deposit(deposit)
+        .block_timestamp(NOW_S * 1_000_000_000)
+        .build());
+}
+
+/// Enough to cover one feed's storage in any test.
+fn ample_deposit() -> NearToken {
+    NearToken::from_near(1)
+}
+
+fn deploy_and_map() -> Contract {
+    deploy_and_map_with(config())
+}
+
+fn deploy_and_map_with(config: ConfigArgs) -> Contract {
+    set_owner_context();
+    let mut contract = Contract::new(owner(), config);
+    contract.admin_set_feed_mapping(price_id(), Some(FEED_ID));
+    contract
+}
+
+#[test]
+fn ingests_payload_and_serves_pyth_views() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+
+    assert!(contract.price_feed_exists(price_id()));
+
+    let ema = contract.list_ema_prices_no_older_than(vec![price_id()], 600);
+    let price = ema.get(&price_id()).unwrap().as_ref().unwrap();
+    assert_eq!(price.price.0, 123_000);
+    assert_eq!(price.conf.0, 50);
+    assert_eq!(price.expo, -8);
+    assert_eq!(price.publish_time.as_secs(), i64::try_from(NOW_S).unwrap());
+
+    let spot = contract.get_price_unsafe(price_id()).unwrap();
+    assert_eq!(spot.price.0, 123_456);
+
+    // Unmapped identifier resolves to nothing.
+    let unknown = PriceIdentifier([0x22; 32]);
+    assert!(!contract.price_feed_exists(unknown));
+    assert!(contract
+        .list_ema_prices_no_older_than(vec![unknown], 600)
+        .get(&unknown)
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+fn non_suffixed_views_serve_fresh_data() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+
+    // The non-suffixed Pyth methods serve data within the default validity window.
+    assert_eq!(contract.get_price(price_id()).unwrap().price.0, 123_456);
+    assert_eq!(contract.get_ema_price(price_id()).unwrap().price.0, 123_000);
+    assert!(contract
+        .list_prices(vec![price_id()])
+        .get(&price_id())
+        .unwrap()
+        .is_some());
+    assert!(contract
+        .list_ema_prices(vec![price_id()])
+        .get(&price_id())
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn non_suffixed_views_apply_default_validity() {
+    // Default validity 100s, but the ingestion window stays at 600s.
+    let mut contract = deploy_and_map_with(ConfigArgs {
+        default_valid_time_period_s: 100,
+        ..config()
+    });
+
+    relayer_context(ample_deposit());
+    // Published 500s ago: stored (within the 600s ingestion window)...
+    contract.update_price_feeds(Base64VecU8(real_time(
+        (NOW_S - 500) * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+
+    // ...but older than the 100s default window, so the non-suffixed views report nothing.
+    assert!(contract.get_price(price_id()).is_none());
+    assert!(contract.get_ema_price(price_id()).is_none());
+    assert!(contract
+        .list_prices(vec![price_id()])
+        .get(&price_id())
+        .unwrap()
+        .is_none());
+    assert!(contract
+        .list_ema_prices(vec![price_id()])
+        .get(&price_id())
+        .unwrap()
+        .is_none());
+
+    // The unsafe + explicit-window variants still serve it.
+    assert!(contract.get_price_unsafe(price_id()).is_some());
+    assert_eq!(
+        contract
+            .get_price_no_older_than(price_id(), 600)
+            .unwrap()
+            .price
+            .0,
+        123_456
+    );
+}
+
+#[test]
+fn stale_prices_are_filtered_by_age() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // Published 500s ago; within the 600s verification window so it stores...
+    contract.update_price_feeds(Base64VecU8(real_time(
+        (NOW_S - 500) * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+
+    // ...but a 100s freshness query rejects it, while unsafe + a wide window accept it.
+    assert!(contract
+        .list_ema_prices_no_older_than(vec![price_id()], 100)
+        .get(&price_id())
+        .unwrap()
+        .is_none());
+    assert!(contract
+        .list_ema_prices_no_older_than(vec![price_id()], 600)
+        .get(&price_id())
+        .unwrap()
+        .is_some());
+    assert!(contract
+        .list_ema_prices_unsafe(vec![price_id()])
+        .get(&price_id())
+        .unwrap()
+        .is_some());
+}
+
+#[test]
+fn replays_are_ignored_and_newer_updates_apply() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    let first = real_time(NOW_S * 1_000_000, 100, 100, 1);
+    contract.update_price_feeds(Base64VecU8(first.clone()));
+
+    // Same timestamp again => ignored (monotonic gate); price stays 100. Overwrite attempt consumes
+    // no storage, so a zero deposit is accepted.
+    relayer_context(NearToken::from_yoctonear(0));
+    contract.update_price_feeds(Base64VecU8(first));
+    assert_eq!(contract.get_price_unsafe(price_id()).unwrap().price.0, 100);
+
+    // A strictly newer payload applies (same footprint => still free).
+    contract.update_price_feeds(Base64VecU8(real_time((NOW_S + 1) * 1_000_000, 200, 200, 1)));
+    assert_eq!(contract.get_price_unsafe(price_id()).unwrap().price.0, 200);
+}
+
+#[test]
+fn full_deposit_refunded_when_no_new_storage() {
+    let mut contract = deploy_and_map();
+
+    // First update creates the feed (consumes storage).
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time(NOW_S * 1_000_000, 100, 100, 1)));
+
+    // A strictly-newer overwrite consumes no new storage; with update_fee = 0 the whole attached
+    // deposit must be refunded. (relayer_context resets the VM, so only this call's receipts remain.)
+    let deposit = NearToken::from_near(1);
+    relayer_context(deposit);
+    contract.update_price_feeds(Base64VecU8(real_time((NOW_S + 1) * 1_000_000, 200, 200, 1)));
+
+    let refunds: Vec<NearToken> = get_created_receipts()
+        .into_iter()
+        .flat_map(|receipt| receipt.actions)
+        .filter_map(|action| match action {
+            MockAction::Transfer { deposit, .. } => Some(deposit),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(refunds, vec![deposit]);
+}
+
+#[test]
+fn newer_package_with_older_feed_timestamp_does_not_regress() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // First: package + per-feed timestamp at NOW.
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        full_props(100, 100, 1, NOW_S * 1_000_000),
+    )));
+
+    // Second: newer *package* timestamp (NOW+10) but an *older* per-feed FeedUpdateTimestamp
+    // (NOW-10). The per-feed monotonic gate must reject it, so the stored feed does not regress.
+    relayer_context(NearToken::from_yoctonear(0));
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        (NOW_S + 10) * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        full_props(999, 999, 1, (NOW_S - 10) * 1_000_000),
+    )));
+
+    let feed = contract.get_price_unsafe(price_id()).unwrap();
+    assert_eq!(feed.price.0, 100);
+    assert_eq!(feed.publish_time.as_secs(), i64::try_from(NOW_S).unwrap());
+}
+
+#[test]
+fn future_feed_timestamp_is_rejected() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // Package timestamp is current (passes the verifier window), but the per-feed FeedUpdateTimestamp
+    // is far in the future (beyond max_timestamp_ahead_s), so the feed must not be stored.
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        full_props(123_456, 123_000, 50, (NOW_S + 10_000) * 1_000_000),
+    )));
+
+    assert!(!contract.price_feed_exists(price_id()));
+}
+
+#[test]
+fn future_feed_within_tolerance_is_stored_but_not_fresh() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // Per-feed timestamp 5s ahead of block time: within max_timestamp_ahead_s, so it is stored...
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        full_props(123_456, 123_000, 50, (NOW_S + 5) * 1_000_000),
+    )));
+    assert!(contract.price_feed_exists(price_id()));
+
+    // ...but a future publish time is never "fresh": the age-gated and non-suffixed views fail
+    // closed (matching the proxy-oracle cache).
+    assert!(contract.get_price_no_older_than(price_id(), 600).is_none());
+    assert!(contract
+        .get_ema_price_no_older_than(price_id(), 600)
+        .is_none());
+    assert!(contract.get_price(price_id()).is_none());
+    assert!(contract.get_ema_price(price_id()).is_none());
+
+    // The unsafe variants make no freshness promise, so they still expose it.
+    assert_eq!(
+        contract.get_price_unsafe(price_id()).unwrap().price.0,
+        123_456
+    );
+}
+
+#[test]
+fn missing_spot_confidence_skips_feed() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(NearToken::from_yoctonear(0));
+    // Price present but no Confidence property: not definitely-correct, so the feed is not stored.
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(123_456).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::EmaPrice(Some(Price::from_mantissa(123_000).unwrap())),
+            PayloadPropertyValue::EmaConfidence(Some(Price::from_mantissa(50).unwrap())),
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                NOW_S * 1_000_000,
+            ))),
+        ],
+    )));
+    assert!(!contract.price_feed_exists(price_id()));
+}
+
+#[test]
+fn ema_price_without_ema_confidence_skips_feed() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(NearToken::from_yoctonear(0));
+    // EmaPrice present but no EmaConfidence: a half-specified EMA is malformed, so the whole feed
+    // is skipped (no spot-only storage, no fabricated confidence).
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(123_456).unwrap())),
+            PayloadPropertyValue::Confidence(Some(Price::from_mantissa(50).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::EmaPrice(Some(Price::from_mantissa(123_000).unwrap())),
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                NOW_S * 1_000_000,
+            ))),
+        ],
+    )));
+    assert!(!contract.price_feed_exists(price_id()));
+}
+
+#[test]
+fn duplicate_feed_id_in_payload_is_first_wins() {
+    let mut contract = deploy_and_map();
+
+    let feed = |price: i64| PayloadFeedData {
+        feed_id: PriceFeedId(FEED_ID),
+        properties: vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(price).unwrap())),
+            PayloadPropertyValue::Confidence(Some(Price::from_mantissa(1).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                NOW_S * 1_000_000,
+            ))),
+        ],
+    };
+    let payload = sign(&PayloadData {
+        timestamp_us: TimestampUs::from_micros(NOW_S * 1_000_000),
+        channel_id: ChannelId::REAL_TIME,
+        feeds: vec![feed(111), feed(222)],
+    });
+
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(payload));
+
+    // Both entries carry the same publish timestamp, so the monotonic gate keeps the first.
+    assert_eq!(contract.get_price_unsafe(price_id()).unwrap().price.0, 111);
+}
+
+#[test]
+fn negative_confidence_skips_feed() {
+    let mut contract = deploy_and_map();
+
+    // Negative spot confidence is malformed -> the feed is skipped entirely (no storage consumed).
+    relayer_context(NearToken::from_yoctonear(0));
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        -1,
+    )));
+    assert!(!contract.price_feed_exists(price_id()));
+
+    // Negative EMA confidence likewise skips the feed.
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(123_456).unwrap())),
+            PayloadPropertyValue::Confidence(Some(Price::from_mantissa(50).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::EmaPrice(Some(Price::from_mantissa(123_000).unwrap())),
+            PayloadPropertyValue::EmaConfidence(Some(Price::from_mantissa(-1).unwrap())),
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                NOW_S * 1_000_000,
+            ))),
+        ],
+    )));
+    assert!(!contract.price_feed_exists(price_id()));
+}
+
+#[test]
+fn payload_without_ema_serves_spot_only() {
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // No EmaPrice property: spot is stored, but EMA must not be synthesized from spot.
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(123_456).unwrap())),
+            PayloadPropertyValue::Confidence(Some(Price::from_mantissa(50).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                NOW_S * 1_000_000,
+            ))),
+        ],
+    )));
+
+    // Spot works...
+    assert_eq!(
+        contract.get_price_unsafe(price_id()).unwrap().price.0,
+        123_456
+    );
+    // ...but the EMA surface returns nothing (no spot fallback).
+    assert!(contract.get_ema_price_unsafe(price_id()).is_none());
+    assert!(contract
+        .list_ema_prices_unsafe(vec![price_id()])
+        .get(&price_id())
+        .unwrap()
+        .is_none());
+}
+
+#[test]
+#[should_panic(expected = "Insufficient deposit")]
+fn insufficient_storage_deposit_for_new_feed_panics() {
+    let mut contract = deploy_and_map();
+
+    // A brand-new feed consumes storage; a zero deposit cannot cover it.
+    relayer_context(NearToken::from_yoctonear(0));
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+}
+
+#[test]
+#[should_panic(expected = "Insufficient deposit")]
+fn update_fee_must_be_covered() {
+    let mut contract = deploy_and_map_with(ConfigArgs {
+        update_fee: NearToken::from_near(5),
+        ..config()
+    });
+
+    // The deposit covers storage but not the 5 NEAR fee.
+    relayer_context(NearToken::from_millinear(100));
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+}
+
+#[test]
+fn update_fee_is_retained_and_excess_refunded() {
+    let update_fee = NearToken::from_millinear(10);
+    let mut contract = deploy_and_map_with(ConfigArgs {
+        update_fee,
+        ..config()
+    });
+
+    // First update creates the feed (consumes storage); fund it amply.
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time(NOW_S * 1_000_000, 100, 100, 1)));
+    assert!(contract.price_feed_exists(price_id()));
+
+    // A strictly-newer overwrite consumes no new storage, so the only charge is `update_fee`: the
+    // refund must be exactly deposit - update_fee. (relayer_context resets the VM, so only this
+    // call's receipts remain; no-new-storage zeroes the storage term so the arithmetic is exact.)
+    let deposit = NearToken::from_near(1);
+    relayer_context(deposit);
+    contract.update_price_feeds(Base64VecU8(real_time((NOW_S + 1) * 1_000_000, 200, 200, 1)));
+
+    let refunds: Vec<NearToken> = get_created_receipts()
+        .into_iter()
+        .flat_map(|receipt| receipt.actions)
+        .filter_map(|action| match action {
+            MockAction::Transfer { deposit, .. } => Some(deposit),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(refunds, vec![deposit.saturating_sub(update_fee)]);
+}
+
+#[test]
+#[should_panic(expected = "signer is not trusted")]
+fn rejects_untrusted_signer_payload() {
+    let mut contract = deploy_and_map();
+
+    // Reconfigure to trust a different signer, then submit a payload from the original key.
+    set_owner_context();
+    let mut cfg = config();
+    cfg.signers[0].public_key = [0xAB; 32];
+    contract.admin_set_config(cfg);
+
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time(NOW_S * 1_000_000, 100, 100, 1)));
+}
+
+#[test]
+#[should_panic(expected = "Owner only")]
+fn admin_methods_reject_non_owner() {
+    let mut contract = deploy_and_map();
+
+    // Non-owner attempting an admin mutation must panic (1 yocto attached to pass the payable gate).
+    testing_env!(VMContextBuilder::new()
+        .predecessor_account_id("attacker.near".parse().unwrap())
+        .attached_deposit(NearToken::from_yoctonear(1))
+        .block_timestamp(NOW_S * 1_000_000_000)
+        .build());
+    contract.admin_set_feed_mapping(PriceIdentifier([0x33; 32]), Some(99));
+}
+
+#[test]
+#[should_panic(expected = "Owner only")]
+fn admin_withdraw_rejects_non_owner() {
+    let mut contract = deploy_and_map();
+
+    testing_env!(VMContextBuilder::new()
+        .predecessor_account_id("attacker.near".parse().unwrap())
+        .attached_deposit(NearToken::from_yoctonear(1))
+        .block_timestamp(NOW_S * 1_000_000_000)
+        .build());
+    let _ = contract.admin_withdraw(NearToken::from_yoctonear(1));
+}
+
+#[test]
+fn owner_can_withdraw() {
+    let mut contract = deploy_and_map();
+    set_owner_context();
+    // Owner withdrawal schedules a transfer without panicking.
+    let _ = contract.admin_withdraw(NearToken::from_yoctonear(1));
+}
+
+// --- Config validation (W1) ---
+
+#[test]
+#[should_panic(expected = "signer set must not be empty")]
+fn empty_signer_set_rejected() {
+    set_owner_context();
+    let _ = Contract::new(
+        owner(),
+        ConfigArgs {
+            signers: vec![],
+            ..config()
+        },
+    );
+}
+
+#[test]
+#[should_panic(expected = "duplicate signer public key")]
+fn duplicate_signers_rejected() {
+    set_owner_context();
+    let signer = TrustedSigner {
+        public_key: signer_public_key(),
+        expires_at_s: NOW_S + 1,
+    };
+    let _ = Contract::new(
+        owner(),
+        ConfigArgs {
+            signers: vec![signer.clone(), signer],
+            ..config()
+        },
+    );
+}
+
+#[test]
+fn signer_set_serializes_in_public_key_order() {
+    // The `BTreeMap`-backed `SignerSet` yields a deterministic, public-key-sorted array regardless
+    // of insertion order — locking the structural-uniqueness representation's wire behavior.
+    let mut contract = deploy_and_map();
+    set_owner_context();
+    // Insert two signers that bracket the default key, in non-sorted order.
+    contract.admin_set_signer(hex::encode([0xFF; 32]), Some(NOW_S + 1));
+    contract.admin_set_signer(hex::encode([0x00; 32]), Some(NOW_S + 1));
+
+    let json = near_sdk::serde_json::to_value(&contract.get_config().signers).unwrap();
+    let keys: Vec<String> = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["public_key"].as_str().unwrap().to_string())
+        .collect();
+    let mut sorted = keys.clone();
+    sorted.sort();
+    assert_eq!(keys, sorted, "signers must serialize in public-key order");
+    assert_eq!(keys.len(), 3);
+}
+
+#[test]
+#[should_panic(expected = "max_timestamp_delay_s must be non-zero")]
+fn zero_delay_window_rejected() {
+    set_owner_context();
+    let _ = Contract::new(
+        owner(),
+        ConfigArgs {
+            max_timestamp_delay_s: 0,
+            ..config()
+        },
+    );
+}
+
+#[test]
+#[should_panic(expected = "default_valid_time_period_s must be non-zero")]
+fn zero_default_validity_rejected() {
+    set_owner_context();
+    let _ = Contract::new(
+        owner(),
+        ConfigArgs {
+            default_valid_time_period_s: 0,
+            ..config()
+        },
+    );
+}
+
+#[test]
+#[should_panic(expected = "signer set must not be empty")]
+fn admin_set_config_validates() {
+    let mut contract = deploy_and_map();
+    set_owner_context();
+    contract.admin_set_config(ConfigArgs {
+        signers: vec![],
+        ..config()
+    });
+}
+
+#[test]
+#[should_panic(expected = "cannot remove the last signer")]
+fn admin_set_signer_cannot_remove_last() {
+    let mut contract = deploy_and_map();
+    set_owner_context();
+    // config() has exactly one signer; removing it (`None`) must be rejected.
+    contract.admin_set_signer(hex::encode(signer_public_key()), None);
+}
+
+#[test]
+fn admin_set_signer_removes_non_last_signer() {
+    let mut contract = deploy_and_map();
+    set_owner_context();
+
+    // Add a second signer, then remove the original — leaving exactly the new one.
+    let other = [0xCD; 32];
+    contract.admin_set_signer(hex::encode(other), Some(NOW_S + 1));
+    contract.admin_set_signer(hex::encode(signer_public_key()), None);
+
+    let json = near_sdk::serde_json::to_value(&contract.get_config().signers).unwrap();
+    let keys: Vec<String> = json
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["public_key"].as_str().unwrap().to_string())
+        .collect();
+    assert_eq!(keys, vec![hex::encode(other)]);
+}
+
+// --- Signer rotation (Solana key rotation) ---
+
+#[test]
+fn rotating_in_a_new_signer_accepts_its_updates() {
+    // A second Lazer key — the rotation target. (Pyth rotates its ed25519 signer on the Solana
+    // program; the owner mirrors that here via `admin_set_signer`.)
+    let new_key = SigningKey::from_bytes(&[9u8; 32]);
+
+    let mut contract = deploy_and_map();
+
+    // Owner rotates the new key in (keeping the existing one during the overlap window).
+    set_owner_context();
+    contract.admin_set_signer(
+        hex::encode(new_key.verifying_key().to_bytes()),
+        Some(NOW_S + 1_000_000),
+    );
+
+    // A payload signed by the newly trusted key now verifies and stores.
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time_signed_by(
+        &new_key,
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+    assert_eq!(
+        contract.get_price_unsafe(price_id()).unwrap().price.0,
+        123_456
+    );
+}
+
+#[test]
+#[should_panic(expected = "signer is not trusted")]
+fn refreshing_signer_expiry_into_the_past_rejects_updates() {
+    let mut contract = deploy_and_map();
+
+    // Refresh the (only) signer's expiry to `now` — i.e. lapse it (`expires_at_s > now` is false).
+    // This exercises both upsert-refresh and the expiry gate in verification.
+    set_owner_context();
+    contract.admin_set_signer(hex::encode(signer_public_key()), Some(NOW_S));
+
+    relayer_context(ample_deposit());
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+}
+
+// --- Stateless verify_update view ---
+
+#[test]
+fn verify_update_returns_data_without_writing_storage() {
+    let contract = deploy_and_map();
+
+    relayer_context(NearToken::from_yoctonear(0)); // a view: no deposit needed
+    let view = contract.verify_update(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+
+    // Full verified update is returned.
+    assert_eq!(view.signer, signer_public_key());
+    assert_eq!(view.timestamp_ns.as_secs(), NOW_S);
+    assert_eq!(view.feeds.len(), 1);
+    let feed = &view.feeds[0];
+    assert_eq!(feed.feed_id, FEED_ID);
+    assert_eq!(feed.price.unwrap().0, 123_456);
+    assert_eq!(feed.ema_price.unwrap().0, 123_000);
+    assert_eq!(feed.confidence.unwrap().0, 50);
+    assert_eq!(feed.exponent, Some(EXPO));
+
+    // ...and nothing was persisted.
+    assert!(!contract.price_feed_exists(price_id()));
+    assert!(contract.get_feed_data(FEED_ID).is_none());
+}
+
+#[test]
+fn verify_update_surfaces_non_pyth_properties() {
+    let contract = deploy_and_map();
+    relayer_context(NearToken::from_yoctonear(0));
+
+    // A payload carrying properties outside the Pyth subset.
+    let view = contract.verify_update(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        vec![
+            PayloadPropertyValue::Price(Some(Price::from_mantissa(100).unwrap())),
+            PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::PublisherCount(9),
+            PayloadPropertyValue::BestBidPrice(Some(Price::from_mantissa(99).unwrap())),
+        ],
+    )));
+    let feed = &view.feeds[0];
+    assert_eq!(feed.publisher_count, Some(9));
+    assert_eq!(feed.best_bid_price.unwrap().0, 99);
+}
+
+#[test]
+#[should_panic(expected = "signer is not trusted")]
+fn verify_update_rejects_untrusted_signer() {
+    let key_b = SigningKey::from_bytes(&[9u8; 32]);
+    let contract = deploy_and_map(); // trusts the default key, not key_b
+
+    relayer_context(NearToken::from_yoctonear(0));
+    let _ = contract.verify_update(Base64VecU8(real_time_signed_by(
+        &key_b,
+        NOW_S * 1_000_000,
+        100,
+        100,
+        1,
+    )));
+}

--- a/contract/pyth-pro/contract/tests/test.rs
+++ b/contract/pyth-pro/contract/tests/test.rs
@@ -13,6 +13,7 @@ use pyth_lazer_protocol::payload::{PayloadData, PayloadFeedData, PayloadProperty
 use pyth_lazer_protocol::time::TimestampUs;
 use pyth_lazer_protocol::{ChannelId, Price, PriceFeedId};
 use templar_common::oracle::pyth::PriceIdentifier;
+use templar_common::versioned_state::MigrateExternalInterface;
 
 use templar_pyth_pro_adapter_contract::{ConfigArgs, Contract, TrustedSigner};
 
@@ -695,6 +696,45 @@ fn owner_can_withdraw() {
     set_owner_context();
     // Owner withdrawal schedules a transfer without panicking.
     let _ = contract.admin_withdraw(NearToken::from_yoctonear(1));
+}
+
+#[test]
+#[should_panic(expected = "Owner only")]
+fn admin_upgrade_rejects_non_owner() {
+    let mut contract = deploy_and_map();
+
+    // 1 yocto attached so the failure is the owner gate, not the payable gate.
+    testing_env!(VMContextBuilder::new()
+        .predecessor_account_id("attacker.near".parse().unwrap())
+        .attached_deposit(NearToken::from_yoctonear(1))
+        .block_timestamp(NOW_S * 1_000_000_000)
+        .build());
+    let _ = contract.admin_upgrade(Base64VecU8(vec![0u8]), Base64VecU8(vec![]));
+}
+
+#[test]
+#[should_panic(expected = "Requires attached deposit of exactly 1 yoctoNEAR")]
+fn admin_upgrade_requires_one_yocto() {
+    let mut contract = deploy_and_map();
+
+    // Owner, but no deposit: the payable gate must reject before any deploy is scheduled.
+    testing_env!(VMContextBuilder::new()
+        .predecessor_account_id(owner())
+        .attached_deposit(NearToken::from_yoctonear(0))
+        .block_timestamp(NOW_S * 1_000_000_000)
+        .build());
+    let _ = contract.admin_upgrade(Base64VecU8(vec![0u8]), Base64VecU8(vec![]));
+}
+
+#[test]
+fn fresh_deploy_is_at_state_version_one() {
+    let _contract = deploy_and_map();
+
+    // A fresh deploy stamps the on-chain state version, and target == stored, so no migration is
+    // pending. (`admin_upgrade`'s batched `migrate` is the seam for future version bumps.)
+    assert_eq!(Contract::get_target_state_version(), 1);
+    assert_eq!(Contract::get_stored_state_version(), 1);
+    assert!(!Contract::needs_migration());
 }
 
 // --- Config validation (W1) ---

--- a/contract/pyth-pro/pull-payloads.mjs
+++ b/contract/pyth-pro/pull-payloads.mjs
@@ -93,14 +93,27 @@ ws.on("open", () => {
 });
 
 ws.on("message", (data) => {
-  const message = JSON.parse(data.toString());
+  let message;
+  try {
+    message = JSON.parse(data.toString());
+  } catch (error) {
+    console.error("Skipping non-JSON WS frame:", error);
+    return;
+  }
   if (message.type !== "streamUpdated") {
     console.log(JSON.stringify(message, null, 2));
     return;
   }
   if (count >= MAX_MESSAGES) return;
   count += 1;
-  writePayloadFiles(count, message);
+  try {
+    writePayloadFiles(count, message);
+  } catch (error) {
+    console.error("Failed to write payload files:", error);
+    ws.close();
+    process.exitCode = 1;
+    return;
+  }
   console.log(`Wrote payload ${count}/${MAX_MESSAGES}`);
   if (count >= MAX_MESSAGES) ws.close();
 });

--- a/contract/pyth-pro/pull-payloads.mjs
+++ b/contract/pyth-pro/pull-payloads.mjs
@@ -34,6 +34,10 @@ const WS_URL =
 const CHANNEL = process.env.PYTH_PRO_CHANNEL ?? "fixed_rate@200ms";
 const OUT_DIR = process.env.PYTH_PRO_OUT ?? "payloads";
 const MAX_MESSAGES = Number.parseInt(process.env.MAX_MESSAGES ?? "5", 10);
+if (!Number.isInteger(MAX_MESSAGES) || MAX_MESSAGES <= 0) {
+  console.error("MAX_MESSAGES must be a positive integer.");
+  process.exit(1);
+}
 const FIELD_NAME = "solana";
 const PROPERTIES = [
   "price",

--- a/contract/pyth-pro/pull-payloads.mjs
+++ b/contract/pyth-pro/pull-payloads.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+// Throwaway helper for capturing Pyth Pro / Lazer payload fixtures over the WS stream.
+//
+// Usage:
+//   npm install --no-save ws
+//   PYTH_PRO_API_KEY=... FEED_IDS=7,8,1,27,23 node contract/pyth-pro/pull-payloads.mjs
+//
+// Optional: PYTH_PRO_CHANNEL=fixed_rate@200ms  PYTH_PRO_OUT=payloads  MAX_MESSAGES=5
+
+import fs from "node:fs";
+import path from "node:path";
+import process from "node:process";
+import WebSocket from "ws";
+
+const TOKEN = process.env.PYTH_PRO_API_KEY ?? process.env.ACCESS_TOKEN;
+if (!TOKEN) {
+  console.error("Set PYTH_PRO_API_KEY or ACCESS_TOKEN.");
+  process.exit(1);
+}
+
+const FEED_IDS = (process.env.FEED_IDS ?? "")
+  .split(",")
+  .map((s) => Number(s.trim()))
+  .filter((n) => Number.isInteger(n) && n > 0);
+if (FEED_IDS.length === 0) {
+  console.error(
+    "Set FEED_IDS to a comma-separated list of Lazer feed ids, e.g. FEED_IDS=7,8,1,27,23.",
+  );
+  process.exit(1);
+}
+
+const WS_URL =
+  process.env.PYTH_PRO_WS_URL ?? "wss://pyth-lazer-0.dourolabs.app/v1/stream";
+const CHANNEL = process.env.PYTH_PRO_CHANNEL ?? "fixed_rate@200ms";
+const OUT_DIR = process.env.PYTH_PRO_OUT ?? "payloads";
+const MAX_MESSAGES = Number.parseInt(process.env.MAX_MESSAGES ?? "5", 10);
+const FIELD_NAME = "solana";
+const PROPERTIES = [
+  "price",
+  "confidence",
+  "exponent",
+  "emaPrice",
+  "emaConfidence",
+  "feedUpdateTimestamp",
+];
+
+function writePayloadFiles(index, message) {
+  const prefix = path.join(
+    OUT_DIR,
+    `${String(index).padStart(3, "0")}-${message.parsed?.timestampUs ?? index}`,
+  );
+  fs.writeFileSync(`${prefix}.json`, `${JSON.stringify(message, null, 2)}\n`);
+
+  const binary = message[FIELD_NAME];
+  if (!binary?.data) {
+    throw new Error(
+      `streamUpdated message did not include the requested ${FIELD_NAME} payload`,
+    );
+  }
+  const encoding = binary.encoding ?? "hex";
+  const other = encoding === "hex" ? "base64" : "hex";
+  fs.writeFileSync(`${prefix}.${FIELD_NAME}.${encoding}`, `${binary.data}\n`);
+  fs.writeFileSync(
+    `${prefix}.${FIELD_NAME}.${other}`,
+    `${Buffer.from(binary.data, encoding).toString(other)}\n`,
+  );
+}
+
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+const ws = new WebSocket(WS_URL, {
+  headers: { Authorization: `Bearer ${TOKEN}` },
+});
+let count = 0;
+
+ws.on("open", () => {
+  console.log(`Connected to ${WS_URL}`);
+  ws.send(
+    JSON.stringify({
+      type: "subscribe",
+      subscriptionId: 1,
+      priceFeedIds: FEED_IDS,
+      properties: PROPERTIES,
+      formats: [FIELD_NAME],
+      channel: CHANNEL,
+      ignoreInvalidFeeds: true,
+    }),
+  );
+});
+
+ws.on("message", (data) => {
+  const message = JSON.parse(data.toString());
+  if (message.type !== "streamUpdated") {
+    console.log(JSON.stringify(message, null, 2));
+    return;
+  }
+  if (count >= MAX_MESSAGES) return;
+  count += 1;
+  writePayloadFiles(count, message);
+  console.log(`Wrote payload ${count}/${MAX_MESSAGES}`);
+  if (count >= MAX_MESSAGES) ws.close();
+});
+
+ws.on("close", () => console.log(`Done. Output: ${OUT_DIR}`));
+ws.on("error", (error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/contract/pyth-pro/query-solana-trusted-signers.mjs
+++ b/contract/pyth-pro/query-solana-trusted-signers.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Query and decode the Pyth Pro Solana storage account without Anchor.
+//
+// Usage:
+//   node contract/pyth-pro/query-solana-trusted-signers.mjs
+//   SOLANA_RPC_URL=https://api.mainnet-beta.solana.com node contract/pyth-pro/query-solana-trusted-signers.mjs
+
+import process from "node:process";
+
+const RPC_URL =
+  process.env.PYTH_PRO_SOLANA_RPC_URL ??
+  process.env.SOLANA_RPC_URL ??
+  "https://api.mainnet-beta.solana.com";
+const PROGRAM_ID =
+  process.env.PYTH_PRO_SOLANA_PROGRAM ??
+  "pytd2yyk641x7ak7mkaasSJVXh6YYZnC7wTmtgAyxPt";
+const STORAGE_ACCOUNT =
+  process.env.PYTH_PRO_SOLANA_STORAGE ??
+  "3rdJbqfnagQ4yx9HXJViD4zc4xpiSqmFsKpPuSCQVyQL";
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const ANCHOR_DISCRIMINATOR_BYTES = 8;
+const PUBKEY_BYTES = 32;
+const U64_BYTES = 8;
+const I64_BYTES = 8;
+const SPACE_FOR_TRUSTED_SIGNERS = 5;
+const EXPECTED_ACCOUNT_BYTES = 381;
+
+function base58Encode(bytes) {
+  let value = BigInt(`0x${Buffer.from(bytes).toString("hex") || "0"}`);
+  let out = "";
+  while (value > 0n) {
+    const mod = Number(value % 58n);
+    out = BASE58_ALPHABET[mod] + out;
+    value /= 58n;
+  }
+  for (const byte of bytes) {
+    if (byte === 0) out = `1${out}`;
+    else break;
+  }
+  return out || "1";
+}
+
+function unixSecondsToIso(seconds) {
+  if (seconds <= 0n) return null;
+  return new Date(Number(seconds) * 1000).toISOString();
+}
+
+function readPubkey(data, offset) {
+  const bytes = data.subarray(offset, offset + PUBKEY_BYTES);
+  return {
+    base58: base58Encode(bytes),
+    hex: bytes.toString("hex"),
+  };
+}
+
+function readTrustedSigner(data, offset, nowS) {
+  const pubkey = readPubkey(data, offset);
+  const expiresAt = data.readBigInt64LE(offset + PUBKEY_BYTES);
+  return {
+    publicKey: pubkey.base58,
+    publicKeyHex: pubkey.hex,
+    expiresAt: expiresAt.toString(),
+    expiresAtIso: unixSecondsToIso(expiresAt),
+    active: expiresAt > nowS,
+  };
+}
+
+async function getStorageAccount() {
+  const response = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "getAccountInfo",
+      params: [STORAGE_ACCOUNT, { encoding: "base64", commitment: "confirmed" }],
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`Solana RPC failed: ${response.status} ${response.statusText}`);
+  }
+  const body = await response.json();
+  if (body.error) {
+    throw new Error(`Solana RPC error: ${JSON.stringify(body.error)}`);
+  }
+  const account = body.result?.value;
+  if (!account) {
+    throw new Error(`Storage account not found: ${STORAGE_ACCOUNT}`);
+  }
+  return {
+    context: body.result.context,
+    account,
+    data: Buffer.from(account.data[0], "base64"),
+  };
+}
+
+function decodeStorage(data, account, context) {
+  if (data.length !== EXPECTED_ACCOUNT_BYTES) {
+    throw new Error(`Unexpected storage account size: got ${data.length}, expected ${EXPECTED_ACCOUNT_BYTES}`);
+  }
+  if (account.owner !== PROGRAM_ID) {
+    throw new Error(`Unexpected storage account owner: got ${account.owner}, expected ${PROGRAM_ID}`);
+  }
+
+  let offset = ANCHOR_DISCRIMINATOR_BYTES;
+  const topAuthority = readPubkey(data, offset);
+  offset += PUBKEY_BYTES;
+  const treasury = readPubkey(data, offset);
+  offset += PUBKEY_BYTES;
+  const singleUpdateFeeLamports = data.readBigUInt64LE(offset);
+  offset += U64_BYTES;
+
+  const numTrustedSigners = data.readUInt8(offset);
+  offset += 1;
+  if (numTrustedSigners > SPACE_FOR_TRUSTED_SIGNERS) {
+    throw new Error(`Invalid numTrustedSigners: ${numTrustedSigners}`);
+  }
+  const trustedSignersBase = offset;
+  const nowS = BigInt(Math.floor(Date.now() / 1000));
+  const trustedSigners = [];
+  for (let i = 0; i < numTrustedSigners; i += 1) {
+    trustedSigners.push(
+      readTrustedSigner(data, trustedSignersBase + i * (PUBKEY_BYTES + I64_BYTES), nowS),
+    );
+  }
+
+  return {
+    rpcUrl: RPC_URL,
+    slot: context.slot,
+    programId: PROGRAM_ID,
+    storageAccount: STORAGE_ACCOUNT,
+    topAuthority: topAuthority.base58,
+    treasury: treasury.base58,
+    singleUpdateFeeLamports: singleUpdateFeeLamports.toString(),
+    trustedSigners,
+  };
+}
+
+const { context, account, data } = await getStorageAccount();
+console.log(JSON.stringify(decodeStorage(data, account, context), null, 2));

--- a/contract/pyth-pro/query-solana-trusted-signers.mjs
+++ b/contract/pyth-pro/query-solana-trusted-signers.mjs
@@ -67,16 +67,19 @@ function readTrustedSigner(data, offset, nowS) {
 }
 
 async function getStorageAccount() {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
   const response = await fetch(RPC_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
+    signal: controller.signal,
     body: JSON.stringify({
       jsonrpc: "2.0",
       id: 1,
       method: "getAccountInfo",
       params: [STORAGE_ACCOUNT, { encoding: "base64", commitment: "confirmed" }],
     }),
-  });
+  }).finally(() => clearTimeout(timeout));
   if (!response.ok) {
     throw new Error(`Solana RPC failed: ${response.status} ${response.statusText}`);
   }

--- a/contract/pyth-pro/solana-payload-signer.mjs
+++ b/contract/pyth-pro/solana-payload-signer.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+// Inspect a base64 or hex Pyth Pro Solana-format payload and verify its Ed25519 signature.
+//
+// Usage:
+//   node contract/pyth-pro/solana-payload-signer.mjs <BASE64_OR_HEX_PAYLOAD>
+//   cat <captured.solana.base64> | node contract/pyth-pro/solana-payload-signer.mjs
+
+import crypto from "node:crypto";
+import fs from "node:fs";
+import process from "node:process";
+
+const BASE58_ALPHABET = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+const SOLANA_FORMAT_MAGIC = 2182742457;
+const PAYLOAD_FORMAT_MAGIC = 2479346549;
+const ED25519_SPKI_PREFIX = Buffer.from("302a300506032b6570032100", "hex");
+
+function base58Encode(bytes) {
+  let value = BigInt(`0x${Buffer.from(bytes).toString("hex") || "0"}`);
+  let out = "";
+  while (value > 0n) {
+    const mod = Number(value % 58n);
+    out = BASE58_ALPHABET[mod] + out;
+    value /= 58n;
+  }
+  for (const byte of bytes) {
+    if (byte === 0) out = `1${out}`;
+    else break;
+  }
+  return out || "1";
+}
+
+function readInput() {
+  const arg = process.argv[2];
+  if (arg) {
+    if (fs.existsSync(arg) && fs.statSync(arg).isFile()) {
+      return fs.readFileSync(arg, "utf8").trim();
+    }
+    return arg.trim();
+  }
+
+  if (process.stdin.isTTY) {
+    throw new Error("Pass a payload string, a payload file path, or pipe payload data on stdin");
+  }
+  return fs.readFileSync(0, "utf8").trim();
+}
+
+function decodePayload(rawInput) {
+  const input = rawInput.startsWith("0x") ? rawInput.slice(2) : rawInput;
+  if (/^[0-9a-fA-F]+$/.test(input) && input.length % 2 === 0) {
+    return Buffer.from(input, "hex");
+  }
+  return Buffer.from(input, "base64");
+}
+
+function parseFeedIds(payload) {
+  let offset = 0;
+  const magic = payload.readUInt32LE(offset);
+  offset += 4;
+  const timestampUs = payload.readBigUInt64LE(offset);
+  offset += 8;
+  const channel = payload.readUInt8(offset);
+  offset += 1;
+  const feedCount = payload.readUInt8(offset);
+  offset += 1;
+
+  const feedIds = [];
+  for (let i = 0; i < feedCount; i += 1) {
+    const feedId = payload.readUInt32LE(offset);
+    offset += 4;
+    feedIds.push(feedId);
+    const propertyCount = payload.readUInt8(offset);
+    offset += 1;
+
+    for (let j = 0; j < propertyCount; j += 1) {
+      const property = payload.readUInt8(offset);
+      offset += 1;
+      // Property tags = `PriceFeedProperty` discriminants (0-indexed) in the pinned protocol fork.
+      switch (property) {
+        case 0:  // price
+        case 1:  // bestBidPrice
+        case 2:  // bestAskPrice
+        case 5:  // confidence
+        case 10: // emaPrice
+        case 11: // emaConfidence
+          offset += 8; // bare LE i64 (0 = absent)
+          break;
+        case 3:  // publisherCount (u16)
+        case 4:  // exponent (i16)
+        case 9:  // marketSession (i16)
+          offset += 2;
+          break;
+        case 6:  // fundingRate
+        case 7:  // fundingTimestamp
+        case 8:  // fundingRateInterval
+        case 12: { // feedUpdateTimestamp
+          const present = payload.readUInt8(offset); // 1-byte presence flag + optional LE i64/u64
+          offset += 1;
+          if (present) offset += 8;
+          break;
+        }
+        default:
+          throw new Error(`Unsupported property ${property} in payload parser`);
+      }
+    }
+  }
+
+  if (offset !== payload.length) {
+    throw new Error(`Payload parser left ${payload.length - offset} trailing bytes`);
+  }
+  return { magic, timestampUs: timestampUs.toString(), channel, feedIds };
+}
+
+const raw = decodePayload(readInput());
+if (raw.length < 102) throw new Error(`Solana payload too short: ${raw.length}`);
+
+const envelopeMagic = raw.readUInt32LE(0);
+const signature = raw.subarray(4, 68);
+const publicKey = raw.subarray(68, 100);
+const payloadLength = raw.readUInt16LE(100);
+const payload = raw.subarray(102);
+
+if (envelopeMagic !== SOLANA_FORMAT_MAGIC) {
+  throw new Error(`Unexpected Solana envelope magic: ${envelopeMagic}`);
+}
+if (payloadLength !== payload.length) {
+  throw new Error(`Payload length mismatch: header=${payloadLength}, actual=${payload.length}`);
+}
+
+const key = crypto.createPublicKey({
+  key: Buffer.concat([ED25519_SPKI_PREFIX, publicKey]),
+  format: "der",
+  type: "spki",
+});
+const signatureVerified = crypto.verify(null, payload, key, signature);
+const parsedPayload = parseFeedIds(payload);
+if (parsedPayload.magic !== PAYLOAD_FORMAT_MAGIC) {
+  throw new Error(`Unexpected inner payload magic: ${parsedPayload.magic}`);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      publicKey: base58Encode(publicKey),
+      publicKeyHex: publicKey.toString("hex"),
+      signatureVerified,
+      payloadLength,
+      timestampUs: parsedPayload.timestampUs,
+      channel: parsedPayload.channel,
+      feedIds: parsedPayload.feedIds,
+    },
+    null,
+    2,
+  ),
+);

--- a/contract/pyth-pro/solana-payload-signer.mjs
+++ b/contract/pyth-pro/solana-payload-signer.mjs
@@ -49,6 +49,9 @@ function decodePayload(rawInput) {
   if (/^[0-9a-fA-F]+$/.test(input) && input.length % 2 === 0) {
     return Buffer.from(input, "hex");
   }
+  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(input) || input.length % 4 !== 0) {
+    throw new Error("Input must be valid hex or base64");
+  }
   return Buffer.from(input, "base64");
 }
 

--- a/contract/pyth-pro/verifier/Cargo.toml
+++ b/contract/pyth-pro/verifier/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+edition.workspace = true
+license.workspace = true
+name = "templar-pyth-pro-verifier"
+repository.workspace = true
+version = "0.1.0"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+byteorder = "1"
+pyth-lazer-protocol.workspace = true
+templar-primitives.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+base64.workspace = true
+ed25519-dalek.workspace = true
+rstest.workspace = true
+
+[lints]
+workspace = true

--- a/contract/pyth-pro/verifier/README.md
+++ b/contract/pyth-pro/verifier/README.md
@@ -12,8 +12,8 @@ the [adapter overview](../README.md).
   decode the solana envelope, check the carried public key is trusted and unexpired, verify the
   ed25519 signature over the payload, decode the (little-endian) payload, then apply the channel
   filter and freshness window.
-- `VerifyParams` — `trusted_signers`, `now_s`, `max_timestamp_delay_s`, `max_timestamp_ahead_s`,
-  `allowed_channel_id` (all seconds).
+- `VerifyParams` — `trusted_signers`, `now_s`, `max_timestamp_delay_s`, `max_timestamp_ahead_s`
+  (seconds), and `allowed_channel_id` (channel byte).
 - `VerifiedUpdate { signer: [u8; 32], channel_id, timestamp: Nanoseconds, feeds: Vec<ParsedFeed> }`;
   each `ParsedFeed` field is `None` when the property was absent (or carried Lazer's zero sentinel).
 

--- a/contract/pyth-pro/verifier/README.md
+++ b/contract/pyth-pro/verifier/README.md
@@ -1,0 +1,28 @@
+# templar-pyth-pro-verifier
+
+Chain-agnostic verification and parsing for Pyth Pro (formerly Pyth Lazer) price updates. No `near-sdk`;
+the host supplies a [`Crypto`] impl and converts the neutral result into its own ABI types. See
+the [adapter overview](../README.md).
+
+## API
+
+- `Crypto` — host crypto: a single `ed25519_verify(signature, message, public_key) -> bool`
+  (on NEAR, `env::ed25519_verify`).
+- `verify_solana_update(crypto, raw_message, params) -> Result<VerifiedUpdate, VerifyError>` —
+  decode the solana envelope, check the carried public key is trusted and unexpired, verify the
+  ed25519 signature over the payload, decode the (little-endian) payload, then apply the channel
+  filter and freshness window.
+- `VerifyParams` — `trusted_signers`, `now_s`, `max_timestamp_delay_s`, `max_timestamp_ahead_s`,
+  `allowed_channel_id` (all seconds).
+- `VerifiedUpdate { signer: [u8; 32], channel_id, timestamp: Nanoseconds, feeds: Vec<ParsedFeed> }`;
+  each `ParsedFeed` field is `None` when the property was absent (or carried Lazer's zero sentinel).
+
+## Notes
+
+- Targets Pyth Pro's **solana** format (ed25519 — NEAR's native scheme), little-endian payload.
+  The signer is identified by the 32-byte ed25519 public key carried in the envelope, so there is
+  no hashing, recovery, or address derivation — just a membership check plus a signature verify.
+- The verifier may use `std`; the upstream parser it wraps uses `std::io`, and the NEAR contract
+  target provides `std`. It must not depend on `near-sdk`.
+- Tests sign payloads with `ed25519-dalek` and round-trip through `verify_solana_update`; the
+  `tests/real_pyth_pro_payloads.rs` regression test runs over real captured solana payloads.

--- a/contract/pyth-pro/verifier/src/crypto.rs
+++ b/contract/pyth-pro/verifier/src/crypto.rs
@@ -1,0 +1,9 @@
+/// Cryptographic primitive the verifier needs, supplied by the host runtime.
+///
+/// On NEAR this maps directly onto `env::ed25519_verify` (ed25519 is NEAR's native signature
+/// scheme); keeping it behind a trait lets the verification logic stay chain-agnostic and
+/// unit-testable off-chain.
+pub trait Crypto {
+    /// Verify that `signature` (64 bytes) over `message` is valid for the ed25519 `public_key`.
+    fn ed25519_verify(&self, signature: &[u8; 64], message: &[u8], public_key: &[u8; 32]) -> bool;
+}

--- a/contract/pyth-pro/verifier/src/error.rs
+++ b/contract/pyth-pro/verifier/src/error.rs
@@ -1,0 +1,31 @@
+use thiserror::Error;
+
+/// Reasons a Pyth Pro update may be rejected during verification.
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum VerifyError {
+    /// The outer signed-message envelope could not be decoded.
+    #[error("failed to decode Lazer message envelope: {0}")]
+    Envelope(String),
+    /// The inner price payload could not be decoded.
+    #[error("failed to decode payload: {0}")]
+    Payload(String),
+    /// The message or payload was not canonically encoded (e.g. trailing bytes), so it does not
+    /// re-serialize to the exact signed/received bytes.
+    #[error("message is not canonically encoded")]
+    NonCanonical,
+    /// The ed25519 signature did not verify against the carried public key.
+    #[error("ed25519 signature verification failed")]
+    Signature,
+    /// The signer is not in the trusted set, or its trust has expired.
+    #[error("signer is not trusted or has expired")]
+    UntrustedSigner,
+    /// The payload was published on a channel the adapter does not accept.
+    #[error("payload channel {got} is not accepted")]
+    Channel { got: u8 },
+    /// The payload timestamp is older than the configured freshness window allows.
+    #[error("payload timestamp is too old")]
+    TimestampTooOld,
+    /// The payload timestamp is further in the future than the configured window allows.
+    #[error("payload timestamp is too far in the future")]
+    TimestampTooFarAhead,
+}

--- a/contract/pyth-pro/verifier/src/error.rs
+++ b/contract/pyth-pro/verifier/src/error.rs
@@ -9,10 +9,13 @@ pub enum VerifyError {
     /// The inner price payload could not be decoded.
     #[error("failed to decode payload: {0}")]
     Payload(String),
-    /// The message or payload was not canonically encoded (e.g. trailing bytes), so it does not
-    /// re-serialize to the exact signed/received bytes.
-    #[error("message is not canonically encoded")]
-    NonCanonical,
+    /// Decoding the message or payload left trailing bytes — the cursor did not reach the end of
+    /// the input. This rejects trailing / non-exhaustive encodings only; it does **not**
+    /// re-serialize and byte-compare, so an in-band non-canonical encoding that still parses and
+    /// fully consumes its input is not caught here (any such mutation would instead fail the
+    /// ed25519 signature check, which is computed over the exact signed bytes).
+    #[error("message or payload has trailing bytes (non-exhaustive encoding)")]
+    TrailingBytes,
     /// The ed25519 signature did not verify against the carried public key.
     #[error("ed25519 signature verification failed")]
     Signature,

--- a/contract/pyth-pro/verifier/src/lib.rs
+++ b/contract/pyth-pro/verifier/src/lib.rs
@@ -1,0 +1,17 @@
+//! Chain-agnostic verification and parsing for Pyth Pro (formerly Pyth Lazer) price updates.
+//!
+//! This crate wraps the upstream [`pyth_lazer_protocol`] wire-format parser (built with its
+//! minimal, `default-features = false` feature set) and adds the trust checks an on-chain
+//! adapter needs: an ed25519 signature check against a trusted, non-expired signer set, channel
+//! filtering, and a timestamp freshness window. It targets Pyth Pro's **solana** delivery format
+//! (ed25519 — NEAR's native scheme). It deliberately contains no chain-specific types — the host
+//! (e.g. a NEAR contract) supplies a [`Crypto`] implementation and converts the neutral
+//! [`VerifiedUpdate`] into its own storage/ABI types.
+
+mod crypto;
+mod error;
+mod verify;
+
+pub use crypto::Crypto;
+pub use error::VerifyError;
+pub use verify::{verify_solana_update, ParsedFeed, TrustedSigner, VerifiedUpdate, VerifyParams};

--- a/contract/pyth-pro/verifier/src/verify.rs
+++ b/contract/pyth-pro/verifier/src/verify.rs
@@ -81,7 +81,7 @@ pub fn verify_solana_update<C: Crypto>(
     let message = SolanaMessage::deserialize(&mut cursor)
         .map_err(|e| VerifyError::Envelope(e.to_string()))?;
     if cursor.position() != raw_message.len() as u64 {
-        return Err(VerifyError::NonCanonical);
+        return Err(VerifyError::TrailingBytes);
     }
 
     // The signer pubkey is carried in the envelope — trust it only if it's in the configured,
@@ -102,7 +102,7 @@ pub fn verify_solana_update<C: Crypto>(
     let data = PayloadData::deserialize::<byteorder::LE>(&mut payload_cursor)
         .map_err(|e| VerifyError::Payload(e.to_string()))?;
     if payload_cursor.position() != message.payload.len() as u64 {
-        return Err(VerifyError::NonCanonical);
+        return Err(VerifyError::TrailingBytes);
     }
 
     let channel_id = data.channel_id.0;
@@ -429,7 +429,7 @@ mod tests {
         let signers = [signer_for(&key, now_s + 1000)];
         assert_eq!(
             verify_solana_update(&TestCrypto, &raw, &params(&signers, now_s)),
-            Err(VerifyError::NonCanonical)
+            Err(VerifyError::TrailingBytes)
         );
     }
 
@@ -445,7 +445,7 @@ mod tests {
         let signers = [signer_for(&key, now_s + 1000)];
         assert_eq!(
             verify_solana_update(&TestCrypto, &raw, &params(&signers, now_s)),
-            Err(VerifyError::NonCanonical)
+            Err(VerifyError::TrailingBytes)
         );
     }
 

--- a/contract/pyth-pro/verifier/src/verify.rs
+++ b/contract/pyth-pro/verifier/src/verify.rs
@@ -1,0 +1,483 @@
+use std::io::Cursor;
+
+use pyth_lazer_protocol::message::SolanaMessage;
+use pyth_lazer_protocol::payload::{PayloadData, PayloadFeedData, PayloadPropertyValue};
+use templar_primitives::Nanoseconds;
+
+use crate::crypto::Crypto;
+use crate::error::VerifyError;
+
+/// A trusted publisher: the 32-byte ed25519 public key whose signatures are accepted, and the
+/// unix-seconds instant after which that trust lapses (mirrors the Lazer contract's per-signer
+/// `expiresAt`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TrustedSigner {
+    pub public_key: [u8; 32],
+    pub expires_at_s: u64,
+}
+
+/// The neutral, per-feed result of parsing a payload — preserves every Lazer property so callers
+/// (e.g. the stateless `verify_update` view) get full data, not just the Pyth-compatible subset.
+///
+/// Each field is `None` when the property was absent (or, for prices, carried Lazer's zero
+/// sentinel). NOTE: "not requested" and "requested but missing" both collapse to `None` here; the
+/// official EVM contract distinguishes them via a tri-state map — a possible future enrichment.
+/// Price-like values are raw `i64` mantissas (interpret with `exponent`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedFeed {
+    pub feed_id: u32,
+    pub price: Option<i64>,
+    pub best_bid_price: Option<i64>,
+    pub best_ask_price: Option<i64>,
+    pub publisher_count: Option<u16>,
+    pub exponent: Option<i16>,
+    pub confidence: Option<i64>,
+    pub funding_rate: Option<i64>,
+    pub funding_timestamp: Option<Nanoseconds>,
+    pub funding_rate_interval: Option<Nanoseconds>,
+    pub market_session: Option<i16>,
+    pub ema_price: Option<i64>,
+    pub ema_confidence: Option<i64>,
+    pub feed_update_timestamp: Option<Nanoseconds>,
+}
+
+/// A successfully verified Lazer update.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedUpdate {
+    /// The trusted ed25519 signer public key that produced the signature.
+    pub signer: [u8; 32],
+    /// The channel the payload was published on.
+    pub channel_id: u8,
+    /// The payload-level timestamp.
+    pub timestamp: Nanoseconds,
+    /// One entry per feed present in the payload.
+    pub feeds: Vec<ParsedFeed>,
+}
+
+/// Trust/freshness parameters for [`verify_solana_update`]. All durations are in whole seconds.
+pub struct VerifyParams<'a> {
+    pub trusted_signers: &'a [TrustedSigner],
+    pub now_s: u64,
+    pub max_timestamp_delay_s: u64,
+    pub max_timestamp_ahead_s: u64,
+    /// If `Some`, only payloads on this channel are accepted; `None` accepts any channel.
+    pub allowed_channel_id: Option<u8>,
+}
+
+/// Verify and parse a Pyth Pro **solana**-format (ed25519) signed message. ("solana" is Pyth's
+/// name for the format; the verification runs on NEAR, whose native scheme is ed25519.)
+///
+/// Checks, in order: envelope decode, trusted-and-unexpired signer (the pubkey is carried in the
+/// envelope), ed25519 signature over the payload, payload decode (which also validates the inner
+/// payload magic), channel filter, and freshness window.
+pub fn verify_solana_update<C: Crypto>(
+    crypto: &C,
+    raw_message: &[u8],
+    params: &VerifyParams<'_>,
+) -> Result<VerifiedUpdate, VerifyError> {
+    // Parse from a cursor and require it to reach the end — no trailing bytes (mirrors the official
+    // Sui contract's `cursor.destroy_empty()`). Cheap: just the parse plus a position compare.
+    let mut cursor = Cursor::new(raw_message);
+    let message = SolanaMessage::deserialize(&mut cursor)
+        .map_err(|e| VerifyError::Envelope(e.to_string()))?;
+    if cursor.position() != raw_message.len() as u64 {
+        return Err(VerifyError::NonCanonical);
+    }
+
+    // The signer pubkey is carried in the envelope — trust it only if it's in the configured,
+    // unexpired set, then confirm it actually produced the signature over the payload.
+    let signer = message.public_key;
+    let trusted = params
+        .trusted_signers
+        .iter()
+        .any(|s| s.public_key == signer && s.expires_at_s > params.now_s);
+    if !trusted {
+        return Err(VerifyError::UntrustedSigner);
+    }
+    if !crypto.ed25519_verify(&message.signature, &message.payload, &signer) {
+        return Err(VerifyError::Signature);
+    }
+
+    let mut payload_cursor = Cursor::new(message.payload.as_slice());
+    let data = PayloadData::deserialize::<byteorder::LE>(&mut payload_cursor)
+        .map_err(|e| VerifyError::Payload(e.to_string()))?;
+    if payload_cursor.position() != message.payload.len() as u64 {
+        return Err(VerifyError::NonCanonical);
+    }
+
+    let channel_id = data.channel_id.0;
+    if let Some(allowed) = params.allowed_channel_id {
+        if channel_id != allowed {
+            return Err(VerifyError::Channel { got: channel_id });
+        }
+    }
+
+    // Freshness window is checked on the protocol type's whole seconds; the stored result carries
+    // the unit in the type (`Nanoseconds`).
+    let timestamp_secs = data.timestamp_us.as_secs();
+    if timestamp_secs.saturating_add(params.max_timestamp_delay_s) < params.now_s {
+        return Err(VerifyError::TimestampTooOld);
+    }
+    if timestamp_secs > params.now_s.saturating_add(params.max_timestamp_ahead_s) {
+        return Err(VerifyError::TimestampTooFarAhead);
+    }
+    let timestamp = Nanoseconds::from_micros(data.timestamp_us.as_micros());
+
+    let feeds = data.feeds.into_iter().map(parse_feed).collect();
+
+    Ok(VerifiedUpdate {
+        signer,
+        channel_id,
+        timestamp,
+        feeds,
+    })
+}
+
+fn parse_feed(feed: PayloadFeedData) -> ParsedFeed {
+    let mut parsed = ParsedFeed {
+        feed_id: feed.feed_id.0,
+        price: None,
+        best_bid_price: None,
+        best_ask_price: None,
+        publisher_count: None,
+        exponent: None,
+        confidence: None,
+        funding_rate: None,
+        funding_timestamp: None,
+        funding_rate_interval: None,
+        market_session: None,
+        ema_price: None,
+        ema_confidence: None,
+        feed_update_timestamp: None,
+    };
+
+    for property in feed.properties {
+        match property {
+            PayloadPropertyValue::Price(Some(p)) => parsed.price = Some(p.mantissa_i64()),
+            PayloadPropertyValue::BestBidPrice(Some(p)) => {
+                parsed.best_bid_price = Some(p.mantissa_i64());
+            }
+            PayloadPropertyValue::BestAskPrice(Some(p)) => {
+                parsed.best_ask_price = Some(p.mantissa_i64());
+            }
+            PayloadPropertyValue::PublisherCount(n) => parsed.publisher_count = Some(n),
+            PayloadPropertyValue::Exponent(e) => parsed.exponent = Some(e),
+            PayloadPropertyValue::Confidence(Some(p)) => parsed.confidence = Some(p.mantissa_i64()),
+            PayloadPropertyValue::FundingRate(Some(r)) => parsed.funding_rate = Some(r.mantissa()),
+            PayloadPropertyValue::FundingTimestamp(Some(t)) => {
+                parsed.funding_timestamp = Some(Nanoseconds::from_micros(t.as_micros()));
+            }
+            PayloadPropertyValue::FundingRateInterval(Some(d)) => {
+                parsed.funding_rate_interval = Some(Nanoseconds::from_micros(d.as_micros()));
+            }
+            PayloadPropertyValue::MarketSession(ms) => {
+                parsed.market_session = Some(i16::from(ms));
+            }
+            PayloadPropertyValue::EmaPrice(Some(p)) => parsed.ema_price = Some(p.mantissa_i64()),
+            PayloadPropertyValue::EmaConfidence(Some(p)) => {
+                parsed.ema_confidence = Some(p.mantissa_i64());
+            }
+            PayloadPropertyValue::FeedUpdateTimestamp(Some(t)) => {
+                parsed.feed_update_timestamp = Some(Nanoseconds::from_micros(t.as_micros()));
+            }
+            // `None`-sentinel price-likes leave the corresponding field as `None`.
+            _ => {}
+        }
+    }
+
+    parsed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::{Signature, Signer, SigningKey, VerifyingKey};
+    use pyth_lazer_protocol::message::SolanaMessage;
+    use pyth_lazer_protocol::payload::{PayloadData, PayloadFeedData, PayloadPropertyValue};
+    use pyth_lazer_protocol::time::TimestampUs;
+    use pyth_lazer_protocol::{ChannelId, Price, PriceFeedId};
+
+    /// Test double for [`Crypto`] using `ed25519-dalek`.
+    struct TestCrypto;
+
+    impl Crypto for TestCrypto {
+        fn ed25519_verify(
+            &self,
+            signature: &[u8; 64],
+            message: &[u8],
+            public_key: &[u8; 32],
+        ) -> bool {
+            let Ok(key) = VerifyingKey::from_bytes(public_key) else {
+                return false;
+            };
+            key.verify_strict(message, &Signature::from_bytes(signature))
+                .is_ok()
+        }
+    }
+
+    fn sample_payload(timestamp_us: u64, channel: u8) -> Vec<u8> {
+        let data = PayloadData {
+            timestamp_us: TimestampUs::from_micros(timestamp_us),
+            channel_id: ChannelId(channel),
+            feeds: vec![PayloadFeedData {
+                feed_id: PriceFeedId(2),
+                properties: vec![
+                    PayloadPropertyValue::Price(Some(Price::from_mantissa(123_456).unwrap())),
+                    PayloadPropertyValue::Confidence(Some(Price::from_mantissa(50).unwrap())),
+                    PayloadPropertyValue::Exponent(-8),
+                    PayloadPropertyValue::EmaPrice(Some(Price::from_mantissa(123_000).unwrap())),
+                    PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
+                        timestamp_us,
+                    ))),
+                ],
+            }],
+        };
+        let mut payload = Vec::new();
+        data.serialize::<byteorder::LE>(&mut payload).unwrap();
+        payload
+    }
+
+    fn signed_message(signing_key: &SigningKey, payload: &[u8]) -> Vec<u8> {
+        let message = SolanaMessage {
+            payload: payload.to_vec(),
+            signature: signing_key.sign(payload).to_bytes(),
+            public_key: signing_key.verifying_key().to_bytes(),
+        };
+        let mut raw = Vec::new();
+        message.serialize(&mut raw).unwrap();
+        raw
+    }
+
+    fn signer_for(signing_key: &SigningKey, expires_at_s: u64) -> TrustedSigner {
+        TrustedSigner {
+            public_key: signing_key.verifying_key().to_bytes(),
+            expires_at_s,
+        }
+    }
+
+    #[test]
+    fn verifies_and_parses_a_well_formed_update() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+        let payload = sample_payload(now_s * 1_000_000, ChannelId::REAL_TIME.0);
+        let raw = signed_message(&key, &payload);
+
+        let signers = [signer_for(&key, now_s + 1000)];
+        let params = VerifyParams {
+            trusted_signers: &signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: Some(ChannelId::REAL_TIME.0),
+        };
+
+        let update = verify_solana_update(&TestCrypto, &raw, &params).unwrap();
+        assert_eq!(update.channel_id, ChannelId::REAL_TIME.0);
+        assert_eq!(
+            update.timestamp,
+            Nanoseconds::from_micros(now_s * 1_000_000)
+        );
+        assert_eq!(update.feeds.len(), 1);
+        let feed = &update.feeds[0];
+        assert_eq!(feed.feed_id, 2);
+        assert_eq!(feed.price, Some(123_456));
+        assert_eq!(feed.confidence, Some(50));
+        assert_eq!(feed.exponent, Some(-8));
+        assert_eq!(feed.ema_price, Some(123_000));
+        assert_eq!(feed.ema_confidence, None);
+        assert_eq!(
+            feed.feed_update_timestamp,
+            Some(Nanoseconds::from_micros(now_s * 1_000_000))
+        );
+    }
+
+    #[test]
+    fn duplicate_property_last_wins() {
+        // `parse_feed` has no duplicate-property policy; the last occurrence wins. Pin that.
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+        let data = PayloadData {
+            timestamp_us: TimestampUs::from_micros(now_s * 1_000_000),
+            channel_id: ChannelId::REAL_TIME,
+            feeds: vec![PayloadFeedData {
+                feed_id: PriceFeedId(2),
+                properties: vec![
+                    PayloadPropertyValue::Price(Some(Price::from_mantissa(100).unwrap())),
+                    PayloadPropertyValue::Price(Some(Price::from_mantissa(200).unwrap())),
+                    PayloadPropertyValue::Exponent(-8),
+                ],
+            }],
+        };
+        let mut payload = Vec::new();
+        data.serialize::<byteorder::LE>(&mut payload).unwrap();
+        let raw = signed_message(&key, &payload);
+
+        let signers = [signer_for(&key, now_s + 1000)];
+        let params = VerifyParams {
+            trusted_signers: &signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: None,
+        };
+
+        let update = verify_solana_update(&TestCrypto, &raw, &params).unwrap();
+        assert_eq!(update.feeds[0].price, Some(200));
+    }
+
+    #[test]
+    fn rejects_untrusted_signer() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let other = SigningKey::from_bytes(&[9u8; 32]);
+        let now_s = 1_700_000_000;
+        let payload = sample_payload(now_s * 1_000_000, ChannelId::REAL_TIME.0);
+        let raw = signed_message(&key, &payload);
+
+        let signers = [signer_for(&other, now_s + 1000)];
+        let params = VerifyParams {
+            trusted_signers: &signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: None,
+        };
+
+        assert_eq!(
+            verify_solana_update(&TestCrypto, &raw, &params),
+            Err(VerifyError::UntrustedSigner)
+        );
+    }
+
+    #[test]
+    fn rejects_expired_signer() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+        let payload = sample_payload(now_s * 1_000_000, ChannelId::REAL_TIME.0);
+        let raw = signed_message(&key, &payload);
+
+        let signers = [signer_for(&key, now_s - 1)];
+        let params = VerifyParams {
+            trusted_signers: &signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: None,
+        };
+
+        assert_eq!(
+            verify_solana_update(&TestCrypto, &raw, &params),
+            Err(VerifyError::UntrustedSigner)
+        );
+    }
+
+    #[test]
+    fn rejects_stale_and_wrong_channel() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+
+        let stale_payload = sample_payload((now_s - 600) * 1_000_000, ChannelId::REAL_TIME.0);
+        let stale_raw = signed_message(&key, &stale_payload);
+        let signers = [signer_for(&key, now_s + 1000)];
+        let params = VerifyParams {
+            trusted_signers: &signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: None,
+        };
+        assert_eq!(
+            verify_solana_update(&TestCrypto, &stale_raw, &params),
+            Err(VerifyError::TimestampTooOld)
+        );
+
+        let payload = sample_payload(now_s * 1_000_000, ChannelId::FIXED_RATE_200.0);
+        let raw = signed_message(&key, &payload);
+        let params = VerifyParams {
+            trusted_signers: &signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: Some(ChannelId::REAL_TIME.0),
+        };
+        assert_eq!(
+            verify_solana_update(&TestCrypto, &raw, &params),
+            Err(VerifyError::Channel {
+                got: ChannelId::FIXED_RATE_200.0
+            })
+        );
+    }
+
+    fn params(signers: &[TrustedSigner], now_s: u64) -> VerifyParams<'_> {
+        VerifyParams {
+            trusted_signers: signers,
+            now_s,
+            max_timestamp_delay_s: 60,
+            max_timestamp_ahead_s: 60,
+            allowed_channel_id: None,
+        }
+    }
+
+    #[test]
+    fn rejects_trailing_envelope_bytes() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+        let mut raw = signed_message(
+            &key,
+            &sample_payload(now_s * 1_000_000, ChannelId::REAL_TIME.0),
+        );
+        raw.push(0xFF); // junk after the canonical envelope
+        let signers = [signer_for(&key, now_s + 1000)];
+        assert_eq!(
+            verify_solana_update(&TestCrypto, &raw, &params(&signers, now_s)),
+            Err(VerifyError::NonCanonical)
+        );
+    }
+
+    #[test]
+    fn rejects_trailing_signed_payload_bytes() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+        // Trailing junk *inside* the signed payload: the envelope is canonical, but the payload
+        // parser leaves bytes unconsumed.
+        let mut payload = sample_payload(now_s * 1_000_000, ChannelId::REAL_TIME.0);
+        payload.push(0xFF);
+        let raw = signed_message(&key, &payload);
+        let signers = [signer_for(&key, now_s + 1000)];
+        assert_eq!(
+            verify_solana_update(&TestCrypto, &raw, &params(&signers, now_s)),
+            Err(VerifyError::NonCanonical)
+        );
+    }
+
+    #[test]
+    fn preserves_non_pyth_properties() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let now_s = 1_700_000_000;
+        let data = PayloadData {
+            timestamp_us: TimestampUs::from_micros(now_s * 1_000_000),
+            channel_id: ChannelId::REAL_TIME,
+            feeds: vec![PayloadFeedData {
+                feed_id: PriceFeedId(2),
+                properties: vec![
+                    PayloadPropertyValue::Price(Some(Price::from_mantissa(100).unwrap())),
+                    PayloadPropertyValue::Exponent(-8),
+                    PayloadPropertyValue::PublisherCount(7),
+                    PayloadPropertyValue::BestBidPrice(Some(Price::from_mantissa(99).unwrap())),
+                    PayloadPropertyValue::BestAskPrice(Some(Price::from_mantissa(101).unwrap())),
+                ],
+            }],
+        };
+        let mut payload = Vec::new();
+        data.serialize::<byteorder::LE>(&mut payload).unwrap();
+        let raw = signed_message(&key, &payload);
+        let signers = [signer_for(&key, now_s + 1000)];
+
+        let feed = &verify_solana_update(&TestCrypto, &raw, &params(&signers, now_s))
+            .unwrap()
+            .feeds[0];
+        // Properties beyond the Pyth subset are retained, not dropped.
+        assert_eq!(feed.publisher_count, Some(7));
+        assert_eq!(feed.best_bid_price, Some(99));
+        assert_eq!(feed.best_ask_price, Some(101));
+    }
+}

--- a/contract/pyth-pro/verifier/tests/real_pyth_pro_payloads.rs
+++ b/contract/pyth-pro/verifier/tests/real_pyth_pro_payloads.rs
@@ -1,0 +1,227 @@
+#![allow(clippy::unwrap_used)]
+
+//! Regression tests over real Pyth Pro **solana**-format (ed25519) payloads captured offline from
+//! the Lazer endpoint. The signer pubkey is carried in each envelope, so trust is established by
+//! reading it out (no recovery).
+
+use base64::Engine;
+use ed25519_dalek::{Signature, VerifyingKey};
+use pyth_lazer_protocol::message::SolanaMessage;
+use rstest::rstest;
+use templar_primitives::Nanoseconds;
+use templar_pyth_pro_verifier::{
+    verify_solana_update, Crypto, TrustedSigner, VerifyError, VerifyParams,
+};
+
+const PAYLOAD_001: &str = "uQEagohEipEVyTiNYf6VaHJFux40+GmgzXaVUuzszi4nJMWpoMH4WZB0W3SMzUM41gQlkeJYJDydLouwjUDVBbksHwqA78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHk0AKB5JsVAYAAwUHAAAABgD4hPUFAAAAAAUwKwAAAAAAAAT4/wqlkfUFAAAAAAsGNgAAAAAAAAwBQAoHkmxUBgAIAAAABgAvcfQFAAAAAAVeLAAAAAAAAAT4/wpWYvQFAAAAAAt1NwAAAAAAAAwBQAoHkmxUBgABAAAABgAqfglX/QUAAAV2rg9cAQAAAAT4/wqgFefA+wUAAAv8FrtEAQAAAAwBQAoHkmxUBgAbAAAABgC9d+INAAAAAAU27QEAAAAAAAT4/wqQi9sNAAAAAAu07wAAAAAAAAwBQAoHkmxUBgAXAAAABgDQwVgBAAAAAAWSGAAAAAAAAAT4/wqs8FYBAAAAAAvgGAAAAAAAAAwBQAoHkmxUBgA=";
+const PAYLOAD_002: &str = "uQEagrbhXBQ0obffIhLeKsWy2+I5qMVP2dTi8kZYNjSc6yRRzcrMBXpvvZitAPKAe6Pao5xcNcg964VaW9rpiS61EgaA78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHk4AXCpJsVAYAAwUHAAAABgDxhPUFAAAAAAU3KwAAAAAAAAT4/wqlkfUFAAAAAAsGNgAAAAAAAAwBgBcKkmxUBgAIAAAABgDXcfQFAAAAAAW2KwAAAAAAAAT4/wpaYvQFAAAAAAt1NwAAAAAAAAwBgBcKkmxUBgABAAAABgDz+QVX/QUAAAUn7ONkAQAAAAT4/wqAqevA+wUAAAukkbtEAQAAAAwBgBcKkmxUBgAbAAAABgC9d+INAAAAAAU27QEAAAAAAAT4/wqci9sNAAAAAAu27wAAAAAAAAwBgBcKkmxUBgAXAAAABgDQwVgBAAAAAAWSGAAAAAAAAAT4/wqz8FYBAAAAAAvgGAAAAAAAAAwBgBcKkmxUBgA=";
+const PAYLOAD_003: &str = "uQEaggCqEFmq/DHcSpPiMlB1L1ebTDHQirAGoOF63nYAABPprL05D0YcyR34nzmaRh7/wRYQJe1IhEaxqGIy4rMm2wiA78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHk8AkDZJsVAYAAwUHAAAABgDxhPUFAAAAAAU3KwAAAAAAAAT4/wqlkfUFAAAAAAsGNgAAAAAAAAwBwCQNkmxUBgAIAAAABgDXcfQFAAAAAAW2KwAAAAAAAAT4/wpbYvQFAAAAAAt0NwAAAAAAAAwBwCQNkmxUBgABAAAABgDy+QVX/QUAAAUO1cJhAQAAAAT4/wpgPfDA+wUAAAus/LtEAQAAAAwBwCQNkmxUBgAbAAAABgC9d+INAAAAAAXYFgIAAAAAAAT4/wqri9sNAAAAAAu47wAAAAAAAAwBwCQNkmxUBgAXAAAABgBlxlgBAAAAAAX9EwAAAAAAAAT4/wq78FYBAAAAAAvgGAAAAAAAAAwBwCQNkmxUBgA=";
+const PAYLOAD_004: &str = "uQEagnoT9YVSg5gtkZHx0ejedhZoDwEePxhfEvQ5UbwjQxmgJmL9jgGRy6h+EaNjQwYHGCTKFqWZzrWd/ehgKSCytAuA78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHkwAyEJJsVAYAAwUHAAAABgDxhPUFAAAAAAU3KwAAAAAAAAT4/wqmkfUFAAAAAAsFNgAAAAAAAAwBADIQkmxUBgAIAAAABgDXcfQFAAAAAAW2KwAAAAAAAAT4/wpdYvQFAAAAAAt0NwAAAAAAAAwBADIQkmxUBgABAAAABgDy+QVX/QUAAAUpCzhCAQAAAAT4/wrgV/bA+wUAAAu88btEAQAAAAwBADIQkmxUBgAbAAAABgC9d+INAAAAAAUH5gEAAAAAAAT4/wrEi9sNAAAAAAu67wAAAAAAAAwBADIQkmxUBgAXAAAABgB01FgBAAAAAAXjJgAAAAAAAAT4/wrA8FYBAAAAAAvgGAAAAAAAAAwBADIQkmxUBgA=";
+const PAYLOAD_005: &str = "uQEags5APgOMCMAXqPRoS1putpV3DUQ5b2njS7XRh9JCkTvBJyr/El+UQkPVSjgfvB/l2mDY4O0BF/tNa/JWK/oHGg6A78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHk0A/E5JsVAYAAwUHAAAABgDxhPUFAAAAAAU3KwAAAAAAAAT4/wqmkfUFAAAAAAsFNgAAAAAAAAwBQD8TkmxUBgAIAAAABgDacfQFAAAAAAWzKwAAAAAAAAT4/wpaYvQFAAAAAAt0NwAAAAAAAAwBQD8TkmxUBgABAAAABgCmfwpX/QUAAAVtZ99kAQAAAAT4/wogZfnA+wUAAAt0YbxEAQAAAAwBQD8TkmxUBgAbAAAABgC9d+INAAAAAAXYFgIAAAAAAAT4/wrXi9sNAAAAAAu87wAAAAAAAAwBQD8TkmxUBgAXAAAABgDv5FgBAAAAAAUfIwAAAAAAAAT4/wrE8FYBAAAAAAvgGAAAAAAAAAwBQD8TkmxUBgA=";
+
+const EXPECTED_FEEDS: [u32; 5] = [7, 8, 1, 27, 23];
+
+struct TestCrypto;
+
+impl Crypto for TestCrypto {
+    fn ed25519_verify(&self, signature: &[u8; 64], message: &[u8], public_key: &[u8; 32]) -> bool {
+        let Ok(key) = VerifyingKey::from_bytes(public_key) else {
+            return false;
+        };
+        key.verify_strict(message, &Signature::from_bytes(signature))
+            .is_ok()
+    }
+}
+
+fn decode_fixture(payload_base64: &str) -> Vec<u8> {
+    base64::engine::general_purpose::STANDARD
+        .decode(payload_base64)
+        .unwrap()
+}
+
+/// The signer pubkey is carried in the solana envelope — read it directly (no recovery).
+fn signer_of(raw: &[u8]) -> [u8; 32] {
+    SolanaMessage::deserialize_slice(raw).unwrap().public_key
+}
+
+fn params_for(trusted_signers: &[TrustedSigner], now_s: u64) -> VerifyParams<'_> {
+    VerifyParams {
+        trusted_signers,
+        now_s,
+        max_timestamp_delay_s: 60,
+        max_timestamp_ahead_s: 60,
+        allowed_channel_id: None,
+    }
+}
+
+#[rstest]
+#[case::payload_001(PAYLOAD_001, 1_781_675_143_400_000)]
+#[case::payload_002(PAYLOAD_002, 1_781_675_143_600_000)]
+#[case::payload_003(PAYLOAD_003, 1_781_675_143_800_000)]
+#[case::payload_004(PAYLOAD_004, 1_781_675_144_000_000)]
+#[case::payload_005(PAYLOAD_005, 1_781_675_144_200_000)]
+fn verifies_real_pyth_pro_solana_payloads(
+    #[case] payload_base64: &str,
+    #[case] expected_timestamp_us: u64,
+) {
+    let raw = decode_fixture(payload_base64);
+    let now_s = expected_timestamp_us / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: signer_of(&raw),
+        expires_at_s: now_s + 3_600,
+    }];
+    let update =
+        verify_solana_update(&TestCrypto, &raw, &params_for(&trusted_signers, now_s)).unwrap();
+
+    let expected_timestamp = Nanoseconds::from_micros(expected_timestamp_us);
+    assert_eq!(update.timestamp, expected_timestamp);
+    assert_eq!(update.feeds.len(), EXPECTED_FEEDS.len());
+    assert_eq!(
+        update
+            .feeds
+            .iter()
+            .map(|feed| feed.feed_id)
+            .collect::<Vec<_>>(),
+        EXPECTED_FEEDS
+    );
+    for feed in &update.feeds {
+        assert!(
+            feed.price.is_some(),
+            "missing price for feed {}",
+            feed.feed_id
+        );
+        assert!(
+            feed.confidence.is_some(),
+            "missing confidence for feed {}",
+            feed.feed_id
+        );
+        assert!(
+            feed.ema_price.is_some(),
+            "missing EMA price for feed {}",
+            feed.feed_id
+        );
+        assert!(
+            feed.ema_confidence.is_some(),
+            "missing EMA confidence for feed {}",
+            feed.feed_id
+        );
+        assert_eq!(feed.exponent, Some(-8));
+        assert_eq!(feed.feed_update_timestamp, Some(expected_timestamp));
+    }
+}
+
+#[test]
+fn rejects_real_payload_with_untrusted_signer() {
+    let raw = decode_fixture(PAYLOAD_001);
+    let now_s = 1_781_675_143_400_000 / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: [0x42; 32],
+        expires_at_s: now_s + 3_600,
+    }];
+
+    assert_eq!(
+        verify_solana_update(&TestCrypto, &raw, &params_for(&trusted_signers, now_s)),
+        Err(VerifyError::UntrustedSigner)
+    );
+}
+
+#[test]
+fn rejects_real_payload_with_expired_signer() {
+    let raw = decode_fixture(PAYLOAD_001);
+    let now_s = 1_781_675_143_400_000 / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: signer_of(&raw),
+        expires_at_s: now_s,
+    }];
+
+    assert_eq!(
+        verify_solana_update(&TestCrypto, &raw, &params_for(&trusted_signers, now_s)),
+        Err(VerifyError::UntrustedSigner)
+    );
+}
+
+#[test]
+fn rejects_real_payload_outside_timestamp_window() {
+    let raw = decode_fixture(PAYLOAD_001);
+    let timestamp_s = 1_781_675_143_400_000 / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: signer_of(&raw),
+        expires_at_s: timestamp_s + 3_600,
+    }];
+
+    let old = verify_solana_update(
+        &TestCrypto,
+        &raw,
+        &params_for(&trusted_signers, timestamp_s + 61),
+    );
+    assert_eq!(old, Err(VerifyError::TimestampTooOld));
+
+    let ahead = verify_solana_update(
+        &TestCrypto,
+        &raw,
+        &params_for(&trusted_signers, timestamp_s - 61),
+    );
+    assert_eq!(ahead, Err(VerifyError::TimestampTooFarAhead));
+}
+
+#[test]
+fn rejects_real_payload_on_wrong_channel() {
+    let raw = decode_fixture(PAYLOAD_001);
+    let now_s = 1_781_675_143_400_000 / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: signer_of(&raw),
+        expires_at_s: now_s + 3_600,
+    }];
+    let update =
+        verify_solana_update(&TestCrypto, &raw, &params_for(&trusted_signers, now_s)).unwrap();
+    let wrong_channel = update.channel_id ^ 1;
+    let params = VerifyParams {
+        trusted_signers: &trusted_signers,
+        now_s,
+        max_timestamp_delay_s: 60,
+        max_timestamp_ahead_s: 60,
+        allowed_channel_id: Some(wrong_channel),
+    };
+
+    assert_eq!(
+        verify_solana_update(&TestCrypto, &raw, &params),
+        Err(VerifyError::Channel {
+            got: update.channel_id
+        })
+    );
+}
+
+#[test]
+fn rejects_corrupted_real_payload_envelope() {
+    let fixture = decode_fixture(PAYLOAD_001);
+    let mut raw = fixture.clone();
+    raw.truncate(raw.len() - 1);
+    let now_s = 1_781_675_143_400_000 / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: signer_of(&fixture),
+        expires_at_s: now_s + 3_600,
+    }];
+
+    assert!(verify_solana_update(&TestCrypto, &raw, &params_for(&trusted_signers, now_s)).is_err());
+}
+
+#[test]
+fn rejects_tampered_real_payload_signature() {
+    let raw = decode_fixture(PAYLOAD_001);
+    let mut message = SolanaMessage::deserialize_slice(&raw).unwrap();
+    // Flip a signature bit; the carried (trusted) pubkey is unchanged, so this fails the ed25519
+    // check rather than the trust check.
+    message.signature[0] ^= 0x01;
+    let mut tampered = Vec::new();
+    message.serialize(&mut tampered).unwrap();
+    let now_s = 1_781_675_143_400_000 / 1_000_000;
+    let trusted_signers = [TrustedSigner {
+        public_key: signer_of(&raw),
+        expires_at_s: now_s + 3_600,
+    }];
+
+    assert_eq!(
+        verify_solana_update(&TestCrypto, &tampered, &params_for(&trusted_signers, now_s)),
+        Err(VerifyError::Signature)
+    );
+}

--- a/primitives/src/time.rs
+++ b/primitives/src/time.rs
@@ -39,6 +39,11 @@ impl Nanoseconds {
         Self(SU64::new(value))
     }
 
+    /// Creates a `Nanoseconds` value from microseconds.
+    pub const fn from_micros(value: u64) -> Self {
+        Self(SU64::new(value.saturating_mul(1_000)))
+    }
+
     /// Creates a `Nanoseconds` value from milliseconds.
     pub const fn from_ms(value: u64) -> Self {
         Self(SU64::new(value.saturating_mul(1_000_000)))
@@ -57,6 +62,11 @@ impl Nanoseconds {
     /// Returns the value as milliseconds, truncated.
     pub const fn as_ms(&self) -> u64 {
         self.0 .0 / 1_000_000
+    }
+
+    /// Returns the value as microseconds, truncated.
+    pub const fn as_micros(&self) -> u64 {
+        self.0 .0 / 1_000
     }
 
     /// Returns the value as nanoseconds.


### PR DESCRIPTION
## What

A push-style NEAR oracle adapter that ingests **Pyth Pro (Lazer)** solana-format (ed25519) signed price payloads and re-serves them through the **same view ABI as `pyth-oracle.near`** — a drop-in Pyth oracle for the market and proxy-oracle. Integrates as `OracleType::Pyth(<adapter account>)` with no proxy-oracle changes.

## Crates

| Crate | Path | Role |
|-------|------|------|
| `templar-pyth-pro-verifier` | `contract/pyth-pro/verifier` | Chain-agnostic verify + parse. No `near-sdk`. |
| `templar-pyth-pro-adapter-contract` | `contract/pyth-pro/contract` | NEAR cdylib: storage, governance, fees, Pyth views. |

- **Verifier**: trusted/unexpired ed25519 signer (pubkey carried in the envelope), signature check, **canonical-encoding** rejection (cursor-exhaustion, no trailing bytes), channel filter, freshness window. Wraps a forked, slimmed `pyth-lazer-protocol` **pinned by exact rev** — bumps are security-sensitive.
- **Contract**: owner-only `admin_*`; permissionless `#[payable] update_price_feeds` with per-feed **monotonic anti-replay** and storage-fee/refund; stateless `verify_update` view returning the full Lazer property set; `BTreeMap`-backed `SignerSet` with structural uniqueness (serializes transparently as `Vec<TrustedSigner>`).
- `admin_set_signer(public_key, expires_at_s: Option<u64>)` — `Some` = add/refresh, `None` = remove (cannot remove the last).
- Confidence/EMA discipline: a feed is stored only with price + exponent + positive confidence; EMA only when both EMA price and positive EMA confidence are present (never synthesized from spot).
- `primitives`: `Nanoseconds::{from_micros, as_micros}`.
- Docs (README / SPEC / per-crate READMEs / TRUSTED_SIGNERS runbook), JS sanity tools, and an `AGENTS.md` high-impact-areas entry.

## Testing

- `cargo test -p templar-pyth-pro-verifier -p templar-pyth-pro-adapter-contract` — **53 tests** (verifier lib 8 + real captured-payload regression 11 + contract 34).
- `cargo check --target wasm32-unknown-unknown -p templar-pyth-pro-adapter-contract`.
- `cargo fmt` clean; pyth-pro code clippy-clean.

## Notes for reviewers

- Targets Pyth's **solana** (ed25519) format deliberately — NEAR's native scheme, so verification is a single `env::ed25519_verify` with no keccak/ecrecover/address derivation.
- Documented narrowing: the verifier preserves every Lazer property as `Option` but does not distinguish "not requested" from "requested-but-missing" (the official EVM `triStateMap` does).
- Real trusted signer(s) for a `config_prod` must be confirmed on-chain before mainnet — see `TRUSTED_SIGNERS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/474)
<!-- Reviewable:end -->
