### PR TITLE
fix(gateway): route RPC API key through a header, not the URL (ENG-415)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13233,6 +13233,7 @@ dependencies = [
  "templar-gateway-store",
  "templar-gateway-types",
  "tokio",
+ "url",
 ]
 
 [[package]]
@@ -13395,6 +13396,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "templar-common",
+ "templar-gateway-client",
  "templar-gateway-core",
  "templar-gateway-methods-dispatch",
  "templar-gateway-methods-spec",

--- a/gateway/client/Cargo.toml
+++ b/gateway/client/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 [dependencies]
 clap = { workspace = true, optional = true }
 near-api.workspace = true
+url.workspace = true
 templar-gateway-core.workspace = true
 templar-gateway-methods-dispatch.workspace = true
 templar-gateway-store.workspace = true

--- a/gateway/client/src/lib.rs
+++ b/gateway/client/src/lib.rs
@@ -27,7 +27,7 @@
 //! [`OperationStore`]: templar_gateway_core::OperationStore
 
 mod network;
-pub use network::Network;
+pub use network::{Network, NetworkConfigBuilder};
 
 mod pagination;
 pub use pagination::collect_paginated;

--- a/gateway/client/src/network.rs
+++ b/gateway/client/src/network.rs
@@ -2,6 +2,8 @@
 
 use std::fmt;
 
+use near_api::NetworkConfig;
+
 /// A NEAR network, used by off-chain consumers (CLIs, bots, services) to pick
 /// the default RPC endpoint when constructing a [`crate::Client`].
 ///
@@ -38,5 +40,160 @@ impl fmt::Display for Network {
             Network::Mainnet => "mainnet",
             Network::Testnet => "testnet",
         })
+    }
+}
+
+/// Builds a [`near_api::NetworkConfig`] for off-chain consumers, resolving the
+/// RPC URL and attaching any API key as a header.
+///
+/// The API key must be sent as a header rather than embedded in the URL:
+/// near_api's OpenAPI client builds each request path with `format!("{url}/")`,
+/// which appends a slash after the base URL's query string and corrupts a
+/// FastNear-style `?apiKey=...` parameter (the endpoint then answers `401`). This
+/// builder routes the key through [`near_api::RPCEndpoint::with_api_key`] instead.
+/// For backwards compatibility, a key still supplied as an `apiKey` query
+/// parameter is extracted from the URL and moved to the header.
+pub struct NetworkConfigBuilder {
+    network_name: String,
+    rpc_url: url::Url,
+    api_key: Option<String>,
+}
+
+impl NetworkConfigBuilder {
+    /// Start from a [`Network`], defaulting the RPC URL to its public endpoint.
+    // The enum's RPC URLs are compile-time constants known to be valid, so the
+    // parse cannot fail in practice.
+    #[allow(clippy::expect_used)]
+    #[must_use]
+    pub fn new(network: Network) -> Self {
+        Self {
+            network_name: network.to_string(),
+            rpc_url: network
+                .rpc_url()
+                .parse()
+                .expect("Network::rpc_url must be a valid URL"),
+            api_key: None,
+        }
+    }
+
+    /// Start from an explicit network name and pre-parsed RPC URL, for consumers
+    /// that don't select via the [`Network`] enum.
+    #[must_use]
+    pub fn from_url(name: impl Into<String>, rpc_url: url::Url) -> Self {
+        Self {
+            network_name: name.into(),
+            rpc_url,
+            api_key: None,
+        }
+    }
+
+    /// Override the RPC URL (e.g. from a `--rpc-url` flag). `None` keeps the
+    /// current value, so a bare `Some`/`None` CLI argument can be passed through.
+    ///
+    /// The URL is parsed here so an invalid value fails at the call site rather
+    /// than in [`build`](Self::build).
+    ///
+    /// # Errors
+    /// Returns an error if `rpc_url` is `Some` and fails to parse.
+    pub fn rpc_url(mut self, rpc_url: Option<&str>) -> Result<Self, url::ParseError> {
+        if let Some(rpc_url) = rpc_url {
+            self.rpc_url = rpc_url.parse()?;
+        }
+        Ok(self)
+    }
+
+    /// Set the RPC API key, sent as an `Authorization` header. Takes precedence
+    /// over a key embedded in the URL; `None` falls back to that embedded key.
+    #[must_use]
+    pub fn api_key(mut self, api_key: Option<String>) -> Self {
+        self.api_key = api_key;
+        self
+    }
+
+    /// Resolve the configuration, moving any API key onto the endpoint header.
+    #[must_use]
+    pub fn build(mut self) -> NetworkConfig {
+        let embedded_key = self
+            .rpc_url
+            .query_pairs()
+            .find(|(key, _)| key == "apiKey")
+            .map(|(_, value)| value.into_owned());
+        if embedded_key.is_some() {
+            self.rpc_url.set_query(None);
+        }
+
+        let mut network = NetworkConfig::from_rpc_url(&self.network_name, self.rpc_url);
+        if let Some(api_key) = self.api_key.or(embedded_key) {
+            network.rpc_endpoints = network
+                .rpc_endpoints
+                .into_iter()
+                .map(|endpoint| endpoint.with_api_key(api_key.clone()))
+                .collect();
+        }
+
+        network
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NetworkConfigBuilder;
+
+    #[test]
+    fn embedded_api_key_moves_to_header() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/?apiKey=SECRET"
+                .parse()
+                .unwrap(),
+        )
+        .build();
+
+        let endpoint = &network.rpc_endpoints[0];
+        assert_eq!(endpoint.url.as_str(), "https://rpc.mainnet.fastnear.com/");
+        assert_eq!(endpoint.bearer_header.as_deref(), Some("Bearer SECRET"));
+    }
+
+    #[test]
+    fn explicit_api_key_takes_precedence_over_embedded() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/?apiKey=FROM_URL"
+                .parse()
+                .unwrap(),
+        )
+        .api_key(Some("EXPLICIT".to_owned()))
+        .build();
+
+        let endpoint = &network.rpc_endpoints[0];
+        assert!(endpoint.url.query().is_none());
+        assert_eq!(endpoint.bearer_header.as_deref(), Some("Bearer EXPLICIT"));
+    }
+
+    #[test]
+    fn no_api_key_leaves_endpoint_bare() {
+        let network = NetworkConfigBuilder::new(super::Network::Testnet).build();
+
+        assert!(network.rpc_endpoints[0].bearer_header.is_none());
+    }
+
+    #[test]
+    fn rpc_url_override_replaces_default() {
+        let network = NetworkConfigBuilder::new(super::Network::Testnet)
+            .rpc_url(Some("https://example.invalid/"))
+            .unwrap()
+            .build();
+
+        assert_eq!(
+            network.rpc_endpoints[0].url.as_str(),
+            "https://example.invalid/"
+        );
+    }
+
+    #[test]
+    fn invalid_rpc_url_override_errors_early() {
+        let result = NetworkConfigBuilder::new(super::Network::Testnet).rpc_url(Some("not a url"));
+
+        assert!(result.is_err());
     }
 }

--- a/gateway/client/src/network.rs
+++ b/gateway/client/src/network.rs
@@ -104,23 +104,21 @@ impl NetworkConfigBuilder {
 
     /// Set the RPC API key, sent as an `Authorization` header. Takes precedence
     /// over a key embedded in the URL; `None` falls back to that embedded key.
+    ///
+    /// A blank or whitespace-only value (e.g. an empty env var parsed as
+    /// `Some("")`) is treated as unset, so it doesn't suppress an embedded key.
     #[must_use]
     pub fn api_key(mut self, api_key: Option<String>) -> Self {
-        self.api_key = api_key;
+        self.api_key = api_key
+            .map(|key| key.trim().to_owned())
+            .filter(|key| !key.is_empty());
         self
     }
 
     /// Resolve the configuration, moving any API key onto the endpoint header.
     #[must_use]
     pub fn build(mut self) -> NetworkConfig {
-        let embedded_key = self
-            .rpc_url
-            .query_pairs()
-            .find(|(key, _)| key == "apiKey")
-            .map(|(_, value)| value.into_owned());
-        if embedded_key.is_some() {
-            self.rpc_url.set_query(None);
-        }
+        let embedded_key = self.take_embedded_api_key();
 
         let mut network = NetworkConfig::from_rpc_url(&self.network_name, self.rpc_url);
         if let Some(api_key) = self.api_key.or(embedded_key) {
@@ -132,6 +130,37 @@ impl NetworkConfigBuilder {
         }
 
         network
+    }
+
+    /// Remove and return an `apiKey` query parameter from the RPC URL, leaving
+    /// any other query parameters intact.
+    fn take_embedded_api_key(&mut self) -> Option<String> {
+        let mut api_key = None;
+        let remaining: Vec<(String, String)> = self
+            .rpc_url
+            .query_pairs()
+            .filter_map(|(key, value)| {
+                if key == "apiKey" {
+                    api_key = Some(value.into_owned());
+                    None
+                } else {
+                    Some((key.into_owned(), value.into_owned()))
+                }
+            })
+            .collect();
+
+        if api_key.is_some() {
+            if remaining.is_empty() {
+                self.rpc_url.set_query(None);
+            } else {
+                self.rpc_url
+                    .query_pairs_mut()
+                    .clear()
+                    .extend_pairs(remaining);
+            }
+        }
+
+        api_key
     }
 }
 
@@ -152,6 +181,50 @@ mod tests {
         let endpoint = &network.rpc_endpoints[0];
         assert_eq!(endpoint.url.as_str(), "https://rpc.mainnet.fastnear.com/");
         assert_eq!(endpoint.bearer_header.as_deref(), Some("Bearer SECRET"));
+    }
+
+    #[test]
+    fn embedded_api_key_extraction_preserves_other_query_params() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/?apiKey=SECRET&foo=bar"
+                .parse()
+                .unwrap(),
+        )
+        .build();
+
+        let endpoint = &network.rpc_endpoints[0];
+        assert_eq!(
+            endpoint.url.as_str(),
+            "https://rpc.mainnet.fastnear.com/?foo=bar"
+        );
+        assert_eq!(endpoint.bearer_header.as_deref(), Some("Bearer SECRET"));
+    }
+
+    #[test]
+    fn blank_api_key_falls_back_to_embedded() {
+        let network = NetworkConfigBuilder::from_url(
+            "mainnet",
+            "https://rpc.mainnet.fastnear.com/?apiKey=EMBEDDED"
+                .parse()
+                .unwrap(),
+        )
+        .api_key(Some(String::new()))
+        .build();
+
+        assert_eq!(
+            network.rpc_endpoints[0].bearer_header.as_deref(),
+            Some("Bearer EMBEDDED")
+        );
+    }
+
+    #[test]
+    fn blank_api_key_without_embedded_leaves_bare() {
+        let network = NetworkConfigBuilder::new(super::Network::Testnet)
+            .api_key(Some("   ".to_owned()))
+            .build();
+
+        assert!(network.rpc_endpoints[0].bearer_header.is_none());
     }
 
     #[test]

--- a/service/accumulator/src/lib.rs
+++ b/service/accumulator/src/lib.rs
@@ -54,6 +54,10 @@ pub struct Args {
     /// Custom RPC URL (overrides default network RPC).
     #[arg(long, env = "RPC_URL")]
     pub rpc_url: Option<String>,
+    /// API key for the RPC endpoint, sent as an `Authorization` header. May also
+    /// be supplied as an `apiKey` query parameter on `--rpc-url`.
+    #[arg(long, env = "RPC_API_KEY")]
+    pub rpc_api_key: Option<String>,
     /// Interval between accumulations in seconds.
     #[arg(short, long, default_value_t = 600, env = "INTERVAL")]
     pub interval: u64,

--- a/service/accumulator/src/main.rs
+++ b/service/accumulator/src/main.rs
@@ -2,9 +2,8 @@ use std::{collections::HashMap, future::Future, time::Duration};
 
 use anyhow::Context;
 use clap::Parser;
-use near_api::NetworkConfig;
 use templar_accumulator::{list_all_deployments, Accumulator, Args};
-use templar_gateway_client::SigningClient;
+use templar_gateway_client::{NetworkConfigBuilder, SigningClient};
 use tracing::{error, info};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
@@ -108,17 +107,18 @@ async fn run_service(
     args: Args,
     shutdown: impl Future<Output = ()> + Send + 'static,
 ) -> anyhow::Result<()> {
-    let rpc_url = args
-        .rpc_url
-        .clone()
-        .unwrap_or_else(|| args.network.rpc_url().to_owned());
-
-    info!(network = %args.network, %rpc_url, "Connecting to RPC");
-
-    let network = NetworkConfig::from_rpc_url(
-        &args.network.to_string(),
-        rpc_url.parse().context("invalid RPC URL")?,
+    // Don't log the resolved RPC URL: an embedded `apiKey` makes it secret-bearing.
+    info!(
+        network = %args.network,
+        custom_rpc = args.rpc_url.is_some(),
+        "Connecting to RPC"
     );
+
+    let network = NetworkConfigBuilder::new(args.network)
+        .rpc_url(args.rpc_url.as_deref())
+        .context("invalid RPC URL")?
+        .api_key(args.rpc_api_key.clone())
+        .build();
 
     let client = SigningClient::connect(
         network,

--- a/service/gateway/Cargo.toml
+++ b/service/gateway/Cargo.toml
@@ -17,6 +17,7 @@ near-api.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sqlx.workspace = true
+templar-gateway-client.workspace = true
 templar-gateway-core.workspace = true
 templar-gateway-methods-dispatch.workspace = true
 templar-gateway-oracle-updates-spec.workspace = true

--- a/service/gateway/src/config.rs
+++ b/service/gateway/src/config.rs
@@ -66,6 +66,11 @@ pub struct Config {
     )]
     pub near_rpc_url: Url,
 
+    /// API key for the RPC endpoint, sent as an `Authorization` header. May also
+    /// be supplied as an `apiKey` query parameter on `--near-rpc-url`.
+    #[arg(long, env = "NEAR_RPC_API_KEY")]
+    pub near_rpc_api_key: Option<String>,
+
     /// Postgres database URL for durable gateway operation storage.
     #[arg(long, env = "GATEWAY_DATABASE_URL")]
     pub database_url: Option<String>,

--- a/service/gateway/src/main.rs
+++ b/service/gateway/src/main.rs
@@ -6,7 +6,7 @@ mod rpc;
 use crate::rpc::attach_gateway;
 use clap::Parser;
 use jsonrpsee::server::ServerBuilder;
-use near_api::NetworkConfig;
+use templar_gateway_client::NetworkConfigBuilder;
 use templar_gateway_core::GatewayContext;
 use templar_gateway_oracle_updates_dispatch::GatewayContextBuilderOracleExt;
 use tokio::signal;
@@ -23,12 +23,14 @@ async fn main() -> anyhow::Result<()> {
 
     let signers = config.build_signers().await?;
     let store = config.build_store().await?;
-    let context =
-        GatewayContext::builder(NetworkConfig::from_rpc_url("gateway", config.near_rpc_url))
-            .with_pyth_source(config.pyth_hermes_url)
-            .with_redstone_source(&config.redstone_node_path)
-            .map_err(anyhow::Error::from)?
-            .build();
+    let network = NetworkConfigBuilder::from_url("gateway", config.near_rpc_url)
+        .api_key(config.near_rpc_api_key)
+        .build();
+    let context = GatewayContext::builder(network)
+        .with_pyth_source(config.pyth_hermes_url)
+        .with_redstone_source(&config.redstone_node_path)
+        .map_err(anyhow::Error::from)?
+        .build();
     let service = GatewayService::spawn(context, signers, store)?;
 
     let server = ServerBuilder::default().build(config.listen_addr).await?;

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -63,11 +63,14 @@ pub struct Args {
     #[arg(short, long, env = "NEAR_NETWORK", default_value_t = Network::Testnet)]
     pub network: Network,
 
-    /// Custom RPC URL (overrides default network RPC). To authenticate with a
-    /// provider, embed the key in the URL, e.g.
-    /// `https://rpc.mainnet.fastnear.com/?apiKey=<key>`.
+    /// Custom RPC URL (overrides default network RPC).
     #[arg(long, env = "NEAR_RPC_URL")]
     pub near_rpc_url: Option<String>,
+
+    /// API key for the RPC endpoint, sent as an `Authorization` header. May also
+    /// be supplied as an `apiKey` query parameter on `--near-rpc-url`.
+    #[arg(long, env = "NEAR_RPC_API_KEY")]
+    pub near_rpc_api_key: Option<String>,
 
     /// Transaction timeout in seconds
     #[arg(long, env = "TRANSACTION_TIMEOUT", default_value_t = 60)]
@@ -377,6 +380,7 @@ impl Args {
             signer_account: self.signer_account.clone(),
             network: self.network,
             near_rpc_url: self.near_rpc_url.clone(),
+            near_rpc_api_key: self.near_rpc_api_key.clone(),
             transaction_timeout: self.transaction_timeout,
             liquidation_scan_interval: self.liquidation_scan_interval,
             registry_refresh_interval: self.registry_refresh_interval,
@@ -435,6 +439,7 @@ mod tests {
             signer_account: "liquidator.testnet".parse().unwrap(),
             network: Network::Testnet,
             near_rpc_url: None,
+            near_rpc_api_key: None,
             transaction_timeout: 60,
             liquidation_scan_interval: 600,
             registry_refresh_interval: 3600,

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -8,7 +8,7 @@
 use std::{collections::HashMap, num::NonZeroU32, sync::Arc, time::Duration};
 
 use near_sdk::AccountId;
-use templar_gateway_client::{collect_paginated, Network, SigningClient};
+use templar_gateway_client::{collect_paginated, Network, NetworkConfigBuilder, SigningClient};
 use templar_gateway_methods_spec::{contract, market, registry};
 use templar_gateway_types::common::Pagination;
 use tokio::{
@@ -60,8 +60,10 @@ pub struct ServiceConfig {
     pub signer_account: AccountId,
     /// Network to operate on
     pub network: Network,
-    /// RPC URL (embed any provider key in the URL, e.g. `…/?apiKey=<key>`)
+    /// Custom RPC URL (overrides the network default)
     pub near_rpc_url: Option<String>,
+    /// API key for the RPC endpoint, sent as an `Authorization` header
+    pub near_rpc_api_key: Option<String>,
     /// Transaction timeout in seconds
     pub transaction_timeout: u64,
     /// Interval between liquidation scans in seconds
@@ -133,23 +135,19 @@ impl LiquidatorService {
     /// client cannot be constructed for the configured signer.
     #[allow(clippy::expect_used)]
     pub fn new(config: ServiceConfig) -> Self {
-        let near_rpc_url = config
-            .near_rpc_url
-            .clone()
-            .unwrap_or_else(|| config.network.rpc_url().to_string());
-
-        // Don't log `near_rpc_url`: operators embed their provider `apiKey` in
-        // it, so the URL is secret-bearing.
+        // Don't log the resolved RPC URL: an embedded `apiKey` makes it
+        // secret-bearing.
         tracing::info!(
             network = %config.network,
             custom_rpc = config.near_rpc_url.is_some(),
             "Connecting to RPC"
         );
 
-        let network = near_api::NetworkConfig::from_rpc_url(
-            &config.network.to_string(),
-            near_rpc_url.parse().expect("invalid NEAR_RPC_URL"),
-        );
+        let network = NetworkConfigBuilder::new(config.network)
+            .rpc_url(config.near_rpc_url.as_deref())
+            .expect("invalid NEAR_RPC_URL")
+            .api_key(config.near_rpc_api_key.clone())
+            .build();
 
         // The gateway client signs with `near_api::SecretKey`; the CLI parses a
         // `near_crypto::SecretKey`, so round-trip through the shared string form.

--- a/tools/harvest-static-yield/Cargo.toml
+++ b/tools/harvest-static-yield/Cargo.toml
@@ -11,7 +11,7 @@ clap.workspace = true
 near-account-id.workspace = true
 near-api.workspace = true
 templar-common = { workspace = true, features = ["rpc"] }
-templar-gateway-client.workspace = true
+templar-gateway-client = { workspace = true, features = ["clap"] }
 templar-gateway-methods-spec.workspace = true
 templar-gateway-types.workspace = true
 tokio.workspace = true

--- a/tools/harvest-static-yield/src/main.rs
+++ b/tools/harvest-static-yield/src/main.rs
@@ -1,56 +1,15 @@
-use std::{
-    collections::{HashMap, HashSet},
-    fmt::Display,
-    str::FromStr,
-};
+use std::collections::{HashMap, HashSet};
 
 use anyhow::Context;
 use clap::Parser;
 use near_account_id::AccountId;
-use near_api::{NetworkConfig, SecretKey};
+use near_api::SecretKey;
 use templar_common::asset::{BorrowAsset, BorrowAssetAmount, FungibleAsset};
 use templar_common::SU128;
-use templar_gateway_client::{Client, SigningClient};
+use templar_gateway_client::{Client, Network, NetworkConfigBuilder, SigningClient};
 use templar_gateway_methods_spec::{contract, market, registry, storage, token};
 use templar_gateway_types::{common::Pagination, Market, MarketVersion, NearToken};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-#[derive(Clone, Debug)]
-enum Network {
-    Mainnet,
-    Testnet,
-}
-
-impl Network {
-    pub fn rpc_url(&self) -> &str {
-        match self {
-            Self::Mainnet => "https://rpc.mainnet.near.org",
-            Self::Testnet => "https://rpc.testnet.near.org",
-        }
-    }
-}
-
-impl FromStr for Network {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s.to_lowercase().trim() {
-            "mainnet" => Ok(Self::Mainnet),
-            "testnet" => Ok(Self::Testnet),
-            _ => Err("expected \"mainnet\" or \"testnet\""),
-        }
-    }
-}
-
-impl Display for Network {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Mainnet => "mainnet",
-            Self::Testnet => "testnet",
-        }
-        .fmt(f)
-    }
-}
 
 #[derive(Debug, Clone, Parser)]
 struct Cli {
@@ -66,6 +25,10 @@ struct Cli {
     /// Specify a custom RPC URL.
     #[arg(long, env = "RPC_URL")]
     pub rpc_url: Option<String>,
+    /// API key for the RPC endpoint, sent as an `Authorization` header. May also
+    /// be supplied as an `apiKey` query parameter on `--rpc-url`.
+    #[arg(long, env = "RPC_API_KEY")]
+    pub rpc_api_key: Option<String>,
     /// Account ID to harvest static yield for.
     #[arg(short, long, env = "ACCOUNT_ID")]
     pub account_id: AccountId,
@@ -115,17 +78,18 @@ pub async fn main() -> anyhow::Result<()> {
 
     tracing::info!(account_id = %args.account_id, "Harvesting static yield");
 
-    let rpc_url = args
-        .rpc_url
-        .as_deref()
-        .unwrap_or_else(|| args.network.rpc_url());
-
-    tracing::info!(network = %args.network, rpc_url = %rpc_url, "Connecting to RPC");
-
-    let network = NetworkConfig::from_rpc_url(
-        &args.network.to_string(),
-        rpc_url.parse().context("invalid RPC URL")?,
+    // Don't log the resolved RPC URL: an embedded `apiKey` makes it secret-bearing.
+    tracing::info!(
+        network = %args.network,
+        custom_rpc = args.rpc_url.is_some(),
+        "Connecting to RPC"
     );
+
+    let network = NetworkConfigBuilder::new(args.network)
+        .rpc_url(args.rpc_url.as_deref())
+        .context("invalid RPC URL")?
+        .api_key(args.rpc_api_key.clone())
+        .build();
 
     let client = SigningClient::connect(network, args.account_id.clone(), args.secret_key.clone())?;
 


### PR DESCRIPTION
## Problem

Running `harvest-static-yield` (and every other gateway consumer) against a FastNear **premium** endpoint fails with a `401`:

```
Failed to list deployments on registry ... near query failed: ...
Response { url: "https://rpc.mainnet.fastnear.com/?apiKey=<key>/", status: 401, ... }
```

Note the trailing `/` after the key.

### Root cause

`near-api` 0.8.5 routes RPC through `near-openapi-client` 0.8.0, which builds every request URL with `format!("{}/", self.baseurl)` (`near-openapi-client-0.8.0/src/lib.rs:473` and siblings). It appends `/` to the base URL, so when the key is embedded as a query parameter (`…/?apiKey=KEY`) the request URL becomes `…/?apiKey=KEY/` — the slash is absorbed into the `apiKey` value and FastNear rejects it.

Embedding the key in the URL query string is fundamentally incompatible with this client. The intended mechanism is `RPCEndpoint::with_api_key`, which sends the key via an `Authorization` header.

This affected **all four** consumers, which each hand-built a `NetworkConfig` and embedded the key in the URL (the liquidator's config doc even instructed operators to do so).

## Fix

Add a shared `NetworkConfigBuilder` in `templar-gateway-client` (next to the existing `Network` enum) that:

- resolves the RPC URL (from the `Network` default or an override),
- parses the URL **up front** so an invalid value fails at the call site (`build()` is infallible),
- extracts any embedded `?apiKey=` for backwards compatibility, and
- attaches the key as a header via `RPCEndpoint::with_api_key`.

`SigningClient::connect` / `Client::builder` still take a ready `NetworkConfig` — the builder is purely a construction helper, so the kernel stays ignorant of RPC auth.

All four consumers now route through it and gain a `*_API_KEY` env (`RPC_API_KEY` / `NEAR_RPC_API_KEY`):

- `tools/harvest-static-yield` — also dropped its stale private `Network` enum (was pointing at the deprecated `rpc.mainnet.near.org`)
- `service/accumulator`
- `service/liquidator` — fixed the config doc that instructed embedding the key in the URL
- `service/gateway`

Each consumer also stops logging the resolved RPC URL, which is secret-bearing when a key is embedded.

**Backwards compatible:** operators who still pass `…/?apiKey=KEY` keep working — the key is auto-moved to the header.

## Testing

- `NetworkConfigBuilder` unit tests (5): embedded-key → header, explicit-key precedence, no-key, url override, and invalid-url-fails-early.
- `cargo fmt` / `cargo clippy` / `cargo check --tests` clean on the touched crates.

> Note: `templar-liquidator` currently has a pre-existing compile break on `dev` unrelated to this change (`templar_gateway_types::U128` in `swap/{oneclick,ref}.rs`, plus sqlx-offline `database.rs` errors); this PR's liquidator edits introduce no new errors.

Closes ENG-415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/488)
<!-- Reviewable:end -->
