### PR TITLE
docs: add vault curator guide

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,6 +11,7 @@
 - [Smart Contract Deployments](./deployments.md)
 - [Oracles](./oracles.md)
 - [Protocol Governance](./governance.md)
+- [Vault Curator Guide](./curator-guide.md)
 - [Monitoring and Risk Management](./monitoring.md)
 - [Frontend Security](./frontend-security.md)
 - [Testing](./testing.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -11,7 +11,7 @@
 - [Smart Contract Deployments](./deployments.md)
 - [Oracles](./oracles.md)
 - [Protocol Governance](./governance.md)
-- [Vault Curator Guide](./curator-guide.md)
+- [Soroban Vault Curator Guide](./curator-guide.md)
 - [Monitoring and Risk Management](./monitoring.md)
 - [Frontend Security](./frontend-security.md)
 - [Testing](./testing.md)

--- a/docs/src/curator-guide.md
+++ b/docs/src/curator-guide.md
@@ -1,113 +1,82 @@
-# Soroban Vault Curator Guide
+# Vault Curator Guide (Soroban)
 
-This guide is for curators operating a Templar **Soroban (Stellar)** vault. It
-covers how the vault is structured, the fee economics a curator earns, the
-configurable risk "switches" and their timelock rules, and the tooling — the
-vault CLI/SDK and the curated-vault frontend — used to drive day-to-day
-operations.
+This guide explains how a Templar **Soroban** vault is structured and the economic
+and governance levers available to a curator: the fees a curator earns, the
+configurable risk "switches" and their timelock rules, and the tooling
+(CLI/SDK and frontend) used to operate a vault day to day.
 
-> **Source & architecture**
->
-> - Vault architecture and code (kernel + executors):
->   <https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/README.md>
-> - Soroban runtime specifics:
->   <https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/soroban/README.md>
-> - Vault CLI / client SDK:
->   <https://github.com/Templar-Protocol/contracts/blob/dev/client/vault/README.md>
-> - Curated-vault frontend (UI): <https://app.templarfi.org/vaults/curator/>
+> **Key references**
+> - **Architecture & code:** [`contract/vault/README.md`](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/README.md) (kernel + executor design, state machine, withdrawal/allocation flows). Soroban runtime specifics live in [`contract/vault/soroban/README.md`](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/soroban/README.md).
+> - **Vault CLI / client SDK:** [`client/vault/README.md`](https://github.com/Templar-Protocol/contracts/blob/dev/client/vault/README.md).
+> - **Curated vault frontend (UI):** [app.templarfi.org/vaults/curator](https://app.templarfi.org/vaults/curator/).
 
 ## High-level vault structure
 
 A Templar vault is a **single-asset, ERC-4626-style yield vault**. Depositors
-supply one underlying token and receive transferable **shares** (a SEP-41 token
-on Soroban); the curator allocates the pooled assets across a chosen set of
-on-chain lending **markets** to earn yield.
+supply one underlying SEP-41 token and receive transferable **SEP-41 shares**;
+the curator allocates the pooled assets across a chosen set of on-chain lending
+**markets** (adapters) to earn yield.
 
-**Kernel + executor architecture** (see the [architecture
-README](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/README.md)):
+**Kernel + executor architecture** (see the [architecture README](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/README.md)):
 
 - `templar-vault-kernel` — chain-agnostic source of truth: state machine, math,
   fee accrual, and invariants. It returns *effects* (mint/burn/transfer/emit)
   rather than touching chain state directly.
-- `contract/vault/soroban` — the Soroban executor (`CuratorVault<S, A, E>`): it
-  loads versioned state, enforces RBAC via `require_auth()` + the shared
-  `ActionKind` policy, applies a kernel action, and executes the resulting
-  effects against the SEP-41 share token and the underlying asset token.
+- **Soroban executor** (`contract/vault/soroban`) — `SorobanVaultContract`
+  entrypoints wrap `CuratorVault<S, A, E>`, which loads versioned state, enforces
+  RBAC via `require_auth()` + `ActionKind`, applies the kernel action, and runs
+  the resulting effects against the SEP-41 share and asset tokens.
+- **Governance contract** (`contract/vault/soroban/governance`) — a *separate*
+  contract that owns proposal submission, timelocks, approvals, revocation, and
+  abdication. Vault-bound changes cross the boundary through a single bridge,
+  `execute_governance(env, caller, payload)`; the runtime remains the canonical
+  owner of applied config/policy state.
 - `contract/vault/curator-primitives` — shared policy/RBAC/governance helpers
   (caps, cap groups, supply queue, timelocks, restrictions).
 
 **Accounting invariant:** `total_assets = idle_assets + external_assets`.
 
-- `idle_assets` — uninvested cash buffer held by the vault, and the liquidity
-  buffer for atomic withdrawals.
+- `idle_assets` — uninvested buffer held by the vault; also the liquidity source
+  for immediate withdrawals (there is no separate "idle market"). Unsolicited
+  direct transfers into the vault are reconciled as idle assets for existing
+  shareholders, not captured as profit by the next depositor.
 - `external_assets` — principal deployed into markets via adapters.
 
-**Markets are adapters.** On Soroban, markets are reached through adapter
-contracts that must be **allow-listed and added to the supply queue through
-governance before allocation**:
+**Two withdrawal modes** (a Soroban-specific design point):
 
-- **Blend adapter** (`contract/vault/soroban/blend-adapter`) — integrates the
-  Blend lending protocol.
-- **Custodial adapter** (`contract/vault/soroban/custodial-adapter`) — an
-  offchain-managed route that forwards assets to a configured custodian/multisig.
-  Its NAV is *reported* accounting; treat the custodian and its offchain process
-  as part of the vault's trust boundary.
+- `withdraw` / `redeem` — **atomic** ERC-4626-style exits from **idle liquidity
+  only**. They never enqueue work or pull from adapters, and fail if the request
+  exceeds `idle_assets`. (The 4626 proxy's `maxWithdraw`/`maxRedeem` are bounded
+  by idle assets and can read `0` even when a holder's shares are backed by
+  market-deployed assets.)
+- `request_withdraw` → `execute_withdraw` — the **async, keeper-routed** path for
+  positions that need allocator work. `request_withdraw` escrows shares, starts a
+  cooldown, and locks a fixed `expected_assets` claim; `execute_withdraw`
+  (allocator-authorized) settles the head request only when it is cooled down and
+  fully covered by idle assets, otherwise it fails atomically and leaves the
+  request queued.
 
 **Roles:**
 
-- **Owner / Governance** — top-level governance (curator/sentinel assignment,
-  fees, timelocks, restrictions). On Soroban, proposal submission, timelocks, and
-  approvals live in a dedicated **governance contract**.
+- **Owner** — top-level governance.
 - **Curator** — policy admin: market caps, cap groups, supply queue, market
   removal. Implicitly holds the Allocator role.
-- **Allocator** — operational keeper: allocations, rebalances, withdrawal
-  execution, refreshes.
-- **Sentinel** — emergency authority: pause / tighten restrictions immediately,
-  abort in-flight operations, and revoke pending timelocked changes. The Sentinel
-  is a **separate emergency role** from the governance contract.
+- **Allocator** — operational keeper: allocations, rebalances, `execute_withdraw`,
+  refreshes.
+- **Sentinel** — emergency authority (a *separate* role holder; the governance
+  contract is **not** implicitly the Sentinel): pause / tighten restrictions
+  immediately, abort in-flight operations, and revoke pending timelocked changes.
 
-## Soroban specifics every curator should know
-
-**Two withdrawal modes** (see the [Soroban
-README](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/soroban/README.md#soroban-specific-withdrawal-path)):
-
-- `withdraw` / `redeem` — ERC-4626-style **atomic exits from idle liquidity
-  only**. They never enqueue work and fail if the requested assets exceed
-  `idle_assets`. So `maxWithdraw` / `maxRedeem` can read `0` even when a holder's
-  shares are backed by market-deployed assets.
-- `request_withdraw` + `execute_withdraw` — the **async** path for positions that
-  need allocator/keeper work. `request_withdraw` escrows shares and locks in a
-  fixed `expected_assets` claim at request time; `execute_withdraw` (an
-  **allocator** action, not a public user exit) settles the queue head only when
-  it is cooled down and fully covered by idle assets, otherwise it fails
-  atomically and leaves the request queued. The queue does *not* reserve idle
-  liquidity against later atomic exits.
-
-**Governance control-plane boundary.** Vault-bound governance actions cross from
-the governance contract into the runtime through a single bridge,
-`execute_governance(env, caller, payload)`. Emergency **pause and restriction
-tightening are immediate Sentinel actions**; **unpause and relaxing/removing
-restrictions are governance actions that must clear the configured timelock**
-before the runtime applies them.
-
-**Fee anchor & idle reconciliation.** Unsolicited underlying transfers are
-treated as idle assets for *existing* shareholders, not as profit the next
-depositor can capture. Deposits, fee refreshes, and idle resyncs read the live
-asset balance, update `idle_assets`, and reset the `fee_anchor`. When fees are
-active, deposits **crystallize elapsed fees first**, so deposit principal cannot
-erase already-accrued fees.
-
-**TTL keeper responsibility.** Soroban storage is not permanent. A vault
-deployment **must** include a keeper that periodically calls the permissionless
-`ExtendTtl` path. Related contracts (share token, governance, adapters, proxy,
-oracle) each need their own TTL maintenance — they do not inherit the vault
-runtime's renewal.
+**Operational note — TTL keeper.** Soroban contract data is not permanent. Every
+vault deployment must run an ops job that periodically calls the permissionless
+`ExtendTtl` path. Related contracts (share token, governance, adapters, 4626
+proxy, oracle) each maintain their **own** TTL and do not inherit the vault's
+renewal.
 
 ## Curator economics (fees)
 
 There are two fee types. Both are **minted as new SEP-41 shares** to a
-configurable recipient (so a recipient must be able to hold shares to receive
-them).
+configurable recipient.
 
 | Fee | Basis | Cap |
 |-----|-------|-----|
@@ -115,17 +84,24 @@ them).
 | **Performance** | AUM **growth** since the last accrual checkpoint; zero on flat or down periods | **50% of profit** |
 
 Rates are WAD-scaled (`1e18 = 100%`). Each fee has its own recipient, and they
-can differ. Two nuances worth understanding:
+can differ.
 
-- **Checkpoint, not all-time high-water mark.** Fees accrue on *every*
-  interaction, and the fee anchor resets to current AUM each time. Profit is
-  `current_AUM − anchor_AUM`. If AUM is flat or down versus the anchor, the
-  performance fee is zero — but because the anchor resets downward after a loss,
-  a subsequent recovery *is* chargeable. This is "growth since the last
-  checkpoint", not "growth above the all-time peak".
+Two nuances worth understanding:
+
+- **Checkpoint, not all-time high-water mark.** On Soroban, share-pricing paths
+  (`DepositWithMin`, `RefreshFees`, `ResyncIdleBalance`) first reconcile
+  `idle_assets` against the live asset-token balance, then reset the `fee_anchor`
+  to the reconciled total at the current ledger time. Profit is measured as
+  `current_AUM − anchor_AUM`; if AUM is flat or down, the performance fee is zero.
+  Because the anchor resets after each interaction, a recovery following a loss is
+  chargeable — this is "growth since the last checkpoint", not "above the all-time
+  peak". When fees are active, a deposit first crystallizes elapsed fees before
+  the post-deposit anchor is written, so deposit principal cannot erase accrued
+  fees.
 - **Anti-donation cap** (`max_total_assets_growth_rate`, optional). Caps how fast
-  AUM is allowed to count toward fees, preventing a one-block donation from
-  inflating fees. Relaxing or removing this cap is timelocked.
+  AUM is allowed to count for fee accrual:
+  `effective_AUM = min(current, last × (1 + max_rate × dt/yr))`. Relaxing or
+  removing this cap is timelocked.
 
 ## Governance switches and the timelock rule
 
@@ -135,84 +111,107 @@ changes that **protect or benefit depositors** take effect **immediately**.
 Timelocks are configurable per kind, bounded between **0 and 30 days** (default 2
 days).
 
+On Soroban, immediate Sentinel actions (pause, tighten restrictions) are applied
+directly; everything timelocked is submitted to the governance contract and only
+applied by the runtime after the delay via `execute_governance`.
+
 | Switch | Immediate (depositor-friendly) | Timelocked (depositor-adverse) |
 |--------|-------------------------------|-------------------------------|
-| **Fees** | Fee **decrease** | Fee **increase**, recipient change, relaxing the growth cap |
+| **Fees** | Fee **decrease** | Fee **increase**, any **recipient change**, relaxing the growth cap |
 | **Market cap** | **Lower** cap (incl. set to 0 = stop deposits) | **Raise** cap, or a **new** market |
 | **Cap group** (absolute + relative) | **Tighten** (lower / add a cap) | **Loosen** (raise / remove a cap). Relative cap ≤ 100% |
 | **Restrictions** | **Pause / tighten** (blacklist, narrow whitelist) | **Unpause / relax** |
+| **Skim recipient** | — | Recipient change and skim execution are timelocked |
 | **Timelock length** | **Lengthen** | **Shorten** (waits under the old, longer timelock) |
 | **Market removal** | — | Always timelocked; requires the cap to already be 0 |
 
 Other levers:
 
-- **Supply queue** — the ordered list of allocation targets (up to 64 markets, no
-  duplicates, every market must have a cap > 0).
-- **Cap groups** — cluster correlated markets under a shared limit; the effective
+- **Supply queue** (`set_supply_queue`) — the ordered list of allocation targets.
+  Up to 64 markets, no duplicates, every market must have a cap > 0, and the
+  vault must be Idle.
+- **Cap groups** — cluster correlated markets under a shared limit. The effective
   limit is `min(absolute_cap, relative_cap × total_AUM)`.
-- **Cooldowns** — withdrawal (default 1 hour), market refresh, idle resync.
-- **Abdicate** — permanently and irreversibly disable a governance method.
+- **Allocator and adapter-allowlist** changes are routed through
+  `execute_governance`.
+- **Cooldowns** — withdrawal (default **1 hour**), market refresh (30 seconds),
+  idle resync (120 seconds).
+- **Abdicate** — permanently and irreversibly disable a governance method (for
+  example, to lock fees forever).
+
+**Adapters (markets).** Soroban ships two adapter types you allow-list and add to
+the supply queue before allocation:
+
+- **Blend adapter** (`contract/vault/soroban/blend-adapter`) — integrates a Blend
+  lending pool.
+- **Custodial adapter** (`contract/vault/soroban/custodial-adapter`) — an
+  offchain-managed route that forwards assets to a configured custodian/multisig;
+  its NAV is explicit reported accounting. Treat the custodian and its offchain
+  process as part of the vault's trust boundary, and verify the custodial runbook
+  before production use.
 
 ## Worked examples
 
-1. **Raising the performance fee 10% → 20%** is timelocked; depositors can
-   withdraw and the Sentinel can revoke. *Lowering* it applies instantly.
+1. **Raising the performance fee 10% → 20%** is timelocked (e.g. 2 days):
+   submitted to the governance contract, applied by the runtime only after the
+   delay; depositors can exit and the Sentinel can revoke. *Lowering* it 20% → 10%
+   applies instantly.
 2. **A market turns risky.** Cutting its cap 1M → 500k is **immediate**; setting
-   it to **0** stops new allocations now. *Raising* a cap is timelocked.
-3. **Incident response.** Pausing is **immediate**; *un-pausing* is timelocked,
-   so users get notice before normal operation resumes.
-4. **A cap group "blue-chip"** with absolute 5M and relative 40%: at 8M AUM the
-   cluster holds at most `min(5M, 0.40 × 8M) = 3.2M`; it scales with AUM until
-   the 5M ceiling binds.
-5. **Fee accrual.** The vault grows 10M → 11M; a 20% performance fee mints ~200k
-   (assets-equivalent) of shares to the performance recipient (20% of the 1M
-   gain), plus time-weighted management shares on the 10M base. Both dilute
-   existing holders by exactly the minted amount.
+   it to **0** stops new allocations now (the first step of winding it down).
+   *Raising* a cap 1M → 2M is timelocked.
+3. **Incident response.** Pausing is an **immediate** Sentinel action; *un-pausing*
+   is a governance action that must pass the timelock, so users get notice before
+   normal operation resumes.
+4. **A cap group "blue-chip"** with an absolute cap of 5M and a relative cap of
+   40%: at 8M AUM the cluster can hold at most `min(5M, 0.40 × 8M = 3.2M) = 3.2M`.
+   The limit scales with AUM until the 5M ceiling binds.
+5. **Fee accrual.** The vault grows 10M → 11M between interactions. With a 20%
+   performance fee, roughly 200k (assets-equivalent) of shares mint to the
+   performance recipient (20% of the 1M gain); a 2%/yr management fee additionally
+   mints time-weighted shares on the 10M base for the elapsed interval. Both are
+   dilutive to existing holders by exactly the minted share amount.
 
-## Operating a vault: the vault CLI / client SDK
+## Operating a vault: CLI and frontend
 
-Day-to-day curator and allocator operations run through the **vault client SDK**
-("the vault CLI"). It locks in a focused set of production-ready flows — with
-proper fee/gas attachment, nonce handling, and retry logic — rather than
-exposing the full contract surface.
+### Vault CLI / client SDK
 
-**Full reference:**
-<https://github.com/Templar-Protocol/contracts/blob/dev/client/vault/README.md>
+The vault client SDK ([`client/vault/README.md`](https://github.com/Templar-Protocol/contracts/blob/dev/client/vault/README.md))
+is purpose-built for **curator/allocator automation**. Rather than exposing the
+full contract surface, it locks in a focused set of curated, production-ready
+flows with proper fee/deposit attachment, nonce handling, and retry logic:
 
-Highlights:
+- **Curator/allocator operations:** `reallocate` (supply/withdraw a market),
+  `refresh_markets`, `set_fees`, `execute_withdrawal`.
+- **User-style flows:** `deposit`, `withdraw` / `redeem` (two-phase:
+  preview → request → execute), `storage_deposit`.
+- **Views & previews:** `get_total_assets`, `get_idle_balance`, `get_fees`,
+  `get_configuration`, `get_restrictions`, `convert_to_shares` / `convert_to_assets`,
+  `preview_deposit` / `preview_withdraw` / `preview_redeem`,
+  `build_real_assets_report` — 50+ methods generated via the
+  `impl_vault_methods!` macro.
 
-- **Bindings for multiple languages** via UniFFI — Python, TypeScript, and Rust —
-  generated from the vault contract ABI, so the same flows are available to
-  automation and to the frontend.
-- **Curator / allocator flows**: `deposit`, `refresh_markets` (update the vault's
-  view of market assets), `reallocate` (supply to / withdraw from a market),
-  `withdraw` / `redeem`, `execute_withdrawal`, and config calls such as
-  `set_fees`.
-- **View & preview helpers**: `get_total_assets`, `get_idle_balance`,
-  `get_configuration`, `get_fees`, `preview_deposit` / `preview_withdraw` /
-  `preview_redeem`, and `build_real_assets_report`.
-- **Production reliability**: multi-key pooling with least-loaded selection,
-  per-key nonce management with retry on stale nonces, TTL-based view caching,
-  and zeroizing key handling. Built for unattended curator/allocator bots.
+It ships **type-safe bindings** for **Python** (native async), **TypeScript**
+(generated from the contract ABI), and **Rust** (direct library usage) via
+UniFFI, plus production conveniences: a multi-key pool with least-loaded
+selection, per-key nonce caching with retry, TTL-based view caching, zeroizing
+key handling, and health/observability reporting. See the README for prepared
+deposit/withdraw/redeem/refresh/reallocate flow examples and client configuration.
 
-Typical reallocation (curator operation):
+### Curated vault frontend
 
-```python
-from templar_vault_client import AllocationDelta, Delta
+The [curated vault UI at **app.templarfi.org/vaults/curator**](https://app.templarfi.org/vaults/curator/)
+is the reference frontend for curators — a wallet-based interface over the same
+vault operations the CLI/SDK exposes (deposit, withdraw/redeem, refresh,
+reallocate, and curator governance actions). It builds transactions with the
+correct parameters and delegates all signing to the user's connected wallet; the
+frontend never handles private keys. Use it to drive vault operations interactively
+without scripting against the SDK.
 
-# Supply idle assets to a market
-await client.reallocate(AllocationDelta.Supply(Delta(market=market_id, amount=amount)))
+### Soroban on-chain operations
 
-# Pull assets back from a market
-await client.reallocate(AllocationDelta.Withdraw(Delta(market=market_id, amount=amount)))
-```
-
-## Curated-vault frontend (UI)
-
-For curators who prefer a UI over scripting, the **curated-vault frontend at
-<https://app.templarfi.org/vaults/curator/>** is the reference interface over the
-same vault operations the CLI/SDK exposes (deposit, withdraw/redeem, refresh,
-reallocate, fee and policy changes). It builds the transactions with the correct
-gas/deposit policy and **delegates signing to the user's connected wallet** — the
-frontend never handles private keys. It is the no-code path to the same flows
-documented above.
+For deployment and direct on-chain interaction, the Soroban runtime ships
+`justfile` recipes (`setup`, `deploy-all`, `demo-deposit`, `demo-withdraw`,
+adapter build/deploy) driven by `stellar-cli` v26. See
+[`contract/vault/soroban/README.md`](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/soroban/README.md)
+for prerequisites, the deployment artifact/size budget, state-size limits, and the
+TTL keeper requirement.

--- a/docs/src/curator-guide.md
+++ b/docs/src/curator-guide.md
@@ -1,0 +1,132 @@
+# Vault Curator Guide
+
+This guide explains how a Templar vault is structured and the economic and
+governance levers available to a curator: the fees a curator earns and the
+configurable "switches" that control risk — together with the timelock rules
+that govern when each change takes effect.
+
+## High-level vault structure
+
+A Templar vault is a **single-asset, ERC-4626-style yield vault**. Depositors
+supply one underlying token (NEP-141 on NEAR / SEP-41 on Soroban) and receive
+transferable **shares**; the curator allocates the pooled assets across a chosen
+set of on-chain lending **markets** to earn yield.
+
+**Kernel + executor architecture:**
+
+- `templar-vault-kernel` — chain-agnostic source of truth: state machine, math,
+  fee accrual, and invariants. It returns *effects* (mint/burn/transfer/emit)
+  rather than touching chain state directly.
+- `contract/vault/near` and `contract/vault/soroban` — per-chain executors that
+  persist state, enforce authorization, and execute kernel effects.
+- `contract/vault/curator-primitives` — shared policy/RBAC/governance helpers
+  (caps, cap groups, supply queue, timelocks, restrictions).
+
+**Accounting invariant:** `total_assets = idle_assets + external_assets`.
+
+- `idle_assets` — uninvested cash buffer held by the vault. It also serves as the
+  withdrawal liquidity buffer; there is no separate "idle market".
+- `external_assets` — principal deployed into markets.
+
+**Flows:**
+
+- **Deposit** → the vault mints shares pro-rata; assets sit idle until allocated.
+- **Allocate** (Allocator/keeper) → moves idle assets into markets in
+  **supply-queue** order, respecting per-market and cap-group limits.
+- **Withdraw** → two-phase, async, keeper-routed: `request_withdraw` escrows the
+  shares and starts a cooldown; after the cooldown, `execute_withdraw` pulls
+  liquidity from idle first, then from markets along a route, then settles and
+  burns the escrowed shares.
+
+**Roles:**
+
+- **Owner** — top-level governance (sets curator/sentinel, fees, timelocks,
+  restrictions).
+- **Curator** — policy admin: market caps, cap groups, supply queue, and market
+  removal. Implicitly holds the Allocator role.
+- **Allocator** — operational keeper: allocations, rebalances, withdrawals,
+  refreshes.
+- **Sentinel** — emergency authority: pause / tighten restrictions immediately,
+  abort in-flight operations, and **revoke any pending timelocked change**.
+
+## Curator economics (fees)
+
+There are two fee types. Both are **minted as new shares** to a configurable
+recipient (so a recipient must be able to hold shares / be registered to receive
+them).
+
+| Fee | Basis | Cap |
+|-----|-------|-----|
+| **Management** | Time-weighted on AUM (`rate × AUM × elapsed / 1yr`), accrues regardless of performance | **5% / year** |
+| **Performance** | AUM **growth** since the last accrual checkpoint; zero on flat or down periods | **50% of profit** |
+
+Rates are WAD-scaled (`1e18 = 100%`). Each fee has its own recipient, and they
+can differ.
+
+Two nuances worth understanding:
+
+- **Checkpoint, not all-time high-water mark.** Fees accrue on *every*
+  interaction (deposit, withdraw, allocate, fee change), and the fee anchor
+  resets to the current AUM each time. Profit is measured as
+  `current_AUM − anchor_AUM`. If AUM is flat or down versus the anchor, the
+  performance fee is zero — but because the anchor resets downward after a loss,
+  a subsequent recovery *is* chargeable. This is "growth since the last
+  checkpoint", not "growth above the all-time peak". (Losses are rare in
+  over-collateralized lending, but the distinction matters.)
+- **Anti-donation cap** (`max_total_assets_growth_rate`, optional). Caps how fast
+  AUM is allowed to count for fee accrual:
+  `effective_AUM = min(current, last × (1 + max_rate × dt/yr))`. This prevents a
+  one-block token donation from inflating fees. Relaxing or removing this cap is
+  timelocked.
+
+## Governance switches and the timelock rule
+
+**The principle behind every switch:** changes that **disadvantage depositors**
+are **timelocked** (so depositors can exit first, and the Sentinel can veto);
+changes that **protect or benefit depositors** take effect **immediately**.
+
+Timelocks are configurable per kind, bounded between **0 and 30 days** (default 2
+days).
+
+| Switch | Function | Immediate (depositor-friendly) | Timelocked (depositor-adverse) |
+|--------|----------|-------------------------------|-------------------------------|
+| **Fees** | `set_fees` | Fee **decrease** | Fee **increase**, any **recipient change**, relaxing the growth cap |
+| **Market cap** | `submit_cap` | **Lower** cap (incl. set to 0 = stop deposits) | **Raise** cap, or a **new** market |
+| **Cap group** (absolute + relative) | `submit_cap_group_update` | **Tighten** (lower / add a cap) | **Loosen** (raise / remove a cap). Relative cap ≤ 100% |
+| **Restrictions** | `set_restrictions` | **Pause / tighten** (blacklist, narrow whitelist) | **Unpause / relax** |
+| **Timelock length** | `submit_timelock` | **Lengthen** | **Shorten** (waits under the old, longer timelock) |
+| **Market removal** | `submit_market_removal` | — | Always timelocked; requires the cap to already be 0 |
+
+Other levers:
+
+- **Supply queue** (`set_supply_queue`) — the ordered list of allocation targets.
+  Up to 64 markets, no duplicates, every market must have a cap > 0, and the
+  vault must be Idle.
+- **Cap groups** — cluster correlated markets under a shared limit. The effective
+  limit is `min(absolute_cap, relative_cap × total_AUM)`.
+- **Cooldowns** — withdrawal (default **1 hour**), market refresh (30 seconds),
+  idle resync (120 seconds).
+- **Abdicate** (`abdicate`) — permanently and irreversibly disable a governance
+  method (for example, to lock fees forever).
+- **Sentinel revoke** — `revoke_pending_*` cancels any pending timelocked change.
+
+## Worked examples
+
+1. **Raising the performance fee 10% → 20%** is timelocked (e.g. 2 days).
+   Depositors see the pending change and can withdraw; the Sentinel can revoke
+   it. *Lowering* it 20% → 10% applies instantly.
+2. **A market turns risky.** Cutting its cap 1M → 500k USDC is **immediate**;
+   setting it to **0** stops new allocations now (the first step of winding it
+   down). *Raising* a cap 1M → 2M is timelocked.
+3. **Incident response.** `set_restrictions(Paused)` halts the vault
+   **immediately**; *un-pausing* is timelocked, so users get notice before
+   normal operation resumes.
+4. **A cap group "blue-chip"** with an absolute cap of 5M and a relative cap of
+   40%: at 8M AUM the cluster can hold at most `min(5M, 0.40 × 8M = 3.2M) = 3.2M`.
+   The limit scales with AUM until the 5M ceiling binds.
+5. **Fee accrual.** The vault grows 10M → 11M between interactions. With a 20%
+   performance fee, roughly 200k (assets-equivalent) of shares mint to the
+   performance recipient (20% of the 1M gain); a 2%/yr management fee
+   additionally mints time-weighted shares on the 10M base for the elapsed
+   interval. Both are dilutive to existing holders by exactly the minted share
+   amount.

--- a/docs/src/curator-guide.md
+++ b/docs/src/curator-guide.md
@@ -1,58 +1,112 @@
-# Vault Curator Guide
+# Soroban Vault Curator Guide
 
-This guide explains how a Templar vault is structured and the economic and
-governance levers available to a curator: the fees a curator earns and the
-configurable "switches" that control risk — together with the timelock rules
-that govern when each change takes effect.
+This guide is for curators operating a Templar **Soroban (Stellar)** vault. It
+covers how the vault is structured, the fee economics a curator earns, the
+configurable risk "switches" and their timelock rules, and the tooling — the
+vault CLI/SDK and the curated-vault frontend — used to drive day-to-day
+operations.
+
+> **Source & architecture**
+>
+> - Vault architecture and code (kernel + executors):
+>   <https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/README.md>
+> - Soroban runtime specifics:
+>   <https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/soroban/README.md>
+> - Vault CLI / client SDK:
+>   <https://github.com/Templar-Protocol/contracts/blob/dev/client/vault/README.md>
+> - Curated-vault frontend (UI): <https://app.templarfi.org/vaults/curator/>
 
 ## High-level vault structure
 
 A Templar vault is a **single-asset, ERC-4626-style yield vault**. Depositors
-supply one underlying token (NEP-141 on NEAR / SEP-41 on Soroban) and receive
-transferable **shares**; the curator allocates the pooled assets across a chosen
-set of on-chain lending **markets** to earn yield.
+supply one underlying token and receive transferable **shares** (a SEP-41 token
+on Soroban); the curator allocates the pooled assets across a chosen set of
+on-chain lending **markets** to earn yield.
 
-**Kernel + executor architecture:**
+**Kernel + executor architecture** (see the [architecture
+README](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/README.md)):
 
 - `templar-vault-kernel` — chain-agnostic source of truth: state machine, math,
   fee accrual, and invariants. It returns *effects* (mint/burn/transfer/emit)
   rather than touching chain state directly.
-- `contract/vault/near` and `contract/vault/soroban` — per-chain executors that
-  persist state, enforce authorization, and execute kernel effects.
+- `contract/vault/soroban` — the Soroban executor (`CuratorVault<S, A, E>`): it
+  loads versioned state, enforces RBAC via `require_auth()` + the shared
+  `ActionKind` policy, applies a kernel action, and executes the resulting
+  effects against the SEP-41 share token and the underlying asset token.
 - `contract/vault/curator-primitives` — shared policy/RBAC/governance helpers
   (caps, cap groups, supply queue, timelocks, restrictions).
 
 **Accounting invariant:** `total_assets = idle_assets + external_assets`.
 
-- `idle_assets` — uninvested cash buffer held by the vault. It also serves as the
-  withdrawal liquidity buffer; there is no separate "idle market".
-- `external_assets` — principal deployed into markets.
+- `idle_assets` — uninvested cash buffer held by the vault, and the liquidity
+  buffer for atomic withdrawals.
+- `external_assets` — principal deployed into markets via adapters.
 
-**Flows:**
+**Markets are adapters.** On Soroban, markets are reached through adapter
+contracts that must be **allow-listed and added to the supply queue through
+governance before allocation**:
 
-- **Deposit** → the vault mints shares pro-rata; assets sit idle until allocated.
-- **Allocate** (Allocator/keeper) → moves idle assets into markets in
-  **supply-queue** order, respecting per-market and cap-group limits.
-- **Withdraw** → two-phase, async, keeper-routed: `request_withdraw` escrows the
-  shares and starts a cooldown; after the cooldown, `execute_withdraw` pulls
-  liquidity from idle first, then from markets along a route, then settles and
-  burns the escrowed shares.
+- **Blend adapter** (`contract/vault/soroban/blend-adapter`) — integrates the
+  Blend lending protocol.
+- **Custodial adapter** (`contract/vault/soroban/custodial-adapter`) — an
+  offchain-managed route that forwards assets to a configured custodian/multisig.
+  Its NAV is *reported* accounting; treat the custodian and its offchain process
+  as part of the vault's trust boundary.
 
 **Roles:**
 
-- **Owner** — top-level governance (sets curator/sentinel, fees, timelocks,
-  restrictions).
-- **Curator** — policy admin: market caps, cap groups, supply queue, and market
+- **Owner / Governance** — top-level governance (curator/sentinel assignment,
+  fees, timelocks, restrictions). On Soroban, proposal submission, timelocks, and
+  approvals live in a dedicated **governance contract**.
+- **Curator** — policy admin: market caps, cap groups, supply queue, market
   removal. Implicitly holds the Allocator role.
-- **Allocator** — operational keeper: allocations, rebalances, withdrawals,
-  refreshes.
+- **Allocator** — operational keeper: allocations, rebalances, withdrawal
+  execution, refreshes.
 - **Sentinel** — emergency authority: pause / tighten restrictions immediately,
-  abort in-flight operations, and **revoke any pending timelocked change**.
+  abort in-flight operations, and revoke pending timelocked changes. The Sentinel
+  is a **separate emergency role** from the governance contract.
+
+## Soroban specifics every curator should know
+
+**Two withdrawal modes** (see the [Soroban
+README](https://github.com/Templar-Protocol/contracts/blob/dev/contract/vault/soroban/README.md#soroban-specific-withdrawal-path)):
+
+- `withdraw` / `redeem` — ERC-4626-style **atomic exits from idle liquidity
+  only**. They never enqueue work and fail if the requested assets exceed
+  `idle_assets`. So `maxWithdraw` / `maxRedeem` can read `0` even when a holder's
+  shares are backed by market-deployed assets.
+- `request_withdraw` + `execute_withdraw` — the **async** path for positions that
+  need allocator/keeper work. `request_withdraw` escrows shares and locks in a
+  fixed `expected_assets` claim at request time; `execute_withdraw` (an
+  **allocator** action, not a public user exit) settles the queue head only when
+  it is cooled down and fully covered by idle assets, otherwise it fails
+  atomically and leaves the request queued. The queue does *not* reserve idle
+  liquidity against later atomic exits.
+
+**Governance control-plane boundary.** Vault-bound governance actions cross from
+the governance contract into the runtime through a single bridge,
+`execute_governance(env, caller, payload)`. Emergency **pause and restriction
+tightening are immediate Sentinel actions**; **unpause and relaxing/removing
+restrictions are governance actions that must clear the configured timelock**
+before the runtime applies them.
+
+**Fee anchor & idle reconciliation.** Unsolicited underlying transfers are
+treated as idle assets for *existing* shareholders, not as profit the next
+depositor can capture. Deposits, fee refreshes, and idle resyncs read the live
+asset balance, update `idle_assets`, and reset the `fee_anchor`. When fees are
+active, deposits **crystallize elapsed fees first**, so deposit principal cannot
+erase already-accrued fees.
+
+**TTL keeper responsibility.** Soroban storage is not permanent. A vault
+deployment **must** include a keeper that periodically calls the permissionless
+`ExtendTtl` path. Related contracts (share token, governance, adapters, proxy,
+oracle) each need their own TTL maintenance — they do not inherit the vault
+runtime's renewal.
 
 ## Curator economics (fees)
 
-There are two fee types. Both are **minted as new shares** to a configurable
-recipient (so a recipient must be able to hold shares / be registered to receive
+There are two fee types. Both are **minted as new SEP-41 shares** to a
+configurable recipient (so a recipient must be able to hold shares to receive
 them).
 
 | Fee | Basis | Cap |
@@ -61,72 +115,104 @@ them).
 | **Performance** | AUM **growth** since the last accrual checkpoint; zero on flat or down periods | **50% of profit** |
 
 Rates are WAD-scaled (`1e18 = 100%`). Each fee has its own recipient, and they
-can differ.
-
-Two nuances worth understanding:
+can differ. Two nuances worth understanding:
 
 - **Checkpoint, not all-time high-water mark.** Fees accrue on *every*
-  interaction (deposit, withdraw, allocate, fee change), and the fee anchor
-  resets to the current AUM each time. Profit is measured as
+  interaction, and the fee anchor resets to current AUM each time. Profit is
   `current_AUM − anchor_AUM`. If AUM is flat or down versus the anchor, the
   performance fee is zero — but because the anchor resets downward after a loss,
   a subsequent recovery *is* chargeable. This is "growth since the last
-  checkpoint", not "growth above the all-time peak". (Losses are rare in
-  over-collateralized lending, but the distinction matters.)
+  checkpoint", not "growth above the all-time peak".
 - **Anti-donation cap** (`max_total_assets_growth_rate`, optional). Caps how fast
-  AUM is allowed to count for fee accrual:
-  `effective_AUM = min(current, last × (1 + max_rate × dt/yr))`. This prevents a
-  one-block token donation from inflating fees. Relaxing or removing this cap is
-  timelocked.
+  AUM is allowed to count toward fees, preventing a one-block donation from
+  inflating fees. Relaxing or removing this cap is timelocked.
 
 ## Governance switches and the timelock rule
 
 **The principle behind every switch:** changes that **disadvantage depositors**
 are **timelocked** (so depositors can exit first, and the Sentinel can veto);
 changes that **protect or benefit depositors** take effect **immediately**.
-
 Timelocks are configurable per kind, bounded between **0 and 30 days** (default 2
 days).
 
-| Switch | Function | Immediate (depositor-friendly) | Timelocked (depositor-adverse) |
-|--------|----------|-------------------------------|-------------------------------|
-| **Fees** | `set_fees` | Fee **decrease** | Fee **increase**, any **recipient change**, relaxing the growth cap |
-| **Market cap** | `submit_cap` | **Lower** cap (incl. set to 0 = stop deposits) | **Raise** cap, or a **new** market |
-| **Cap group** (absolute + relative) | `submit_cap_group_update` | **Tighten** (lower / add a cap) | **Loosen** (raise / remove a cap). Relative cap ≤ 100% |
-| **Restrictions** | `set_restrictions` | **Pause / tighten** (blacklist, narrow whitelist) | **Unpause / relax** |
-| **Timelock length** | `submit_timelock` | **Lengthen** | **Shorten** (waits under the old, longer timelock) |
-| **Market removal** | `submit_market_removal` | — | Always timelocked; requires the cap to already be 0 |
+| Switch | Immediate (depositor-friendly) | Timelocked (depositor-adverse) |
+|--------|-------------------------------|-------------------------------|
+| **Fees** | Fee **decrease** | Fee **increase**, recipient change, relaxing the growth cap |
+| **Market cap** | **Lower** cap (incl. set to 0 = stop deposits) | **Raise** cap, or a **new** market |
+| **Cap group** (absolute + relative) | **Tighten** (lower / add a cap) | **Loosen** (raise / remove a cap). Relative cap ≤ 100% |
+| **Restrictions** | **Pause / tighten** (blacklist, narrow whitelist) | **Unpause / relax** |
+| **Timelock length** | **Lengthen** | **Shorten** (waits under the old, longer timelock) |
+| **Market removal** | — | Always timelocked; requires the cap to already be 0 |
 
 Other levers:
 
-- **Supply queue** (`set_supply_queue`) — the ordered list of allocation targets.
-  Up to 64 markets, no duplicates, every market must have a cap > 0, and the
-  vault must be Idle.
-- **Cap groups** — cluster correlated markets under a shared limit. The effective
+- **Supply queue** — the ordered list of allocation targets (up to 64 markets, no
+  duplicates, every market must have a cap > 0).
+- **Cap groups** — cluster correlated markets under a shared limit; the effective
   limit is `min(absolute_cap, relative_cap × total_AUM)`.
-- **Cooldowns** — withdrawal (default **1 hour**), market refresh (30 seconds),
-  idle resync (120 seconds).
-- **Abdicate** (`abdicate`) — permanently and irreversibly disable a governance
-  method (for example, to lock fees forever).
-- **Sentinel revoke** — `revoke_pending_*` cancels any pending timelocked change.
+- **Cooldowns** — withdrawal (default 1 hour), market refresh, idle resync.
+- **Abdicate** — permanently and irreversibly disable a governance method.
 
 ## Worked examples
 
-1. **Raising the performance fee 10% → 20%** is timelocked (e.g. 2 days).
-   Depositors see the pending change and can withdraw; the Sentinel can revoke
-   it. *Lowering* it 20% → 10% applies instantly.
-2. **A market turns risky.** Cutting its cap 1M → 500k USDC is **immediate**;
-   setting it to **0** stops new allocations now (the first step of winding it
-   down). *Raising* a cap 1M → 2M is timelocked.
-3. **Incident response.** `set_restrictions(Paused)` halts the vault
-   **immediately**; *un-pausing* is timelocked, so users get notice before
-   normal operation resumes.
-4. **A cap group "blue-chip"** with an absolute cap of 5M and a relative cap of
-   40%: at 8M AUM the cluster can hold at most `min(5M, 0.40 × 8M = 3.2M) = 3.2M`.
-   The limit scales with AUM until the 5M ceiling binds.
-5. **Fee accrual.** The vault grows 10M → 11M between interactions. With a 20%
-   performance fee, roughly 200k (assets-equivalent) of shares mint to the
-   performance recipient (20% of the 1M gain); a 2%/yr management fee
-   additionally mints time-weighted shares on the 10M base for the elapsed
-   interval. Both are dilutive to existing holders by exactly the minted share
-   amount.
+1. **Raising the performance fee 10% → 20%** is timelocked; depositors can
+   withdraw and the Sentinel can revoke. *Lowering* it applies instantly.
+2. **A market turns risky.** Cutting its cap 1M → 500k is **immediate**; setting
+   it to **0** stops new allocations now. *Raising* a cap is timelocked.
+3. **Incident response.** Pausing is **immediate**; *un-pausing* is timelocked,
+   so users get notice before normal operation resumes.
+4. **A cap group "blue-chip"** with absolute 5M and relative 40%: at 8M AUM the
+   cluster holds at most `min(5M, 0.40 × 8M) = 3.2M`; it scales with AUM until
+   the 5M ceiling binds.
+5. **Fee accrual.** The vault grows 10M → 11M; a 20% performance fee mints ~200k
+   (assets-equivalent) of shares to the performance recipient (20% of the 1M
+   gain), plus time-weighted management shares on the 10M base. Both dilute
+   existing holders by exactly the minted amount.
+
+## Operating a vault: the vault CLI / client SDK
+
+Day-to-day curator and allocator operations run through the **vault client SDK**
+("the vault CLI"). It locks in a focused set of production-ready flows — with
+proper fee/gas attachment, nonce handling, and retry logic — rather than
+exposing the full contract surface.
+
+**Full reference:**
+<https://github.com/Templar-Protocol/contracts/blob/dev/client/vault/README.md>
+
+Highlights:
+
+- **Bindings for multiple languages** via UniFFI — Python, TypeScript, and Rust —
+  generated from the vault contract ABI, so the same flows are available to
+  automation and to the frontend.
+- **Curator / allocator flows**: `deposit`, `refresh_markets` (update the vault's
+  view of market assets), `reallocate` (supply to / withdraw from a market),
+  `withdraw` / `redeem`, `execute_withdrawal`, and config calls such as
+  `set_fees`.
+- **View & preview helpers**: `get_total_assets`, `get_idle_balance`,
+  `get_configuration`, `get_fees`, `preview_deposit` / `preview_withdraw` /
+  `preview_redeem`, and `build_real_assets_report`.
+- **Production reliability**: multi-key pooling with least-loaded selection,
+  per-key nonce management with retry on stale nonces, TTL-based view caching,
+  and zeroizing key handling. Built for unattended curator/allocator bots.
+
+Typical reallocation (curator operation):
+
+```python
+from templar_vault_client import AllocationDelta, Delta
+
+# Supply idle assets to a market
+await client.reallocate(AllocationDelta.Supply(Delta(market=market_id, amount=amount)))
+
+# Pull assets back from a market
+await client.reallocate(AllocationDelta.Withdraw(Delta(market=market_id, amount=amount)))
+```
+
+## Curated-vault frontend (UI)
+
+For curators who prefer a UI over scripting, the **curated-vault frontend at
+<https://app.templarfi.org/vaults/curator/>** is the reference interface over the
+same vault operations the CLI/SDK exposes (deposit, withdraw/redeem, refresh,
+reallocate, fee and policy changes). It builds the transactions with the correct
+gas/deposit policy and **delegates signing to the user's connected wallet** — the
+frontend never handles private keys. It is the no-code path to the same flows
+documented above.


### PR DESCRIPTION
## Summary

Adds a curator-facing guide to the mdBook covering:

- **Vault structure** — single-asset ERC-4626-style vault, kernel + executor architecture, the `total_assets = idle_assets + external_assets` invariant, deposit/allocate/withdraw flows, and the Owner / Curator / Allocator / Sentinel roles.
- **Curator economics** — management fee (time-weighted, ≤ 5%/yr) and performance fee (on AUM growth since the last checkpoint, ≤ 50% of profit), both minted as shares; the checkpoint-vs-high-water-mark nuance; and the optional anti-donation growth cap.
- **Governance switches & timelock rule** — the depositor-protection asymmetry (adverse changes timelocked, protective changes immediate) across fees, market caps, cap groups, restrictions, timelock length, and market removal, plus worked examples.

Facts were cross-checked against `common/src/vault/*`, `contract/vault/curator-primitives/src/governance/mod.rs`, `contract/vault/near/src/lib.rs`, and `contract/vault/README.md`.

## Changes

- `docs/src/curator-guide.md` — new page
- `docs/src/SUMMARY.md` — add the page to the table of contents

Docs-only; no source or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ASzv2a4MhTTQ9RpkFvfRNw)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/485)
<!-- Reviewable:end -->
