### PR TITLE
fix(pyth-pro): require EMA on the stateful storage path (ENG-385)

### DIFF
--- a/contract/pyth-pro/SPEC.md
+++ b/contract/pyth-pro/SPEC.md
@@ -40,7 +40,10 @@ An accepted update must satisfy:
 - channel is allowed;
 - package timestamp is within configured past/future bounds;
 - each stored feed has price, exponent, and explicit non-negative confidence;
-- EMA is stored only when EMA price and explicit non-negative EMA confidence are both present;
+- EMA price and explicit non-negative EMA confidence are **required** for storage: a spot-only
+  payload is rejected wholesale (the feed is skipped), so it cannot overwrite a stored feed and drop
+  its EMA. This applies only to the stateful storage path; the stateless `verify_update` view stays
+  at parity with the official Pyth Pro contracts and does not require EMA;
 - effective per-feed publish time strictly advances stored data;
 - age-gated reads reject stale and future-dated prices.
 

--- a/contract/pyth-pro/SPEC.md
+++ b/contract/pyth-pro/SPEC.md
@@ -39,8 +39,9 @@ An accepted update must satisfy:
 - the ed25519 signature verifies over the payload under that public key;
 - channel is allowed;
 - package timestamp is within configured past/future bounds;
-- each stored feed has price, exponent, and explicit non-negative confidence;
-- EMA price and explicit non-negative EMA confidence are **required** for storage: a spot-only
+- each stored feed has price, exponent, and explicit strictly-positive confidence (a wire `0` is
+  indistinguishable from absent and is rejected);
+- EMA price and explicit strictly-positive EMA confidence are **required** for storage: a spot-only
   payload is rejected wholesale (the feed is skipped), so it cannot overwrite a stored feed and drop
   its EMA. This applies only to the stateful storage path; the stateless `verify_update` view stays
   at parity with the official Pyth Pro contracts and does not require EMA;

--- a/contract/pyth-pro/contract/README.md
+++ b/contract/pyth-pro/contract/README.md
@@ -39,7 +39,7 @@ Permissionless write (`#[payable]`):
   carrying more than `config.max_feeds_per_update` feeds are rejected up front (keeps the emitted
   event/log bounded). A feed is stored only with both a price and an exponent, only if its effective
   per-feed publish timestamp strictly advances (anti-replay) and is not too far in the future. EMA
-  (price + non-negative confidence) is **required**: a spot-only payload is rejected wholesale, so it
+  (price + strictly-positive confidence) is **required**: a spot-only payload is rejected wholesale, so it
   can never overwrite a stored feed and drop its EMA. EMA is never derived from spot. (The stateless
   `verify_update` view does not require EMA — see below.) The caller must attach a deposit covering
   the newly consumed storage plus `config.update_fee`; the excess is refunded. Updates that only

--- a/contract/pyth-pro/contract/README.md
+++ b/contract/pyth-pro/contract/README.md
@@ -38,9 +38,10 @@ Permissionless write (`#[payable]`):
 - `update_price_feeds(payload: Base64VecU8)` — verify and store; emits `UpdatePrices`. Bundles
   carrying more than `config.max_feeds_per_update` feeds are rejected up front (keeps the emitted
   event/log bounded). A feed is stored only with both a price and an exponent, only if its effective
-  per-feed publish timestamp strictly advances (anti-replay) and is not too far in the future, and
-  EMA is stored only when the payload actually carried it (never derived from spot). The caller must
-  attach a deposit covering
+  per-feed publish timestamp strictly advances (anti-replay) and is not too far in the future. EMA
+  (price + non-negative confidence) is **required**: a spot-only payload is rejected wholesale, so it
+  can never overwrite a stored feed and drop its EMA. EMA is never derived from spot. (The stateless
+  `verify_update` view does not require EMA — see below.) The caller must attach a deposit covering
   the newly consumed storage plus `config.update_fee`; the excess is refunded. Updates that only
   overwrite known feeds consume no new storage, so with a zero fee they are effectively free.
 

--- a/contract/pyth-pro/contract/src/lib.rs
+++ b/contract/pyth-pro/contract/src/lib.rs
@@ -645,8 +645,8 @@ impl Contract {
     }
 }
 
-/// A confidence is usable only when explicitly present and non-negative; absent or negative ⇒
-/// `None`, and the caller skips the feed. On the Lazer wire a `0` confidence is indistinguishable
+/// A confidence is usable only when explicitly present and strictly positive; absent, zero, or
+/// negative ⇒ `None`, and the caller skips the feed. On the Lazer wire a `0` confidence is indistinguishable
 /// from "absent" (both deserialize to `None` upstream), so a stored feed always carries a genuine
 /// positive confidence — we reject the ambiguous/invalid case rather than mold it into a
 /// precise-looking zero.

--- a/contract/pyth-pro/contract/src/lib.rs
+++ b/contract/pyth-pro/contract/src/lib.rs
@@ -279,8 +279,8 @@ impl TryFrom<ConfigArgs> for Config {
 }
 
 /// EMA price/confidence for a feed, following the same fixed-point `expo` as the spot price.
-/// Present only when the signed payload actually carried an EMA price — never synthesized from
-/// spot data.
+/// Required by the stateful storage path (a payload without a valid EMA is rejected); never
+/// synthesized from spot data.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[near(serializers = [borsh, json])]
 pub struct EmaData {
@@ -295,8 +295,9 @@ pub struct EmaData {
 pub struct FeedData {
     pub price: I64,
     pub conf: U64,
-    /// EMA data, present only when the payload carried it (no fallback to spot).
-    pub ema: Option<EmaData>,
+    /// EMA data. The stateful storage path requires it (see [`FeedData::from_parsed`]), so a stored
+    /// feed always carries EMA; it is never synthesized from spot.
+    pub ema: EmaData,
     pub expo: i32,
     /// Per-feed publish time (Lazer `FeedUpdateTimestamp`, else the payload timestamp), in
     /// nanoseconds. Drives both the served freshness and the monotonic anti-replay gate. The `_ns`
@@ -316,10 +317,10 @@ impl FeedData {
         })
     }
 
-    /// EMA [`Price`] view (`list_ema_prices_*` / `get_ema_price_*`); `None` if no EMA was carried.
+    /// EMA [`Price`] view (`list_ema_prices_*` / `get_ema_price_*`). A stored feed always carries
+    /// EMA, so this is `None` only when the publish time can't be represented (see [`Self::to_price`]).
     fn to_ema_price(&self) -> Option<Price> {
-        let ema = self.ema.as_ref()?;
-        self.to_price(ema.price, ema.conf)
+        self.to_price(self.ema.price, self.ema.conf)
     }
 
     /// Spot [`Price`] view (`list_prices_*` / `get_price_*`).
@@ -329,9 +330,15 @@ impl FeedData {
 
     /// Fallibly build a storable feed from a parsed (wire) feed, owning every intrinsic validity
     /// rule. Returns `None` when the feed must be skipped: missing price or exponent, missing or
-    /// invalid spot confidence, an `EmaPrice` without a valid `EmaConfidence`, or an effective
-    /// publish timestamp more than `max_ahead_s` seconds beyond `now`. (Anti-replay is relational
-    /// and handled by the caller.)
+    /// invalid spot confidence, a missing or invalid EMA price/confidence, or an effective publish
+    /// timestamp more than `max_ahead_s` seconds beyond `now`. (Anti-replay is relational and
+    /// handled by the caller.)
+    ///
+    /// EMA is **required** here: a spot-only signed payload is rejected (the whole feed is skipped)
+    /// so it can never overwrite a stored feed and drop its EMA — a market-DoS vector, since the
+    /// market reads EMA via `list_ema_prices_no_older_than`. This applies only to the stateful
+    /// storage path; the stateless [`Contract::verify_update`] view does not call this and stays at
+    /// parity with the official Pyth Pro contracts (spot-only payloads allowed).
     fn from_parsed(
         parsed: &verifier::ParsedFeed,
         package: Nanoseconds,
@@ -350,14 +357,12 @@ impl FeedData {
             return None;
         }
 
-        // EMA is stored only when the payload carried an EMA price *and* a valid EMA confidence;
-        // never fall back to spot. A half-specified EMA makes the whole feed malformed.
-        let ema = match parsed.ema_price {
-            Some(ema_price) => Some(EmaData {
-                price: I64(ema_price),
-                conf: U64(require_confidence(parsed.ema_confidence)?),
-            }),
-            None => None,
+        // EMA is mandatory on the stateful path: require both an EMA price and a valid EMA
+        // confidence, never falling back to spot. A missing or half-specified EMA skips the whole
+        // feed, so a spot-only update can't overwrite a stored feed and wipe its EMA.
+        let ema = EmaData {
+            price: I64(parsed.ema_price?),
+            conf: U64(require_confidence(parsed.ema_confidence)?),
         };
 
         Some(Self {

--- a/contract/pyth-pro/contract/tests/test.rs
+++ b/contract/pyth-pro/contract/tests/test.rs
@@ -3,7 +3,7 @@
 use byteorder::LE;
 use ed25519_dalek::{Signer, SigningKey};
 use near_sdk::{
-    json_types::Base64VecU8,
+    json_types::{Base64VecU8, I64},
     mock::MockAction,
     test_utils::{get_created_receipts, VMContextBuilder},
     testing_env, AccountId, NearToken,
@@ -505,6 +505,8 @@ fn duplicate_feed_id_in_payload_is_first_wins() {
             PayloadPropertyValue::Price(Some(Price::from_mantissa(price).unwrap())),
             PayloadPropertyValue::Confidence(Some(Price::from_mantissa(1).unwrap())),
             PayloadPropertyValue::Exponent(EXPO),
+            PayloadPropertyValue::EmaPrice(Some(Price::from_mantissa(price).unwrap())),
+            PayloadPropertyValue::EmaConfidence(Some(Price::from_mantissa(1).unwrap())),
             PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
                 NOW_S * 1_000_000,
             ))),
@@ -586,37 +588,91 @@ fn negative_confidence_skips_feed() {
     assert!(!contract.price_feed_exists(price_id()));
 }
 
+fn spot_only_props(price: i64, conf: i64, timestamp_us: u64) -> Vec<PayloadPropertyValue> {
+    vec![
+        PayloadPropertyValue::Price(Some(Price::from_mantissa(price).unwrap())),
+        PayloadPropertyValue::Confidence(Some(Price::from_mantissa(conf).unwrap())),
+        PayloadPropertyValue::Exponent(EXPO),
+        PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(timestamp_us))),
+    ]
+}
+
 #[test]
-fn payload_without_ema_serves_spot_only() {
+fn payload_without_ema_is_skipped() {
     let mut contract = deploy_and_map();
 
     relayer_context(ample_deposit());
-    // No EmaPrice property: spot is stored, but EMA must not be synthesized from spot.
+    // The stateful path requires EMA: a spot-only payload stores nothing at all (no spot-only
+    // feeds), so it can never overwrite/wipe a stored feed's EMA.
     contract.update_price_feeds(Base64VecU8(build_payload(
         NOW_S * 1_000_000,
         ChannelId::REAL_TIME.0,
-        vec![
-            PayloadPropertyValue::Price(Some(Price::from_mantissa(123_456).unwrap())),
-            PayloadPropertyValue::Confidence(Some(Price::from_mantissa(50).unwrap())),
-            PayloadPropertyValue::Exponent(EXPO),
-            PayloadPropertyValue::FeedUpdateTimestamp(Some(TimestampUs::from_micros(
-                NOW_S * 1_000_000,
-            ))),
-        ],
+        spot_only_props(123_456, 50, NOW_S * 1_000_000),
     )));
 
-    // Spot works...
+    assert!(!contract.price_feed_exists(price_id()));
+    assert!(contract.get_price_unsafe(price_id()).is_none());
+    assert!(contract.get_ema_price_unsafe(price_id()).is_none());
+}
+
+#[test]
+fn spot_only_update_cannot_wipe_stored_ema() {
+    // Regression for the market-DoS vector (ENG-385): a relayer submits a valid signed spot-only
+    // update with a strictly-newer timestamp for an already-mapped feed. It must NOT overwrite the
+    // stored full feed and drop its EMA.
+    let mut contract = deploy_and_map();
+
+    relayer_context(ample_deposit());
+    // Honest full update at NOW: spot + EMA both stored.
+    contract.update_price_feeds(Base64VecU8(real_time(
+        NOW_S * 1_000_000,
+        123_456,
+        123_000,
+        50,
+    )));
+    assert_eq!(
+        contract.get_ema_price_unsafe(price_id()).unwrap().price.0,
+        123_000
+    );
+
+    // Attacker's spot-only update at NOW+5s (strictly newer): rejected wholesale, so nothing
+    // changes — the EMA survives, and even the (authentic) newer spot is not applied.
+    contract.update_price_feeds(Base64VecU8(build_payload(
+        (NOW_S + 5) * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        spot_only_props(999_999, 50, (NOW_S + 5) * 1_000_000),
+    )));
+
+    assert_eq!(
+        contract.get_ema_price_unsafe(price_id()).unwrap().price.0,
+        123_000,
+        "spot-only update must not wipe the stored EMA"
+    );
     assert_eq!(
         contract.get_price_unsafe(price_id()).unwrap().price.0,
-        123_456
+        123_456,
+        "the rejected spot-only update must not advance spot either"
     );
-    // ...but the EMA surface returns nothing (no spot fallback).
-    assert!(contract.get_ema_price_unsafe(price_id()).is_none());
-    assert!(contract
-        .list_ema_prices_unsafe(vec![price_id()])
-        .get(&price_id())
-        .unwrap()
-        .is_none());
+}
+
+#[test]
+fn verify_update_stays_at_parity_for_spot_only_payloads() {
+    // The stateless verify-and-return surface must match the official Pyth Pro contracts: it does
+    // NOT require EMA. A spot-only payload still verifies and returns its parsed properties.
+    let contract = deploy_and_map();
+
+    let view = contract.verify_update(Base64VecU8(build_payload(
+        NOW_S * 1_000_000,
+        ChannelId::REAL_TIME.0,
+        spot_only_props(123_456, 50, NOW_S * 1_000_000),
+    )));
+
+    let feed = &view.feeds[0];
+    assert_eq!(feed.price, Some(I64(123_456)));
+    assert!(
+        feed.ema_price.is_none(),
+        "spot-only payload carries no EMA, but verify_update still returns the feed"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Fixes the reviewer-found availability bug in the Pyth Pro NEAR adapter (ENG-385, follow-up to #474).

## Vulnerability
Pyth Pro payloads are requestable with a **selected property set**, so a valid signed payload can carry spot (`price`/`conf`/`expo`/timestamp) but omit `EmaPrice`. `FeedData::from_parsed` treated EMA as optional, and `update_price_feeds` overwrites the **entire** `FeedData` whenever the single `publish_time_ns` strictly advances.

So an **unprivileged relayer** (the write path is permissionless — authenticity is cryptographic) could submit a valid signed **spot-only** update for an already-mapped feed with a newer timestamp, replacing a fresh EMA with `None`. Since the Templar market reads via `list_ema_prices_no_older_than`, price-dependent operations are then denied until a full EMA-carrying update with a later timestamp is accepted — and the attacker can repeat this to **sustain the outage** or race honest updates. Griefing/DoS, not fund theft.

The vector is asymmetric: `price` is mandatory in `from_parsed`, so spot is never wiped by an EMA-only update — only EMA is exposed.

## Fix
Require EMA (price + non-negative confidence) on the **stateful** path: a spot-only payload now skips the whole feed, so it can never overwrite/wipe a stored feed's EMA. `FeedData.ema` is non-optional.

This is more Pyth-faithful (spot and EMA stay atomically paired under one `publish_time`) and the smallest correct change. We never legitimately receive spot-only updates — a Pyth Pro subscription delivers requested properties together at the channel cadence.

**Scope:** the requirement lives in `FeedData::from_parsed` (stateful path only). The stateless `verify_update` view does not route through it, so it stays at **parity with the official Pyth Pro contracts** (spot-only payloads still verify and return) — locked in by a dedicated test.

## Tests
- `spot_only_update_cannot_wipe_stored_ema` — the DoS regression
- `payload_without_ema_is_skipped` — spot-only payload stores nothing (inverts the old `payload_without_ema_serves_spot_only`)
- `verify_update_stays_at_parity_for_spot_only_payloads` — stateless parity preserved

42 contract + 8 verifier + 11 regression tests pass; fmt, wasm32, and abi-on workspace clippy all clean. No state migration (adapter not deployed anywhere yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/478)
<!-- Reviewable:end -->
