### PR TITLE
feat: cover Soroban vault curator operations

### DIFF
--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -146,6 +146,109 @@ Common role terms:
   allow adapters and place them into the typed supply queue before allocations can route through
   them.
 
+### Allocation Through Adapters
+
+Allocation is a two-step mental model:
+
+1. Governance configures which adapter contract serves each market id.
+2. Allocators later move assets by market id and amount; they do not choose an adapter at execution
+   time.
+
+Adapters can exist in the deployment manifest before they are usable by the vault. A Blend or
+custodial adapter becomes an active supply route only after governance adds it to the allowed
+adapter set and binds it into the supply queue:
+
+```sh
+tmplr-soroban-vault governance submit-set-allowed-adapters \
+  --admin GCURATOR_OR_MULTISIG... \
+  --adapters CBLENDADAPTER...,CCUSTODIALADAPTER...
+
+tmplr-soroban-vault governance submit-set-supply-queue \
+  --admin GCURATOR_OR_MULTISIG... \
+  --entry 0:CBLENDADAPTER... \
+  --entry 1:CCUSTODIALADAPTER...
+```
+
+Each `--entry` is `market_id:adapter_address`. The `market_id` is the same value passed later to
+`curator allocate-supply --market` and `curator allocate-withdraw --market`.
+
+Once setup is accepted, the allocation command is deliberately small:
+
+```sh
+tmplr-soroban-vault curator allocate-supply \
+  --caller GALLOCATOR... \
+  --market 0 \
+  --amount 100 \
+  --asset-decimals 7
+```
+
+The CLI sends a compact vault command containing the caller, market id, amount, and direction. The
+vault resolves the adapter from its stored market binding. For supply, the bound adapter must still
+be in the allowed adapter set. For withdrawal, the vault uses the stored market binding so assets can
+be recovered from an existing route even if governance has removed that adapter from new supply.
+
+The supply queue is typed by market id, not by list position. Reordering the queue does not change
+which adapter a market id uses, and an existing market id cannot be rebound to a different adapter by
+submitting a new queue entry. UIs should present adapter selection as a governance/setup workflow and
+present routine allocation as `direction + market id + amount + caller`.
+
+For cross-chain Templar market routes, keep the accounting boundary at the adapter. The vault does
+not track each off-chain hop after assets leave Stellar, and it does not map individual vault shares
+to a NEAR account, universal account, or market position. User shares are derived from vault NAV:
+`total_assets / total_shares`. The adapter reports the aggregate route NAV back to the vault through
+its `total_assets(asset)` surface, and the vault incorporates that value when allocators supply,
+withdraw, or run `curator refresh-markets`.
+
+Operationally, a Templar route may move assets through custody, bridge or intents infrastructure,
+and a NEAR-side supply position. From the Stellar vault's perspective, that path is one
+adapter-bound market route. Yield is reflected when the route NAV reported by the adapter increases;
+the vault share rate changes from aggregate NAV, not from per-user off-chain positions.
+
+Withdrawals use two different CLI surfaces:
+
+- `curator allocate-withdraw` is an allocator operation. It pulls liquidity back from the adapter
+  bound to a market id by calling the adapter's `progress_withdrawal(vault, asset, amount)`. The
+  `amount` is the requested adapter withdrawal amount; the vault accounts the assets actually
+  returned by the adapter.
+- `user request-withdraw` and `user execute-withdraw` are user exit operations. `request-withdraw`
+  queues shares for withdrawal after the configured cooldown. `execute-withdraw` attempts to pay the
+  next ready request from idle vault assets. If idle assets are not sufficient, an allocator first
+  uses `curator allocate-withdraw` to bring liquidity back from one or more market adapters, then
+  `user execute-withdraw` can settle the queued request.
+- `curator abort-withdrawing` is the recovery operation for a stale in-flight withdrawal operation.
+  Use it only when the vault is stuck in `Withdrawing` and operators have identified the operation id
+  to abort.
+
+```sh
+tmplr-soroban-vault curator allocate-withdraw \
+  --caller GALLOCATOR... \
+  --market 0 \
+  --amount 25 \
+  --asset-decimals 7
+
+tmplr-soroban-vault user request-withdraw \
+  --owner GUSER... \
+  --shares 10 \
+  --share-decimals manifest \
+  --min-assets-out 9.9 \
+  --asset-decimals 7
+
+tmplr-soroban-vault user execute-withdraw --operator GUSER...
+
+tmplr-soroban-vault curator abort-withdrawing \
+  --caller GALLOCATOR_OR_SENTINEL... \
+  --op-id 42
+```
+
+Curator commands fall into three groups:
+
+- Allocation: `curator allocate-supply`, `curator allocate-withdraw`, and
+  `curator abort-withdrawing`.
+- Maintenance: `curator refresh-markets`, `curator refresh-fees`, and `curator resync-idle`.
+- Governance conveniences for zero-timelock/local workflows: `curator set-allowed-adapters` and
+  `curator set-supply-queue`. Production or timelocked deployments normally use the matching
+  `governance submit-*` and `governance accept-ready` commands.
+
 For timelocked deployments, submit commands create proposals and `accept-ready` accepts them only
 after the relevant timelock has elapsed. Use `governance queue` and `governance explain` to inspect
 pending proposal ids and readiness.
@@ -466,6 +569,14 @@ tmplr-soroban-vault curator allocate-supply \
   --market 0 \
   --amount 1.25 \
   --asset-decimals 7
+
+# Allocator recovery from an in-flight withdrawing state.
+tmplr-soroban-vault curator abort-withdrawing --caller G... --op-id 42
+
+# Curator maintenance operations.
+tmplr-soroban-vault curator refresh-markets --caller G... --markets 0,1
+tmplr-soroban-vault curator refresh-fees
+tmplr-soroban-vault curator resync-idle
 
 # Submit and optionally accept governance-backed supply queue changes.
 tmplr-soroban-vault curator set-supply-queue \

--- a/tools/soroban-vault-cli/src/cli.rs
+++ b/tools/soroban-vault-cli/src/cli.rs
@@ -566,6 +566,13 @@ pub enum CuratorCommand {
         #[arg(long, default_value_t = 7)]
         asset_decimals: u32,
     },
+    /// Abort a stale in-flight withdrawal operation and return the vault to idle.
+    AbortWithdrawing {
+        #[arg(long)]
+        caller: AddressStr,
+        #[arg(long)]
+        op_id: u64,
+    },
     /// Refresh one or more market ids through the vault command payload.
     RefreshMarkets {
         #[arg(long)]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -2299,6 +2299,14 @@ fn run_curator<E: CommandExecutor>(
                 &AllocationDelta::Withdraw(*market, amount),
             )
         }
+        CuratorCommand::AbortWithdrawing { caller, op_id } => execute_vault(
+            stellar,
+            manifest,
+            WireVaultCommand::AbortWithdrawing {
+                caller: caller.to_string(),
+                op_id: *op_id,
+            },
+        ),
         CuratorCommand::RefreshMarkets { caller, markets } => execute_vault(
             stellar,
             manifest,
@@ -4401,8 +4409,9 @@ mod tests {
     use crate::{
         artifacts::ArtifactSpec,
         cli::{
-            ArtifactName, Cli, Commands, DeployArgs, DeployCommand, DeployStackArgs, ExtendTtlArgs,
-            GovernanceArgs, ShareTokenArgs, UserArgs, DEFAULT_CONTRACT_SOURCE_REPO,
+            ArtifactName, Cli, Commands, CuratorArgs, CuratorCommand, DeployArgs, DeployCommand,
+            DeployStackArgs, ExtendTtlArgs, GovernanceArgs, ShareTokenArgs, UserArgs,
+            DEFAULT_CONTRACT_SOURCE_REPO,
         },
         stellar::{CommandExecutor, CommandOutput},
     };
@@ -4586,6 +4595,41 @@ mod tests {
             parse_proposal_id("proposal 1\ntx hash: abcdef9876543210").expect("proposal id");
 
         assert_eq!(proposal_id, 1);
+    }
+
+    #[test]
+    fn curator_abort_withdrawing_encodes_vault_command() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = base_cli(
+            state,
+            Commands::Curator(CuratorArgs {
+                command: CuratorCommand::AbortWithdrawing {
+                    caller: ACCOUNT.parse().expect("caller"),
+                    op_id: 42,
+                },
+            }),
+        );
+        let executor = RecordingExecutor::new();
+
+        run(&cli, &executor).expect("abort withdrawing");
+
+        let calls = submitted_calls(&executor.calls());
+        let payload = calls
+            .iter()
+            .flat_map(|(_, args)| args.windows(2))
+            .find_map(|pair| (pair[0] == "--payload").then_some(pair[1].as_str()))
+            .expect("payload argument");
+        let bytes = hex::decode(payload).expect("decode payload hex");
+        let command = WireVaultCommand::decode(&bytes).expect("decode vault command");
+        assert_eq!(
+            command,
+            WireVaultCommand::AbortWithdrawing {
+                caller: ACCOUNT.to_string(),
+                op_id: 42,
+            }
+        );
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/profile.rs
+++ b/tools/soroban-vault-cli/src/profile.rs
@@ -265,6 +265,7 @@ fn needs_caller(raw_args: &[String]) -> bool {
         "extend-ttl",
         "allocate-supply",
         "allocate-withdraw",
+        "abort-withdrawing",
         "refresh-markets",
     ]
     .into_iter()


### PR DESCRIPTION
## Summary

- Adds `tmplr-soroban-vault curator abort-withdrawing --caller ... --op-id ...` so the CLI can emit the existing vault `AbortWithdrawing` recovery command.
- Wires profile caller defaults for `abort-withdrawing`, matching allocation and refresh curator commands.
- Documents the full curator command surface: allocation, withdrawal recovery, maintenance, and zero-timelock governance conveniences.
- Clarifies adapter binding/allocation semantics and distinguishes allocator liquidity withdrawal from user withdrawal settlement.
- Explains the Templar-market route accounting boundary: offchain custody/bridge/NEAR-market steps are represented to the vault as adapter-reported aggregate NAV, which drives the share rate.

## Validation

- `cargo fmt -p templar-soroban-vault-cli`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/templar-contracts-docs-target cargo test -p templar-soroban-vault-cli curator_abort_withdrawing_encodes_vault_command -- --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/data/tmp/templar-contracts-docs-target cargo test -p templar-soroban-vault-cli -- --nocapture`
- `git diff --check`
- post-commit hook: Soroban size-budget-check passed (`128902` bytes)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/476)
<!-- Reviewable:end -->
