### PR TITLE
feat(manager): tmplrmgr fail-fast & operational-correctness hardening (ENG-446)

### DIFF
--- a/script/deploy.sh
+++ b/script/deploy.sh
@@ -76,14 +76,18 @@ TMPLRMGR_GLOBAL_ARGS=(
     --network "$NETWORK"
 )
 
-# operator-signed call (governance admin / deployer)
+# operator-signed call (governance admin / deployer). Credentials are per-write
+# args sourced from SIGNER_ID/SECRET_KEY in the environment, so they no longer
+# precede the subcommand (they're structural on each write command now).
 operator() {
-    tmplrmgr "${TMPLRMGR_GLOBAL_ARGS[@]}" --signer-id "$SIGNER_ID" --secret-key "$SECRET_KEY" "$@"
+    SIGNER_ID="$SIGNER_ID" SECRET_KEY="$SECRET_KEY" \
+        tmplrmgr "${TMPLRMGR_GLOBAL_ARGS[@]}" "$@"
 }
 
 # registry-signed call (initial oracle owner)
 registry() {
-    tmplrmgr "${TMPLRMGR_GLOBAL_ARGS[@]}" --signer-id "$REGISTRY_ID" --secret-key "$REGISTRY_SECRET_KEY" "$@"
+    SIGNER_ID="$REGISTRY_ID" SECRET_KEY="$REGISTRY_SECRET_KEY" \
+        tmplrmgr "${TMPLRMGR_GLOBAL_ARGS[@]}" "$@"
 }
 
 echo "Deploying proxy oracle ($PROXY_ORACLE_ID)..."
@@ -91,6 +95,7 @@ operator registry deploy \
     --registry-id "$REGISTRY_ID" \
     --name "$PROXY_ORACLE_NAME" \
     --version-key "$PROXY_ORACLE_VERSION_KEY" \
+    --init-args null \
     --deposit "3.5 NEAR"
 
 echo "Deploying governance ($GOVERNANCE_ID)..."

--- a/tools/manager/src/cli.rs
+++ b/tools/manager/src/cli.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
 use clap::{ArgAction, Parser, Subcommand};
-use near_account_id::AccountId;
 use templar_gateway_client::Network;
 use tracing::level_filters::LevelFilter;
 
+use super::commands::signer::SignerArgs;
 use super::commands::{
     AccountNs, ContractNs, FtNs, MarketNs, ProxyOracleGovernanceNs, ProxyOracleNs,
     ProxyOracleOwnerNs, RecoverNep141, RedstoneNs, RegistryNs, StorageNs,
@@ -46,18 +46,6 @@ pub struct Cli {
         value_name = "KEY"
     )]
     pub rpc_api_key: Option<String>,
-    /// Account that signs write transactions (required by every write command).
-    #[arg(long, global = true, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
-    pub signer_id: Option<AccountId>,
-    /// Private key for `--signer-id`, in `ed25519:…` form.
-    #[arg(
-        long,
-        global = true,
-        env = "SECRET_KEY",
-        hide_env_values = true,
-        value_name = "SECRET_KEY"
-    )]
-    pub secret_key: Option<String>,
     /// Base URL for transaction explorer links (the tx hash is appended).
     /// Defaults to the Nearblocks explorer for the selected network.
     #[arg(long, global = true, value_name = "URL")]
@@ -160,7 +148,7 @@ pub enum Command {
     /// Invoke a gateway read method by its full RPC name with raw JSON params.
     Read(GenericMethodCall),
     /// Invoke a gateway write method by its full RPC name with raw JSON params.
-    Write(GenericMethodCall),
+    Write(WriteMethodCall),
 }
 
 #[derive(clap::Args, Debug)]
@@ -174,4 +162,15 @@ pub struct GenericMethodCall {
     /// Method params read from a JSON file.
     #[arg(long, value_name = "PATH")]
     pub json_file: Option<PathBuf>,
+}
+
+/// A generic write invocation: the method call plus the signer credentials it
+/// requires. Reads flatten only [`GenericMethodCall`], so credentials are an
+/// unexpected argument there.
+#[derive(clap::Args, Debug)]
+pub struct WriteMethodCall {
+    #[command(flatten)]
+    pub call: GenericMethodCall,
+    #[command(flatten)]
+    pub signer: SignerArgs,
 }

--- a/tools/manager/src/commands/account/delete.rs
+++ b/tools/manager/src/commands/account/delete.rs
@@ -2,11 +2,15 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::account as spec;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct Delete {
     /// Account to receive the deleted account's remaining balance.
     #[arg(long, value_name = "ACCOUNT_ID")]
     beneficiary_id: AccountId,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Delete {

--- a/tools/manager/src/commands/deploy_common.rs
+++ b/tools/manager/src/commands/deploy_common.rs
@@ -1,10 +1,9 @@
 use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::registry as spec;
-use templar_gateway_types::{Base64Bytes, NearToken};
+use templar_gateway_types::{primitive::PublicKey, Base64Bytes, NearToken};
 
 use crate::commands::full_access_key::FullAccessKeyArgs;
-use crate::context::CliContext;
 
 /// Flags shared by every "deploy a registered version to a new sub-account"
 /// command. Flatten this alongside the command's init-args-specific flags, then
@@ -29,17 +28,17 @@ pub struct DeployCommonArgs {
 
 impl DeployCommonArgs {
     /// Build the registry deploy spec from these shared flags and the caller's
-    /// init-args bytes, granting the operator's full access keys (resolved via
-    /// `ctx`) so it retains control of the new account.
-    pub fn into_deploy(self, ctx: &CliContext, init_args: Vec<u8>) -> anyhow::Result<spec::Deploy> {
-        let full_access_keys = self.full_access_keys.resolve(ctx)?;
-        Ok(spec::Deploy {
+    /// init-args bytes, granting the operator's full access keys (the signer's
+    /// `signer_public_key` by default) so it retains control of the new account.
+    pub fn into_deploy(self, signer_public_key: PublicKey, init_args: Vec<u8>) -> spec::Deploy {
+        let full_access_keys = self.full_access_keys.resolve(signer_public_key);
+        spec::Deploy {
             registry_id: self.registry_id,
             name: self.name,
             version_key: self.version_key,
             init_args: Base64Bytes(init_args),
             full_access_keys: Some(full_access_keys),
             deposit: self.deposit,
-        })
+        }
     }
 }

--- a/tools/manager/src/commands/ft/transfer.rs
+++ b/tools/manager/src/commands/ft/transfer.rs
@@ -3,6 +3,8 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::ft as spec;
 use templar_primitives::SU128;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct Transfer {
     /// Token contract to transfer from.
@@ -17,6 +19,8 @@ pub struct Transfer {
     /// Optional memo attached to the transfer.
     #[arg(long, value_name = "TEXT")]
     memo: Option<String>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Transfer {

--- a/tools/manager/src/commands/ft/transfer_call.rs
+++ b/tools/manager/src/commands/ft/transfer_call.rs
@@ -3,6 +3,8 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::ft as spec;
 use templar_primitives::SU128;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct TransferCall {
     /// Token contract to transfer from.
@@ -20,6 +22,8 @@ pub struct TransferCall {
     /// Optional memo attached to the transfer.
     #[arg(long, value_name = "TEXT")]
     memo: Option<String>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl TransferCall {

--- a/tools/manager/src/commands/full_access_key.rs
+++ b/tools/manager/src/commands/full_access_key.rs
@@ -2,8 +2,6 @@ use clap::Args;
 use near_api::PublicKey as CliPublicKey;
 use templar_gateway_types::primitive::PublicKey;
 
-use crate::context::CliContext;
-
 /// The shared full-access-key options for from-registry create/deploy commands,
 /// flattened into each so every new account is provisioned the same way: the
 /// signer's key is granted by default (so the operator retains control), plus any
@@ -19,12 +17,12 @@ pub struct FullAccessKeyArgs {
 }
 
 impl FullAccessKeyArgs {
-    /// Resolve the keys granted to the new account: the signer's key by default
+    /// Resolve the keys granted to the new account: `signer_public_key` by default
     /// (unless suppressed), plus the explicit extras, de-duplicated.
-    pub fn resolve(&self, ctx: &CliContext) -> anyhow::Result<Vec<PublicKey>> {
+    pub fn resolve(&self, signer_public_key: PublicKey) -> Vec<PublicKey> {
         let mut keys = Vec::with_capacity(self.with_full_access_key.len() + 1);
         if !self.no_signer_full_access_key {
-            keys.push(ctx.signer_public_key()?);
+            keys.push(signer_public_key);
         }
         for key in &self.with_full_access_key {
             let key = PublicKey::from(*key);
@@ -32,7 +30,7 @@ impl FullAccessKeyArgs {
                 keys.push(key);
             }
         }
-        Ok(keys)
+        keys
     }
 }
 
@@ -41,6 +39,13 @@ mod tests {
     use super::*;
 
     const KEY_B: &str = "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w";
+    // A throwaway ed25519 secret; only its public half is used.
+    const SIGNER_SECRET: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
+
+    fn signer_key() -> PublicKey {
+        let secret: near_api::SecretKey = SIGNER_SECRET.parse().expect("valid signer secret");
+        PublicKey::from(secret.public_key())
+    }
 
     fn args(no_signer: bool, extra: &[&str]) -> FullAccessKeyArgs {
         FullAccessKeyArgs {
@@ -56,29 +61,24 @@ mod tests {
     fn grants_signer_key_by_default() {
         // The signer's key is granted on every deploy — the operator must retain
         // control of the new account.
-        let ctx = CliContext::for_test();
-        let signer = ctx.signer_public_key().expect("test signer");
-        assert_eq!(args(false, &[]).resolve(&ctx).unwrap(), vec![signer]);
+        let signer = signer_key();
+        assert_eq!(args(false, &[]).resolve(signer.clone()), vec![signer]);
     }
 
     #[test]
     fn no_signer_flag_drops_signer_key() {
-        let ctx = CliContext::for_test();
-        assert!(args(true, &[]).resolve(&ctx).unwrap().is_empty());
+        assert!(args(true, &[]).resolve(signer_key()).is_empty());
         // With extras and --no-signer, only the extras are granted.
         let key_b = PublicKey::from(KEY_B.parse::<CliPublicKey>().unwrap());
-        assert_eq!(args(true, &[KEY_B]).resolve(&ctx).unwrap(), vec![key_b]);
+        assert_eq!(args(true, &[KEY_B]).resolve(signer_key()), vec![key_b]);
     }
 
     #[test]
     fn appends_and_dedups_extra_keys() {
-        let ctx = CliContext::for_test();
-        let signer = ctx.signer_public_key().expect("test signer");
+        let signer = signer_key();
         let signer_str = signer.0.to_string();
         // Extras that repeat the signer key or each other are dropped.
-        let keys = args(false, &[&signer_str, KEY_B, KEY_B])
-            .resolve(&ctx)
-            .unwrap();
+        let keys = args(false, &[&signer_str, KEY_B, KEY_B]).resolve(signer.clone());
         let key_b = PublicKey::from(KEY_B.parse::<CliPublicKey>().unwrap());
         assert_eq!(keys, vec![signer, key_b]);
     }

--- a/tools/manager/src/commands/market/create.rs
+++ b/tools/manager/src/commands/market/create.rs
@@ -7,7 +7,7 @@ use templar_gateway_methods_spec::market as spec;
 use templar_gateway_types::NearToken;
 
 use crate::commands::full_access_key::FullAccessKeyArgs;
-use crate::context::CliContext;
+use crate::commands::signer::SignerArgs;
 
 /// Deploy a market from a registered version, granting the signer a full access
 /// key so the operator retains control of the new account.
@@ -30,6 +30,8 @@ pub struct Create {
     /// Deposit funding the new account's storage and balance.
     #[arg(long, value_name = "AMOUNT")]
     deposit: NearToken,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 #[derive(Deserialize)]
@@ -39,8 +41,8 @@ struct MarketInitArgs {
 }
 
 impl Create {
-    pub fn try_into_spec(self, ctx: &CliContext) -> anyhow::Result<spec::Create> {
-        let full_access_keys = self.full_access_keys.resolve(ctx)?;
+    pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
+        let full_access_keys = self.full_access_keys.resolve(self.signer.public_key()?);
         let file = std::fs::File::open(&self.init_args_file).with_context(|| {
             format!(
                 "open market init args from {}",

--- a/tools/manager/src/commands/market/remove.rs
+++ b/tools/manager/src/commands/market/remove.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 use near_account_id::AccountId;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct Remove {
     /// Recovered assets and the remaining balance are sent here.
@@ -10,6 +12,8 @@ pub struct Remove {
     /// asset fails.
     #[arg(long)]
     force: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Remove {

--- a/tools/manager/src/commands/market/remove.rs
+++ b/tools/manager/src/commands/market/remove.rs
@@ -12,6 +12,9 @@ pub struct Remove {
     /// asset fails.
     #[arg(long)]
     force: bool,
+    /// Credentials for the market account being removed — `market remove` is
+    /// self-signed, so the signer both authorizes the teardown and identifies the
+    /// target account (there is no separate market-id flag).
     #[command(flatten)]
     pub(crate) signer: SignerArgs,
 }

--- a/tools/manager/src/commands/mod.rs
+++ b/tools/manager/src/commands/mod.rs
@@ -12,6 +12,7 @@ pub mod proxy_oracle_owner;
 pub mod recover;
 pub mod redstone;
 pub mod registry;
+pub mod signer;
 pub mod storage;
 
 pub use account::AccountNs;

--- a/tools/manager/src/commands/proxy_oracle/update_prices.rs
+++ b/tools/manager/src/commands/proxy_oracle/update_prices.rs
@@ -4,6 +4,7 @@ use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use super::parse_price_identifier;
+use crate::commands::signer::SignerArgs;
 
 #[derive(Args, Debug)]
 pub struct UpdatePrices {
@@ -13,6 +14,8 @@ pub struct UpdatePrices {
     /// Price identifier (32-byte hex) to refresh; repeat the flag per feed.
     #[arg(long = "price-id", value_name = "HEX", value_parser = parse_price_identifier, required = true)]
     price_ids: Vec<PriceIdentifier>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl UpdatePrices {

--- a/tools/manager/src/commands/proxy_oracle_governance/create.rs
+++ b/tools/manager/src/commands/proxy_oracle_governance/create.rs
@@ -10,7 +10,7 @@ use templar_proxy_oracle_near_governance_common::TtlConfig;
 use super::{load_json_file, uniform_ttls};
 use crate::commands::deploy_common::DeployCommonArgs;
 use crate::commands::duration::parse_duration;
-use crate::context::CliContext;
+use crate::commands::signer::SignerArgs;
 
 /// Create (deploy-from-registry) a governance contract, building its
 /// `new(proxy_oracle_id, admin_id, ttls)` init args from typed flags.
@@ -34,6 +34,8 @@ pub struct GovernanceCreate {
     /// Full TtlConfig JSON, overriding --ttl-default with per-operation TTLs
     #[arg(long, value_name = "PATH")]
     ttls_file: Option<PathBuf>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 /// Init args for the governance contract's `new(proxy_oracle_id, admin_id, ttls)`.
@@ -45,7 +47,8 @@ struct GovernanceInit {
 }
 
 impl GovernanceCreate {
-    pub fn try_into_spec(self, ctx: &CliContext) -> anyhow::Result<registry_spec::Deploy> {
+    pub fn try_into_spec(self) -> anyhow::Result<registry_spec::Deploy> {
+        let signer_public_key = self.signer.public_key()?;
         let ttls = match self.ttls_file {
             Some(path) => load_json_file(&path).context("parse TtlConfig")?,
             None => uniform_ttls(self.ttl_default),
@@ -58,6 +61,6 @@ impl GovernanceCreate {
         };
         let init_args = serde_json::to_vec(&init).context("encode governance init args")?;
 
-        self.common.into_deploy(ctx, init_args)
+        Ok(self.common.into_deploy(signer_public_key, init_args))
     }
 }

--- a/tools/manager/src/commands/proxy_oracle_governance/create_proposal.rs
+++ b/tools/manager/src/commands/proxy_oracle_governance/create_proposal.rs
@@ -19,6 +19,7 @@ use templar_proxy_oracle_near_governance_common::Operation;
 use super::{decode_base64, load_json_file, OperationKind, Role};
 use crate::commands::duration::parse_duration;
 use crate::commands::proxy_oracle::parse_price_identifier;
+use crate::commands::signer::SignerArgs;
 use crate::proxy::load_proxy_file;
 
 #[derive(Args, Debug)]
@@ -36,6 +37,8 @@ pub struct CreateProposal {
     /// Blocks for the full (effective) TTL, so it is only practical for short ones.
     #[arg(long)]
     execute_when_ready: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
     #[command(subcommand)]
     operation: ProposalOperation,
 }

--- a/tools/manager/src/commands/proxy_oracle_governance/execute_proposal.rs
+++ b/tools/manager/src/commands/proxy_oracle_governance/execute_proposal.rs
@@ -2,6 +2,8 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct ExecuteProposalArgs {
     /// Governance contract account.
@@ -14,6 +16,8 @@ pub struct ExecuteProposalArgs {
     /// failing if it has not yet matured.
     #[arg(long)]
     when_ready: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl ExecuteProposalArgs {

--- a/tools/manager/src/commands/proxy_oracle_governance/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle_governance/mod.rs
@@ -28,6 +28,8 @@ use templar_proxy_oracle_near_governance_common::TtlConfig;
 // (derived upstream behind the crate's `clap` feature), avoiding a local mirror.
 pub use templar_proxy_oracle_near_governance_common::{OperationKind, Role};
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Subcommand, Debug)]
 #[command(rename_all = "kebab-case")]
 pub enum ProxyOracleGovernanceNs {
@@ -36,7 +38,7 @@ pub enum ProxyOracleGovernanceNs {
     /// Create a governance proposal.
     CreateProposal(CreateProposal),
     /// Cancel a pending proposal.
-    CancelProposal(ProposalRef),
+    CancelProposal(CancelProposal),
     /// Execute a matured proposal.
     ExecuteProposal(ExecuteProposalArgs),
     /// Read a single proposal.
@@ -72,16 +74,30 @@ pub struct ProposalRef {
 }
 
 impl ProposalRef {
-    pub fn cancel(self) -> spec::CancelProposal {
-        spec::CancelProposal {
-            governance_id: self.governance_id,
-            id: self.id,
-        }
-    }
     pub fn get(self) -> spec::GetProposal {
         spec::GetProposal {
             governance_id: self.governance_id,
             id: self.id,
+        }
+    }
+}
+
+/// `cancel-proposal`: a proposal reference plus the signer credentials the write
+/// requires. Distinct from the read-only `get-proposal`, which reuses the bare
+/// [`ProposalRef`] and so carries no credentials.
+#[derive(Args, Debug)]
+pub struct CancelProposal {
+    #[command(flatten)]
+    proposal: ProposalRef,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
+}
+
+impl CancelProposal {
+    pub fn cancel(self) -> spec::CancelProposal {
+        spec::CancelProposal {
+            governance_id: self.proposal.governance_id,
+            id: self.proposal.id,
         }
     }
 }

--- a/tools/manager/src/commands/proxy_oracle_owner/accept_owner.rs
+++ b/tools/manager/src/commands/proxy_oracle_owner/accept_owner.rs
@@ -2,12 +2,16 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_owner as spec;
 
+use crate::commands::signer::SignerArgs;
+
 /// Accept a pending ownership transfer of a proxy-oracle account.
 #[derive(Args, Debug)]
 pub struct AcceptOwner {
     /// Proxy-oracle account.
     #[arg(long, value_name = "ACCOUNT_ID")]
     oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl AcceptOwner {

--- a/tools/manager/src/commands/proxy_oracle_owner/propose_owner.rs
+++ b/tools/manager/src/commands/proxy_oracle_owner/propose_owner.rs
@@ -2,6 +2,8 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_owner as spec;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct ProposeOwner {
     /// Proxy-oracle account.
@@ -10,6 +12,8 @@ pub struct ProposeOwner {
     /// Account to propose as the new owner (omit to clear any pending proposal).
     #[arg(long, value_name = "ACCOUNT_ID")]
     account_id: Option<AccountId>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl ProposeOwner {

--- a/tools/manager/src/commands/proxy_oracle_owner/renounce_owner.rs
+++ b/tools/manager/src/commands/proxy_oracle_owner/renounce_owner.rs
@@ -2,12 +2,16 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_owner as spec;
 
+use crate::commands::signer::SignerArgs;
+
 /// Renounce ownership of a proxy-oracle account.
 #[derive(Args, Debug)]
 pub struct RenounceOwner {
     /// Proxy-oracle account.
     #[arg(long, value_name = "ACCOUNT_ID")]
     oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl RenounceOwner {

--- a/tools/manager/src/commands/recover.rs
+++ b/tools/manager/src/commands/recover.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 use near_account_id::AccountId;
 
+use crate::commands::signer::SignerArgs;
+
 /// Recover a NEP-141 balance from the signer account to a beneficiary, then
 /// unregister the signer's storage. The signer is both the source of the tokens
 /// and the account whose storage is unregistered.
@@ -15,4 +17,6 @@ pub struct RecoverNep141 {
     /// Forwarded to `storage_unregister(force = …)`; only affects unregistration.
     #[arg(long)]
     pub force: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }

--- a/tools/manager/src/commands/redstone/create.rs
+++ b/tools/manager/src/commands/redstone/create.rs
@@ -7,7 +7,7 @@ use templar_common::oracle::redstone::config;
 use templar_gateway_methods_spec::registry as registry_spec;
 
 use crate::commands::deploy_common::DeployCommonArgs;
-use crate::context::CliContext;
+use crate::commands::signer::SignerArgs;
 
 /// Deploy a RedStone price adapter from a registered version, granting the
 /// signer a full access key so the operator retains control of the new account.
@@ -33,10 +33,13 @@ pub struct Create {
     /// Path to a full init args JSON file.
     #[arg(long, value_name = "PATH")]
     init_args_file: Option<PathBuf>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Create {
-    pub fn try_into_spec(self, ctx: &CliContext) -> anyhow::Result<registry_spec::Deploy> {
+    pub fn try_into_spec(self) -> anyhow::Result<registry_spec::Deploy> {
+        let signer_public_key = self.signer.public_key()?;
         let init_bytes = if self.prod {
             serde_json::to_vec(&json!({ "config": config::prod() }))
                 .context("serialize prod config")?
@@ -52,6 +55,6 @@ impl Create {
             anyhow::bail!("provide --prod, --test, --init-args, or --init-args-file");
         };
 
-        self.common.into_deploy(ctx, init_bytes)
+        Ok(self.common.into_deploy(signer_public_key, init_bytes))
     }
 }

--- a/tools/manager/src/commands/redstone/set_role.rs
+++ b/tools/manager/src/commands/redstone/set_role.rs
@@ -3,6 +3,7 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::redstone as spec;
 
 use super::RoleArg;
+use crate::commands::signer::SignerArgs;
 
 #[derive(Args, Debug)]
 pub struct SetRole {
@@ -18,6 +19,8 @@ pub struct SetRole {
     /// Revoke the role instead of granting it.
     #[arg(long)]
     revoke: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl SetRole {

--- a/tools/manager/src/commands/redstone/update_prices.rs
+++ b/tools/manager/src/commands/redstone/update_prices.rs
@@ -6,6 +6,8 @@ use templar_common::oracle::redstone::FeedId;
 use templar_gateway_methods_spec::redstone as spec;
 use templar_gateway_types::Base64Bytes;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct UpdatePrices {
     /// RedStone adapter account to update.
@@ -22,6 +24,8 @@ pub struct UpdatePrices {
         value_name = "PATH"
     )]
     node_path: PathBuf,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl UpdatePrices {

--- a/tools/manager/src/commands/redstone/write_prices.rs
+++ b/tools/manager/src/commands/redstone/write_prices.rs
@@ -8,6 +8,8 @@ use templar_common::oracle::redstone::FeedId;
 use templar_gateway_methods_spec::redstone as spec;
 use templar_gateway_types::Base64Bytes;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 #[command(group(
     clap::ArgGroup::new("payload").args(["payload_base64", "payload_base64_file"]).required(true)
@@ -25,6 +27,8 @@ pub struct WritePrices {
     /// Path to a file containing a base64-encoded RedStone payload.
     #[arg(long, value_name = "PATH")]
     payload_base64_file: Option<PathBuf>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl WritePrices {

--- a/tools/manager/src/commands/registry/add_version.rs
+++ b/tools/manager/src/commands/registry/add_version.rs
@@ -9,6 +9,8 @@ use templar_gateway_methods_spec::registry as spec;
 use templar_gateway_types::{Base64Bytes, NearToken};
 use templar_tools_common::build::{build_contract, load_contract, LoadedContract};
 
+use crate::commands::signer::SignerArgs;
+
 /// Rough NEAR-per-byte storage staking rate used to size a global-hash upload
 /// (matches the registry contract's own accounting).
 const STORAGE_AMOUNT_PER_BYTE: NearToken = NearToken::from_yoctonear(10_000_000_000_000_000_000);
@@ -154,6 +156,8 @@ pub struct AddVersion {
     /// Deposit in NEAR. Estimated from the WASM size and deploy mode when omitted.
     #[arg(long, value_name = "AMOUNT")]
     deposit: Option<NearToken>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl AddVersion {

--- a/tools/manager/src/commands/registry/add_version.rs
+++ b/tools/manager/src/commands/registry/add_version.rs
@@ -33,53 +33,59 @@ impl From<DeployModeArg> for DeployMode {
     }
 }
 
+/// The known NEAR contracts, as shorthand values for `--contract`. Each maps to
+/// an `ArtifactId` under `contract/*`, collapsing what used to be one boolean
+/// flag per contract into a single validated value.
+#[derive(Clone, Copy, Debug, ValueEnum)]
+enum ContractArg {
+    Registry,
+    Market,
+    Vault,
+    /// `uac` is kept as a legacy alias for the old shorthand flag.
+    #[value(alias = "uac")]
+    UniversalAccount,
+    ProxyOracle,
+    ProxyOracleGovernance,
+    LstOracle,
+    RedstoneAdapter,
+    PythLazerAdapter,
+}
+
+impl From<ContractArg> for ArtifactId {
+    fn from(contract: ContractArg) -> Self {
+        match contract {
+            ContractArg::Registry => Self::Registry,
+            ContractArg::Market => Self::Market,
+            ContractArg::Vault => Self::Vault,
+            ContractArg::UniversalAccount => Self::UniversalAccount,
+            ContractArg::ProxyOracle => Self::ProxyOracle,
+            ContractArg::ProxyOracleGovernance => Self::ProxyGovernance,
+            ContractArg::LstOracle => Self::LstOracle,
+            ContractArg::RedstoneAdapter => Self::RedstoneAdapter,
+            ContractArg::PythLazerAdapter => Self::PythLazerAdapter,
+        }
+    }
+}
+
 /// Where the WASM to register comes from, and how to identify it.
 ///
-/// Exactly one contract selector is required: a shortcut flag (one per NEAR
-/// contract under `contract/*`), `--package` (a Cargo package name or artifact
-/// ID), or `--wasm` (an explicit file). The shortcut/`--package` modes resolve
-/// a workspace package and, by default, build it reproducibly (`--no-build`
+/// Exactly one contract selector is required: `--contract <CONTRACT>` (a known
+/// NEAR contract), `--package` (a Cargo package name or artifact ID), or
+/// `--wasm` (an explicit file). The `--contract`/`--package` modes resolve a
+/// workspace package and, by default, build it reproducibly (`--no-build`
 /// uploads the last `target/near` build instead); `--wasm` uploads arbitrary
 /// bytes and so requires `--version-key`.
-#[allow(clippy::struct_excessive_bools)] // one bool per contract shortcut flag
 #[derive(Args, Debug)]
 #[command(group(
     ArgGroup::new("contract_source")
-        .args([
-            "registry", "market", "vault", "uac", "proxy_oracle", "proxy_governance",
-            "lst_oracle", "redstone_adapter", "pyth_lazer_adapter", "package", "wasm",
-        ])
+        .args(["contract", "package", "wasm"])
         .required(true)
         .multiple(false)
 ))]
 pub struct ContractSource {
-    /// Registry contract
-    #[arg(long)]
-    registry: bool,
-    /// Market contract
-    #[arg(long)]
-    market: bool,
-    /// Vault contract
-    #[arg(long)]
-    vault: bool,
-    /// Universal account contract
-    #[arg(long)]
-    uac: bool,
-    /// Proxy oracle contract
-    #[arg(long)]
-    proxy_oracle: bool,
-    /// Proxy oracle governance contract
-    #[arg(long)]
-    proxy_governance: bool,
-    /// LST oracle contract
-    #[arg(long)]
-    lst_oracle: bool,
-    /// RedStone adapter contract
-    #[arg(long)]
-    redstone_adapter: bool,
-    /// Pyth Lazer adapter contract
-    #[arg(long)]
-    pyth_lazer_adapter: bool,
+    /// Known NEAR contract to build and register.
+    #[arg(long, value_enum, value_name = "CONTRACT")]
+    contract: Option<ContractArg>,
     /// Contract by Cargo package name or artifact ID (e.g. `market`)
     #[arg(long, visible_alias = "artifact", value_name = "NAME")]
     package: Option<String>,
@@ -96,20 +102,9 @@ pub struct ContractSource {
 
 impl ContractSource {
     fn artifact(&self) -> Option<ArtifactId> {
-        [
-            (self.registry, ArtifactId::Registry),
-            (self.market, ArtifactId::Market),
-            (self.vault, ArtifactId::Vault),
-            (self.uac, ArtifactId::UniversalAccount),
-            (self.proxy_oracle, ArtifactId::ProxyOracle),
-            (self.proxy_governance, ArtifactId::ProxyGovernance),
-            (self.lst_oracle, ArtifactId::LstOracle),
-            (self.redstone_adapter, ArtifactId::RedstoneAdapter),
-            (self.pyth_lazer_adapter, ArtifactId::PythLazerAdapter),
-        ]
-        .into_iter()
-        .find_map(|(selected, id)| selected.then_some(id))
-        .or_else(|| self.package.as_deref().and_then(|p| p.parse().ok()))
+        self.contract
+            .map(ArtifactId::from)
+            .or_else(|| self.package.as_deref().and_then(|p| p.parse().ok()))
     }
 
     /// Resolve the bytes to upload and, when derivable, the canonical version
@@ -150,8 +145,8 @@ pub struct AddVersion {
     /// when omitted; required with --wasm.
     #[arg(long, value_name = "KEY")]
     version_key: Option<String>,
-    /// Deployment mode
-    #[arg(long, value_enum, default_value = "normal")]
+    /// Deployment mode (choose explicitly).
+    #[arg(long, value_enum)]
     deploy_mode: DeployModeArg,
     /// Deposit in NEAR. Estimated from the WASM size and deploy mode when omitted.
     #[arg(long, value_name = "AMOUNT")]
@@ -202,51 +197,63 @@ mod tests {
         source: ContractSource,
     }
 
-    fn source_for(flag: &str) -> ContractSource {
-        Harness::try_parse_from(["tmplrmgr", flag])
-            .expect("shortcut flag should parse")
+    fn source_for(value: &str) -> ContractSource {
+        Harness::try_parse_from(["tmplrmgr", "--contract", value])
+            .expect("--contract value should parse")
             .source
     }
 
     #[test]
-    fn each_contract_shortcut_maps_to_its_artifact() {
+    fn each_contract_value_maps_to_its_artifact() {
         let cases = [
-            ("--registry", ArtifactId::Registry),
-            ("--market", ArtifactId::Market),
-            ("--vault", ArtifactId::Vault),
-            ("--uac", ArtifactId::UniversalAccount),
-            ("--proxy-oracle", ArtifactId::ProxyOracle),
-            ("--proxy-governance", ArtifactId::ProxyGovernance),
-            ("--lst-oracle", ArtifactId::LstOracle),
-            ("--redstone-adapter", ArtifactId::RedstoneAdapter),
-            ("--pyth-lazer-adapter", ArtifactId::PythLazerAdapter),
+            ("registry", ArtifactId::Registry),
+            ("market", ArtifactId::Market),
+            ("vault", ArtifactId::Vault),
+            ("universal-account", ArtifactId::UniversalAccount),
+            ("proxy-oracle", ArtifactId::ProxyOracle),
+            ("proxy-oracle-governance", ArtifactId::ProxyGovernance),
+            ("lst-oracle", ArtifactId::LstOracle),
+            ("redstone-adapter", ArtifactId::RedstoneAdapter),
+            ("pyth-lazer-adapter", ArtifactId::PythLazerAdapter),
         ];
-        for (flag, expected) in cases {
-            assert_eq!(source_for(flag).artifact(), Some(expected), "flag {flag}");
+        for (value, expected) in cases {
+            assert_eq!(
+                source_for(value).artifact(),
+                Some(expected),
+                "value {value}"
+            );
         }
     }
 
-    /// Guard: every NEAR contract under `contract/*` must have a shortcut, so a
-    /// newly-added contract can't silently ship without one.
     #[test]
-    fn every_contract_artifact_has_a_shortcut() {
+    fn uac_is_a_legacy_alias_for_universal_account() {
+        assert_eq!(
+            source_for("uac").artifact(),
+            Some(ArtifactId::UniversalAccount)
+        );
+    }
+
+    /// Guard: every NEAR contract under `contract/*` must have a `--contract`
+    /// value, so a newly-added contract can't silently ship without one.
+    #[test]
+    fn every_contract_artifact_has_a_value() {
         for id in ArtifactId::ALL {
             if id.metadata().source_path.starts_with("contract/") {
-                let flag = match id {
-                    ArtifactId::Registry => "--registry",
-                    ArtifactId::Market => "--market",
-                    ArtifactId::Vault => "--vault",
-                    ArtifactId::UniversalAccount => "--uac",
-                    ArtifactId::ProxyOracle => "--proxy-oracle",
-                    ArtifactId::ProxyGovernance => "--proxy-governance",
-                    ArtifactId::LstOracle => "--lst-oracle",
-                    ArtifactId::RedstoneAdapter => "--redstone-adapter",
-                    ArtifactId::PythLazerAdapter => "--pyth-lazer-adapter",
+                let value = match id {
+                    ArtifactId::Registry => "registry",
+                    ArtifactId::Market => "market",
+                    ArtifactId::Vault => "vault",
+                    ArtifactId::UniversalAccount => "universal-account",
+                    ArtifactId::ProxyOracle => "proxy-oracle",
+                    ArtifactId::ProxyGovernance => "proxy-oracle-governance",
+                    ArtifactId::LstOracle => "lst-oracle",
+                    ArtifactId::RedstoneAdapter => "redstone-adapter",
+                    ArtifactId::PythLazerAdapter => "pyth-lazer-adapter",
                     other => {
-                        panic!("{other:?} lives under contract/* but has no add-version shortcut")
+                        panic!("{other:?} lives under contract/* but has no --contract value")
                     }
                 };
-                assert_eq!(source_for(flag).artifact(), Some(id));
+                assert_eq!(source_for(value).artifact(), Some(id));
             }
         }
     }

--- a/tools/manager/src/commands/registry/clear_deployments.rs
+++ b/tools/manager/src/commands/registry/clear_deployments.rs
@@ -1,6 +1,8 @@
 use clap::Args;
 use near_account_id::AccountId;
 
+use crate::commands::signer::SecretKeyArgs;
+
 #[derive(Args, Debug)]
 pub struct ClearDeployments {
     /// Registry whose deployments to clear.
@@ -12,6 +14,8 @@ pub struct ClearDeployments {
     /// Continue past a market that fails to remove instead of stopping.
     #[arg(long)]
     force: bool,
+    #[command(flatten)]
+    pub(crate) signer: SecretKeyArgs,
 }
 
 impl ClearDeployments {

--- a/tools/manager/src/commands/registry/deploy.rs
+++ b/tools/manager/src/commands/registry/deploy.rs
@@ -1,28 +1,51 @@
 use anyhow::Context as _;
-use clap::Args;
+use clap::{ArgGroup, Args};
 use templar_gateway_methods_spec::registry as spec;
 
 use crate::commands::deploy_common::DeployCommonArgs;
-use crate::context::CliContext;
+use crate::commands::signer::SignerArgs;
 
 /// Deploy an already-registered contract version to a new account, granting full
 /// access keys (the signer's by default) so the operator retains control.
+///
+/// Init args must be given explicitly — inline `--init-args` or `--init-args-file`,
+/// exactly one — so a no-arg-init contract has to state its intent with
+/// `--init-args null` rather than falling back to it silently.
 #[derive(Args, Debug)]
+#[command(group(
+    ArgGroup::new("init")
+        .args(["init_args", "init_args_file"])
+        .required(true)
+        .multiple(false)
+))]
 pub struct Deploy {
     #[command(flatten)]
     common: DeployCommonArgs,
-    /// JSON file with the contract's init args (defaults to `null`).
+    /// Contract init args as an inline JSON string (e.g. `null` or `{"owner_id":"a.near"}`).
+    #[arg(long, value_name = "JSON")]
+    init_args: Option<String>,
+    /// JSON file with the contract's init args.
     #[arg(long, value_name = "PATH")]
     init_args_file: Option<std::path::PathBuf>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Deploy {
-    pub fn try_into_spec(self, ctx: &CliContext) -> anyhow::Result<spec::Deploy> {
-        let init_bytes = match self.init_args_file {
-            Some(path) => std::fs::read(&path)
+    pub fn try_into_spec(self) -> anyhow::Result<spec::Deploy> {
+        let signer_public_key = self.signer.public_key()?;
+        // clap's required, mutually-exclusive `init` group guarantees exactly one
+        // source is present.
+        let init_bytes = match (self.init_args, self.init_args_file) {
+            (Some(json), _) => {
+                serde_json::from_str::<serde_json::Value>(&json)
+                    .context("--init-args is not valid JSON")?;
+                json.into_bytes()
+            }
+            (None, Some(path)) => std::fs::read(&path)
                 .with_context(|| format!("read init args from {}", path.display()))?,
-            None => b"null".to_vec(),
+            (None, None) => unreachable!("clap requires one of --init-args / --init-args-file"),
         };
-        self.common.into_deploy(ctx, init_bytes)
+        Ok(self.common.into_deploy(signer_public_key, init_bytes))
     }
 }

--- a/tools/manager/src/commands/registry/remove.rs
+++ b/tools/manager/src/commands/registry/remove.rs
@@ -1,11 +1,15 @@
 use clap::Args;
 use near_account_id::AccountId;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct Remove {
     /// Account to receive the registry account's remaining balance.
     #[arg(long, value_name = "ACCOUNT_ID")]
     beneficiary_id: AccountId,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Remove {

--- a/tools/manager/src/commands/registry/remove_version.rs
+++ b/tools/manager/src/commands/registry/remove_version.rs
@@ -2,6 +2,8 @@ use clap::{ArgGroup, Args};
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::registry as spec;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 #[command(group(
     ArgGroup::new("which_version").args(["version_key", "all"]).required(true)
@@ -16,6 +18,8 @@ pub struct RemoveVersion {
     /// Remove every version currently in the registry.
     #[arg(long)]
     all: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl RemoveVersion {

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -1,0 +1,78 @@
+//! Signer credentials as structural, per-operation arguments. Flattening these
+//! into a write command's args makes the invalid states unrepresentable at the
+//! parser: a write with no credentials can't parse, and credentials on a read are
+//! an unexpected argument — enforcement lives in clap, not a runtime check.
+
+use clap::Args;
+use near_account_id::AccountId;
+use near_api::SecretKey;
+use templar_gateway_types::{primitive::PublicKey, ManagedAccountId};
+
+/// The account that signs a write and its secret key — both required. Flatten
+/// into every write command's args so the pairing is structural: neither half
+/// can be supplied without the other.
+#[derive(Args, Debug, Clone)]
+pub struct SignerArgs {
+    /// Account that signs the transaction.
+    #[arg(long, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
+    signer_id: AccountId,
+    /// Private key for `--signer-id`, in `ed25519:…` form.
+    #[arg(
+        long,
+        env = "SECRET_KEY",
+        hide_env_values = true,
+        value_name = "SECRET_KEY"
+    )]
+    secret_key: String,
+}
+
+impl SignerArgs {
+    /// The signing account.
+    pub fn account_id(&self) -> ManagedAccountId {
+        ManagedAccountId::from(self.signer_id.clone())
+    }
+
+    /// The signer's public key, used by from-registry deploys that grant it a
+    /// full access key on the new account.
+    pub fn public_key(&self) -> anyhow::Result<PublicKey> {
+        Ok(PublicKey::from(self.secret()?.public_key()))
+    }
+
+    /// The signing account together with its secret key.
+    pub fn resolve(&self) -> anyhow::Result<(ManagedAccountId, SecretKey)> {
+        Ok((self.account_id(), self.secret()?))
+    }
+
+    fn secret(&self) -> anyhow::Result<SecretKey> {
+        parse_secret_key(&self.secret_key)
+    }
+}
+
+/// A secret key with no bound account — for teardown flows (e.g. `registry
+/// clear-deployments`) that sign many discovered accounts with one authorized
+/// key, so there is no single `--signer-id`.
+#[derive(Args, Debug, Clone)]
+pub struct SecretKeyArgs {
+    /// Private key that signs each discovered account, in `ed25519:…` form.
+    #[arg(
+        long,
+        env = "SECRET_KEY",
+        hide_env_values = true,
+        value_name = "SECRET_KEY"
+    )]
+    secret_key: String,
+}
+
+impl SecretKeyArgs {
+    /// The parsed secret key.
+    pub fn secret(&self) -> anyhow::Result<SecretKey> {
+        parse_secret_key(&self.secret_key)
+    }
+}
+
+/// Parse a secret key without echoing the input in the error (it is a secret).
+fn parse_secret_key(secret_key: &str) -> anyhow::Result<SecretKey> {
+    secret_key
+        .parse::<SecretKey>()
+        .map_err(|_| anyhow::anyhow!("invalid --secret-key"))
+}

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -3,15 +3,23 @@
 //! parser: a write with no credentials can't parse, and credentials on a read are
 //! an unexpected argument — enforcement lives in clap, not a runtime check.
 
+use std::fmt;
+
 use clap::Args;
 use near_account_id::AccountId;
 use near_api::SecretKey;
 use templar_gateway_types::{primitive::PublicKey, ManagedAccountId};
 
+/// Placeholder for the secret key in `Debug` output, so `{:?}` on a command that
+/// flattens these args never echoes credentials.
+const REDACTED: &str = "<redacted>";
+
 /// The account that signs a write and its secret key — both required. Flatten
 /// into every write command's args so the pairing is structural: neither half
 /// can be supplied without the other.
-#[derive(Args, Debug, Clone)]
+///
+/// `Debug` is hand-written to redact `secret_key`; do not derive it.
+#[derive(Args, Clone)]
 pub struct SignerArgs {
     /// Account that signs the transaction.
     #[arg(long, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
@@ -24,6 +32,15 @@ pub struct SignerArgs {
         value_name = "SECRET_KEY"
     )]
     secret_key: String,
+}
+
+impl fmt::Debug for SignerArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SignerArgs")
+            .field("signer_id", &self.signer_id)
+            .field("secret_key", &REDACTED)
+            .finish()
+    }
 }
 
 impl SignerArgs {
@@ -51,7 +68,9 @@ impl SignerArgs {
 /// A secret key with no bound account — for teardown flows (e.g. `registry
 /// clear-deployments`) that sign many discovered accounts with one authorized
 /// key, so there is no single `--signer-id`.
-#[derive(Args, Debug, Clone)]
+///
+/// `Debug` is hand-written to redact `secret_key`; do not derive it.
+#[derive(Args, Clone)]
 pub struct SecretKeyArgs {
     /// Private key that signs each discovered account, in `ed25519:…` form.
     #[arg(
@@ -61,6 +80,14 @@ pub struct SecretKeyArgs {
         value_name = "SECRET_KEY"
     )]
     secret_key: String,
+}
+
+impl fmt::Debug for SecretKeyArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretKeyArgs")
+            .field("secret_key", &REDACTED)
+            .finish()
+    }
 }
 
 impl SecretKeyArgs {
@@ -75,4 +102,44 @@ fn parse_secret_key(secret_key: &str) -> anyhow::Result<SecretKey> {
     secret_key
         .parse::<SecretKey>()
         .map_err(|_| anyhow::anyhow!("invalid --secret-key"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    const SECRET: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
+
+    #[derive(Parser)]
+    struct Harness {
+        #[command(flatten)]
+        signer: SignerArgs,
+    }
+
+    #[test]
+    fn debug_redacts_secret_key() {
+        let harness = Harness::try_parse_from([
+            "tmplrmgr",
+            "--signer-id",
+            "signer.testnet",
+            "--secret-key",
+            SECRET,
+        ])
+        .expect("signer args should parse");
+        let rendered = format!("{:?}", harness.signer);
+        assert!(
+            !rendered.contains(SECRET),
+            "secret leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains(REDACTED),
+            "no redaction marker: {rendered}"
+        );
+        // The account id stays visible for diagnostics.
+        assert!(
+            rendered.contains("signer.testnet"),
+            "signer id missing: {rendered}"
+        );
+    }
 }

--- a/tools/manager/src/commands/storage/deposit.rs
+++ b/tools/manager/src/commands/storage/deposit.rs
@@ -3,6 +3,8 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::storage as spec;
 use templar_gateway_types::NearToken;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct StorageDeposit {
     /// Contract to deposit storage on.
@@ -17,6 +19,8 @@ pub struct StorageDeposit {
     /// Amount of NEAR to deposit.
     #[arg(long, value_name = "AMOUNT")]
     deposit: NearToken,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl StorageDeposit {

--- a/tools/manager/src/commands/storage/ensure_deposit.rs
+++ b/tools/manager/src/commands/storage/ensure_deposit.rs
@@ -3,6 +3,8 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::storage as spec;
 use templar_gateway_types::NearToken;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Clone, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum EnsureModeArg {
@@ -25,6 +27,8 @@ pub struct EnsureDeposit {
     /// Target amount (required for minimum-total and minimum-available modes).
     #[arg(long, value_name = "AMOUNT")]
     amount: Option<NearToken>,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl EnsureDeposit {

--- a/tools/manager/src/commands/storage/unregister.rs
+++ b/tools/manager/src/commands/storage/unregister.rs
@@ -2,6 +2,8 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::storage as spec;
 
+use crate::commands::signer::SignerArgs;
+
 #[derive(Args, Debug)]
 pub struct Unregister {
     /// Contract to unregister storage on.
@@ -10,6 +12,8 @@ pub struct Unregister {
     /// Force unregistration even with a non-zero balance.
     #[arg(long)]
     force: bool,
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
 }
 
 impl Unregister {

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -53,7 +53,7 @@ impl CliContext {
     }
 
     /// Execute a write signed by `signer`, report the tx link, print the JSON
-    /// result, then fail if the operation reverted on chain.
+    /// result, then fail unless the operation succeeded on chain.
     pub(crate) async fn write<S>(&self, signer: SignerArgs, body: S) -> anyhow::Result<()>
     where
         S: MethodSpec<Output = WriteOperationResult>,
@@ -87,37 +87,46 @@ impl CliContext {
     }
 }
 
-/// Fail when a submitted write's terminal status is `Failed`: the RPC round-trip
-/// succeeded but the operation reverted on chain. Emits a concise stderr
-/// diagnostic naming the failed receipt(s), then returns an error so the process
-/// exits non-zero — letting driver scripts stop instead of continuing past a
-/// failed step. Callers print the machine-readable JSON first.
+/// Succeed only when a submitted write reached a `Succeeded` terminal status.
+/// A `Failed` operation (RPC round-trip fine, but reverted on chain) errors with
+/// a concise stderr diagnostic naming the failed receipt(s); a non-terminal
+/// `Pending`/`InProgress` operation also errors, because the CLI's transient
+/// in-memory store has no later resume, so an unconfirmed outcome must not read
+/// as success. Either way the process exits non-zero — letting driver scripts
+/// stop instead of continuing past a failed or unknown step. Callers print the
+/// machine-readable JSON first.
 pub(crate) fn check_operation_status(result: &WriteOperationResult) -> anyhow::Result<()> {
     let operation = &result.operation;
-    if operation.status != OperationStatus::Failed {
-        return Ok(());
-    }
+    match operation.status {
+        OperationStatus::Succeeded => Ok(()),
+        OperationStatus::Failed => {
+            let failed_contracts: Vec<&str> = operation
+                .final_outcome()
+                .map(|outcome| {
+                    outcome
+                        .receipts
+                        .iter()
+                        .filter(|receipt| receipt.status == ReceiptStatus::Failed)
+                        .map(|receipt| receipt.contract_id.as_str())
+                        .collect()
+                })
+                .unwrap_or_default();
 
-    let failed_contracts: Vec<&str> = operation
-        .final_outcome()
-        .map(|outcome| {
-            outcome
-                .receipts
-                .iter()
-                .filter(|receipt| receipt.status == ReceiptStatus::Failed)
-                .map(|receipt| receipt.contract_id.as_str())
-                .collect()
-        })
-        .unwrap_or_default();
-
-    if failed_contracts.is_empty() {
-        anyhow::bail!("operation {} failed on chain", operation.id.0);
+            if failed_contracts.is_empty() {
+                anyhow::bail!("operation {} failed on chain", operation.id.0);
+            }
+            anyhow::bail!(
+                "operation {} failed on chain; reverted receipt(s) on: {}",
+                operation.id.0,
+                failed_contracts.join(", ")
+            )
+        }
+        status @ (OperationStatus::Pending | OperationStatus::InProgress) => anyhow::bail!(
+            "operation {} did not reach a terminal state (status: {status:?}); \
+             its on-chain outcome is unknown",
+            operation.id.0,
+        ),
     }
-    anyhow::bail!(
-        "operation {} failed on chain; reverted receipt(s) on: {}",
-        operation.id.0,
-        failed_contracts.join(", ")
-    )
 }
 
 /// Serialize `output` as a single line of JSON to stdout — the machine-readable
@@ -197,5 +206,19 @@ mod tests {
     fn succeeded_operation_is_ok() {
         check_operation_status(&result("Succeeded", "Succeeded"))
             .expect("a succeeded operation must not error");
+    }
+
+    #[test]
+    fn non_terminal_operation_errors() {
+        // A non-terminal status is an unknown outcome, not a success: with the
+        // CLI's transient store there is no later resume to confirm it.
+        for status in ["Pending", "InProgress"] {
+            let error = check_operation_status(&result(status, "Succeeded"))
+                .expect_err("a non-terminal operation must error");
+            assert!(
+                error.to_string().contains("did not reach a terminal state"),
+                "status {status}: {error}"
+            );
+        }
     }
 }

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -11,59 +11,31 @@ use templar_gateway_client::{Client, NetworkConfigBuilder};
 use templar_gateway_core::{DispatchRead, GatewayContext, PlanWrite};
 use templar_gateway_methods_dispatch::Dispatch;
 use templar_gateway_types::{
-    common::WriteOperationResult, primitive::PublicKey, ManagedAccountId, MethodSpec,
+    common::WriteOperationResult, operation::ReceiptStatus, ManagedAccountId, MethodSpec,
+    OperationStatus,
 };
 
 use crate::cli::Cli;
+use crate::commands::signer::SignerArgs;
 
 pub(crate) struct CliContext {
+    /// An unsigned client for reads. Writes build a per-operation signing client
+    /// from the command's own credentials (see [`CliContext::signing_client`]).
     pub(crate) client: Client,
     network: NetworkConfig,
-    signer_account_id: Option<ManagedAccountId>,
-    signer_secret_key: Option<SecretKey>,
     transaction_url_prefix: String,
 }
 
 impl CliContext {
-    /// The fully-configured signer (account id + its public key, derived from the
-    /// secret), or a precise error naming the missing half. A partial signer
-    /// config builds a valid (read-only) context, so the paired requirement is
-    /// enforced here — lazily, at the point a signer is actually needed — rather
-    /// than up front.
-    fn paired_signer(&self) -> anyhow::Result<(ManagedAccountId, PublicKey)> {
-        match (&self.signer_account_id, &self.signer_secret_key) {
-            (Some(account_id), Some(secret)) => {
-                Ok((account_id.clone(), PublicKey::from(secret.public_key())))
-            }
-            (None, None) => anyhow::bail!("this operation requires --signer-id and --secret-key"),
-            (Some(_), None) => anyhow::bail!("--secret-key is required with --signer-id"),
-            (None, Some(_)) => anyhow::bail!("--signer-id is required with --secret-key"),
-        }
-    }
-
-    /// The signing account, or an error if a complete `--signer-id`/`--secret-key`
-    /// pair was not given.
-    pub(crate) fn signer_account(&self) -> anyhow::Result<ManagedAccountId> {
-        Ok(self.paired_signer()?.0)
-    }
-
-    /// The signer's public key, used by commands that grant it a full access key
-    /// on a newly created account.
-    pub(crate) fn signer_public_key(&self) -> anyhow::Result<PublicKey> {
-        Ok(self.paired_signer()?.1)
-    }
-
-    /// Build a single-signer client for an arbitrary account using the shared
-    /// `--secret-key`. Used by teardown flows (e.g. `registry clear-deployments`)
-    /// that must sign as many discovered accounts with one authorized key.
-    pub(crate) fn signing_client_for(
+    /// Build a single-signer client for `account_id` from `secret_key`. Each
+    /// write signs with credentials carried by its own command, and teardown
+    /// flows (e.g. `registry clear-deployments`) sign many discovered accounts
+    /// with one authorized key.
+    pub(crate) fn signing_client(
         &self,
         account_id: impl Into<ManagedAccountId>,
+        secret_key: SecretKey,
     ) -> anyhow::Result<Client> {
-        let secret_key = self
-            .signer_secret_key
-            .clone()
-            .context("this operation requires --secret-key")?;
         Client::builder(self.network.clone())
             .secret_key(account_id, secret_key)?
             .build()
@@ -80,16 +52,21 @@ impl CliContext {
         print_json(&output)
     }
 
-    /// Execute a write signed by the default signer, report the tx link, and
-    /// print the JSON result.
-    pub(crate) async fn write<S>(&self, body: S) -> anyhow::Result<()>
+    /// Execute a write signed by `signer`, report the tx link, print the JSON
+    /// result, then fail if the operation reverted on chain.
+    pub(crate) async fn write<S>(&self, signer: SignerArgs, body: S) -> anyhow::Result<()>
     where
         S: MethodSpec<Output = WriteOperationResult>,
         Dispatch: PlanWrite<S, GatewayContext>,
     {
-        let output = self.client.execute_as(self.signer_account()?, body).await?;
+        let (account_id, secret_key) = signer.resolve()?;
+        let client = self.signing_client(account_id.clone(), secret_key)?;
+        let output = client.execute_as(account_id, body).await?;
         self.report_tx(&output);
-        print_json(&output)
+        // Print the machine-readable result before checking status, so a reverted
+        // operation still emits its JSON on stdout.
+        print_json(&output)?;
+        check_operation_status(&output)
     }
 
     /// Log the explorer link for a completed write to stderr (the JSON result,
@@ -99,6 +76,48 @@ impl CliContext {
             tracing::info!("tx: {}{}", self.transaction_url_prefix, tx_hash);
         }
     }
+
+    /// Report an intermediate write's tx link, then fail if it reverted — the
+    /// multi-step counterpart to [`write`](CliContext::write) (which also prints
+    /// the JSON), so a reverted step in a teardown/proposal flow aborts instead of
+    /// being treated as success.
+    pub(crate) fn report_checked(&self, result: &WriteOperationResult) -> anyhow::Result<()> {
+        self.report_tx(result);
+        check_operation_status(result)
+    }
+}
+
+/// Fail when a submitted write's terminal status is `Failed`: the RPC round-trip
+/// succeeded but the operation reverted on chain. Emits a concise stderr
+/// diagnostic naming the failed receipt(s), then returns an error so the process
+/// exits non-zero — letting driver scripts stop instead of continuing past a
+/// failed step. Callers print the machine-readable JSON first.
+pub(crate) fn check_operation_status(result: &WriteOperationResult) -> anyhow::Result<()> {
+    let operation = &result.operation;
+    if operation.status != OperationStatus::Failed {
+        return Ok(());
+    }
+
+    let failed_contracts: Vec<&str> = operation
+        .final_outcome()
+        .map(|outcome| {
+            outcome
+                .receipts
+                .iter()
+                .filter(|receipt| receipt.status == ReceiptStatus::Failed)
+                .map(|receipt| receipt.contract_id.as_str())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    if failed_contracts.is_empty() {
+        anyhow::bail!("operation {} failed on chain", operation.id.0);
+    }
+    anyhow::bail!(
+        "operation {} failed on chain; reverted receipt(s) on: {}",
+        operation.id.0,
+        failed_contracts.join(", ")
+    )
 }
 
 /// Serialize `output` as a single line of JSON to stdout — the machine-readable
@@ -111,9 +130,9 @@ pub(crate) fn print_json(output: &impl Serialize) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Build the execution context from parsed CLI args: the network, the gateway
-/// client (backed by a transient in-memory operation store), and the resolved
-/// signer.
+/// Build the execution context from parsed CLI args: the network and an unsigned
+/// gateway client (backed by a transient in-memory operation store) for reads.
+/// Writes sign per-operation with credentials carried by their own command.
 pub(crate) fn build_context(cli: &Cli) -> anyhow::Result<CliContext> {
     let network = NetworkConfigBuilder::new(cli.network)
         .rpc_url(cli.rpc_url.as_deref())
@@ -121,65 +140,62 @@ pub(crate) fn build_context(cli: &Cli) -> anyhow::Result<CliContext> {
         .api_key(cli.rpc_api_key.clone())
         .build();
 
-    let signer_account_id = cli.signer_id.clone().map(ManagedAccountId::from);
-    let signer_secret_key = cli
-        .secret_key
-        .as_deref()
-        .map(|secret_key| {
-            secret_key
-                .parse::<SecretKey>()
-                .map_err(|_| anyhow::anyhow!("invalid --secret-key"))
-        })
-        .transpose()?;
-
-    // Configure the client's default signer only when both halves are present.
-    // A partial or absent pair yields an unsigned (read-only) client — the
-    // signer/write paths report the missing half when a signer is required. Note
-    // teardown flows sign per-account via `signing_client_for`, which needs only
-    // the secret key, so `--secret-key` alone is still useful without `--signer-id`.
-    let mut builder = Client::builder(network.clone());
-    if let (Some(account_id), Some(secret)) = (&signer_account_id, &signer_secret_key) {
-        builder = builder.secret_key(account_id.clone(), secret.clone())?;
-    }
-
     Ok(CliContext {
-        client: builder.build()?,
+        client: Client::read_only(network.clone())?,
         network,
-        signer_account_id,
-        signer_secret_key,
         transaction_url_prefix: cli.transaction_url_prefix(),
     })
 }
 
 #[cfg(test)]
-impl CliContext {
-    /// A signer-configured context for tests: an offline client plus a fixed
-    /// signer key, so FAK-resolving conversions can read [`signer_public_key`].
-    ///
-    /// [`signer_public_key`]: CliContext::signer_public_key
-    pub(crate) fn for_test() -> Self {
-        use templar_gateway_client::Network;
+mod tests {
+    use super::check_operation_status;
+    use serde_json::json;
+    use templar_gateway_types::common::WriteOperationResult;
 
-        // A throwaway ed25519 key; tests never submit, only read its public half.
-        const TEST_SECRET_KEY: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
-        let secret: SecretKey = TEST_SECRET_KEY.parse().expect("valid test secret key");
-        let network = NetworkConfigBuilder::new(Network::Testnet).build();
-        let account = ManagedAccountId::from(
-            "signer.testnet"
-                .parse::<near_account_id::AccountId>()
-                .expect("valid account id"),
+    /// A single-step write result with the given operation status and a reverted
+    /// step whose first receipt has `receipt_status`.
+    fn result(status: &str, receipt_status: &str) -> WriteOperationResult {
+        serde_json::from_value(json!({
+            "operation": {
+                "id": "op-1",
+                "signer_account_id": "signer.testnet",
+                "status": status,
+                "steps": [{
+                    "index": 0,
+                    "status": { "Reverted": {
+                        "tx_hash": "3DeTHGEZzdG5Vpj5b972u45DSRKTBsV87a1eGLCcFQY2",
+                        "outcome": {
+                            "tokens_burnt": "120081144700600000000",
+                            "total_gas_burnt": "1647176572006",
+                            "receipts": [
+                                {"contract_id": "po-market.signer.testnet", "status": receipt_status, "logs": []},
+                                {"contract_id": "signer.testnet", "status": "Succeeded", "logs": []}
+                            ],
+                            "return_value": null
+                        }
+                    }}
+                }]
+            }
+        }))
+        .expect("valid WriteOperationResult json")
+    }
+
+    #[test]
+    fn failed_operation_errors_and_names_reverted_receipt() {
+        let error = check_operation_status(&result("Failed", "Failed"))
+            .expect_err("a failed operation must map to an error (non-zero exit)");
+        let message = error.to_string();
+        assert!(message.contains("op-1"), "message: {message}");
+        assert!(
+            message.contains("po-market.signer.testnet"),
+            "message should name the reverted receipt: {message}"
         );
-        let client = Client::builder(network.clone())
-            .secret_key(account.clone(), secret.clone())
-            .expect("configure test signer")
-            .build()
-            .expect("build test client");
-        Self {
-            client,
-            network,
-            signer_account_id: Some(account),
-            signer_secret_key: Some(secret),
-            transaction_url_prefix: String::new(),
-        }
+    }
+
+    #[test]
+    fn succeeded_operation_is_ok() {
+        check_operation_status(&result("Succeeded", "Succeeded"))
+            .expect("a succeeded operation must not error");
     }
 }

--- a/tools/manager/src/dispatch/generic.rs
+++ b/tools/manager/src/dispatch/generic.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 use std::io::Read as _;
 use templar_gateway_types::MethodSpec;
 
-use crate::cli::GenericMethodCall;
+use crate::cli::{GenericMethodCall, WriteMethodCall};
 use crate::context::CliContext;
 
 pub(super) async fn read(ctx: CliContext, call: GenericMethodCall) -> anyhow::Result<()> {
@@ -26,7 +26,8 @@ pub(super) async fn read(ctx: CliContext, call: GenericMethodCall) -> anyhow::Re
     anyhow::bail!("unsupported read method {method}");
 }
 
-pub(super) async fn write(ctx: CliContext, call: GenericMethodCall) -> anyhow::Result<()> {
+pub(super) async fn write(ctx: CliContext, call: WriteMethodCall) -> anyhow::Result<()> {
+    let WriteMethodCall { call, signer } = call;
     let method = call.method.clone();
     let params = load_params(call)?;
 
@@ -35,7 +36,7 @@ pub(super) async fn write(ctx: CliContext, call: GenericMethodCall) -> anyhow::R
             if method == <$spec as MethodSpec>::RPC_METHOD {
                 let body: $spec = serde_json::from_value(params)
                     .with_context(|| format!("parse parameters for {method}"))?;
-                return ctx.write(body).await;
+                return ctx.write(signer.clone(), body).await;
             }
         };
     }

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -41,7 +41,7 @@ pub(crate) async fn dispatch(ctx: CliContext, command: Command) -> anyhow::Resul
 async fn account(ctx: CliContext, ns: AccountNs) -> anyhow::Result<()> {
     match ns {
         AccountNs::Get(a) => ctx.read(a.into_spec()).await,
-        AccountNs::Delete(a) => ctx.write(a.into_spec()).await,
+        AccountNs::Delete(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
     }
 }
 
@@ -51,8 +51,8 @@ async fn registry(ctx: CliContext, ns: RegistryNs) -> anyhow::Result<()> {
         RegistryNs::ListDeployments(a) => ctx.read(a.into_spec()).await,
         RegistryNs::ListDeploymentsByKind(a) => ctx.read(a.into_spec()).await,
         RegistryNs::GetDeployment(a) => ctx.read(a.into_spec()).await,
-        RegistryNs::AddVersion(a) => ctx.write(a.try_into_spec()?).await,
-        RegistryNs::Deploy(a) => ctx.write(a.try_into_spec(&ctx)?).await,
+        RegistryNs::AddVersion(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        RegistryNs::Deploy(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         RegistryNs::RemoveVersion(a) => teardown::remove_version(ctx, a).await,
         RegistryNs::Remove(a) => teardown::registry_remove(ctx, a).await,
         RegistryNs::ClearDeployments(a) => teardown::clear_deployments(ctx, a).await,
@@ -63,27 +63,29 @@ async fn storage(ctx: CliContext, ns: StorageNs) -> anyhow::Result<()> {
     match ns {
         StorageNs::GetBalanceBounds(a) => ctx.read(a.into_spec()).await,
         StorageNs::GetBalanceOf(a) => ctx.read(a.into_spec()).await,
-        StorageNs::Deposit(a) => ctx.write(a.into_spec()).await,
-        StorageNs::Unregister(a) => ctx.write(a.into_spec()).await,
-        StorageNs::EnsureDeposit(a) => ctx.write(a.try_into_spec()?).await,
+        StorageNs::Deposit(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
+        StorageNs::Unregister(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
+        StorageNs::EnsureDeposit(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
     }
 }
 
 async fn ft(ctx: CliContext, ns: FtNs) -> anyhow::Result<()> {
     match ns {
         FtNs::GetBalanceOf(a) => ctx.read(a.into_spec()).await,
-        FtNs::Transfer(a) => ctx.write(a.into_spec()).await,
-        FtNs::TransferCall(a) => ctx.write(a.into_spec()).await,
+        FtNs::Transfer(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
+        FtNs::TransferCall(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
     }
 }
 
 async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
     match ns {
-        MarketNs::Create(a) => ctx.write(a.try_into_spec(&ctx)?).await,
+        MarketNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         MarketNs::Remove(a) => {
-            let signer = ctx.signer_account()?;
-            teardown::remove_market(&ctx, &ctx.client, signer, a.beneficiary_id(), a.force())
-                .await?;
+            // `market remove` is self-signed: the signer is the market account
+            // being torn down.
+            let (market, secret_key) = a.signer.resolve()?;
+            let client = ctx.signing_client(market.clone(), secret_key)?;
+            teardown::remove_market(&ctx, &client, market, a.beneficiary_id(), a.force()).await?;
             print_json(&serde_json::json!({ "removed": true }))
         }
     }
@@ -94,7 +96,7 @@ async fn proxy_oracle(ctx: CliContext, ns: ProxyOracleNs) -> anyhow::Result<()> 
         ProxyOracleNs::GetProxy(a) => ctx.read(a.into_spec()).await,
         ProxyOracleNs::ListProxies(a) => ctx.read(a.into_spec()).await,
         ProxyOracleNs::PriceFeedExists(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleNs::UpdatePrices(a) => ctx.write(a.into_spec()).await,
+        ProxyOracleNs::UpdatePrices(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
     }
 }
 
@@ -102,9 +104,9 @@ async fn proxy_oracle_owner(ctx: CliContext, ns: ProxyOracleOwnerNs) -> anyhow::
     match ns {
         ProxyOracleOwnerNs::GetOwner(a) => ctx.read(a.into_spec()).await,
         ProxyOracleOwnerNs::GetProposedOwner(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleOwnerNs::ProposeOwner(a) => ctx.write(a.into_spec()).await,
-        ProxyOracleOwnerNs::AcceptOwner(a) => ctx.write(a.into_spec()).await,
-        ProxyOracleOwnerNs::RenounceOwner(a) => ctx.write(a.into_spec()).await,
+        ProxyOracleOwnerNs::ProposeOwner(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
+        ProxyOracleOwnerNs::AcceptOwner(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
+        ProxyOracleOwnerNs::RenounceOwner(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
     }
 }
 
@@ -113,9 +115,9 @@ async fn proxy_oracle_governance(
     ns: ProxyOracleGovernanceNs,
 ) -> anyhow::Result<()> {
     match ns {
-        ProxyOracleGovernanceNs::Create(a) => ctx.write(a.try_into_spec(&ctx)?).await,
+        ProxyOracleGovernanceNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         ProxyOracleGovernanceNs::CreateProposal(a) => proposals::create(ctx, a).await,
-        ProxyOracleGovernanceNs::CancelProposal(a) => ctx.write(a.cancel()).await,
+        ProxyOracleGovernanceNs::CancelProposal(a) => ctx.write(a.signer.clone(), a.cancel()).await,
         ProxyOracleGovernanceNs::ExecuteProposal(a) => proposals::execute(ctx, a).await,
         ProxyOracleGovernanceNs::GetProposal(a) => ctx.read(a.get()).await,
         ProxyOracleGovernanceNs::ListProposals(a) => ctx.read(a.into_spec()).await,
@@ -131,12 +133,12 @@ async fn proxy_oracle_governance(
 
 async fn redstone(ctx: CliContext, ns: RedstoneNs) -> anyhow::Result<()> {
     match ns {
-        RedstoneNs::Create(a) => ctx.write(a.try_into_spec(&ctx)?).await,
+        RedstoneNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         RedstoneNs::GetConfig(a) => ctx.read(a.into_spec()).await,
         RedstoneNs::ReadPriceData(a) => ctx.read(a.into_spec()).await,
         RedstoneNs::ListRole(a) => ctx.read(a.into_spec()).await,
-        RedstoneNs::SetRole(a) => ctx.write(a.into_spec()).await,
-        RedstoneNs::WritePrices(a) => ctx.write(a.try_into_spec()?).await,
+        RedstoneNs::SetRole(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
+        RedstoneNs::WritePrices(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         RedstoneNs::UpdatePrices(a) => prices::update_redstone(ctx, a).await,
     }
 }

--- a/tools/manager/src/dispatch/prices.rs
+++ b/tools/manager/src/dispatch/prices.rs
@@ -24,5 +24,6 @@ pub(super) async fn update_redstone(
         .context("fetch RedStone payload")?;
     drop(kill_tx);
 
-    ctx.write(args.into_spec(payload)).await
+    let signer = args.signer.clone();
+    ctx.write(signer, args.into_spec(payload)).await
 }

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -6,8 +6,9 @@ use anyhow::Context as _;
 use near_account_id::AccountId;
 use serde::Serialize;
 use templar_common::oracle::pyth::PriceIdentifier;
+use templar_gateway_client::Client;
 use templar_gateway_methods_spec::proxy_oracle_governance as gov;
-use templar_gateway_types::common::WriteOperationResult;
+use templar_gateway_types::{common::WriteOperationResult, ManagedAccountId};
 
 use crate::commands::proxy_oracle_governance::{CreateProposal, ExecuteProposalArgs};
 use crate::context::{print_json, CliContext};
@@ -18,6 +19,8 @@ use crate::context::{print_json, CliContext};
 /// id. Always emits the resolved proposal id so scripts can learn it. With
 /// `--execute-when-ready`, waits for the proposal's TTL to elapse and executes.
 pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow::Result<()> {
+    let (signer, secret_key) = args.signer.resolve()?;
+    let client = ctx.signing_client(signer.clone(), secret_key)?;
     let governance_id = args.governance_id().clone();
     let execute_when_ready = args.execute_when_ready();
 
@@ -43,17 +46,18 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
         }
     };
 
-    let create = ctx
-        .client
-        .execute_as(ctx.signer_account()?, args.try_into_spec(id)?)
+    let create = client
+        .execute_as(signer.clone(), args.try_into_spec(id)?)
         .await?;
-    ctx.report_tx(&create);
+    // Fail fast if the create reverted, before waiting on / executing a proposal
+    // that was never created.
+    ctx.report_checked(&create)?;
     // Emit the id now so it survives a later wait/execute failure below.
     tracing::info!(proposal_id = id, "created proposal");
 
     let execute = if execute_when_ready {
         wait_for_maturity(&ctx, &governance_id, id).await?;
-        let result = execute_now(&ctx, &governance_id, id).await?;
+        let result = execute_now(&ctx, &client, &signer, &governance_id, id).await?;
         Some(result)
     } else {
         None
@@ -73,26 +77,28 @@ pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyho
     if args.when_ready() {
         wait_for_maturity(&ctx, args.governance_id(), args.id()).await?;
     }
-    ctx.write(args.into_spec()).await
+    ctx.write(args.signer.clone(), args.into_spec()).await
 }
 
-/// Execute proposal `id` on its own (no idempotency key), reporting the tx link.
+/// Execute proposal `id` on its own (no idempotency key), signed as `signer`
+/// through `client`, reporting the tx link.
 async fn execute_now(
     ctx: &CliContext,
+    client: &Client,
+    signer: &ManagedAccountId,
     governance_id: &AccountId,
     id: u32,
 ) -> anyhow::Result<WriteOperationResult> {
-    let result = ctx
-        .client
+    let result = client
         .execute_as(
-            ctx.signer_account()?,
+            signer.clone(),
             gov::ExecuteProposal {
                 governance_id: governance_id.clone(),
                 id,
             },
         )
         .await?;
-    ctx.report_tx(&result);
+    ctx.report_checked(&result)?;
     Ok(result)
 }
 

--- a/tools/manager/src/dispatch/teardown.rs
+++ b/tools/manager/src/dispatch/teardown.rs
@@ -8,7 +8,7 @@ use templar_gateway_types::{common::Pagination, ManagedAccountId};
 
 use crate::commands::recover::RecoverNep141;
 use crate::commands::registry;
-use crate::context::{print_json, CliContext};
+use crate::context::{check_operation_status, print_json, CliContext};
 
 /// Recover a NEP-141 balance from the signer to a beneficiary, then unregister
 /// the signer's storage — the standalone `recover-nep141` command. Re-reads the
@@ -16,20 +16,14 @@ use crate::context::{print_json, CliContext};
 pub(super) async fn recover_nep141(ctx: CliContext, args: RecoverNep141) -> anyhow::Result<()> {
     use templar_gateway_methods_spec::{storage, token};
 
-    let signer = ctx.signer_account()?;
+    let (signer, secret_key) = args.signer.resolve()?;
+    let client = ctx.signing_client(signer.clone(), secret_key)?;
     let account_id = signer.0.clone();
     let token = token::TokenReference::Ft {
         contract_id: args.token_id.clone(),
     };
 
-    sweep_token(
-        &ctx,
-        &ctx.client,
-        &signer,
-        token.clone(),
-        &args.beneficiary_id,
-    )
-    .await?;
+    sweep_token(&ctx, &client, &signer, token.clone(), &args.beneficiary_id).await?;
 
     // Re-read before unregistering: a failed/partial transfer must not lead to
     // unregistering storage while tokens remain (which would strand them).
@@ -47,8 +41,7 @@ pub(super) async fn recover_nep141(ctx: CliContext, args: RecoverNep141) -> anyh
         );
     }
 
-    let result = ctx
-        .client
+    let result = client
         .execute_as(
             signer,
             storage::Unregister {
@@ -58,7 +51,8 @@ pub(super) async fn recover_nep141(ctx: CliContext, args: RecoverNep141) -> anyh
         )
         .await?;
     ctx.report_tx(&result);
-    print_json(&result)
+    print_json(&result)?;
+    check_operation_status(&result)
 }
 
 /// Remove a single registry version, or every version with `--all`.
@@ -69,18 +63,20 @@ pub(super) async fn remove_version(
     // clap's arg group guarantees exactly one of --version-key / --all, so a
     // present single spec is the single-version case; its absence means --all.
     if let Some(spec) = args.single() {
-        return ctx.write(spec).await;
+        return ctx.write(args.signer.clone(), spec).await;
     }
 
-    let signer = ctx.signer_account()?;
-    let removed = remove_all_versions(&ctx, &signer, args.registry_id()).await?;
+    let (signer, secret_key) = args.signer.resolve()?;
+    let client = ctx.signing_client(signer.clone(), secret_key)?;
+    let removed = remove_all_versions(&ctx, &client, &signer, args.registry_id()).await?;
     print_json(&json!({ "removed": removed }))
 }
 
-/// Remove every version registered under `registry_id`, signed by `signer`,
-/// reporting each tx and returning the removed version keys.
+/// Remove every version registered under `registry_id`, signed as `signer`
+/// through `client`, reporting each tx and returning the removed version keys.
 async fn remove_all_versions(
     ctx: &CliContext,
+    client: &Client,
     signer: &ManagedAccountId,
     registry_id: &AccountId,
 ) -> anyhow::Result<Vec<String>> {
@@ -96,8 +92,7 @@ async fn remove_all_versions(
         .values;
 
     for version_key in &versions {
-        let result = ctx
-            .client
+        let result = client
             .execute_as(
                 signer.clone(),
                 spec::RemoveVersion {
@@ -106,7 +101,7 @@ async fn remove_all_versions(
                 },
             )
             .await?;
-        ctx.report_tx(&result);
+        ctx.report_checked(&result)?;
     }
     Ok(versions)
 }
@@ -116,12 +111,12 @@ async fn remove_all_versions(
 pub(super) async fn registry_remove(ctx: CliContext, args: registry::Remove) -> anyhow::Result<()> {
     use templar_gateway_methods_spec::account;
 
-    let signer = ctx.signer_account()?;
+    let (signer, secret_key) = args.signer.resolve()?;
+    let client = ctx.signing_client(signer.clone(), secret_key)?;
     let registry_id = signer.0.clone();
-    remove_all_versions(&ctx, &signer, &registry_id).await?;
+    remove_all_versions(&ctx, &client, &signer, &registry_id).await?;
 
-    let result = ctx
-        .client
+    let result = client
         .execute_as(
             signer,
             account::Delete {
@@ -130,7 +125,8 @@ pub(super) async fn registry_remove(ctx: CliContext, args: registry::Remove) -> 
         )
         .await?;
     ctx.report_tx(&result);
-    print_json(&result)
+    print_json(&result)?;
+    check_operation_status(&result)
 }
 
 /// Remove every market deployed from the registry, signing each removal as the
@@ -144,6 +140,8 @@ pub(super) async fn clear_deployments(
 
     let beneficiary = args.beneficiary_id();
     let force = args.force();
+    // One authorized key signs every discovered market's self-removal.
+    let secret_key = args.signer.secret()?;
     // Only markets are torn down here (removal reads a market configuration), so
     // filter by kind rather than trying `remove_market` on every deployment.
     let accounts = ctx
@@ -158,7 +156,7 @@ pub(super) async fn clear_deployments(
 
     let mut removed = Vec::new();
     for account in accounts {
-        let client = ctx.signing_client_for(account.clone())?;
+        let client = ctx.signing_client(account.clone(), secret_key.clone())?;
         match remove_market(&ctx, &client, account.clone().into(), &beneficiary, force).await {
             Ok(()) => removed.push(account),
             Err(error) if force => {
@@ -241,8 +239,7 @@ pub(super) async fn remove_market(
             },
         )
         .await?;
-    ctx.report_tx(&result);
-    Ok(())
+    ctx.report_checked(&result)
 }
 
 /// Transfer a token's full balance from `from` to `beneficiary` if non-zero,
@@ -276,7 +273,7 @@ async fn sweep_token(
                 },
             )
             .await?;
-        ctx.report_tx(&result);
+        ctx.report_checked(&result)?;
     }
     Ok(())
 }
@@ -321,7 +318,7 @@ async fn reclaim_storage(
                 },
             )
             .await?;
-        ctx.report_tx(&result);
+        ctx.report_checked(&result)?;
     }
     Ok(())
 }

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -126,16 +126,18 @@ fn write_command_requires_credentials() {
     let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
     let restore = clear_credential_env();
 
-    let error = Cli::try_parse_from([
+    let result = Cli::try_parse_from([
         "tmplrmgr",
         "write",
         "registry.removeVersion",
         "--json",
         r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-    ])
-    .expect_err("a write with no credentials should fail to parse");
+    ]);
 
+    // Restore before asserting: a panic here must not leak cleared env vars into
+    // later tests sharing this process.
     restore();
+    let error = result.expect_err("a write with no credentials should fail to parse");
     assert_eq!(
         error.kind(),
         clap::error::ErrorKind::MissingRequiredArgument

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -39,15 +39,19 @@ fn help_lists_all_top_level_commands() {
 
 #[test]
 fn parses_recover_nep141_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "recover-nep141",
-        "--token-id",
-        "usdt.testnet",
-        "--beneficiary-id",
-        "treasury.testnet",
-        "--force",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "recover-nep141",
+            "--token-id",
+            "usdt.testnet",
+            "--beneficiary-id",
+            "treasury.testnet",
+            "--force",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("recover-nep141 should parse");
     match cli.command {
         super::cli::Command::RecoverNep141(args) => {
@@ -79,6 +83,17 @@ fn parses_read_fallback_with_json() {
     }
 }
 
+const TEST_SECRET_KEY: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
+
+/// Signer credentials appended to write-command argv in parse tests, so the
+/// structural `SignerArgs` are satisfied. Shared by the submodules.
+const CREDS: [&str; 4] = [
+    "--signer-id",
+    "signer.testnet",
+    "--secret-key",
+    TEST_SECRET_KEY,
+];
+
 #[test]
 fn parses_write_fallback_with_json() {
     let cli = Cli::try_parse_from([
@@ -87,16 +102,61 @@ fn parses_write_fallback_with_json() {
         "registry.removeVersion",
         "--json",
         r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        TEST_SECRET_KEY,
     ])
     .expect("write fallback should parse");
 
     match cli.command {
         super::cli::Command::Write(call) => {
-            assert_eq!(call.method, "registry.removeVersion");
-            assert!(call.json.is_some());
+            assert_eq!(call.call.method, "registry.removeVersion");
+            assert!(call.call.json.is_some());
+            call.signer.resolve().expect("credentials should resolve");
         }
         _ => panic!("expected Write variant"),
     }
+}
+
+#[test]
+fn write_command_requires_credentials() {
+    // With credentials structural on the write, omitting them is a parse error —
+    // no build or network work is reachable.
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+
+    let error = Cli::try_parse_from([
+        "tmplrmgr",
+        "write",
+        "registry.removeVersion",
+        "--json",
+        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+    ])
+    .expect_err("a write with no credentials should fail to parse");
+
+    restore();
+    assert_eq!(
+        error.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument
+    );
+}
+
+#[test]
+fn read_command_rejects_credentials() {
+    // Reads don't flatten the signer, so credentials are an unexpected argument.
+    let error = Cli::try_parse_from([
+        "tmplrmgr",
+        "read",
+        "account.get",
+        "--json",
+        r#"{"account_id":"signer.testnet"}"#,
+        "--secret-key",
+        TEST_SECRET_KEY,
+    ])
+    .expect_err("credentials on a read should fail to parse");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::UnknownArgument);
 }
 
 #[test]
@@ -104,20 +164,23 @@ fn invalid_secret_key_error_does_not_echo_input() {
     let secret = "not-a-real-secret-key";
     let cli = Cli::try_parse_from([
         "tmplrmgr",
+        "write",
+        "registry.removeVersion",
+        "--json",
+        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
         "--signer-id",
         "signer.testnet",
         "--secret-key",
         secret,
-        "read",
-        "account.get",
-        "--json",
-        r#"{"account_id":"signer.testnet"}"#,
     ])
     .expect("secret key should parse as an opaque string at the clap boundary");
 
-    let error = match super::context::build_context(&cli) {
-        Ok(_) => panic!("invalid secret key should be rejected after clap parsing"),
-        Err(error) => error,
+    let error = match cli.command {
+        super::cli::Command::Write(call) => call
+            .signer
+            .resolve()
+            .expect_err("invalid secret key should be rejected"),
+        _ => panic!("expected Write variant"),
     };
 
     let message = error.to_string();
@@ -126,84 +189,56 @@ fn invalid_secret_key_error_does_not_echo_input() {
 }
 
 #[test]
-fn secret_key_env_satisfies_signer_configuration() {
+fn signer_env_satisfies_write_credentials() {
+    // Scripted/CI usage relies on SIGNER_ID/SECRET_KEY env sourcing satisfying the
+    // structural credentials with no explicit flags.
     let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let original = std::env::var_os("SECRET_KEY");
-    std::env::set_var(
-        "SECRET_KEY",
-        "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q",
-    );
+    let original_signer = std::env::var_os("SIGNER_ID");
+    let original_secret = std::env::var_os("SECRET_KEY");
+    std::env::set_var("SIGNER_ID", "signer.testnet");
+    std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
 
     let result = (|| {
         let cli = Cli::try_parse_from([
             "tmplrmgr",
-            "--signer-id",
-            "signer.testnet",
-            "read",
-            "account.get",
+            "write",
+            "registry.removeVersion",
             "--json",
-            r#"{"account_id":"signer.testnet"}"#,
+            r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
         ])
         .map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
-        super::context::build_context(&cli)
+        match cli.command {
+            super::cli::Command::Write(call) => call.signer.resolve().map(|_| ()),
+            _ => anyhow::bail!("expected Write variant"),
+        }
     })();
 
+    restore_env("SIGNER_ID", original_signer);
+    restore_env("SECRET_KEY", original_secret);
+
+    result.expect("env-provided credentials should satisfy a write command");
+}
+
+/// Clear the credential env vars (under `ENV_LOCK`) so a "missing credentials"
+/// parse test isn't satisfied by an ambient `SIGNER_ID`/`SECRET_KEY`. Returns a
+/// closure that restores the originals.
+fn clear_credential_env() -> impl FnOnce() {
+    let original_signer = std::env::var_os("SIGNER_ID");
+    let original_secret = std::env::var_os("SECRET_KEY");
+    std::env::remove_var("SIGNER_ID");
+    std::env::remove_var("SECRET_KEY");
+    move || {
+        restore_env("SIGNER_ID", original_signer);
+        restore_env("SECRET_KEY", original_secret);
+    }
+}
+
+fn restore_env(key: &str, original: Option<std::ffi::OsString>) {
     match original {
-        Some(value) => std::env::set_var("SECRET_KEY", value),
-        None => std::env::remove_var("SECRET_KEY"),
+        Some(value) => std::env::set_var(key, value),
+        None => std::env::remove_var(key),
     }
-
-    result.expect("env-provided SECRET_KEY should configure a signed client");
-}
-
-/// A `Cli` with the given signer halves and a trivial read command, built
-/// directly so clap never reads `SIGNER_ID`/`SECRET_KEY` from the environment.
-fn cli_with_signer(signer_id: Option<&str>, secret_key: Option<&str>) -> Cli {
-    use super::cli::{Command, GenericMethodCall};
-    Cli {
-        network: templar_gateway_client::Network::Testnet,
-        rpc_url: None,
-        rpc_api_key: None,
-        signer_id: signer_id.map(|id| id.parse().expect("valid account id")),
-        secret_key: secret_key.map(str::to_owned),
-        transaction_url_prefix: None,
-        quiet: 0,
-        verbose: 0,
-        command: Command::Read(GenericMethodCall {
-            method: "contract.getVersion".to_owned(),
-            json: Some("{}".to_owned()),
-            json_file: None,
-        }),
-    }
-}
-
-#[test]
-fn partial_signer_config_builds_read_only_context() {
-    const TEST_SECRET_KEY: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
-
-    // Only --signer-id: builds a (read-only) context rather than failing up
-    // front, so read commands still work; the signer path reports the missing
-    // secret only when a signer is actually needed.
-    let ctx = super::context::build_context(&cli_with_signer(Some("signer.testnet"), None))
-        .expect("signer-id-only config should still build a read-only context");
-    assert_eq!(
-        ctx.signer_account()
-            .expect_err("a write signer requires both halves")
-            .to_string(),
-        "--secret-key is required with --signer-id"
-    );
-
-    // Only --secret-key: also builds (teardown flows sign per-account with just
-    // the key); the default-signer path reports the missing id.
-    let ctx = super::context::build_context(&cli_with_signer(None, Some(TEST_SECRET_KEY)))
-        .expect("secret-key-only config should still build a context");
-    assert_eq!(
-        ctx.signer_account()
-            .expect_err("a default write signer requires both halves")
-            .to_string(),
-        "--signer-id is required with --secret-key"
-    );
 }
 
 #[test]

--- a/tools/manager/src/tests/deploy_script.rs
+++ b/tools/manager/src/tests/deploy_script.rs
@@ -5,34 +5,127 @@ use crate::cli::{Cli, Command};
 use crate::commands::proxy_oracle_governance::ProxyOracleGovernanceNs;
 use crate::commands::proxy_oracle_owner::ProxyOracleOwnerNs;
 use crate::commands::registry::RegistryNs;
-use crate::context::CliContext;
+
+use super::CREDS;
 
 const COLLATERAL_PRICE_ID: &str =
     "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
 #[test]
-fn registry_deploy_defaults_init_args_to_null() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "deploy",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "proxy-oracle-market",
-        "--version-key",
-        "proxy@1",
-        "--deposit",
-        "3.5 NEAR",
-    ])
+fn registry_deploy_requires_init_args() {
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "proxy-oracle-market",
+            "--version-key",
+            "proxy@1",
+            "--deposit",
+            "3.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
+    .expect_err("deploy with no init args should fail to parse");
+
+    assert_eq!(
+        error.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument
+    );
+}
+
+#[test]
+fn registry_deploy_rejects_both_init_args_sources() {
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "proxy-oracle-market",
+            "--version-key",
+            "proxy@1",
+            "--deposit",
+            "3.5 NEAR",
+            "--init-args",
+            "null",
+            "--init-args-file",
+            "/dev/null",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
+    .expect_err("deploy with both init-args sources should fail to parse");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn registry_deploy_rejects_invalid_inline_init_args() {
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "proxy-oracle-market",
+            "--version-key",
+            "proxy@1",
+            "--deposit",
+            "3.5 NEAR",
+            "--init-args",
+            "{not json",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
+    .expect("registry deploy should parse");
+
+    match cli.command {
+        Command::Registry {
+            command: RegistryNs::Deploy(cmd),
+        } => cmd
+            .try_into_spec()
+            .expect_err("invalid inline JSON should be rejected"),
+        _ => panic!("expected Registry::Deploy"),
+    };
+}
+
+#[test]
+fn registry_deploy_accepts_explicit_inline_null_init_args() {
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "proxy-oracle-market",
+            "--version-key",
+            "proxy@1",
+            "--deposit",
+            "3.5 NEAR",
+            "--init-args",
+            "null",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("registry deploy should parse");
 
     let params = match cli.command {
         Command::Registry {
             command: RegistryNs::Deploy(cmd),
-        } => cmd
-            .try_into_spec(&CliContext::for_test())
-            .expect("deploy should parse"),
+        } => cmd.try_into_spec().expect("deploy should build"),
         _ => panic!("expected Registry::Deploy"),
     };
 
@@ -52,29 +145,31 @@ fn registry_deploy_reads_init_args_file() {
     ));
     std::fs::write(&path, init_args).expect("write init args fixture");
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "deploy",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "proxy-oracle",
-        "--version-key",
-        "proxy-oracle@1",
-        "--init-args-file",
-        path.to_str().expect("fixture path is unicode"),
-        "--deposit",
-        "1 yoctoNEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "proxy-oracle",
+            "--version-key",
+            "proxy-oracle@1",
+            "--init-args-file",
+            path.to_str().expect("fixture path is unicode"),
+            "--deposit",
+            "1 yoctoNEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("registry deploy with init-args-file should parse");
 
     let params = match cli.command {
         Command::Registry {
             command: RegistryNs::Deploy(cmd),
-        } => cmd
-            .try_into_spec(&CliContext::for_test())
-            .expect("deploy should parse"),
+        } => cmd.try_into_spec().expect("deploy should build"),
         _ => panic!("expected Registry::Deploy"),
     };
 
@@ -86,15 +181,19 @@ fn registry_deploy_reads_init_args_file() {
 
 #[test]
 fn proxy_oracle_owner_typed_commands_parse() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "proxy-oracle-owner",
-        "propose-owner",
-        "--oracle-id",
-        "proxy.registry.testnet",
-        "--account-id",
-        "operator.testnet",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "proxy-oracle-owner",
+            "propose-owner",
+            "--oracle-id",
+            "proxy.registry.testnet",
+            "--account-id",
+            "operator.testnet",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("propose-owner should parse");
 
     let params = match cli.command {
@@ -109,13 +208,17 @@ fn proxy_oracle_owner_typed_commands_parse() {
     )
     .expect("typed proposeOwner params should match the gateway spec");
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "proxy-oracle-owner",
-        "accept-owner",
-        "--oracle-id",
-        "proxy.registry.testnet",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "proxy-oracle-owner",
+            "accept-owner",
+            "--oracle-id",
+            "proxy.registry.testnet",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("accept-owner should parse");
 
     let params = match cli.command {
@@ -142,6 +245,8 @@ fn governance_create_proposal_reshapes_legacy_proxy_file() {
     }]);
     let proxy_file = write_legacy_proxy_fixture(&legacy_entries);
 
+    // Credentials flatten at the `create-proposal` level, so they must precede
+    // the `set-proxy` operation subcommand.
     let cli = Cli::try_parse_from([
         "tmplrmgr",
         "proxy-oracle-governance",
@@ -150,6 +255,10 @@ fn governance_create_proposal_reshapes_legacy_proxy_file() {
         "proxy.registry.testnet",
         "--id",
         "0",
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        super::TEST_SECRET_KEY,
         "set-proxy",
         "--price-id",
         COLLATERAL_PRICE_ID,
@@ -180,15 +289,19 @@ fn governance_create_proposal_reshapes_legacy_proxy_file() {
 
 #[test]
 fn governance_execute_proposal_typed_args_parse() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "proxy-oracle-governance",
-        "execute-proposal",
-        "--governance-id",
-        "proxy.registry.testnet",
-        "--id",
-        "0",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "proxy-oracle-governance",
+            "execute-proposal",
+            "--governance-id",
+            "proxy.registry.testnet",
+            "--id",
+            "0",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("execute-proposal should parse");
 
     let params = match cli.command {
@@ -214,6 +327,10 @@ fn create_proposal_set_proxy_requires_price_id() {
         "proxy.registry.testnet",
         "--id",
         "0",
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        super::TEST_SECRET_KEY,
         "set-proxy",
     ])
     .expect_err("set-proxy should require --price-id");
@@ -226,18 +343,22 @@ fn create_proposal_set_proxy_requires_price_id() {
 
 #[test]
 fn json_fallback_still_works_for_create_proposal() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "proxyOracleGovernance.createProposal",
-        "--json",
-        r#"{"governance_id":"proxy.registry.testnet","id":0,"operation":{"SetProxy":{"id":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","proxy":{"aggregator":{"MedianLow":{"sources":[],"min_sources":1}},"freshness_filter":{"max_age_ns":"1","max_clock_drift_ns":"1"}}}},"requested_ttl":"0"}"#,
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "write",
+            "proxyOracleGovernance.createProposal",
+            "--json",
+            r#"{"governance_id":"proxy.registry.testnet","id":0,"operation":{"SetProxy":{"id":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","proxy":{"aggregator":{"MedianLow":{"sources":[],"min_sources":1}},"freshness_filter":{"max_age_ns":"1","max_clock_drift_ns":"1"}}}},"requested_ttl":"0"}"#,
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("write fallback should parse");
 
     let params = match cli.command {
         Command::Write(call) => {
-            let json_str = call.json.expect("json should be present");
+            let json_str = call.call.json.expect("json should be present");
             serde_json::from_str(&json_str).expect("json should parse")
         }
         _ => panic!("expected Write variant"),

--- a/tools/manager/src/tests/ft.rs
+++ b/tools/manager/src/tests/ft.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use serde_json::json;
 
+use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::ft::FtNs;
 
@@ -32,19 +33,23 @@ fn parses_ft_get_balance_of_typed_args() {
 
 #[test]
 fn parses_ft_transfer_typed_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "ft",
-        "transfer",
-        "--contract-id",
-        "token.testnet",
-        "--receiver-id",
-        "bob.testnet",
-        "--amount",
-        "1234567890000000000000000",
-        "--memo",
-        "refund",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "ft",
+            "transfer",
+            "--contract-id",
+            "token.testnet",
+            "--receiver-id",
+            "bob.testnet",
+            "--amount",
+            "1234567890000000000000000",
+            "--memo",
+            "refund",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("transfer should parse");
 
     let params = match cli.command {
@@ -62,17 +67,21 @@ fn parses_ft_transfer_typed_args() {
 
 #[test]
 fn omits_ft_transfer_memo_when_absent() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "ft",
-        "transfer",
-        "--contract-id",
-        "token.testnet",
-        "--receiver-id",
-        "bob.testnet",
-        "--amount",
-        "1",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "ft",
+            "transfer",
+            "--contract-id",
+            "token.testnet",
+            "--receiver-id",
+            "bob.testnet",
+            "--amount",
+            "1",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("transfer without memo should parse");
 
     let params = match cli.command {
@@ -90,21 +99,25 @@ fn omits_ft_transfer_memo_when_absent() {
 
 #[test]
 fn parses_ft_transfer_call_typed_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "ft",
-        "transfer-call",
-        "--contract-id",
-        "token.testnet",
-        "--receiver-id",
-        "app.testnet",
-        "--amount",
-        "42",
-        "--msg",
-        r#"{"action":"stake"}"#,
-        "--memo",
-        "stake",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "ft",
+            "transfer-call",
+            "--contract-id",
+            "token.testnet",
+            "--receiver-id",
+            "app.testnet",
+            "--amount",
+            "42",
+            "--msg",
+            r#"{"action":"stake"}"#,
+            "--memo",
+            "stake",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("transfer-call should parse");
 
     let params = match cli.command {
@@ -137,19 +150,23 @@ fn parses_ft_kebab_case_aliases() {
         _ => panic!("expected Ft variant"),
     }
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "ft",
-        "transfer-call",
-        "--contract-id",
-        "token.testnet",
-        "--receiver-id",
-        "app.testnet",
-        "--amount",
-        "42",
-        "--msg",
-        "stake",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "ft",
+            "transfer-call",
+            "--contract-id",
+            "token.testnet",
+            "--receiver-id",
+            "app.testnet",
+            "--amount",
+            "42",
+            "--msg",
+            "stake",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("transfer-call should parse");
     match cli.command {
         Command::Ft { .. } => {}

--- a/tools/manager/src/tests/market.rs
+++ b/tools/manager/src/tests/market.rs
@@ -1,37 +1,41 @@
 use clap::Parser;
 use serde_json::json;
 
+use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::market::MarketNs;
-use crate::context::CliContext;
 
 #[test]
 fn parses_market_create_typed_args() {
     let init_args = br#"{"configuration":{"time_chunk_configuration":{"duration_ms":"600000"},"borrow_asset":{"Nep141":"usdt.testnet"},"collateral_asset":{"Nep141":"collateral.testnet"},"price_oracle_configuration":{"account_id":"oracle.testnet","collateral_asset_price_id":"cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc","collateral_asset_decimals":24,"borrow_asset_price_id":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","borrow_asset_decimals":6,"price_maximum_age_s":60},"borrow_mcr_maintenance":"1.4","borrow_mcr_liquidation":"1.33333333333333333333333333333333333333","borrow_asset_maximum_usage_ratio":"0.99","borrow_origination_fee":{"Flat":"0"},"borrow_interest_rate_strategy":{"Piecewise":{"base":"0","optimal":"0.9","rate_1":"0.08888888888888888888888888888888888889","rate_2":"2.4"}},"borrow_maximum_duration_ms":null,"borrow_range":{"minimum":"1","maximum":null},"supply_range":{"minimum":"40000","maximum":null},"supply_withdrawal_range":{"minimum":"40000","maximum":null},"supply_withdrawal_fee":{"fee":{"Flat":"0"},"duration":"0","behavior":"Fixed"},"yield_weights":{"supply":4,"static":{"revenue.testnet":1}},"protocol_account_id":"revenue.testnet","liquidation_maximum_spread":"0.1"}}"#;
     let path = write_init_args_fixture("valid", init_args);
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "market",
-        "create",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "market",
-        "--version-key",
-        "market@1",
-        "--init-args-file",
-        path.to_str().expect("fixture path is unicode"),
-        "--deposit",
-        "5.5 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "market",
+            "create",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "market",
+            "--version-key",
+            "market@1",
+            "--init-args-file",
+            path.to_str().expect("fixture path is unicode"),
+            "--deposit",
+            "5.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("market create should parse");
 
     let params = match cli.command {
         Command::Market {
             command: MarketNs::Create(cmd),
         } => cmd
-            .try_into_spec(&CliContext::for_test())
+            .try_into_spec()
             .expect("market create should parse init args"),
         _ => panic!("expected Market::Create"),
     };
@@ -59,28 +63,32 @@ fn market_create_rejects_missing_init_args_file() {
         line!(),
     ));
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "market",
-        "create",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "market",
-        "--version-key",
-        "market@1",
-        "--init-args-file",
-        path.to_str().expect("fixture path is unicode"),
-        "--deposit",
-        "5.5 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "market",
+            "create",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "market",
+            "--version-key",
+            "market@1",
+            "--init-args-file",
+            path.to_str().expect("fixture path is unicode"),
+            "--deposit",
+            "5.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("market create should parse before file loading");
 
     let error = match cli.command {
         Command::Market {
             command: MarketNs::Create(cmd),
         } => cmd
-            .try_into_spec(&CliContext::for_test())
+            .try_into_spec()
             .expect_err("missing init args file should be rejected"),
         _ => panic!("expected Market::Create"),
     };
@@ -92,28 +100,32 @@ fn market_create_rejects_missing_init_args_file() {
 fn market_create_rejects_invalid_init_args() {
     let path = write_init_args_fixture("invalid", br#"{"configuration": null}"#);
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "market",
-        "create",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "market",
-        "--version-key",
-        "market@1",
-        "--init-args-file",
-        path.to_str().expect("fixture path is unicode"),
-        "--deposit",
-        "5.5 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "market",
+            "create",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "market",
+            "--version-key",
+            "market@1",
+            "--init-args-file",
+            path.to_str().expect("fixture path is unicode"),
+            "--deposit",
+            "5.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("market create should parse before init args validation");
 
     let error = match cli.command {
         Command::Market {
             command: MarketNs::Create(cmd),
         } => cmd
-            .try_into_spec(&CliContext::for_test())
+            .try_into_spec()
             .expect_err("invalid init args should be rejected"),
         _ => panic!("expected Market::Create"),
     };
@@ -135,14 +147,18 @@ fn write_init_args_fixture(label: &str, bytes: &[u8]) -> std::path::PathBuf {
 
 #[test]
 fn market_remove_parses_beneficiary_and_force() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "market",
-        "remove",
-        "--beneficiary-id",
-        "treasury.testnet",
-        "--force",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "market",
+            "remove",
+            "--beneficiary-id",
+            "treasury.testnet",
+            "--force",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("market remove should parse");
     let Command::Market {
         command: MarketNs::Remove(cmd),

--- a/tools/manager/src/tests/plan.rs
+++ b/tools/manager/src/tests/plan.rs
@@ -16,6 +16,7 @@ use templar_gateway_types::{
     ManagedAccountId, MethodSpec,
 };
 
+use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::{FtNs, ProxyOracleGovernanceNs, RedstoneNs, StorageNs};
 
@@ -72,19 +73,23 @@ fn single_call(plan: &OperationPlan) -> Call {
 
 #[tokio::test]
 async fn ft_transfer_plans_ft_transfer_action() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "ft",
-        "transfer",
-        "--contract-id",
-        "usdt.testnet",
-        "--receiver-id",
-        "beneficiary.testnet",
-        "--amount",
-        "1000",
-        "--memo",
-        "recovered",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "ft",
+            "transfer",
+            "--contract-id",
+            "usdt.testnet",
+            "--receiver-id",
+            "beneficiary.testnet",
+            "--amount",
+            "1000",
+            "--memo",
+            "recovered",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("ft transfer should parse");
     let body = match cli.command {
         Command::Ft {
@@ -105,17 +110,21 @@ async fn ft_transfer_plans_ft_transfer_action() {
 
 #[tokio::test]
 async fn storage_deposit_plans_storage_deposit_action() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "deposit",
-        "--contract-id",
-        "usdt.testnet",
-        "--beneficiary-id",
-        "alice.testnet",
-        "--deposit",
-        "0.00125 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "deposit",
+            "--contract-id",
+            "usdt.testnet",
+            "--beneficiary-id",
+            "alice.testnet",
+            "--deposit",
+            "0.00125 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("storage deposit should parse");
     let body = match cli.command {
         Command::Storage {
@@ -134,14 +143,18 @@ async fn storage_deposit_plans_storage_deposit_action() {
 
 #[tokio::test]
 async fn storage_unregister_plans_storage_unregister_action() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "unregister",
-        "--contract-id",
-        "usdt.testnet",
-        "--force",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "unregister",
+            "--contract-id",
+            "usdt.testnet",
+            "--force",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("storage unregister should parse");
     let body = match cli.command {
         Command::Storage {
@@ -159,15 +172,19 @@ async fn storage_unregister_plans_storage_unregister_action() {
 
 #[tokio::test]
 async fn governance_cancel_proposal_plans_cancel_action() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "proxy-oracle-governance",
-        "cancel-proposal",
-        "--governance-id",
-        "proxy.registry.testnet",
-        "--id",
-        "3",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "proxy-oracle-governance",
+            "cancel-proposal",
+            "--governance-id",
+            "proxy.registry.testnet",
+            "--id",
+            "3",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("cancel-proposal should parse");
     let body = match cli.command {
         Command::ProxyOracleGovernance {
@@ -186,17 +203,21 @@ async fn governance_cancel_proposal_plans_cancel_action() {
 
 #[tokio::test]
 async fn redstone_set_role_plans_set_role_action() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "redstone",
-        "set-role",
-        "--oracle-id",
-        "redstone.testnet",
-        "--account-id",
-        "updater.testnet",
-        "--role",
-        "trusted-updater",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "redstone",
+            "set-role",
+            "--oracle-id",
+            "redstone.testnet",
+            "--account-id",
+            "updater.testnet",
+            "--role",
+            "trusted-updater",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("redstone set-role should parse");
     let body = match cli.command {
         Command::Redstone {

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -1,10 +1,10 @@
 use clap::Parser;
 use serde_json::{json, Value};
 
+use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::proxy_oracle::ProxyOracleNs;
 use crate::commands::proxy_oracle_governance::ProxyOracleGovernanceNs;
-use crate::context::CliContext;
 
 const PRICE_ID: &str = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
@@ -13,6 +13,9 @@ fn create_proposal(
     args: &[&str],
 ) -> anyhow::Result<templar_gateway_methods_spec::proxy_oracle_governance::CreateProposal> {
     let mut full = vec!["tmplrmgr", "proxy-oracle-governance", "create-proposal"];
+    // Credentials are create-proposal-level, so they precede the operation
+    // subcommand carried in `args`.
+    full.extend_from_slice(&CREDS);
     full.extend_from_slice(args);
     match Cli::try_parse_from(full)
         .expect("create-proposal should parse")
@@ -221,6 +224,10 @@ fn create_proposal_id_is_optional_for_auto_fetch() {
         "create-proposal",
         "--governance-id",
         "gov.testnet",
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        super::TEST_SECRET_KEY,
         "set-proxy",
         "--price-id",
         PRICE_ID,
@@ -252,6 +259,10 @@ fn create_proposal_execute_when_ready_flag() {
         "--id",
         "0",
         "--execute-when-ready",
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        super::TEST_SECRET_KEY,
         "admin-function-call",
         "--method",
         "own_accept_owner",
@@ -284,6 +295,7 @@ fn execute_proposal_when_ready_flag() {
     ] {
         let mut full = vec!["tmplrmgr", "proxy-oracle-governance", "execute-proposal"];
         full.extend_from_slice(&args);
+        full.extend_from_slice(&CREDS);
         let cli = Cli::try_parse_from(full).expect("execute-proposal should parse");
         match cli.command {
             Command::ProxyOracleGovernance {
@@ -299,33 +311,35 @@ fn execute_proposal_when_ready_flag() {
 
 #[test]
 fn governance_create_builds_init_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "proxy-oracle-governance",
-        "create",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "proxy-governance-market",
-        "--version-key",
-        "gov@1",
-        "--proxy-oracle-id",
-        "proxy-oracle-market.registry.testnet",
-        "--admin-id",
-        "operator.testnet",
-        "--ttl-default",
-        "0ns",
-        "--deposit",
-        "3.5 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "proxy-oracle-governance",
+            "create",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "proxy-governance-market",
+            "--version-key",
+            "gov@1",
+            "--proxy-oracle-id",
+            "proxy-oracle-market.registry.testnet",
+            "--admin-id",
+            "operator.testnet",
+            "--ttl-default",
+            "0ns",
+            "--deposit",
+            "3.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("governance create should parse");
 
     let deploy = match cli.command {
         Command::ProxyOracleGovernance {
             command: ProxyOracleGovernanceNs::Create(cmd),
-        } => cmd
-            .try_into_spec(&CliContext::for_test())
-            .expect("into deploy spec"),
+        } => cmd.try_into_spec().expect("into deploy spec"),
         _ => panic!("expected governance create"),
     };
 
@@ -382,17 +396,21 @@ fn governance_role_reads_parse() {
 #[test]
 fn oracle_update_prices_collects_repeated_ids() {
     let borrow = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "proxy-oracle",
-        "update-prices",
-        "--oracle-id",
-        "proxy.testnet",
-        "--price-id",
-        PRICE_ID,
-        "--price-id",
-        borrow,
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "proxy-oracle",
+            "update-prices",
+            "--oracle-id",
+            "proxy.testnet",
+            "--price-id",
+            PRICE_ID,
+            "--price-id",
+            borrow,
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("update-prices should parse");
     let spec = match cli.command {
         Command::ProxyOracle {
@@ -416,6 +434,10 @@ fn add_circuit_breaker_breaker_id_is_optional_and_resolvable() {
         "gov.testnet",
         "--id",
         "0",
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        super::TEST_SECRET_KEY,
         "add-circuit-breaker",
         "--price-id",
         PRICE_ID,
@@ -444,6 +466,10 @@ fn add_circuit_breaker_breaker_id_is_optional_and_resolvable() {
         "gov.testnet",
         "--id",
         "0",
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        super::TEST_SECRET_KEY,
         "add-circuit-breaker",
         "--price-id",
         PRICE_ID,

--- a/tools/manager/src/tests/redstone.rs
+++ b/tools/manager/src/tests/redstone.rs
@@ -1,25 +1,29 @@
 use clap::Parser;
 
+use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::RedstoneNs;
-use crate::context::CliContext;
 
 #[test]
 fn write_prices_decodes_base64_payload() {
     // "hello" encoded as standard base64.
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "redstone",
-        "write-prices",
-        "--oracle-id",
-        "redstone.testnet",
-        "--feed-id",
-        "BTC",
-        "--feed-id",
-        "ETH",
-        "--payload-base64",
-        "aGVsbG8=",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "redstone",
+            "write-prices",
+            "--oracle-id",
+            "redstone.testnet",
+            "--feed-id",
+            "BTC",
+            "--feed-id",
+            "ETH",
+            "--payload-base64",
+            "aGVsbG8=",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("write-prices should parse");
     let params = match cli.command {
         Command::Redstone {
@@ -39,17 +43,21 @@ fn write_prices_decodes_base64_payload() {
 
 #[test]
 fn write_prices_rejects_invalid_base64() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "redstone",
-        "write-prices",
-        "--oracle-id",
-        "redstone.testnet",
-        "--feed-id",
-        "BTC",
-        "--payload-base64",
-        "not valid base64!!!",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "redstone",
+            "write-prices",
+            "--oracle-id",
+            "redstone.testnet",
+            "--feed-id",
+            "BTC",
+            "--payload-base64",
+            "not valid base64!!!",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("write-prices should parse at the clap boundary");
     let error = match cli.command {
         Command::Redstone {
@@ -89,27 +97,29 @@ fn list_role_maps_role_arg_to_snake_case() {
 
 #[test]
 fn create_prod_preset_builds_config_init_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "redstone",
-        "create",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "redstone",
-        "--version-key",
-        "redstone@1",
-        "--prod",
-        "--deposit",
-        "3.5 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "redstone",
+            "create",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "redstone",
+            "--version-key",
+            "redstone@1",
+            "--prod",
+            "--deposit",
+            "3.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("redstone create --prod should parse");
     let deploy = match cli.command {
         Command::Redstone {
             command: RedstoneNs::Create(a),
-        } => a
-            .try_into_spec(&CliContext::for_test())
-            .expect("into deploy spec"),
+        } => a.try_into_spec().expect("into deploy spec"),
         _ => panic!("expected redstone create"),
     };
 
@@ -126,38 +136,46 @@ fn create_prod_preset_builds_config_init_args() {
 #[test]
 fn create_requires_exactly_one_config_source() {
     // --prod and --test are mutually exclusive.
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "redstone",
-        "create",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "redstone",
-        "--version-key",
-        "redstone@1",
-        "--prod",
-        "--test",
-        "--deposit",
-        "3.5 NEAR",
-    ])
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "redstone",
+            "create",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "redstone",
+            "--version-key",
+            "redstone@1",
+            "--prod",
+            "--test",
+            "--deposit",
+            "3.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect_err("--prod with --test should be rejected");
     assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
 }
 
 #[test]
 fn update_prices_defaults_node_path_and_builds_write_spec() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "redstone",
-        "update-prices",
-        "--oracle-id",
-        "redstone.testnet",
-        "--feed-id",
-        "BTC",
-        "--feed-id",
-        "ETH",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "redstone",
+            "update-prices",
+            "--oracle-id",
+            "redstone.testnet",
+            "--feed-id",
+            "BTC",
+            "--feed-id",
+            "ETH",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("update-prices should parse");
     let Command::Redstone {
         command: RedstoneNs::UpdatePrices(cmd),

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -217,7 +217,7 @@ fn add_version_wasm_path_builds_global_hash_spec() {
 }
 
 #[test]
-fn add_version_defaults_to_normal_mode_and_minimal_deposit() {
+fn add_version_normal_mode_uses_minimal_deposit() {
     let path = temp_wasm("normal", b"\0asm-normal");
     let spec = add_version_spec(&[
         "tmplrmgr",
@@ -229,12 +229,41 @@ fn add_version_defaults_to_normal_mode_and_minimal_deposit() {
         path.to_str().unwrap(),
         "--version-key",
         "custom@1.0.0#abc",
+        "--deploy-mode",
+        "normal",
     ])
     .expect("into_spec should succeed");
     std::fs::remove_file(&path).ok();
 
     assert_eq!(spec.deploy_mode, DeployMode::Normal);
     assert_eq!(spec.deposit.as_yoctonear(), 1);
+}
+
+#[test]
+fn add_version_requires_explicit_deploy_mode() {
+    let path = temp_wasm("no-mode", b"\0asm");
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "add-version",
+            "--registry-id",
+            "registry.testnet",
+            "--wasm",
+            path.to_str().unwrap(),
+            "--version-key",
+            "custom@1.0.0#abc",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
+    .expect_err("--deploy-mode must be chosen explicitly");
+    std::fs::remove_file(&path).ok();
+
+    assert_eq!(
+        error.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument
+    );
 }
 
 #[test]
@@ -275,6 +304,8 @@ fn add_version_wasm_requires_explicit_version_key() {
         "registry.testnet",
         "--wasm",
         path.to_str().unwrap(),
+        "--deploy-mode",
+        "normal",
     ]);
     std::fs::remove_file(&path).ok();
 
@@ -294,9 +325,12 @@ fn add_version_rejects_conflicting_contract_sources() {
             "add-version",
             "--registry-id",
             "registry.testnet",
-            "--market",
+            "--contract",
+            "market",
             "--package",
             "proxy-oracle",
+            "--deploy-mode",
+            "normal",
         ]
         .into_iter()
         .chain(CREDS),
@@ -315,6 +349,8 @@ fn add_version_requires_a_contract_source() {
             "add-version",
             "--registry-id",
             "registry.testnet",
+            "--deploy-mode",
+            "normal",
         ]
         .into_iter()
         .chain(CREDS),

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use serde_json::json;
 use templar_common::registry::DeployMode;
 
+use super::{CREDS, TEST_SECRET_KEY};
 use crate::cli::{Cli, Command};
 use crate::commands::registry::RegistryNs;
 
@@ -19,7 +20,7 @@ fn temp_wasm(tag: &str, bytes: &[u8]) -> std::path::PathBuf {
 fn add_version_spec(
     args: &[&str],
 ) -> anyhow::Result<templar_gateway_methods_spec::registry::AddVersion> {
-    match Cli::try_parse_from(args)
+    match Cli::try_parse_from(args.iter().copied().chain(CREDS))
         .expect("add-version should parse")
         .command
     {
@@ -286,16 +287,20 @@ fn add_version_wasm_requires_explicit_version_key() {
 
 #[test]
 fn add_version_rejects_conflicting_contract_sources() {
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "add-version",
-        "--registry-id",
-        "registry.testnet",
-        "--market",
-        "--package",
-        "proxy-oracle",
-    ])
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "add-version",
+            "--registry-id",
+            "registry.testnet",
+            "--market",
+            "--package",
+            "proxy-oracle",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect_err("conflicting contract selectors must be rejected");
 
     assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
@@ -303,13 +308,17 @@ fn add_version_rejects_conflicting_contract_sources() {
 
 #[test]
 fn add_version_requires_a_contract_source() {
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "add-version",
-        "--registry-id",
-        "registry.testnet",
-    ])
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "add-version",
+            "--registry-id",
+            "registry.testnet",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect_err("a contract source is required");
 
     assert_eq!(
@@ -320,15 +329,19 @@ fn add_version_requires_a_contract_source() {
 
 #[test]
 fn remove_version_single_builds_spec() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "remove-version",
-        "--registry-id",
-        "registry.testnet",
-        "--version-key",
-        "market@1",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "remove-version",
+            "--registry-id",
+            "registry.testnet",
+            "--version-key",
+            "market@1",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("remove-version should parse");
     let Command::Registry {
         command: RegistryNs::RemoveVersion(cmd),
@@ -345,14 +358,18 @@ fn remove_version_single_builds_spec() {
 
 #[test]
 fn remove_version_all_has_no_single_spec() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "remove-version",
-        "--registry-id",
-        "registry.testnet",
-        "--all",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "remove-version",
+            "--registry-id",
+            "registry.testnet",
+            "--all",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("remove-version --all should parse");
     let Command::Registry {
         command: RegistryNs::RemoveVersion(cmd),
@@ -365,13 +382,17 @@ fn remove_version_all_has_no_single_spec() {
 
 #[test]
 fn remove_version_requires_version_key_or_all() {
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "remove-version",
-        "--registry-id",
-        "registry.testnet",
-    ])
+    let error = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "remove-version",
+            "--registry-id",
+            "registry.testnet",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect_err("remove-version needs --version-key or --all");
     assert_eq!(
         error.kind(),
@@ -381,13 +402,17 @@ fn remove_version_requires_version_key_or_all() {
 
 #[test]
 fn clear_deployments_defaults_beneficiary_to_registry() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "clear-deployments",
-        "--registry-id",
-        "registry.testnet",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "registry",
+            "clear-deployments",
+            "--registry-id",
+            "registry.testnet",
+        ]
+        .into_iter()
+        .chain(["--secret-key", TEST_SECRET_KEY]),
+    )
     .expect("clear-deployments should parse");
     let Command::Registry {
         command: RegistryNs::ClearDeployments(cmd),

--- a/tools/manager/src/tests/storage.rs
+++ b/tools/manager/src/tests/storage.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use serde_json::json;
 
+use super::CREDS;
 use crate::cli::{Cli, Command};
 use crate::commands::storage::StorageNs;
 
@@ -54,18 +55,22 @@ fn parses_storage_get_balance_of_typed_args() {
 
 #[test]
 fn parses_storage_deposit_typed_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "deposit",
-        "--contract-id",
-        "storage.testnet",
-        "--beneficiary-id",
-        "beneficiary.testnet",
-        "--registration-only",
-        "--deposit",
-        "1.25 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "deposit",
+            "--contract-id",
+            "storage.testnet",
+            "--beneficiary-id",
+            "beneficiary.testnet",
+            "--registration-only",
+            "--deposit",
+            "1.25 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("deposit should parse");
 
     let params = match cli.command {
@@ -82,14 +87,18 @@ fn parses_storage_deposit_typed_args() {
 
 #[test]
 fn parses_storage_unregister_typed_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "unregister",
-        "--contract-id",
-        "storage.testnet",
-        "--force",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "unregister",
+            "--contract-id",
+            "storage.testnet",
+            "--force",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("unregister should parse");
 
     let params = match cli.command {
@@ -106,19 +115,23 @@ fn parses_storage_unregister_typed_args() {
 
 #[test]
 fn parses_storage_ensure_deposit_typed_args() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "ensure-deposit",
-        "--contract-id",
-        "storage.testnet",
-        "--account-id",
-        "alice.testnet",
-        "--mode",
-        "minimum-total",
-        "--amount",
-        "2.5 NEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "ensure-deposit",
+            "--contract-id",
+            "storage.testnet",
+            "--account-id",
+            "alice.testnet",
+            "--mode",
+            "minimum-total",
+            "--amount",
+            "2.5 NEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("ensure-deposit should parse");
 
     let params = match cli.command {
@@ -163,17 +176,21 @@ fn parses_storage_kebab_case_aliases() {
         _ => panic!("expected Storage variant"),
     }
 
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "ensure-deposit",
-        "--contract-id",
-        "storage.testnet",
-        "--account-id",
-        "alice.testnet",
-        "--mode",
-        "registered",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "ensure-deposit",
+            "--contract-id",
+            "storage.testnet",
+            "--account-id",
+            "alice.testnet",
+            "--mode",
+            "registered",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("ensure-deposit should parse");
     match cli.command {
         Command::Storage { .. } => {}
@@ -183,19 +200,23 @@ fn parses_storage_kebab_case_aliases() {
 
 #[test]
 fn registered_ensure_deposit_rejects_amount() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "storage",
-        "ensure-deposit",
-        "--contract-id",
-        "storage.testnet",
-        "--account-id",
-        "alice.testnet",
-        "--mode",
-        "registered",
-        "--amount",
-        "1 yoctoNEAR",
-    ])
+    let cli = Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "storage",
+            "ensure-deposit",
+            "--contract-id",
+            "storage.testnet",
+            "--account-id",
+            "alice.testnet",
+            "--mode",
+            "registered",
+            "--amount",
+            "1 yoctoNEAR",
+        ]
+        .into_iter()
+        .chain(CREDS),
+    )
     .expect("registered ensure-deposit should parse before typed validation");
 
     let error = match cli.command {


### PR DESCRIPTION
Umbrella for a set of `tmplrmgr` (manager CLI) fixes that share one theme: reject or surface invalid/failed states early and structurally, instead of doing expensive/irreversible work and then failing (or silently succeeding). Together they make `tmplrmgr` safe to drive from automation.

Closes ENG-446, ENG-442, ENG-443, ENG-444.

## ENG-442 — signer credentials are structural per write-command
- Drop the global `--signer-id`/`--secret-key`; add a shared `SignerArgs` (both required, env-sourced) flattened into every write command, plus a key-only `SecretKeyArgs` for the `clear-deployments` multi-account teardown.
- Reads no longer accept credentials. Invalid invocations are rejected by clap **before any wasm build or network work**: a write with no credentials can't parse, and credentials on a read are an unexpected argument.
- Context builds an unsigned read client and signs per-operation from each command's own credentials; `paired_signer`/`signer_account`/`signer_public_key` are gone.

## ENG-443 — `registry deploy` requires init args explicitly
- Add inline `--init-args <JSON>` alongside `--init-args-file`, behind a required, mutually-exclusive arg group; drop the silent `null` default; validate inline JSON up front.

## ENG-444 — reverted writes exit non-zero
- `check_operation_status` funnels through `ctx.write` and every direct `execute_as` in teardown/proposals: a `Failed` operation still prints its JSON result, then errors with a concise stderr diagnostic naming the reverted receipt(s) so driver scripts stop instead of continuing past a failed step.

## Also (ergonomics, no Linear issue)
- `registry add-version`: replace the nine per-contract boolean flags with a single validated `--contract <CONTRACT>` value enum (one `--help` line instead of nine); rename the universal-account value to `universal-account` (keeping `uac` as a legacy alias); rename `proxy-governance` → `proxy-oracle-governance` (no alias); drop the `--deploy-mode` default so the operator chooses every time.

## Verification
- `cargo fmt` clean; `cargo clippy --tests -D warnings` clean; **87 lib tests pass**.
- Also driven end-to-end against the built binary (write without creds → required-arg error before any build; read with `--secret-key` → unexpected argument; `registry deploy` without init args → required-group error; `--contract uac` alias resolves; old `--proxy-governance` rejected; `--deploy-mode` required).
- `deploy.sh` updated (env-sourced credentials; explicit `--init-args null`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/500)
<!-- Reviewable:end -->
