### PR TITLE
fix(liquidator): use SU128 after gateway U128 removal

### DIFF
--- a/service/liquidator/src/swap/oneclick.rs
+++ b/service/liquidator/src/swap/oneclick.rs
@@ -27,9 +27,10 @@ use near_sdk::{
 };
 
 use templar_common::asset::{AssetClass, FungibleAsset, FungibleAssetAmount};
+use templar_common::SU128;
 use templar_gateway_client::SigningClient;
 use templar_gateway_methods_spec::{storage, token, tx};
-use templar_gateway_types::{CryptoHash, NearToken, OperationStatus, U128 as GatewayU128};
+use templar_gateway_types::{CryptoHash, NearToken, OperationStatus};
 
 use crate::rpc::{AppError, AppResult};
 use crate::swap::SwapProvider;
@@ -781,7 +782,7 @@ impl OneClickSwap {
             .execute(token::Transfer {
                 token: token::TokenReference::from(from_asset),
                 receiver_id: deposit_account.clone(),
-                amount: GatewayU128(amount.0),
+                amount: SU128::from(amount.0),
                 memo: None,
             })
             .await

--- a/service/liquidator/src/swap/ref.rs
+++ b/service/liquidator/src/swap/ref.rs
@@ -9,11 +9,10 @@ use near_sdk::{
     AccountId,
 };
 use templar_common::asset::{AssetClass, FungibleAsset, FungibleAssetAmount};
+use templar_common::SU128;
 use templar_gateway_client::SigningClient;
 use templar_gateway_methods_spec::{ft, ref_finance, storage, tx};
-use templar_gateway_types::{
-    common::TxExecutionStatus, NearToken, OperationStatus, U128 as GatewayU128,
-};
+use templar_gateway_types::{common::TxExecutionStatus, NearToken, OperationStatus};
 
 use crate::rpc::{AppError, AppResult};
 
@@ -409,7 +408,7 @@ impl SwapProvider for RefSwap {
             .execute(ft::TransferCall {
                 contract_id: from_asset.contract_id().into(),
                 receiver_id: self.contract.clone(),
-                amount: GatewayU128(u128::from(amount)),
+                amount: SU128::from(u128::from(amount)),
                 msg: msg_string,
                 memo: None,
             })


### PR DESCRIPTION
## Problem

`dev` fails to build: the liquidator imports `templar_gateway_types::U128`, which no longer exists.

```
error[E0432]: unresolved import `templar_gateway_types::U128`
  --> service/liquidator/src/swap/oneclick.rs:32:69
  --> service/liquidator/src/swap/ref.rs:15:60
```

This is a merge collision between two PRs that landed close together:

- **#484 (ENG-369)** migrated the liquidator onto the in-process gateway and added new consumers of `templar_gateway_types::U128`.
- **#486 (ENG-392)** *removed* the bespoke gateway `U128`, unifying the gateway numeric wire type on `templar_primitives::SU128`. It updated the ft/mt/token/ref_finance specs and the harvest tool, but couldn't know about #484's new usages.

## Fix

Mirror the exact change #486 applied to the harvest tool, in `swap/oneclick.rs` and `swap/ref.rs`:

- Drop `U128 as GatewayU128` from the `templar_gateway_types` import.
- Add `use templar_common::SU128;` (liquidator already depends on `templar-common`, which re-exports `SU128`).
- Change the two construction sites `GatewayU128(x)` → `SU128::from(x)`.

`token::Transfer.amount` / `ft::TransferCall.amount` are now `SU128`, matching the rest of the gateway surface.

## Verification

- `cargo check -p templar-liquidator --all-targets --all-features` → clean
- `cargo fmt -p templar-liquidator` → applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/489)
<!-- Reviewable:end -->
