### PR TITLE
feat(gateway): tolerate independent oracle-update reverts via continue_on_failure steps (ENG-445)

### DIFF
--- a/gateway/core/src/client/macros.rs
+++ b/gateway/core/src/client/macros.rs
@@ -43,6 +43,7 @@ macro_rules! contract_writes {
                             deposit: options.deposit,
                         },
                     ))],
+                    continue_on_failure: false,
                 })
             }
         )+

--- a/gateway/core/src/client/registry.rs
+++ b/gateway/core/src/client/registry.rs
@@ -92,6 +92,7 @@ impl RegistryClient<'_> {
                 gas: options.gas,
                 deposit: options.deposit,
             }))],
+            continue_on_failure: false,
         })
     }
 
@@ -105,6 +106,7 @@ impl RegistryClient<'_> {
         Ok(PlannedTransaction {
             signer_account_id: options.signer_account_id,
             receiver_id: self.contract_id().to_owned(),
+            continue_on_failure: false,
             actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
                 method_name: ContractMethodName(method_name.to_string()).0,
                 args: ContractArgs::Json(serde_json::to_value(args.borrow())?).try_into_bytes()?,

--- a/gateway/core/src/lib.rs
+++ b/gateway/core/src/lib.rs
@@ -28,9 +28,9 @@ pub use executor::{
 };
 pub use near_client_provider::HasNearClient;
 pub use operation::{
-    CurrentStep, CurrentStepRef, OperationPlan, PendingPreparation, PlannedTransaction,
-    PreparedCurrentStep, PreparedTransactionResult, SharedOperationStore, StoredOperation,
-    SubmittedCurrentStep, SucceededStep,
+    CompletedStep, CurrentStep, CurrentStepRef, OperationPlan, PendingPreparation,
+    PlannedTransaction, PreparedCurrentStep, PreparedTransactionResult, RevertedStep,
+    SharedOperationStore, StoredOperation, SubmittedCurrentStep, SucceededStep,
 };
 pub use operation_driver::{request_fingerprint, OperationDriver};
 pub use oracle_resolution::{get_proxy, query_oracle_kind, resolve_price_dependencies};

--- a/gateway/core/src/operation.rs
+++ b/gateway/core/src/operation.rs
@@ -18,6 +18,11 @@ pub struct PlannedTransaction {
     pub signer_account_id: ManagedAccountId,
     pub receiver_id: AccountId,
     pub actions: Vec<Action>,
+    /// When `true`, an on-chain revert of this step is *recorded and tolerated*:
+    /// the operation advances to the next step instead of aborting. Used for
+    /// independent steps whose failure must not cancel the rest (e.g. one oracle
+    /// update among several). Defaults to `false` — steps are all-or-nothing.
+    pub continue_on_failure: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -38,6 +43,7 @@ impl PlannedTransaction {
             signer_account_id,
             receiver_id,
             actions,
+            continue_on_failure: false,
         }
     }
 
@@ -48,6 +54,14 @@ impl PlannedTransaction {
         action: Action,
     ) -> Self {
         Self::new(signer_account_id, receiver_id, vec![action])
+    }
+
+    /// Mark this step as tolerant of an on-chain revert: on failure the operation
+    /// records the revert and advances to the next step rather than aborting.
+    #[must_use]
+    pub fn continue_on_failure(mut self, continue_on_failure: bool) -> Self {
+        self.continue_on_failure = continue_on_failure;
+        self
     }
 }
 
@@ -71,11 +85,11 @@ impl OperationPlan {
         receiver_id: AccountId,
         actions: Vec<Action>,
     ) -> Self {
-        Self::single(PlannedTransaction {
+        Self::single(PlannedTransaction::new(
             signer_account_id,
             receiver_id,
             actions,
-        })
+        ))
     }
 
     pub fn push(&mut self, step: PlannedTransaction) {
@@ -94,6 +108,28 @@ pub struct SucceededStep {
     pub transaction: PlannedTransaction,
     pub tx_hash: CryptoHash,
     pub outcome: ExecutionOutcome,
+}
+
+/// A step that executed on chain and reverted, but was *tolerated* because it was
+/// [`PlannedTransaction::continue_on_failure`]. Unlike a
+/// [`CurrentStep::Reverted`] — which is terminal — a tolerated revert advances
+/// the operation, so it lives among the completed steps rather than blocking.
+#[derive(Debug, Clone)]
+pub struct RevertedStep {
+    pub transaction: PlannedTransaction,
+    pub tx_hash: CryptoHash,
+    pub outcome: ExecutionOutcome,
+}
+
+/// A step the operation has advanced past: either it succeeded, or it reverted
+/// and was tolerated. Modelling this as an enum (rather than a `reverted: bool`)
+/// makes a "reverted success" unrepresentable, and keeps the invariant that a
+/// [`CurrentStep::Reverted`]/[`CurrentStep::Rejected`] means *exclusively* a
+/// terminal, non-tolerated failure.
+#[derive(Debug, Clone)]
+pub enum CompletedStep {
+    Succeeded(SucceededStep),
+    Reverted(RevertedStep),
 }
 
 #[derive(Debug, Clone)]
@@ -137,7 +173,10 @@ pub struct StoredOperation {
     /// plan is attached — including an empty (no-op) plan, so a no-op is a real
     /// terminal operation rather than being indistinguishable from a reservation.
     pub planned: bool,
-    pub succeeded_steps: Vec<SucceededStep>,
+    /// Steps the operation has advanced past, in execution order — successes and
+    /// tolerated reverts (see [`CompletedStep`]). Everything here is behind the
+    /// cursor; `current_step` is at it; `remaining_steps` are ahead.
+    pub completed_steps: Vec<CompletedStep>,
     pub current_step: Option<CurrentStep>,
     pub remaining_steps: VecDeque<PlannedTransaction>,
 }
@@ -203,7 +242,7 @@ impl StoredOperation {
                 OperationStatus::InProgress
             }
             None if self.remaining_steps.is_empty() => OperationStatus::Succeeded,
-            None if self.succeeded_steps.is_empty() => OperationStatus::Pending,
+            None if self.completed_steps.is_empty() => OperationStatus::Pending,
             None => OperationStatus::InProgress,
         }
     }
@@ -221,6 +260,55 @@ impl StoredOperation {
     /// these. A planned no-op (`planned`, no steps) is *not* a reservation.
     pub fn is_reservation(&self) -> bool {
         !self.planned
+    }
+
+    /// Record `transaction` as a completed success and advance the cursor
+    /// (clear `current_step`). Shared by live execution and reconciliation.
+    pub fn record_success(
+        &mut self,
+        transaction: PlannedTransaction,
+        tx_hash: CryptoHash,
+        outcome: ExecutionOutcome,
+    ) {
+        self.completed_steps
+            .push(CompletedStep::Succeeded(SucceededStep {
+                transaction,
+                tx_hash,
+                outcome,
+            }));
+        self.current_step = None;
+    }
+
+    /// Record an on-chain revert of `transaction`. The transaction's own
+    /// [`PlannedTransaction::continue_on_failure`] flag is the *sole* authority on
+    /// whether the revert is tolerated — advancing the cursor as a completed
+    /// [`CompletedStep::Reverted`] — or terminal — parking it as the failed
+    /// `current_step`. Centralising the decision here is what upholds the
+    /// invariant that a `CurrentStep::Reverted`/`Rejected` means exclusively a
+    /// non-tolerated failure: no caller can put a tolerated revert there, and none
+    /// can drop a non-tolerated one. Shared by live execution, reconciliation, and
+    /// (via the persisted flag) reload.
+    pub fn record_revert(
+        &mut self,
+        transaction: PlannedTransaction,
+        tx_hash: CryptoHash,
+        outcome: ExecutionOutcome,
+    ) {
+        if transaction.continue_on_failure {
+            self.completed_steps
+                .push(CompletedStep::Reverted(RevertedStep {
+                    transaction,
+                    tx_hash,
+                    outcome,
+                }));
+            self.current_step = None;
+        } else {
+            self.current_step = Some(CurrentStep::Reverted {
+                transaction,
+                tx_hash,
+                outcome,
+            });
+        }
     }
 
     #[must_use]
@@ -274,19 +362,26 @@ impl StoredOperation {
 
     fn transaction_step_records(&self) -> Vec<templar_gateway_types::TransactionStepRecord> {
         let mut steps = Vec::with_capacity(
-            self.succeeded_steps.len()
+            self.completed_steps.len()
                 + self.remaining_steps.len()
                 + usize::from(self.current_step.is_some()),
         );
 
         let mut next_index = 0_u32;
-        for step in &self.succeeded_steps {
-            steps.push(templar_gateway_types::TransactionStepRecord {
-                index: next_index,
-                status: StepStatus::Succeeded {
+        for step in &self.completed_steps {
+            let status = match step {
+                CompletedStep::Succeeded(step) => StepStatus::Succeeded {
                     tx_hash: step.tx_hash,
                     outcome: step.outcome.clone(),
                 },
+                CompletedStep::Reverted(step) => StepStatus::Reverted {
+                    tx_hash: step.tx_hash,
+                    outcome: step.outcome.clone(),
+                },
+            };
+            steps.push(templar_gateway_types::TransactionStepRecord {
+                index: next_index,
+                status,
             });
             next_index = next_index.saturating_add(1);
         }
@@ -371,27 +466,21 @@ impl SubmittedCurrentStep<'_> {
         tx_hash: CryptoHash,
         outcome: ExecutionOutcome,
     ) -> GatewayResult<()> {
-        self.operation.succeeded_steps.push(SucceededStep {
-            transaction: self.transaction,
-            tx_hash,
-            outcome,
-        });
-        self.operation.current_step = None;
+        self.operation
+            .record_success(self.transaction, tx_hash, outcome);
         self.store.save_operation(self.operation.clone()).await
     }
 
     /// Record the step as having executed on chain but reverted (final outcome
-    /// was a failure).
+    /// was a failure). Whether that reverts the operation or is tolerated is
+    /// decided by [`StoredOperation::record_revert`] from the step's own flag.
     pub async fn mark_reverted(
         self,
         tx_hash: CryptoHash,
         outcome: ExecutionOutcome,
     ) -> GatewayResult<()> {
-        self.operation.current_step = Some(CurrentStep::Reverted {
-            transaction: self.transaction,
-            tx_hash,
-            outcome,
-        });
+        self.operation
+            .record_revert(self.transaction, tx_hash, outcome);
         self.store.save_operation(self.operation.clone()).await
     }
 

--- a/gateway/core/src/operation_driver.rs
+++ b/gateway/core/src/operation_driver.rs
@@ -530,14 +530,24 @@ impl OperationDriver {
                     if step.is_success {
                         operation.record_success(transaction, tx_hash, step.outcome);
                     } else {
-                        tracing::warn!(
-                            operation_id = %operation.id.0,
-                            %tx_hash,
-                            "current step transaction reverted"
-                        );
                         // Tolerance is decided by the step's own flag, so a
                         // continue_on_failure step reverting mid-reconcile advances
-                        // rather than blocking — same rule as live execution.
+                        // rather than blocking — same rule as live execution. A
+                        // tolerated revert is routine (log quietly); only a terminal,
+                        // blocking revert warrants a warning.
+                        if transaction.continue_on_failure {
+                            tracing::debug!(
+                                operation_id = %operation.id.0,
+                                %tx_hash,
+                                "tolerated step reverted during reconciliation; operation advances"
+                            );
+                        } else {
+                            tracing::warn!(
+                                operation_id = %operation.id.0,
+                                %tx_hash,
+                                "current step transaction reverted"
+                            );
+                        }
                         operation.record_revert(transaction, tx_hash, step.outcome);
                     }
                 }

--- a/gateway/core/src/operation_driver.rs
+++ b/gateway/core/src/operation_driver.rs
@@ -14,7 +14,7 @@ use templar_gateway_types::{
 use crate::{
     CreateOperationResult, CurrentStep, CurrentStepRef, GatewayError, GatewayResult,
     HasIdempotencyKey, HasSignerAccountId, OperationPlan, PlanWrite, SharedExecuteOperation,
-    SharedOperationStore, SharedSignTransaction, StoredOperation, SucceededStep,
+    SharedOperationStore, SharedSignTransaction, StoredOperation,
 };
 use tokio::sync::{Mutex, OwnedMutexGuard};
 
@@ -528,23 +528,17 @@ impl OperationDriver {
             {
                 Ok(step) => {
                     if step.is_success {
-                        operation.succeeded_steps.push(SucceededStep {
-                            transaction,
-                            tx_hash,
-                            outcome: step.outcome,
-                        });
-                        operation.current_step = None;
+                        operation.record_success(transaction, tx_hash, step.outcome);
                     } else {
                         tracing::warn!(
                             operation_id = %operation.id.0,
                             %tx_hash,
                             "current step transaction reverted"
                         );
-                        operation.current_step = Some(CurrentStep::Reverted {
-                            transaction,
-                            tx_hash,
-                            outcome: step.outcome,
-                        });
+                        // Tolerance is decided by the step's own flag, so a
+                        // continue_on_failure step reverting mid-reconcile advances
+                        // rather than blocking — same rule as live execution.
+                        operation.record_revert(transaction, tx_hash, step.outcome);
                     }
                 }
                 Err(error) => {

--- a/gateway/oracle-updates-dispatch/src/oracle_impl.rs
+++ b/gateway/oracle-updates-dispatch/src/oracle_impl.rs
@@ -111,6 +111,16 @@ where
         // underlying updates. Steps execute sequentially, so the proxy read sees the fresh
         // underlying prices this same operation just wrote.
         if matches!(kind, OracleContractKind::Proxy) {
+            // The underlying oracle updates are mutually independent: one reverting must
+            // not cancel the others, nor the re-aggregation. Mark them continue_on_failure
+            // so a revert is recorded and tolerated while the operation advances. The
+            // re-aggregation step appended below stays non-fallible — it always runs (after
+            // whatever underlying prices did land) and its outcome is the operation's verdict.
+            // A direct/LST oracle takes neither branch, so its single underlying update stays
+            // all-or-nothing.
+            for step in &mut plan.steps {
+                step.continue_on_failure = true;
+            }
             plan.steps
                 .push(ctx.near_client().proxy_oracle(oracle_id).update_prices(
                     ContractWriteOptions::new(signer_account_id).tgas(100),
@@ -497,6 +507,11 @@ mod tests {
             plan.steps.len(),
             2,
             "mixed grouping must produce one step per oracle"
+        );
+        assert!(
+            plan.steps.iter().all(|step| !step.continue_on_failure),
+            "plan_grouped_updates must leave steps all-or-nothing; marking underlying \
+             updates continue_on_failure is the proxy branch's job in UpdatePrices::plan"
         );
 
         let mut found_pyth_data_step = false;

--- a/gateway/store/migrations/20260709120000_plan_step_continue_on_failure.down.sql
+++ b/gateway/store/migrations/20260709120000_plan_step_continue_on_failure.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE gateway_plan_steps
+    DROP COLUMN continue_on_failure;

--- a/gateway/store/migrations/20260709120000_plan_step_continue_on_failure.up.sql
+++ b/gateway/store/migrations/20260709120000_plan_step_continue_on_failure.up.sql
@@ -1,0 +1,6 @@
+-- A step may be marked `continue_on_failure`: an on-chain revert of it is
+-- recorded and tolerated (the operation advances to the next step) rather than
+-- aborting the operation. Additive and backward-compatible — pre-existing steps
+-- default to `false` (all-or-nothing), which is their historical behavior.
+ALTER TABLE gateway_plan_steps
+    ADD COLUMN continue_on_failure boolean NOT NULL DEFAULT false;

--- a/gateway/store/src/memory.rs
+++ b/gateway/store/src/memory.rs
@@ -155,7 +155,7 @@ impl OperationStore for MemoryStore {
             // An empty plan here is a reservation; a step-bearing plan is already
             // planned. (A no-op is promoted from a reservation, not created here.)
             planned: !plan.steps.is_empty(),
-            succeeded_steps: vec![],
+            completed_steps: vec![],
             current_step: None,
             remaining_steps: VecDeque::from(plan.steps),
         };
@@ -226,7 +226,7 @@ mod tests {
     use super::*;
     use near_account_id::AccountId;
     use near_api::types::CryptoHash as NearCryptoHash;
-    use templar_gateway_core::{PlannedTransaction, SucceededStep};
+    use templar_gateway_core::{CompletedStep, PlannedTransaction, SucceededStep};
     use templar_gateway_types::operation::ExecutionOutcome;
     use templar_gateway_types::{CryptoHash, NearGas, NearToken};
 
@@ -239,6 +239,7 @@ mod tests {
             signer_account_id: signer(),
             receiver_id: "market.near".parse().unwrap(),
             actions: Vec::new(),
+            continue_on_failure: false,
         }
     }
 
@@ -252,7 +253,7 @@ mod tests {
             id: OperationId(id.to_owned()),
             signer_account_id: signer(),
             planned: true,
-            succeeded_steps: Vec::new(),
+            completed_steps: Vec::new(),
             current_step: None,
             remaining_steps: VecDeque::new(),
         }
@@ -262,16 +263,18 @@ mod tests {
     fn mark_succeeded(operation: &mut StoredOperation) {
         // A succeeded step implies planning completed.
         operation.planned = true;
-        operation.succeeded_steps.push(SucceededStep {
-            transaction: planned_tx(),
-            tx_hash: CryptoHash(NearCryptoHash::default()),
-            outcome: ExecutionOutcome {
-                tokens_burnt: NearToken::from_yoctonear(0),
-                total_gas_burnt: NearGas::from_gas(0),
-                receipts: Vec::new(),
-                return_value: None,
-            },
-        });
+        operation
+            .completed_steps
+            .push(CompletedStep::Succeeded(SucceededStep {
+                transaction: planned_tx(),
+                tx_hash: CryptoHash(NearCryptoHash::default()),
+                outcome: ExecutionOutcome {
+                    tokens_burnt: NearToken::from_yoctonear(0),
+                    total_gas_burnt: NearGas::from_gas(0),
+                    receipts: Vec::new(),
+                    return_value: None,
+                },
+            }));
     }
 
     /// A finished (terminal `Succeeded`) operation: one succeeded step, nothing

--- a/gateway/store/src/postgres.rs
+++ b/gateway/store/src/postgres.rs
@@ -12,8 +12,8 @@ use sqlx::{
     FromRow, PgPool,
 };
 use templar_gateway_core::{
-    CreateOperationResult, CurrentStep, GatewayError, GatewayResult, OperationPlan, OperationStore,
-    PlannedTransaction, StoredOperation, SucceededStep,
+    CompletedStep, CreateOperationResult, CurrentStep, GatewayError, GatewayResult, OperationPlan,
+    OperationStore, PlannedTransaction, RevertedStep, StoredOperation, SucceededStep,
 };
 use templar_gateway_types::{
     operation::{ExecutionOutcome, OperationId, ReceiptOutcome, ReceiptStatus},
@@ -85,6 +85,7 @@ struct StepLifecycleRow {
     signer_account_id: String,
     receiver_id: String,
     actions: Value,
+    continue_on_failure: bool,
     execution_tx_hash: Option<String>,
     signed_transaction: Option<Vec<u8>>,
     submitted_at: Option<DateTime<Utc>>,
@@ -269,7 +270,7 @@ impl OperationStore for PostgresStore {
             // reservation (the no-op case is promoted from a reservation later,
             // never created directly).
             planned: !plan.steps.is_empty(),
-            succeeded_steps: vec![],
+            completed_steps: vec![],
             current_step: None,
             remaining_steps: VecDeque::from(plan.steps),
         };
@@ -661,7 +662,7 @@ async fn insert_operation_steps(
     existing_step_state: &ExistingStepStateByStep,
 ) -> GatewayResult<()> {
     let current_index =
-        insert_succeeded_steps(tx, operation_uuid, operation, existing_step_state).await?;
+        insert_completed_steps(tx, operation_uuid, operation, existing_step_state).await?;
     let remaining_start = insert_current_step(
         tx,
         operation_uuid,
@@ -681,40 +682,53 @@ async fn insert_operation_steps(
     Ok(())
 }
 
-async fn insert_succeeded_steps(
+async fn insert_completed_steps(
     tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
     operation_uuid: uuid::Uuid,
     operation: &StoredOperation,
     existing_step_state: &ExistingStepStateByStep,
 ) -> GatewayResult<i32> {
-    for (index, step) in operation.succeeded_steps.iter().enumerate() {
+    for (index, step) in operation.completed_steps.iter().enumerate() {
         let step_index = step_index(index)?;
         let existing_execution = existing_execution(existing_step_state, step_index)?;
+        // A tolerated revert executed on chain like a success and produced an
+        // outcome, so it persists with the same lifecycle rows — only the outcome
+        // status (Failed) and the step's own `continue_on_failure` flag (on the
+        // plan-step row) mark it, which is what `apply_step_row` reads back.
+        let (transaction, tx_hash, outcome, status) = match step {
+            CompletedStep::Succeeded(step) => (
+                &step.transaction,
+                step.tx_hash,
+                &step.outcome,
+                OutcomeStatusRow::Succeeded,
+            ),
+            CompletedStep::Reverted(step) => (
+                &step.transaction,
+                step.tx_hash,
+                &step.outcome,
+                OutcomeStatusRow::Failed,
+            ),
+        };
         insert_step_lifecycle(
             tx,
             StepLifecycleInsert {
                 operation_id: operation_uuid,
                 step_index,
-                transaction: &step.transaction,
+                transaction,
                 execution: Some(StepExecution {
-                    tx_hash: step.tx_hash,
+                    tx_hash,
                     signed_transaction: &existing_execution.signed_transaction,
                     prepared_at: existing_execution.prepared_at,
                     submitted_at: existing_execution.submitted_at,
                 }),
-                result: Some(StepResult {
-                    tx_hash: step.tx_hash,
-                }),
-                outcome: Some(StepOutcome {
-                    status: OutcomeStatusRow::Succeeded,
-                    outcome: &step.outcome,
-                }),
+                result: Some(StepResult { tx_hash }),
+                outcome: Some(StepOutcome { status, outcome }),
                 existing_state: existing_step_state.get(&step_index),
             },
         )
         .await?;
     }
-    step_index(operation.succeeded_steps.len())
+    step_index(operation.completed_steps.len())
 }
 
 async fn insert_current_step(
@@ -1009,10 +1023,11 @@ INSERT INTO
         signer_account_id,
         receiver_id,
         actions,
+        continue_on_failure,
         created_at
     )
 VALUES
-    ($1, $2, $3, $4, $5, COALESCE($6, NOW()))
+    ($1, $2, $3, $4, $5, $6, COALESCE($7, NOW()))
 ",
     )
     .bind(operation_id)
@@ -1020,6 +1035,7 @@ VALUES
     .bind(transaction.signer_account_id.0.to_string())
     .bind(transaction.receiver_id.to_string())
     .bind(actions)
+    .bind(transaction.continue_on_failure)
     .bind(created_at)
     .execute(&mut **tx)
     .await?;
@@ -1212,6 +1228,7 @@ SELECT
     step.signer_account_id,
     step.receiver_id,
     step.actions,
+    step.continue_on_failure,
     execution.tx_hash AS execution_tx_hash,
     execution.signed_transaction,
     execution.submitted_at,
@@ -1287,7 +1304,7 @@ fn rows_to_stored_operation(
     step_rows: Vec<StepLifecycleRow>,
     mut receipts_by_step: ReceiptMap,
 ) -> GatewayResult<StoredOperation> {
-    let mut succeeded_steps = Vec::new();
+    let mut completed_steps = Vec::new();
     let mut current_step = None;
     let mut remaining_steps = VecDeque::new();
 
@@ -1296,7 +1313,7 @@ fn rows_to_stored_operation(
         apply_step_row(
             row,
             receipts,
-            &mut succeeded_steps,
+            &mut completed_steps,
             &mut current_step,
             &mut remaining_steps,
         )?;
@@ -1321,7 +1338,7 @@ fn rows_to_stored_operation(
         id,
         signer_account_id,
         planned: operation_row.plan_created_at.is_some(),
-        succeeded_steps,
+        completed_steps,
         current_step,
         remaining_steps,
     })
@@ -1330,7 +1347,7 @@ fn rows_to_stored_operation(
 fn apply_step_row(
     row: StepLifecycleRow,
     receipts: Vec<ReceiptOutcome>,
-    succeeded_steps: &mut Vec<SucceededStep>,
+    completed_steps: &mut Vec<CompletedStep>,
     current_step: &mut Option<CurrentStep>,
     remaining_steps: &mut VecDeque<PlannedTransaction>,
 ) -> GatewayResult<()> {
@@ -1375,22 +1392,35 @@ fn apply_step_row(
             )?;
         }
         RowLifecycle::Reverted { tx_hash } => {
-            set_current_step(
-                current_step,
-                row.step_index,
-                CurrentStep::Reverted {
+            let outcome = build_outcome(&row, receipts)?;
+            // The persisted `continue_on_failure` flag is the sole disambiguator:
+            // a tolerated revert reconstructs as a completed step (cursor advanced),
+            // a non-tolerated one as the terminal blocking `current_step`. This
+            // mirrors `StoredOperation::record_revert` at reload time.
+            if transaction.continue_on_failure {
+                completed_steps.push(CompletedStep::Reverted(RevertedStep {
                     transaction,
                     tx_hash,
-                    outcome: build_outcome(&row, receipts)?,
-                },
-            )?;
+                    outcome,
+                }));
+            } else {
+                set_current_step(
+                    current_step,
+                    row.step_index,
+                    CurrentStep::Reverted {
+                        transaction,
+                        tx_hash,
+                        outcome,
+                    },
+                )?;
+            }
         }
         RowLifecycle::Succeeded { tx_hash } => {
-            succeeded_steps.push(SucceededStep {
+            completed_steps.push(CompletedStep::Succeeded(SucceededStep {
                 transaction,
                 tx_hash,
                 outcome: build_outcome(&row, receipts)?,
-            });
+            }));
         }
     }
     Ok(())
@@ -1496,6 +1526,7 @@ fn step_row_transaction(row: &StepLifecycleRow) -> GatewayResult<PlannedTransact
         signer_account_id: ManagedAccountId(parse_account_id(&row.signer_account_id)?),
         receiver_id: parse_account_id(&row.receiver_id)?,
         actions: serde_json::from_value(row.actions.clone())?,
+        continue_on_failure: row.continue_on_failure,
     })
 }
 
@@ -1601,7 +1632,7 @@ mod tests {
                 id: OperationId(uuid::Uuid::new_v4().to_string()),
                 signer_account_id: ManagedAccountId("signer.near".parse().unwrap()),
                 planned: true,
-                succeeded_steps: vec![],
+                completed_steps: vec![],
                 current_step: None,
                 remaining_steps: VecDeque::from([transaction]),
             },
@@ -1612,7 +1643,7 @@ mod tests {
                 id: OperationId(uuid::Uuid::new_v4().to_string()),
                 signer_account_id: ManagedAccountId("signer.near".parse().unwrap()),
                 planned: true,
-                succeeded_steps: vec![],
+                completed_steps: vec![],
                 current_step: Some(CurrentStep::Submitted {
                     transaction,
                     tx_hash: CryptoHash(NearCryptoHash::default()),
@@ -1627,11 +1658,11 @@ mod tests {
                 id: OperationId(uuid::Uuid::new_v4().to_string()),
                 signer_account_id: ManagedAccountId("signer.near".parse().unwrap()),
                 planned: true,
-                succeeded_steps: vec![SucceededStep {
+                completed_steps: vec![CompletedStep::Succeeded(SucceededStep {
                     transaction,
                     tx_hash: CryptoHash(NearCryptoHash::default()),
                     outcome: sample_outcome(),
-                }],
+                })],
                 current_step: None,
                 remaining_steps: VecDeque::new(),
             },
@@ -1643,7 +1674,7 @@ mod tests {
                 id: OperationId(uuid::Uuid::new_v4().to_string()),
                 signer_account_id: ManagedAccountId("signer.near".parse().unwrap()),
                 planned: true,
-                succeeded_steps: vec![],
+                completed_steps: vec![],
                 current_step: Some(CurrentStep::Reverted {
                     transaction,
                     tx_hash: CryptoHash(NearCryptoHash::default()),
@@ -1705,11 +1736,13 @@ mod tests {
         else {
             panic!("expected prepared step");
         };
-        operation.succeeded_steps.push(SucceededStep {
-            transaction,
-            tx_hash,
-            outcome: sample_outcome(),
-        });
+        operation
+            .completed_steps
+            .push(CompletedStep::Succeeded(SucceededStep {
+                transaction,
+                tx_hash,
+                outcome: sample_outcome(),
+            }));
         store.save_operation(operation.clone()).await.unwrap();
 
         let found = store
@@ -1897,11 +1930,13 @@ mod tests {
         else {
             panic!("expected prepared step");
         };
-        operation.succeeded_steps.push(SucceededStep {
-            transaction,
-            tx_hash,
-            outcome: sample_outcome(),
-        });
+        operation
+            .completed_steps
+            .push(CompletedStep::Succeeded(SucceededStep {
+                transaction,
+                tx_hash,
+                outcome: sample_outcome(),
+            }));
         store.save_operation(operation.clone()).await.unwrap();
         let first_completed_at = operation_completed_at(&store.pool, operation_uuid)
             .await
@@ -1950,11 +1985,13 @@ mod tests {
         else {
             panic!("expected prepared step");
         };
-        terminal.succeeded_steps.push(SucceededStep {
-            transaction,
-            tx_hash,
-            outcome: sample_outcome(),
-        });
+        terminal
+            .completed_steps
+            .push(CompletedStep::Succeeded(SucceededStep {
+                transaction,
+                tx_hash,
+                outcome: sample_outcome(),
+            }));
         store.save_operation(terminal.clone()).await.unwrap();
         sqlx::query("DELETE FROM gateway_plan_steps WHERE operation_id = $1")
             .bind(uuid::Uuid::from_str(&terminal.id.0).unwrap())
@@ -2000,11 +2037,13 @@ mod tests {
         else {
             panic!("expected prepared step");
         };
-        operation.succeeded_steps.push(SucceededStep {
-            transaction,
-            tx_hash,
-            outcome: sample_outcome(),
-        });
+        operation
+            .completed_steps
+            .push(CompletedStep::Succeeded(SucceededStep {
+                transaction,
+                tx_hash,
+                outcome: sample_outcome(),
+            }));
         store.save_operation(operation.clone()).await.unwrap();
 
         let before_step_timestamps = step_timestamps(&store.pool, operation_uuid).await;
@@ -2190,7 +2229,10 @@ ORDER BY step_index, receipt_index
     #[test]
     fn rows_round_trip_preserves_succeeded_operation() {
         let operation = sample_operation(OperationStatus::Succeeded);
-        let succeeded_step = operation.succeeded_steps.first().unwrap();
+        let CompletedStep::Succeeded(succeeded_step) = operation.completed_steps.first().unwrap()
+        else {
+            panic!("expected a succeeded completed step");
+        };
         let operation_row = OperationRow {
             id: uuid::Uuid::from_str(&operation.id.0).unwrap(),
             rpc_method: operation.rpc_method.clone(),
@@ -2209,6 +2251,7 @@ ORDER BY step_index, receipt_index
             signer_account_id: operation.signer_account_id.0.to_string(),
             receiver_id: succeeded_step.transaction.receiver_id.to_string(),
             actions: serde_json::to_value(&succeeded_step.transaction.actions).unwrap(),
+            continue_on_failure: false,
             execution_tx_hash: Some(succeeded_step.tx_hash.0.to_string()),
             signed_transaction: Some(to_vec(&dummy_signed_transaction()).unwrap()),
             submitted_at: Some(Utc::now()),
@@ -2223,11 +2266,108 @@ ORDER BY step_index, receipt_index
 
         let restored = rows_to_stored_operation(operation_row, step_rows, receipts).unwrap();
         assert_eq!(restored.status(), OperationStatus::Succeeded);
-        assert_eq!(restored.succeeded_steps.len(), 1);
-        assert_eq!(
-            restored.succeeded_steps.first().unwrap().outcome,
-            sample_outcome()
+        assert_eq!(restored.completed_steps.len(), 1);
+        let CompletedStep::Succeeded(restored_step) = restored.completed_steps.first().unwrap()
+        else {
+            panic!("expected a succeeded completed step");
+        };
+        assert_eq!(restored_step.outcome, sample_outcome());
+    }
+
+    /// Build a lifecycle row for a step that executed on chain and produced an
+    /// outcome (Succeeded or Failed), carrying the given `continue_on_failure` flag.
+    fn completed_step_row(
+        operation_id: uuid::Uuid,
+        step_index: i32,
+        continue_on_failure: bool,
+        outcome_status: OutcomeStatusRow,
+    ) -> StepLifecycleRow {
+        let transaction = sample_transaction();
+        let tx_hash = NearCryptoHash::default().to_string();
+        StepLifecycleRow {
+            operation_id,
+            step_index,
+            signer_account_id: transaction.signer_account_id.0.to_string(),
+            receiver_id: transaction.receiver_id.to_string(),
+            actions: serde_json::to_value(&transaction.actions).unwrap(),
+            continue_on_failure,
+            execution_tx_hash: Some(tx_hash.clone()),
+            signed_transaction: Some(to_vec(&dummy_signed_transaction()).unwrap()),
+            submitted_at: Some(Utc::now()),
+            result_tx_hash: Some(tx_hash),
+            outcome_status: Some(outcome_status),
+            tokens_burnt: Some(sample_outcome().tokens_burnt.as_yoctonear().to_string()),
+            total_gas_burnt: Some(sample_outcome().total_gas_burnt.as_gas().to_string()),
+            return_value: None,
+            created_at: Utc::now(),
+        }
+    }
+
+    fn sample_operation_row(id: uuid::Uuid, completed_at: Option<DateTime<Utc>>) -> OperationRow {
+        OperationRow {
+            id,
+            rpc_method: "tx.transfer".to_owned(),
+            signer_account_id: "signer.near".to_owned(),
+            idempotency_key: None,
+            request_fingerprint_hash: [0; 32].to_vec(),
+            request_payload: serde_json::json!({}),
+            plan_created_at: Some(Utc::now()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            completed_at,
+        }
+    }
+
+    /// A reverted step whose plan row is `continue_on_failure` must reconstruct as a
+    /// tolerated *completed* step (cursor advanced), never as the terminal blocking
+    /// `current_step`. The persisted flag is the sole disambiguator, mirroring
+    /// `StoredOperation::record_revert` at reload time.
+    #[test]
+    fn rows_round_trip_tolerated_revert_becomes_completed_step() {
+        let id = uuid::Uuid::new_v4();
+        let operation_row = sample_operation_row(id, Some(Utc::now()));
+        let step_rows = vec![
+            completed_step_row(id, 0, true, OutcomeStatusRow::Failed),
+            completed_step_row(id, 1, false, OutcomeStatusRow::Succeeded),
+        ];
+
+        let restored =
+            rows_to_stored_operation(operation_row, step_rows, ReceiptMap::default()).unwrap();
+
+        assert!(
+            restored.current_step.is_none(),
+            "a tolerated revert must not block as current_step"
         );
+        assert_eq!(restored.completed_steps.len(), 2);
+        assert!(matches!(
+            restored.completed_steps[0],
+            CompletedStep::Reverted(_)
+        ));
+        assert!(matches!(
+            restored.completed_steps[1],
+            CompletedStep::Succeeded(_)
+        ));
+        assert_eq!(restored.status(), OperationStatus::Succeeded);
+    }
+
+    /// Without the flag, a revert is terminal: it reconstructs as the blocking
+    /// `current_step` and the operation is `Failed` — the invariant the tolerant
+    /// path must never weaken.
+    #[test]
+    fn rows_round_trip_non_tolerated_revert_stays_terminal() {
+        let id = uuid::Uuid::new_v4();
+        let operation_row = sample_operation_row(id, None);
+        let step_rows = vec![completed_step_row(id, 0, false, OutcomeStatusRow::Failed)];
+
+        let restored =
+            rows_to_stored_operation(operation_row, step_rows, ReceiptMap::default()).unwrap();
+
+        assert!(restored.completed_steps.is_empty());
+        assert!(matches!(
+            restored.current_step,
+            Some(CurrentStep::Reverted { .. })
+        ));
+        assert_eq!(restored.status(), OperationStatus::Failed);
     }
 
     #[test]
@@ -2255,6 +2395,7 @@ ORDER BY step_index, receipt_index
                 signer_account_id: operation.signer_account_id.0.to_string(),
                 receiver_id: first_transaction.receiver_id.to_string(),
                 actions: serde_json::to_value(&first_transaction.actions).unwrap(),
+                continue_on_failure: false,
                 execution_tx_hash: Some(tx_hash.clone()),
                 signed_transaction: Some(to_vec(&dummy_signed_transaction()).unwrap()),
                 submitted_at: None,
@@ -2271,6 +2412,7 @@ ORDER BY step_index, receipt_index
                 signer_account_id: operation.signer_account_id.0.to_string(),
                 receiver_id: second_transaction.receiver_id.to_string(),
                 actions: serde_json::to_value(&second_transaction.actions).unwrap(),
+                continue_on_failure: false,
                 execution_tx_hash: Some(tx_hash),
                 signed_transaction: Some(to_vec(&dummy_signed_transaction()).unwrap()),
                 submitted_at: None,

--- a/gateway/store/tests/driver_recovery.rs
+++ b/gateway/store/tests/driver_recovery.rs
@@ -22,9 +22,9 @@ use near_api::types::transaction::{
 use near_api::types::CryptoHash as NearCryptoHash;
 use rstest::rstest;
 use templar_gateway_core::{
-    CreateOperationResult, CurrentStep, ExecuteOperation, GatewayError, GatewayResult,
-    OperationDriver, OperationPlan, OperationStore, PlannedTransaction, PreparedTransactionResult,
-    SignTransaction, StepOutcome, StoredOperation, SucceededStep,
+    CompletedStep, CreateOperationResult, CurrentStep, ExecuteOperation, GatewayError,
+    GatewayResult, OperationDriver, OperationPlan, OperationStore, PlannedTransaction,
+    PreparedTransactionResult, SignTransaction, StepOutcome, StoredOperation, SucceededStep,
 };
 use templar_gateway_store::MemoryStore;
 use templar_gateway_types::{
@@ -267,7 +267,10 @@ fn stored(
         id: OperationId("op-under-test".to_owned()),
         signer_account_id: signer_id(),
         planned,
-        succeeded_steps: succeeded,
+        completed_steps: succeeded
+            .into_iter()
+            .map(CompletedStep::Succeeded)
+            .collect(),
         current_step,
         remaining_steps: remaining.into(),
     }
@@ -576,7 +579,7 @@ async fn recovery_drives_a_multi_step_plan_to_completion() {
 
     let op = store.get_by_id(&op.id).await.unwrap().unwrap();
     assert_eq!(op.status(), OperationStatus::Succeeded);
-    assert_eq!(op.succeeded_steps.len(), 2);
+    assert_eq!(op.completed_steps.len(), 2);
 }
 
 #[tokio::test]
@@ -608,5 +611,81 @@ async fn reconcile_continues_remaining_steps_after_a_submitted_step_lands() {
         .unwrap();
     assert_eq!(record.status, OperationStatus::Succeeded);
     let op = store.get_by_idempotency_key(&key).await.unwrap().unwrap();
-    assert_eq!(op.succeeded_steps.len(), 2);
+    assert_eq!(op.completed_steps.len(), 2);
+}
+
+// ---- continue_on_failure step tolerance ----
+
+/// A `continue_on_failure` step that reverts on chain must be recorded and
+/// tolerated: the operation advances to the next step and can still succeed.
+#[tokio::test]
+async fn continue_on_failure_step_reverts_but_operation_advances_and_succeeds() {
+    let store = Arc::new(MemoryStore::new());
+    let op = stored(
+        true,
+        None,
+        vec![
+            sample_transaction().continue_on_failure(true),
+            sample_transaction(),
+        ],
+        vec![],
+    );
+    store.save_operation(op.clone()).await.unwrap();
+
+    // Step 0 reverts on chain; step 1 succeeds. Both are submitted (the revert of a
+    // tolerated step does not stop the operation), so both submits are consumed.
+    let executor = FakeExecutor::new(
+        vec![Ok(Some(step_outcome(false))), Ok(Some(step_outcome(true)))],
+        vec![],
+    );
+
+    let result = driver(store.clone(), executor)
+        .execute_remaining_steps(op)
+        .await
+        .unwrap();
+
+    assert_eq!(result.status(), OperationStatus::Succeeded);
+    assert!(result.current_step.is_none());
+    assert!(result.remaining_steps.is_empty());
+    assert_eq!(result.completed_steps.len(), 2);
+    assert!(
+        matches!(result.completed_steps[0], CompletedStep::Reverted(_)),
+        "the tolerated revert must be recorded as a completed reverted step"
+    );
+    assert!(matches!(
+        result.completed_steps[1],
+        CompletedStep::Succeeded(_)
+    ));
+}
+
+/// A non-`continue_on_failure` step that reverts is terminal: it fails the
+/// operation and no later step runs. This is the invariant the tolerant path must
+/// not weaken — proven by the executor panicking on a second, unexpected submit.
+#[tokio::test]
+async fn non_fallible_revert_fails_operation_and_stops() {
+    let store = Arc::new(MemoryStore::new());
+    let op = stored(
+        true,
+        None,
+        vec![sample_transaction(), sample_transaction()],
+        vec![],
+    );
+    store.save_operation(op.clone()).await.unwrap();
+
+    // Only one submit is canned: if the driver tried to run step 1 after step 0
+    // reverted, `FakeExecutor` would panic on the unexpected submit.
+    let executor = FakeExecutor::new(vec![Ok(Some(step_outcome(false)))], vec![]);
+
+    let result = driver(store.clone(), executor)
+        .execute_remaining_steps(op)
+        .await
+        .unwrap();
+
+    assert_eq!(result.status(), OperationStatus::Failed);
+    assert!(matches!(
+        result.current_step,
+        Some(CurrentStep::Reverted { .. })
+    ));
+    assert_eq!(result.remaining_steps.len(), 1, "step 1 must not have run");
+    assert!(result.completed_steps.is_empty());
 }

--- a/service/gateway/src/gateway_service.rs
+++ b/service/gateway/src/gateway_service.rs
@@ -287,7 +287,7 @@ mod tests {
             .expect("stored operation should exist");
         assert_eq!(stored.status(), OperationStatus::Succeeded);
         assert!(stored.current_step.is_none());
-        assert_eq!(stored.succeeded_steps.len(), 1);
+        assert_eq!(stored.completed_steps.len(), 1);
 
         service.shutdown().await;
         Ok(())
@@ -359,7 +359,7 @@ mod tests {
         assert_eq!(stored.status(), OperationStatus::Succeeded);
         assert!(stored.current_step.is_none());
         assert!(stored.remaining_steps.is_empty());
-        assert_eq!(stored.succeeded_steps.len(), 2);
+        assert_eq!(stored.completed_steps.len(), 2);
 
         let rate: near_api::Data<String> = Contract(harness.ft_contract_id.clone())
             .call_function("redemption_rate", ())


### PR DESCRIPTION
## Summary

Fixes ENG-445. Oracle updates were batched as sequential steps of a single operation, and the driver aborts an operation on the first reverted step — so one underlying oracle (Pyth/Lazer/RedStone) reverting cancelled every later underlying update **and** the proxy re-aggregation.

This enriches the step model with a per-step `continue_on_failure` flag instead of splitting into multiple operations (which would have changed the idempotency-key contract from 1:1 to 1:N and reworked the store/recovery topology). A tolerated step's on-chain revert is recorded and the operation advances; the re-aggregation is a normal trailing step that always runs and whose outcome is the operation's verdict.

## State machine (the careful part)

- Preserves the load-bearing invariant: `current_step ∈ {Reverted, Rejected}` still means **exclusively** a terminal, non-tolerated failure. A tolerated revert never enters `current_step`.
- `succeeded_steps` → `completed_steps: Vec<CompletedStep>` with a type-distinct `Reverted` variant — no `reverted: bool`, so a "reverted success" is unrepresentable.
- One authoritative `StoredOperation::record_revert`, driven solely by the step's own flag; all three revert sites (live execution, reconciliation, reload) route through it.

## Storage

- Additive `continue_on_failure boolean NOT NULL DEFAULT false` column on `gateway_plan_steps` (backward-compatible, no drain). Reconstruction uses the persisted flag to disambiguate a tolerated completed step from a terminal `current_step`.

## Oracle dispatch

- For a **proxy** oracle the underlying updates are marked `continue_on_failure`; the re-aggregation stays non-fallible. **Direct/LST** oracles are unchanged (all-or-nothing), so a genuine single-oracle failure still surfaces.

## Unchanged

Idempotency-key contract (still 1:1), `WriteOperationResult`/`PlanWrite` shapes, catalog, recovery, and the relayer.

## Tests

- **Core/driver:** a `continue_on_failure` revert advances → `Succeeded` with a `Reverted` step record; a non-tolerated revert still `Failed` and stops (proven by the fake executor panicking on an unexpected second submit).
- **Persistence:** pure `rows_to_stored_operation` round-trip proving the persisted flag drives reconstruction (tolerated → `completed_steps`; otherwise terminal `current_step`).
- `cargo fmt` + `clippy --tests -D warnings` clean.
- Postgres `#[sqlx::test]` and the gateway sandbox `updatePrices` test run in CI (need PG / neard).

## Follow-up

ENG-447 — a plan-time source-payload fetch failure still aborts the whole market update (same symptom, different mechanism; out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/501)
<!-- Reviewable:end -->
