### PR TITLE
feat(pyth-lazer): emit granular NEP-297 events for admin/governance ops (ENG-438)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13868,6 +13868,7 @@ dependencies = [
  "near-sdk",
  "near-sdk-contract-tools",
  "pyth-lazer-protocol",
+ "rstest",
  "schemars 0.8.22",
  "templar-common",
  "templar-pyth-lazer-verifier",

--- a/contract/pyth-lazer/contract/Cargo.toml
+++ b/contract/pyth-lazer/contract/Cargo.toml
@@ -26,6 +26,7 @@ byteorder = "1"
 ed25519-dalek.workspace = true
 near-sdk = { workspace = true, features = ["non-contract-usage", "unit-testing"] }
 pyth-lazer-protocol.workspace = true
+rstest.workspace = true
 
 # fields to configure build with WASM reproducibility, according to specs
 # in https://github.com/near/NEPs/blob/master/neps/nep-0330.md

--- a/contract/pyth-lazer/contract/src/events.rs
+++ b/contract/pyth-lazer/contract/src/events.rs
@@ -1,11 +1,44 @@
-use near_sdk::near;
+use near_sdk::{near, AccountId, NearToken};
 use templar_common::oracle::lazer::FeedData;
 
-/// NEP-297 events emitted by the adapter.
+use crate::Config;
+
+/// NEP-297 events emitted by the adapter. Every owner-gated `admin_*` mutation emits one, carrying
+/// the resulting value (not an old→new diff), so configuration and governance changes leave an
+/// on-chain audit trail. Ownership transfer/renounce is not covered here — `near_sdk_contract_tools`
+/// `Owner` already emits its own NEP-297 events under the `x-own` standard.
 #[near(event_json(standard = "pyth-lazer-adapter"))]
 pub enum PythLazerEvent {
     /// Emitted after a successful `update_price_feeds`, listing the feeds that were written
     /// (by Lazer feed id) together with their new data.
     #[event_version("1.0.0")]
     UpdatePrices { updated_feeds: Vec<(u32, FeedData)> },
+
+    /// Emitted after `admin_set_config` stores a new validated `Config`.
+    #[event_version("1.0.0")]
+    ConfigSet { config: Config },
+
+    /// Emitted after `admin_set_signer` adds or refreshes a signer (`expires_at_s = Some`).
+    #[event_version("1.0.0")]
+    SignerUpserted {
+        public_key: String,
+        expires_at_s: u64,
+    },
+
+    /// Emitted after `admin_set_signer` removes a signer (`expires_at_s = None`).
+    #[event_version("1.0.0")]
+    SignerRemoved { public_key: String },
+
+    /// Emitted after `admin_withdraw` schedules a transfer to the owner.
+    #[event_version("1.0.0")]
+    Withdrawn {
+        amount: NearToken,
+        receiver: AccountId,
+    },
+
+    /// Emitted by `admin_upgrade` before it returns the atomic deploy+migrate `Promise`.
+    /// `code_hash` is the base58 sha256 of the new wasm; `migrated` is whether a migration transform
+    /// was requested (non-empty `migrate_args`).
+    #[event_version("1.0.0")]
+    Upgraded { code_hash: String, migrated: bool },
 }

--- a/contract/pyth-lazer/contract/src/lib.rs
+++ b/contract/pyth-lazer/contract/src/lib.rs
@@ -431,6 +431,10 @@ impl Contract {
         assert_one_yocto();
         Self::require_owner();
         self.config = Config::try_from(config).unwrap_or_else(|e| env::panic_str(e));
+        PythLazerEvent::ConfigSet {
+            config: self.config.clone(),
+        }
+        .emit();
     }
 
     /// Add/refresh (`expires_at_s = Some`) or remove (`expires_at_s = None`) a trusted signer.
@@ -453,6 +457,20 @@ impl Contract {
             None => self.config.signers.remove(&bytes),
         };
         result.unwrap_or_else(|e| env::panic_str(e));
+
+        // Emit only after the upsert/remove succeeds, so a rejected op (last-signer removal, size
+        // bound) emits nothing. `public_key` is normalized to canonical hex, matching `get_config`.
+        match expires_at_s {
+            Some(expires_at_s) => PythLazerEvent::SignerUpserted {
+                public_key: hex::encode(bytes),
+                expires_at_s,
+            }
+            .emit(),
+            None => PythLazerEvent::SignerRemoved {
+                public_key: hex::encode(bytes),
+            }
+            .emit(),
+        }
     }
 
     /// Withdraw `amount` of accrued fees (or any free balance) to the owner. The NEAR runtime's
@@ -463,7 +481,13 @@ impl Contract {
         assert_one_yocto();
         Self::require_owner();
         // `require_owner` guarantees the predecessor is the owner.
-        Promise::new(env::predecessor_account_id()).transfer(amount)
+        let receiver = env::predecessor_account_id();
+        PythLazerEvent::Withdrawn {
+            amount,
+            receiver: receiver.clone(),
+        }
+        .emit();
+        Promise::new(receiver).transfer(amount)
     }
 
     /// Atomically deploy new contract code and run its `migrate` in a single receipt: a failed
@@ -475,6 +499,14 @@ impl Contract {
     pub fn admin_upgrade(&mut self, code: Base64VecU8, migrate_args: Base64VecU8) -> Promise {
         assert_one_yocto();
         Self::require_owner();
+        // Emit before returning the Promise: deploy+migrate is one atomic receipt, so a failed
+        // `migrate` reverts the whole receipt — including this log. Hash (never log) the full wasm to
+        // stay within NEAR's total-log-length limit.
+        PythLazerEvent::Upgraded {
+            code_hash: near_sdk::bs58::encode(env::sha256(&code.0)).into_string(),
+            migrated: !migrate_args.0.is_empty(),
+        }
+        .emit();
         Promise::new(env::current_account_id())
             .deploy_contract(code.0)
             .function_call(

--- a/contract/pyth-lazer/contract/tests/test.rs
+++ b/contract/pyth-lazer/contract/tests/test.rs
@@ -12,9 +12,10 @@ use pyth_lazer_protocol::message::SolanaMessage;
 use pyth_lazer_protocol::payload::{PayloadData, PayloadFeedData, PayloadPropertyValue};
 use pyth_lazer_protocol::time::TimestampUs;
 use pyth_lazer_protocol::{ChannelId, Price, PriceFeedId};
+use rstest::rstest;
 use templar_common::versioned_state::MigrateExternalInterface;
 
-use templar_pyth_lazer_adapter_contract::{ConfigArgs, Contract, TrustedSigner};
+use templar_pyth_lazer_adapter_contract::{Config, ConfigArgs, Contract, TrustedSigner};
 
 const FEED_ID: u32 = 2;
 const NOW_S: u64 = 1_700_000_000;
@@ -921,4 +922,155 @@ fn verify_update_rejects_untrusted_signer() {
         100,
         1,
     )));
+}
+
+// --- NEP-297 admin events (ENG-438) ---
+//
+// Each owner-gated `admin_*` mutation emits one `pyth-lazer-adapter` event carrying the resulting
+// value. Ownership transfer/renounce is not asserted here — `near_sdk_contract_tools::Owner` already
+// emits its own events under the separate `x-own` standard.
+
+/// The single NEP-297 event emitted since the last `testing_env!` reset, with the standard/version
+/// envelope asserted. Panics unless exactly one `EVENT_JSON:` log is present.
+fn single_event() -> near_sdk::serde_json::Value {
+    let logs = near_sdk::test_utils::get_logs();
+    assert_eq!(logs.len(), 1, "expected exactly one log, got {logs:?}");
+    let json = logs[0]
+        .strip_prefix("EVENT_JSON:")
+        .expect("log must be a NEP-297 EVENT_JSON line");
+    let event: near_sdk::serde_json::Value = near_sdk::serde_json::from_str(json).unwrap();
+    assert_eq!(event["standard"], "pyth-lazer-adapter");
+    assert_eq!(event["version"], "1.0.0");
+    event
+}
+
+/// A config carrying `n` distinct signers (used to size the `ConfigSet` payload).
+fn config_with_signers(n: u8) -> ConfigArgs {
+    ConfigArgs {
+        signers: (0..n)
+            .map(|i| TrustedSigner {
+                public_key: [i; 32],
+                expires_at_s: NOW_S + 1_000_000,
+            })
+            .collect(),
+        ..config()
+    }
+}
+
+#[rstest]
+#[case(1)]
+#[case(16)]
+fn admin_set_config_emits_config_set(#[case] signers: u8) {
+    let mut contract = deploy();
+    set_owner_context();
+    contract.admin_set_config(config_with_signers(signers));
+
+    let event = single_event();
+    assert_eq!(event["event"], "config_set");
+    // The payload is the stored, validated `Config`...
+    let stored = near_sdk::serde_json::to_value(contract.get_config()).unwrap();
+    assert_eq!(event["data"]["config"], stored);
+    // ...and it round-trips back through serde to an equivalent `Config`.
+    let roundtrip: Config =
+        near_sdk::serde_json::from_value(event["data"]["config"].clone()).unwrap();
+    assert_eq!(&roundtrip, contract.get_config());
+    // The emitted log stays well within NEAR's log-length limit even with many signers.
+    assert!(near_sdk::test_utils::get_logs()[0].len() < 16_000);
+}
+
+#[test]
+fn admin_set_signer_upsert_emits_signer_upserted() {
+    let mut contract = deploy();
+    set_owner_context();
+    let key = [0xCD; 32];
+    contract.admin_set_signer(hex::encode(key), Some(NOW_S + 42));
+
+    let event = single_event();
+    assert_eq!(event["event"], "signer_upserted");
+    assert_eq!(
+        event["data"]["public_key"].as_str().unwrap(),
+        hex::encode(key)
+    );
+    assert_eq!(event["data"]["expires_at_s"], NOW_S + 42);
+}
+
+#[test]
+fn admin_set_signer_remove_emits_signer_removed() {
+    let mut contract = deploy();
+    set_owner_context();
+    // Add a second signer so removing the original isn't the (rejected) last-signer removal.
+    contract.admin_set_signer(hex::encode([0xCD; 32]), Some(NOW_S + 1));
+
+    set_owner_context(); // reset logs before the op under test
+    contract.admin_set_signer(hex::encode(signer_public_key()), None);
+
+    let event = single_event();
+    assert_eq!(event["event"], "signer_removed");
+    assert_eq!(
+        event["data"]["public_key"].as_str().unwrap(),
+        hex::encode(signer_public_key())
+    );
+}
+
+#[test]
+fn admin_withdraw_emits_withdrawn() {
+    let mut contract = deploy();
+    set_owner_context();
+    let amount = NearToken::from_yoctonear(7);
+    let _ = contract.admin_withdraw(amount);
+
+    let event = single_event();
+    assert_eq!(event["event"], "withdrawn");
+    assert_eq!(event["data"]["amount"].as_str().unwrap(), "7");
+    assert_eq!(
+        event["data"]["receiver"].as_str().unwrap(),
+        owner().as_str()
+    );
+}
+
+#[rstest]
+#[case(vec![1u8, 2, 3], true)]
+#[case(vec![], false)]
+fn admin_upgrade_emits_upgraded(#[case] migrate_args: Vec<u8>, #[case] expected_migrated: bool) {
+    let mut contract = deploy();
+    set_owner_context();
+    let code = vec![0u8, 1, 2, 3, 4];
+    let _ = contract.admin_upgrade(Base64VecU8(code.clone()), Base64VecU8(migrate_args));
+
+    let event = single_event();
+    assert_eq!(event["event"], "upgraded");
+    let expected_hash = near_sdk::bs58::encode(near_sdk::env::sha256(&code)).into_string();
+    assert_eq!(event["data"]["code_hash"].as_str().unwrap(), expected_hash);
+    assert_eq!(event["data"]["migrated"], expected_migrated);
+}
+
+#[test]
+fn rejected_last_signer_removal_emits_no_event() {
+    let mut contract = deploy();
+    set_owner_context();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        contract.admin_set_signer(hex::encode(signer_public_key()), None);
+    }));
+    assert!(result.is_err(), "removing the last signer must be rejected");
+    assert!(
+        near_sdk::test_utils::get_logs().is_empty(),
+        "a rejected op must emit no event"
+    );
+}
+
+#[test]
+fn rejected_invalid_config_emits_no_event() {
+    let mut contract = deploy();
+    set_owner_context();
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        contract.admin_set_config(ConfigArgs {
+            signers: vec![],
+            ..config()
+        });
+    }));
+    assert!(result.is_err(), "an invalid config must be rejected");
+    assert!(
+        near_sdk::test_utils::get_logs().is_empty(),
+        "a rejected op must emit no event"
+    );
 }

--- a/contract/pyth-lazer/contract/tests/test.rs
+++ b/contract/pyth-lazer/contract/tests/test.rs
@@ -935,9 +935,7 @@ fn verify_update_rejects_untrusted_signer() {
 fn single_event() -> near_sdk::serde_json::Value {
     let logs = near_sdk::test_utils::get_logs();
     assert_eq!(logs.len(), 1, "expected exactly one log, got {logs:?}");
-    let json = logs[0]
-        .strip_prefix("EVENT_JSON:")
-        .expect("log must be a NEP-297 EVENT_JSON line");
+    let json = logs[0].strip_prefix("EVENT_JSON:").unwrap();
     let event: near_sdk::serde_json::Value = near_sdk::serde_json::from_str(json).unwrap();
     assert_eq!(event["standard"], "pyth-lazer-adapter");
     assert_eq!(event["version"], "1.0.0");


### PR DESCRIPTION
## Context

The pyth-lazer adapter emitted exactly one NEP-297 event — `UpdatePrices`. Every owner-gated `admin_*` mutation was **silent**, so there was no on-chain audit trail for configuration, signer-set, withdrawal, or upgrade changes. This adds one granular event per admin mutation, carrying the **resulting value only** (new value, no old→new diff), under the existing `pyth-lazer-adapter` standard.

Closes ENG-438. Builds on ENG-437 (the Pyth Pro → Pyth Lazer rename, already merged).

## Changes

New `PythLazerEvent` variants (all `v1.0.0`, standard `pyth-lazer-adapter`), emitted at the end of each admin method on the **success path only**:

| Method | Event | Payload |
| -- | -- | -- |
| `admin_set_config` | `ConfigSet` | the stored, validated `Config` |
| `admin_set_signer` (`Some`) | `SignerUpserted` | `{ public_key, expires_at_s }` |
| `admin_set_signer` (`None`) | `SignerRemoved` | `{ public_key }` |
| `admin_withdraw` | `Withdrawn` | `{ amount, receiver }` (receiver = owner) |
| `admin_upgrade` | `Upgraded` | `{ code_hash, migrated }` |

Notes:
- `admin_set_signer` splits into upsert/remove by its existing `Some`/`None` branch, and emits **after** the `upsert`/`remove` result is `Ok` — so a rejected op (last-signer removal, size bound) emits nothing. `public_key` is normalized to canonical hex.
- `admin_upgrade` logs the **base58 sha256** of the wasm (never the full code — NEAR log-length limit), with `migrated = !migrate_args.is_empty()`. Emitted before returning the Promise; safe because deploy+migrate is one atomic receipt (a failed migrate reverts the whole receipt, including the log).

## Ownership transfer — no code needed

`near_sdk_contract_tools::Owner` v4.0.0 **already** emits its own NEP-297 events for ownership changes, under the separate `x-own` standard (`transfer`/`propose`). Adding our own would double-emit, so ownership transfer/renounce is intentionally not covered here — documented in a comment on `PythLazerEvent`.

## Tests

rstest event-assertion tests asserting `standard`/`version`/`event`/`data` for each op, the `ConfigSet` serde round-trip + log-length bound (with 16 signers), and that rejected paths (last-signer removal, invalid config) emit **zero** logs.

- `cargo fmt` ✅
- `cargo check --target wasm32-unknown-unknown -p templar-pyth-lazer-adapter-contract` ✅
- `./script/test.sh -p templar-pyth-lazer-adapter-contract` → **46 tests run: 46 passed, 0 skipped** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/497)
<!-- Reviewable:end -->
