### PR TITLE
fix(common): unbreak Code Linter — DepositMsg roundtrip helper by reference

### DIFF
--- a/common/src/market/mod.rs
+++ b/common/src/market/mod.rs
@@ -136,36 +136,36 @@ mod tests {
     /// and return the parsed message. This is the regression guard for the
     /// `msg` strings passed to `ft_transfer_call`/`mt_transfer_call`: the
     /// contract deserializes `msg` into [`DepositMsg`] through this same path.
-    fn roundtrip(wire: Value) -> DepositMsg {
+    fn roundtrip(wire: &Value) -> DepositMsg {
         let parsed: DepositMsg = serde_json::from_value(wire.clone()).unwrap();
-        assert_eq!(serde_json::to_value(&parsed).unwrap(), wire);
+        assert_eq!(&serde_json::to_value(&parsed).unwrap(), wire);
         parsed
     }
 
     #[test]
     fn deposit_msg_supply() {
-        let msg = roundtrip(json!("Supply"));
+        let msg = roundtrip(&json!("Supply"));
         assert!(matches!(msg, DepositMsg::Supply));
         assert!(msg.expects_borrow_asset());
     }
 
     #[test]
     fn deposit_msg_collateralize() {
-        let msg = roundtrip(json!("Collateralize"));
+        let msg = roundtrip(&json!("Collateralize"));
         assert!(matches!(msg, DepositMsg::Collateralize));
         assert!(!msg.expects_borrow_asset());
     }
 
     #[test]
     fn deposit_msg_repay() {
-        let msg = roundtrip(json!("Repay"));
+        let msg = roundtrip(&json!("Repay"));
         assert!(matches!(msg, DepositMsg::Repay));
         assert!(msg.expects_borrow_asset());
     }
 
     #[test]
     fn deposit_msg_repay_account() {
-        let msg = roundtrip(json!({ "RepayAccount": { "account_id": "borrow_user.near" } }));
+        let msg = roundtrip(&json!({ "RepayAccount": { "account_id": "borrow_user.near" } }));
         let DepositMsg::RepayAccount(RepayAccountMsg { account_id }) = &msg else {
             panic!("expected RepayAccount, got {msg:?}");
         };
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn deposit_msg_liquidate() {
-        let msg = roundtrip(json!({
+        let msg = roundtrip(&json!({
             "Liquidate": { "account_id": "borrow_user.near", "amount": U128(1_000_000) },
         }));
         let DepositMsg::Liquidate(LiquidateMsg { account_id, amount }) = &msg else {


### PR DESCRIPTION
## Problem

`dev`'s **Code Linter** is red (broken main). The `roundtrip(wire: Value)` test helper in `common/src/market/mod.rs`, added in #479 (ENG-388), passes its argument by value but only borrows it, tripping `clippy::needless_pass_by_value` under the CI gate:

```
cargo clippy --all-features --workspace --tests -- -D warnings
```

```
error: this argument is passed by value, but not consumed in the function body
   --> common/src/market/mod.rs:139:24
    fn roundtrip(wire: Value) -> DepositMsg {
                       ^^^^^ help: consider taking a reference instead: `&Value`
```

This landed because #479's Code Linter was red at merge, and #475 before it had its CI run cancelled — so the last confirmed-green `dev` was #476. Every open PR inherits the failure (PR CI lints the branch merged with `dev`), including #481 and #482.

## Fix

Take `wire: &Value` and pass `&json!(...)` at the call sites. Behaviour is unchanged (the helper already cloned `wire` internally).

## Verification

- `cargo clippy --all-features --workspace --tests --keep-going -- -D warnings` → **clean** (exit 0); this was the only violation.
- `cargo test -p templar-common --lib market::tests` → 6/6 pass.
- `cargo fmt --check` clean.

Unblocks #481 and #482 (they go green on re-run once this is on `dev`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/483)
<!-- Reviewable:end -->
