### PR TITLE
feat(gateway): generate MethodSpec constructors

### DIFF
--- a/gateway/client/src/lib.rs
+++ b/gateway/client/src/lib.rs
@@ -13,11 +13,14 @@
 //! ```ignore
 //! let client = SigningClient::connect(network, account_id, secret_key)?;
 //!
-//! let config = client.read(market::GetConfiguration { market_id }).await?;
+//! let config = client.read(market::GetConfiguration::new(market_id)).await?;
 //! let result = client
-//!     .execute(market::WithdrawStaticYield { market_id, amount: None })
+//!     .execute(market::WithdrawStaticYield::new(market_id, None))
 //!     .await?;
 //! ```
+//!
+//! The request structs keep their public fields, so explicit struct literals
+//! remain available when they are clearer.
 //!
 //! [`OperationStore`]: templar_gateway_core::OperationStore
 

--- a/gateway/macros/src/lib.rs
+++ b/gateway/macros/src/lib.rs
@@ -1,7 +1,52 @@
 use proc_macro::TokenStream;
 
-use quote::quote;
-use syn::{parse_macro_input, Attribute, DeriveInput, Expr, ExprLit, Lit, LitStr, Meta, Type};
+use quote::{format_ident, quote};
+use syn::{
+    parse_macro_input, punctuated::Punctuated, Attribute, Data, DeriveInput, Expr, ExprLit, Fields,
+    GenericArgument, Lit, LitStr, Meta, PathArguments, Token, Type,
+};
+
+fn has_constructor_default(attrs: &[Attribute]) -> syn::Result<bool> {
+    let mut has_default = false;
+
+    for attr in attrs.iter().filter(|attr| attr.path().is_ident("method")) {
+        let entries = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?;
+        for entry in entries {
+            match entry {
+                Meta::Path(path) => {
+                    if path.is_ident("default") {
+                        has_default = true;
+                    } else {
+                        return Err(syn::Error::new_spanned(
+                            path,
+                            "expected `default` for field-level `#[method(...)]`",
+                        ));
+                    }
+                }
+                other => return Err(syn::Error::new_spanned(other, "expected `default`")),
+            }
+        }
+    }
+
+    Ok(has_default)
+}
+
+fn option_inner_ty(ty: &Type) -> Option<&Type> {
+    let Type::Path(type_path) = ty else {
+        return None;
+    };
+    let segment = type_path.path.segments.last()?;
+    if segment.ident != "Option" {
+        return None;
+    }
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    let GenericArgument::Type(inner) = args.args.first()? else {
+        return None;
+    };
+    Some(inner)
+}
 
 fn cleaned_doc_text(attrs: &[Attribute]) -> String {
     let mut lines = Vec::new();
@@ -41,6 +86,69 @@ fn summary_from_doc(doc: &str) -> String {
         .join(" ")
 }
 
+fn constructor_impl(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
+    let ident = &input.ident;
+    let Data::Struct(data) = &input.data else {
+        return Ok(quote! {});
+    };
+    let Fields::Named(fields) = &data.fields else {
+        return Ok(quote! {});
+    };
+
+    let mut new_params = Vec::new();
+    let mut initializers = Vec::new();
+    let mut setters = Vec::new();
+
+    for field in &fields.named {
+        let field_ident = field.ident.as_ref().ok_or_else(|| {
+            syn::Error::new_spanned(field, "MethodSpec constructors require named fields")
+        })?;
+        let has_constructor_default = has_constructor_default(&field.attrs)?;
+        let option_inner = option_inner_ty(&field.ty);
+
+        if !has_constructor_default {
+            let field_ty = &field.ty;
+            new_params.push(quote!(#field_ident: #field_ty));
+            initializers.push(quote!(#field_ident));
+            continue;
+        }
+
+        let default_value = if option_inner.is_some() {
+            quote!(None)
+        } else {
+            quote!(::core::default::Default::default())
+        };
+        initializers.push(quote!(#field_ident: #default_value));
+
+        let setter_ident = format_ident!("with_{}", field_ident);
+        let setter_ty = option_inner.unwrap_or(&field.ty);
+        let setter_value = if option_inner.is_some() {
+            quote!(Some(value))
+        } else {
+            quote!(value)
+        };
+        setters.push(quote! {
+            #[must_use]
+            pub fn #setter_ident(mut self, value: #setter_ty) -> Self {
+                self.#field_ident = #setter_value;
+                self
+            }
+        });
+    }
+
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+    Ok(quote! {
+        impl #impl_generics #ident #ty_generics #where_clause {
+            #[must_use]
+            pub fn new(#(#new_params),*) -> Self {
+                Self { #(#initializers),* }
+            }
+
+            #(#setters)*
+        }
+    })
+}
+
 /// Attach a gateway method spec to an operation struct.
 ///
 /// The operation struct *is* the method input. A `#[method(..)]` helper
@@ -58,6 +166,11 @@ fn summary_from_doc(doc: &str) -> String {
 /// #[method(write = "market.withdrawStaticYield")]
 /// pub struct WithdrawStaticYield { /* .. */ }
 /// ```
+///
+/// The derive also emits an inherent `new(...)` constructor. Fields are
+/// constructor parameters unless they opt into `Default::default()` with
+/// `#[method(default)]`; opted-in fields also get a fluent `with_<field>(...)`
+/// setter. Public fields remain available for explicit struct literals.
 ///
 /// Reads require `output = <Type>`; writes take no output (their output is
 /// always `WriteOperationResult`).
@@ -156,8 +269,11 @@ fn expand(input: &DeriveInput) -> syn::Result<proc_macro2::TokenStream> {
         .attrs
         .iter()
         .any(|attr| attr.path().is_ident("deprecated"));
+    let constructor_impl = constructor_impl(input)?;
 
     Ok(quote! {
+        #constructor_impl
+
         impl templar_gateway_types::MethodSpec for #ident {
             type Output = #output_ty;
 

--- a/gateway/methods-spec/src/chain.rs
+++ b/gateway/methods-spec/src/chain.rs
@@ -10,5 +10,6 @@ use templar_gateway_types::{BlockSummary, CryptoHash};
 #[method(read = "chain.getBlock", output = BlockSummary)]
 pub struct GetBlock {
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[method(default)]
     pub block_hash: Option<CryptoHash>,
 }

--- a/gateway/methods-spec/src/market.rs
+++ b/gateway/methods-spec/src/market.rs
@@ -30,6 +30,7 @@ pub struct GetConfiguration {
 pub struct ListBorrowPositions {
     pub market_id: AccountId,
     #[serde(flatten)]
+    #[method(default)]
     pub args: Pagination,
 }
 
@@ -58,6 +59,7 @@ pub struct GetFinalizedSnapshotsLen {
 pub struct ListFinalizedSnapshots {
     pub market_id: AccountId,
     #[serde(flatten)]
+    #[method(default)]
     pub args: Pagination,
 }
 
@@ -120,6 +122,7 @@ pub struct GetBorrowStatusResult {
 pub struct ListSupplyPositions {
     pub market_id: AccountId,
     #[serde(flatten)]
+    #[method(default)]
     pub args: Pagination,
 }
 

--- a/gateway/methods-spec/src/registry.rs
+++ b/gateway/methods-spec/src/registry.rs
@@ -12,6 +12,7 @@ use templar_gateway_types::{
 pub struct ListDeployments {
     pub registry_id: AccountId,
     #[serde(flatten)]
+    #[method(default)]
     pub args: Pagination,
 }
 
@@ -26,6 +27,7 @@ pub struct ListDeploymentsResult {
 pub struct ListDeploymentsByKind {
     pub registry_id: AccountId,
     #[serde(flatten)]
+    #[method(default)]
     pub args: Pagination,
     pub kind: ContractKind,
 }
@@ -36,6 +38,7 @@ pub struct ListDeploymentsByKind {
 pub struct ListVersions {
     pub registry_id: AccountId,
     #[serde(flatten)]
+    #[method(default)]
     pub args: Pagination,
 }
 
@@ -77,6 +80,7 @@ pub struct Deploy {
     pub version_key: String,
     pub init_args: Base64Bytes,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[method(default)]
     pub full_access_keys: Option<Vec<PublicKey>>,
     pub deposit: NearToken,
 }

--- a/gateway/methods-spec/src/token.rs
+++ b/gateway/methods-spec/src/token.rs
@@ -51,6 +51,7 @@ pub struct Transfer {
     pub receiver_id: AccountId,
     pub amount: SU128,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[method(default)]
     pub memo: Option<String>,
 }
 

--- a/gateway/methods-spec/src/universal_account.rs
+++ b/gateway/methods-spec/src/universal_account.rs
@@ -53,6 +53,7 @@ pub struct Create {
     pub key: KeyId,
     pub chain_id: templar_primitives::SU128,
     pub execute: Option<Box<[Transaction]>>,
+    #[method(default)]
     pub full_access_keys: Option<Vec<PublicKey>>,
     pub deposit: templar_gateway_types::NearToken,
 }

--- a/gateway/methods-spec/tests/eng_393_method_spec.rs
+++ b/gateway/methods-spec/tests/eng_393_method_spec.rs
@@ -1,0 +1,179 @@
+use near_account_id::AccountId;
+use serde_json::json;
+use templar_common::asset::{BorrowAssetAmount, CollateralAssetAmount};
+use templar_gateway_methods_spec::{
+    chain::GetBlock,
+    market::*,
+    registry::{Deploy, ListDeploymentsByKind},
+};
+use templar_gateway_types::{common::Pagination, contract::ContractKind, Base64Bytes, NearToken};
+
+#[test]
+fn liquidate_new_requires_collateral_amount_argument() {
+    let request = Liquidate::new(
+        "market.near".parse::<AccountId>().unwrap(),
+        "alice.near".parse::<AccountId>().unwrap(),
+        BorrowAssetAmount::new(100),
+        Some(CollateralAssetAmount::new(25)),
+    );
+
+    assert_eq!(
+        request,
+        Liquidate {
+            market_id: "market.near".parse().unwrap(),
+            account_id: "alice.near".parse().unwrap(),
+            liquidation_amount: BorrowAssetAmount::new(100),
+            collateral_amount: Some(CollateralAssetAmount::new(25)),
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        json!({
+            "market_id": "market.near",
+            "account_id": "alice.near",
+            "liquidation_amount": "100",
+            "collateral_amount": "25",
+        }),
+    );
+}
+
+#[test]
+fn liquidate_new_still_allows_explicit_none_for_backward_compatibility() {
+    let request = Liquidate::new(
+        "market.near".parse::<AccountId>().unwrap(),
+        "alice.near".parse::<AccountId>().unwrap(),
+        BorrowAssetAmount::new(100),
+        None,
+    );
+
+    assert_eq!(
+        request,
+        Liquidate {
+            market_id: "market.near".parse().unwrap(),
+            account_id: "alice.near".parse().unwrap(),
+            liquidation_amount: BorrowAssetAmount::new(100),
+            collateral_amount: None,
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        json!({
+            "market_id": "market.near",
+            "account_id": "alice.near",
+            "liquidation_amount": "100",
+            "collateral_amount": null,
+        }),
+    );
+}
+
+#[test]
+fn list_borrow_positions_new_defaults_args_to_pagination_default() {
+    let request = ListBorrowPositions::new("market.near".parse().unwrap());
+
+    assert_eq!(
+        request,
+        ListBorrowPositions {
+            market_id: "market.near".parse().unwrap(),
+            args: Pagination::default(),
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        json!({
+            "market_id": "market.near",
+            "offset": null,
+            "count": null,
+        }),
+    );
+}
+
+#[test]
+fn list_borrow_positions_with_args_preserves_flattened_json() {
+    let request = ListBorrowPositions::new("market.near".parse().unwrap()).with_args(Pagination {
+        offset: Some(1),
+        limit: Some(50),
+    });
+
+    assert_eq!(
+        request,
+        ListBorrowPositions {
+            market_id: "market.near".parse().unwrap(),
+            args: Pagination {
+                offset: Some(1),
+                limit: Some(50),
+            },
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        json!({
+            "market_id": "market.near",
+            "offset": 1,
+            "count": 50,
+        }),
+    );
+}
+
+#[test]
+fn deploy_new_defaults_full_access_keys_to_none() {
+    let request = Deploy::new(
+        "registry.near".parse().unwrap(),
+        "market".to_owned(),
+        "v1.0.0".to_owned(),
+        Base64Bytes(vec![1, 2, 3]),
+        NearToken::from_near(1),
+    );
+
+    assert_eq!(
+        request,
+        Deploy {
+            registry_id: "registry.near".parse().unwrap(),
+            name: "market".to_owned(),
+            version_key: "v1.0.0".to_owned(),
+            init_args: Base64Bytes(vec![1, 2, 3]),
+            full_access_keys: None,
+            deposit: NearToken::from_near(1),
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        json!({
+            "registry_id": "registry.near",
+            "name": "market",
+            "version_key": "v1.0.0",
+            "init_args": "AQID",
+            "deposit": NearToken::from_near(1).as_yoctonear().to_string(),
+        }),
+    );
+}
+
+#[test]
+fn list_deployments_by_kind_new_keeps_required_fields_after_defaulted_args() {
+    let request = ListDeploymentsByKind::new("registry.near".parse().unwrap(), ContractKind::Vault);
+
+    assert_eq!(
+        request,
+        ListDeploymentsByKind {
+            registry_id: "registry.near".parse().unwrap(),
+            args: Pagination::default(),
+            kind: ContractKind::Vault,
+        },
+    );
+    assert_eq!(
+        serde_json::to_value(&request).unwrap(),
+        json!({
+            "registry_id": "registry.near",
+            "offset": null,
+            "count": null,
+            "kind": "vault",
+        }),
+    );
+}
+
+#[test]
+fn get_block_new_defaults_block_hash_to_none() {
+    let request = GetBlock::new();
+
+    assert_eq!(request, GetBlock { block_hash: None });
+    assert_eq!(serde_json::to_value(&request).unwrap(), json!({}));
+}

--- a/gateway/methods-spec/tests/eng_393_method_spec.rs
+++ b/gateway/methods-spec/tests/eng_393_method_spec.rs
@@ -5,8 +5,23 @@ use templar_gateway_methods_spec::{
     chain::GetBlock,
     market::*,
     registry::{Deploy, ListDeploymentsByKind},
+    universal_account::Create as UniversalAccountCreate,
 };
 use templar_gateway_types::{common::Pagination, contract::ContractKind, Base64Bytes, NearToken};
+use templar_primitives::SU128;
+use templar_universal_account::{transaction::Transaction, KeyId};
+
+type UniversalAccountCreateConstructor = fn(
+    AccountId,
+    String,
+    String,
+    KeyId,
+    SU128,
+    Option<Box<[Transaction]>>,
+    NearToken,
+) -> UniversalAccountCreate;
+
+fn assert_universal_account_create_constructor(_: UniversalAccountCreateConstructor) {}
 
 #[test]
 fn liquidate_new_requires_collateral_amount_argument() {
@@ -145,6 +160,11 @@ fn deploy_new_defaults_full_access_keys_to_none() {
             "deposit": NearToken::from_near(1).as_yoctonear().to_string(),
         }),
     );
+}
+
+#[test]
+fn universal_account_create_new_accepts_seven_required_arguments() {
+    assert_universal_account_create_constructor(UniversalAccountCreate::new);
 }
 
 #[test]

--- a/service/accumulator/src/lib.rs
+++ b/service/accumulator/src/lib.rs
@@ -254,9 +254,7 @@ impl Accumulator {
     async fn get_static_accounts(&self) -> anyhow::Result<Vec<AccountId>> {
         let configuration = self
             .client
-            .read(market::GetConfiguration {
-                market_id: self.market.clone(),
-            })
+            .read(market::GetConfiguration::new(self.market.clone()))
             .await?;
 
         Ok(static_accounts(&configuration))
@@ -348,9 +346,7 @@ async fn list_deployments(
 /// non-existent (best-effort filter), matching the legacy behaviour.
 async fn account_exists(client: &SigningClient, account_id: &AccountId) -> bool {
     client
-        .read(account::Get {
-            account_id: account_id.clone(),
-        })
+        .read(account::Get::new(account_id.clone()))
         .await
         .is_ok()
 }

--- a/service/accumulator/src/lib.rs
+++ b/service/accumulator/src/lib.rs
@@ -115,13 +115,12 @@ impl Accumulator {
             let market = market.clone();
             async move {
                 let result = client
-                    .read(market::ListBorrowPositions {
-                        market_id: market,
-                        args: Pagination {
+                    .read(
+                        market::ListBorrowPositions::new(market).with_args(Pagination {
                             offset: Some(offset),
                             limit: Some(count),
-                        },
-                    })
+                        }),
+                    )
                     .await?;
                 anyhow::Ok(result.positions.into_iter().collect::<Vec<_>>())
             }
@@ -135,11 +134,11 @@ impl Accumulator {
     async fn apply_interest(&self, account_id: AccountId) -> anyhow::Result<()> {
         let result = self
             .client
-            .execute(market::ApplyInterest {
-                market_id: self.market.clone(),
-                account_id: Some(account_id),
-                snapshot_limit: None,
-            })
+            .execute(market::ApplyInterest::new(
+                self.market.clone(),
+                Some(account_id),
+                None,
+            ))
             .await?;
         info!(operation_id = %result.operation.id.0, "Applied interest");
         Ok(())
@@ -183,9 +182,7 @@ impl Accumulator {
     async fn supports_static_yield(&self) -> bool {
         let version = match self
             .client
-            .read(contract::GetVersion {
-                contract_id: self.market.clone(),
-            })
+            .read(contract::GetVersion::new(self.market.clone()))
             .await
         {
             Ok(version) => version,
@@ -205,11 +202,11 @@ impl Accumulator {
     async fn accumulate_static_yield(&self, account_id: AccountId) -> anyhow::Result<()> {
         let result = self
             .client
-            .execute(market::AccumulateStaticYield {
-                market_id: self.market.clone(),
-                account_id: Some(account_id),
-                snapshot_limit: None,
-            })
+            .execute(market::AccumulateStaticYield::new(
+                self.market.clone(),
+                Some(account_id),
+                None,
+            ))
             .await?;
         info!(operation_id = %result.operation.id.0, "Accumulated static yield");
         Ok(())

--- a/service/liquidator/src/executor.rs
+++ b/service/liquidator/src/executor.rs
@@ -172,12 +172,12 @@ impl LiquidationExecutor {
         let tx_start = std::time::Instant::now();
         let tx_result = self
             .client
-            .execute(market::Liquidate {
-                market_id: self.market.clone(),
-                account_id: borrow_account.clone(),
+            .execute(market::Liquidate::new(
+                self.market.clone(),
+                borrow_account.clone(),
                 liquidation_amount,
-                collateral_amount: Some(collateral_amount), // Request specific collateral amount calculated by strategy
-            })
+                Some(collateral_amount),
+            ))
             .await;
 
         match tx_result {

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -166,9 +166,7 @@ impl OracleFetcher {
         // oracle through the direct Pyth path until restart.
         let result = match self
             .client
-            .read(lst_oracle::GetOracleId {
-                oracle_id: oracle.clone(),
-            })
+            .read(lst_oracle::GetOracleId::new(oracle.clone()))
             .await
         {
             Ok(response) => {
@@ -309,10 +307,7 @@ impl OracleFetcher {
             for &pid in price_ids {
                 let result = self
                     .client
-                    .read(lst_oracle::GetTransformer {
-                        oracle_id: oracle.clone(),
-                        price_identifier: pid,
-                    })
+                    .read(lst_oracle::GetTransformer::new(oracle.clone(), pid))
                     .await
                     .map_err(|error| LiquidatorError::PriceFetchError(error.into()))?;
                 match result.transformer {
@@ -339,10 +334,7 @@ impl OracleFetcher {
             for &pid in price_ids {
                 let result = self
                     .client
-                    .read(proxy_oracle::GetProxy {
-                        oracle_id: oracle.clone(),
-                        id: pid,
-                    })
+                    .read(proxy_oracle::GetProxy::new(oracle.clone(), pid))
                     .await
                     .map_err(|error| LiquidatorError::PriceFetchError(error.into()))?;
                 if let Some(proxy) = result.proxy {

--- a/service/liquidator/src/scanner.rs
+++ b/service/liquidator/src/scanner.rs
@@ -54,11 +54,11 @@ impl MarketScanner {
     ) -> Result<Option<BorrowStatus>, RpcError> {
         let result = self
             .client
-            .read(market::GetBorrowStatus {
-                market_id: self.market.clone(),
-                account_id: account_id.clone(),
-                oracle_response: oracle_response.clone(),
-            })
+            .read(market::GetBorrowStatus::new(
+                self.market.clone(),
+                account_id.clone(),
+                oracle_response.clone(),
+            ))
             .await
             .map_err(RpcError::from)?;
         Ok(result.status)
@@ -72,10 +72,10 @@ impl MarketScanner {
     ) -> Result<Option<BorrowPosition>, RpcError> {
         let result = self
             .client
-            .read(market::GetBorrowPosition {
-                market_id: self.market.clone(),
-                account_id: account_id.clone(),
-            })
+            .read(market::GetBorrowPosition::new(
+                self.market.clone(),
+                account_id.clone(),
+            ))
             .await
             .map_err(RpcError::from)?;
         Ok(result.position)
@@ -91,13 +91,12 @@ impl MarketScanner {
         loop {
             let page = self
                 .client
-                .read(market::ListBorrowPositions {
-                    market_id: self.market.clone(),
-                    args: Pagination {
+                .read(
+                    market::ListBorrowPositions::new(self.market.clone()).with_args(Pagination {
                         offset: Some(current_offset),
                         limit: Some(page_size),
-                    },
-                })
+                    }),
+                )
                 .await
                 .map_err(|e| LiquidatorError::ListBorrowPositionsError(e.into()))?
                 .positions;

--- a/service/liquidator/src/scanner.rs
+++ b/service/liquidator/src/scanner.rs
@@ -160,9 +160,7 @@ impl MarketScanner {
     async fn get_contract_version(&self) -> Option<String> {
         match self
             .client
-            .read(contract::GetVersion {
-                contract_id: self.market.clone(),
-            })
+            .read(contract::GetVersion::new(self.market.clone()))
             .await
         {
             Ok(result) => Some(result.version_string),

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -451,9 +451,7 @@ impl LiquidatorService {
                 // (proxy-oracles, redstone-adapters) won't have this method.
                 let config = match self
                     .client
-                    .read(market::GetConfiguration {
-                        market_id: market.clone(),
-                    })
+                    .read(market::GetConfiguration::new(market.clone()))
                     .await
                 {
                     Ok(config) => {
@@ -485,9 +483,7 @@ impl LiquidatorService {
                 // Step 2: Check contract version using NEP-330
                 let version_result = self
                     .client
-                    .read(contract::GetVersion {
-                        contract_id: market.clone(),
-                    })
+                    .read(contract::GetVersion::new(market.clone()))
                     .await
                     .ok()
                     .map(|result| result.version_string);

--- a/service/liquidator/src/swap/oneclick.rs
+++ b/service/liquidator/src/swap/oneclick.rs
@@ -612,9 +612,7 @@ impl OneClickSwap {
         // Query storage_balance_bounds to get minimum deposit required
         let bounds = self
             .client
-            .read(storage::GetBalanceBounds {
-                contract_id: token_contract.contract_id().into(),
-            })
+            .read(storage::GetBalanceBounds::new(token_contract.contract_id().into()))
             .await
             .map_err(|e| {
                 tracing::error!(?e, token = %token_contract.contract_id(), "Failed to query storage_balance_bounds");
@@ -779,12 +777,11 @@ impl OneClickSwap {
         // `token::Transfer` is standard-agnostic so NEP-245 collateral works too.
         let operation_result = self
             .client
-            .execute(token::Transfer {
-                token: token::TokenReference::from(from_asset),
-                receiver_id: deposit_account.clone(),
-                amount: SU128::from(amount.0),
-                memo: None,
-            })
+            .execute(token::Transfer::new(
+                token::TokenReference::from(from_asset),
+                deposit_account.clone(),
+                SU128::from(amount.0),
+            ))
             .await
             .map_err(|e| AppError::Rpc(e.into()))?;
 

--- a/service/liquidator/src/swap/ref.rs
+++ b/service/liquidator/src/swap/ref.rs
@@ -476,9 +476,7 @@ impl SwapProvider for RefSwap {
         // Query storage_balance_bounds to get minimum deposit required
         let bounds = self
             .client
-            .read(storage::GetBalanceBounds {
-                contract_id: token_contract.contract_id().into(),
-            })
+            .read(storage::GetBalanceBounds::new(token_contract.contract_id().into()))
             .await
             .map_err(|e| {
                 tracing::debug!(?e, token = %token_contract.contract_id(), "Failed to query storage_balance_bounds");

--- a/service/relayer/src/app/mod.rs
+++ b/service/relayer/src/app/mod.rs
@@ -158,11 +158,7 @@ impl App {
     /// affects the pre-flight affordability gate, never the amount charged.
     #[tracing::instrument(skip(self), fields(gas = %gas))]
     pub async fn estimate_cost_of_gas(&self, gas: Gas) -> Option<NearToken> {
-        let gas_price = match self
-            .gateway
-            .read(chain::GetBlock { block_hash: None })
-            .await
-        {
+        let gas_price = match self.gateway.read(chain::GetBlock::new()).await {
             Ok(result) => result.gas_price,
             Err(error) => {
                 tracing::error!(%error, "Failed to fetch gas price");
@@ -215,9 +211,7 @@ impl App {
                 let gateway = self.gateway.clone();
                 async move {
                     match gateway
-                        .read(market::GetConfiguration {
-                            market_id: market.clone(),
-                        })
+                        .read(market::GetConfiguration::new(market.clone()))
                         .await
                     {
                         Ok(configuration) => Some((market, configuration)),
@@ -290,9 +284,7 @@ impl App {
                         // simply never storage-deposited.
                         let storage_balance_bounds = self
                             .gateway
-                            .read(storage::GetBalanceBounds {
-                                contract_id: contract_id.clone(),
-                            })
+                            .read(storage::GetBalanceBounds::new(contract_id.clone()))
                             .await
                             .ok()
                             .map(|result| result.bounds);
@@ -340,9 +332,7 @@ impl App {
         {
             match self
                 .gateway
-                .read(market::GetConfiguration {
-                    market_id: market_id.clone(),
-                })
+                .read(market::GetConfiguration::new(market_id.clone()))
                 .await
             {
                 Ok(configuration) => {
@@ -400,9 +390,7 @@ impl App {
         for market_id in market_ids {
             let configuration = self
                 .gateway
-                .read(market::GetConfiguration {
-                    market_id: market_id.clone(),
-                })
+                .read(market::GetConfiguration::new(market_id.clone()))
                 .await?;
             let oracle_cfg = configuration.price_oracle_configuration;
             let oracle_id = oracle_cfg.account_id.clone();

--- a/service/relayer/src/route/get_market_prices.rs
+++ b/service/relayer/src/route/get_market_prices.rs
@@ -35,9 +35,7 @@ pub async fn get_market_prices(
     // so there's no relayer-side market state to go stale.
     let config = match app
         .gateway
-        .read(market::GetConfiguration {
-            market_id: market_id.clone(),
-        })
+        .read(market::GetConfiguration::new(market_id.clone()))
         .await
     {
         Ok(config) => config,

--- a/service/relayer/src/route/universal_account/create.rs
+++ b/service/relayer/src/route/universal_account/create.rs
@@ -340,14 +340,13 @@ pub async fn create(
             app.args.ua.account_id.clone(),
             gas_cost_estimate,
             NearToken::from_near(0),
-            registry::Deploy {
-                registry_id: app.args.ua.registry_id.clone(),
-                name: account_slug,
-                version_key: app.args.ua.version_key.clone(),
-                init_args: Base64Bytes(init_args),
-                full_access_keys: None,
-                deposit: NearToken::from_yoctonear(0),
-            },
+            registry::Deploy::new(
+                app.args.ua.registry_id.clone(),
+                account_slug,
+                app.args.ua.version_key.clone(),
+                Base64Bytes(init_args),
+                NearToken::from_yoctonear(0),
+            ),
         )
         .await
     {

--- a/service/relayer/src/route/universal_account/relay.rs
+++ b/service/relayer/src/route/universal_account/relay.rs
@@ -244,10 +244,7 @@ pub async fn relay(
             app.args.relay.account_id.clone(),
             cost_of_gas,
             NearToken::from_near(0),
-            ua::Execute {
-                account_id,
-                args: args_raw,
-            },
+            ua::Execute::new(account_id, args_raw),
         )
         .await
     {

--- a/tools/harvest-static-yield/src/main.rs
+++ b/tools/harvest-static-yield/src/main.rs
@@ -42,9 +42,7 @@ struct Cli {
 
 async fn market_version(client: &Client, market_id: AccountId) -> anyhow::Result<MarketVersion> {
     let version = client
-        .read(contract::GetVersion {
-            contract_id: market_id.clone(),
-        })
+        .read(contract::GetVersion::new(market_id.clone()))
         .await?;
     version
         .parsed

--- a/tools/harvest-static-yield/src/main.rs
+++ b/tools/harvest-static-yield/src/main.rs
@@ -8,7 +8,7 @@ use templar_common::asset::{BorrowAsset, BorrowAssetAmount, FungibleAsset};
 use templar_common::SU128;
 use templar_gateway_client::{Client, Network, NetworkConfigBuilder, SigningClient};
 use templar_gateway_methods_spec::{contract, market, registry, storage, token};
-use templar_gateway_types::{common::Pagination, Market, MarketVersion, NearToken};
+use templar_gateway_types::{Market, MarketVersion, NearToken};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
 #[derive(Debug, Clone, Parser)]
@@ -98,10 +98,7 @@ pub async fn main() -> anyhow::Result<()> {
     for registry in args.registry_id {
         tracing::info!(%registry, "Loading markets from registry");
         match client
-            .read(registry::ListDeployments {
-                registry_id: registry.clone(),
-                args: Pagination::default(),
-            })
+            .read(registry::ListDeployments::new(registry.clone()))
             .await
         {
             Ok(result) => markets.extend(result.account_ids),
@@ -124,9 +121,7 @@ pub async fn main() -> anyhow::Result<()> {
 
         let (version, configuration) = tokio::join!(
             market_version(&client, market_id.clone()),
-            client.read(market::GetConfiguration {
-                market_id: market_id.clone(),
-            }),
+            client.read(market::GetConfiguration::new(market_id.clone())),
         );
         let version = match version {
             Ok(version) => version,
@@ -146,16 +141,14 @@ pub async fn main() -> anyhow::Result<()> {
         let asset_contract = configuration.borrow_asset.contract_id().to_owned();
         tracing::info!(%market_id, "Checking storage requirements");
         if let Ok(bounds) = client
-            .read(storage::GetBalanceBounds {
-                contract_id: asset_contract.clone(),
-            })
+            .read(storage::GetBalanceBounds::new(asset_contract.clone()))
             .await
         {
             let balance = match client
-                .read(storage::GetBalanceOf {
-                    contract_id: asset_contract.clone(),
-                    account_id: args.account_id.clone(),
-                })
+                .read(storage::GetBalanceOf::new(
+                    asset_contract.clone(),
+                    args.account_id.clone(),
+                ))
                 .await
             {
                 Ok(result) => result.balance,
@@ -176,11 +169,11 @@ pub async fn main() -> anyhow::Result<()> {
         if version.requires_static_yield_accumulation() {
             tracing::info!(%market_id, %version, "Running static yield accumulation");
             if let Err(error) = client
-                .execute(market::AccumulateStaticYield {
-                    market_id: market_id.clone(),
-                    account_id: None,
-                    snapshot_limit: None,
-                })
+                .execute(market::AccumulateStaticYield::new(
+                    market_id.clone(),
+                    None,
+                    None,
+                ))
                 .await
             {
                 tracing::error!(%market_id, %version, %error, "Failed to run static yield accumulation");
@@ -189,10 +182,10 @@ pub async fn main() -> anyhow::Result<()> {
         }
 
         let yield_amount = match client
-            .read(market::GetStaticYield {
-                market_id: market_id.clone(),
-                account_id: args.account_id.clone(),
-            })
+            .read(market::GetStaticYield::new(
+                market_id.clone(),
+                args.account_id.clone(),
+            ))
             .await
         {
             Ok(result) => result.borrow_asset_total(),
@@ -209,10 +202,7 @@ pub async fn main() -> anyhow::Result<()> {
 
         tracing::info!(%market_id, %yield_amount, "Withdrawing yield");
         let result = match client
-            .execute(market::WithdrawStaticYield {
-                market_id: market_id.clone(),
-                amount: None,
-            })
+            .execute(market::WithdrawStaticYield::new(market_id.clone(), None))
             .await
         {
             Ok(result) => result,
@@ -248,12 +238,11 @@ pub async fn main() -> anyhow::Result<()> {
     for (asset, amount) in accumulated_assets {
         tracing::info!(%asset, %receiver_id, %amount, "Sending yield");
         match client
-            .execute(token::Transfer {
-                token: token::TokenReference::from(&asset),
-                receiver_id: receiver_id.clone(),
-                amount: SU128::from(u128::from(amount)),
-                memo: None,
-            })
+            .execute(token::Transfer::new(
+                token::TokenReference::from(&asset),
+                receiver_id.clone(),
+                SU128::from(u128::from(amount)),
+            ))
             .await
         {
             Ok(result) => {


### PR DESCRIPTION
## Summary
- Generate `MethodSpec::new(...)` constructors from the derive macro
- Add explicit `#[method(default)]` support for constructor-omitted fields
- Adopt constructors only at call sites where they improve readability and reduce LOC

## Verification
- `cargo fmt --all -- --check`
- `GIT_MASTER=1 git diff --check`
- `cargo test -p templar-gateway-macros`
- `cargo test -p templar-gateway-methods-spec -- --nocapture`
- `cargo test -p templar-gateway-oracle-updates-spec -- --nocapture`
- `cargo test -p templar-gateway-catalog`
- `cargo check --workspace`
- `cargo check -p templar-accumulator -p templar-liquidator -p templar-relayer -p harvest-static-yield`
- `cargo test -p templar-accumulator -p templar-liquidator -p templar-relayer --lib`
- `cargo test -p harvest-static-yield --bins`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/492)
<!-- Reviewable:end -->
