### PR TITLE
fix(gateway): connect the Pyth Lazer source on demand (ENG-452)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13447,6 +13447,7 @@ dependencies = [
  "near-sdk",
  "pyth-lazer-protocol",
  "reqwest 0.12.28",
+ "rstest",
  "schemars 0.8.22",
  "serde",
  "serde_json",

--- a/gateway/oracle-updates-dispatch/Cargo.toml
+++ b/gateway/oracle-updates-dispatch/Cargo.toml
@@ -42,6 +42,7 @@ clap = ["dep:clap"]
 [dev-dependencies]
 ed25519-dalek.workspace = true
 near-api.workspace = true
+rstest.workspace = true
 templar-pyth-lazer-verifier.workspace = true
 
 [lints]

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -63,6 +63,7 @@ pub struct LazerSourceConfig {
     api_token: RedactedString,
     channel: Channel,
     max_payload_age: Duration,
+    idle_timeout: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -93,6 +94,7 @@ impl LazerSourceConfig {
             api_token,
             channel,
             max_payload_age,
+            idle_timeout: STREAM_IDLE_TIMEOUT,
         })
     }
 
@@ -109,7 +111,16 @@ impl LazerSourceConfig {
             api_token: RedactedString::from("test-token"),
             channel: parse_channel("fixed_rate@200ms".to_owned()).expect("valid channel"),
             max_payload_age,
+            idle_timeout: STREAM_IDLE_TIMEOUT,
         }
+    }
+
+    /// Test-only: shorten the idle timeout so a silent-stream test needn't wait
+    /// [`STREAM_IDLE_TIMEOUT`].
+    #[cfg(test)]
+    pub(crate) fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
+        self.idle_timeout = idle_timeout;
+        self
     }
 }
 
@@ -376,6 +387,13 @@ impl StreamTask {
         let mut stream = self.connect().await?;
         self.replay_subscriptions(&mut stream).await?;
 
+        // One deadline for the whole connection, reset only by traffic from the server.
+        // Rebuilding a `timeout(..., stream.next())` each iteration would restart the
+        // idle timer every time the request branch won, so a steady trickle of fetches
+        // would hide a silent, dead socket indefinitely.
+        let idle = tokio::time::sleep(self.config.idle_timeout);
+        tokio::pin!(idle);
+
         loop {
             // Every subscription was rejected: drop the connection instead of letting
             // it idle. A connection exists exactly while a subscription does.
@@ -384,9 +402,11 @@ impl StreamTask {
             }
 
             tokio::select! {
-                message = timeout(STREAM_IDLE_TIMEOUT, stream.next()) => {
-                    let message = message
-                        .map_err(|_| LazerClientError::Request("websocket idle timeout".to_owned()))?;
+                () = &mut idle => {
+                    return Err(LazerClientError::Request("websocket idle timeout".to_owned()));
+                }
+                message = stream.next() => {
+                    idle.as_mut().reset(Instant::now() + self.config.idle_timeout);
                     let Some(message) = message else {
                         return Err(LazerClientError::Request("websocket closed".to_owned()));
                     };
@@ -472,6 +492,11 @@ impl StreamTask {
 
     /// Hand the caller the slot of a subscription covering `feed_ids`, creating one if
     /// no live subscription already does.
+    ///
+    /// A requester that timed out or was cancelled has dropped its receiver. Hand the
+    /// slot over *before* touching any state, so an abandoned request cannot evict a
+    /// live subscription or strand one that nothing is waiting on — which would also
+    /// hold the connection open forever.
     fn register(&mut self, request: SubscribeRequest) -> Registration {
         let SubscribeRequest { feed_ids, slot_tx } = request;
 
@@ -484,11 +509,14 @@ impl StreamTask {
             return Registration::default();
         }
 
+        let (slot, slot_rx) = watch::channel(Slot::Waiting);
+        if slot_tx.send(slot_rx).is_err() {
+            return Registration::default();
+        }
+
         let evicted = self.evict_to_fit();
         let id = SubscriptionId(self.next_id);
         self.next_id += 1;
-        let (slot, slot_rx) = watch::channel(Slot::Waiting);
-        let _ = slot_tx.send(slot_rx);
         self.subscriptions
             .insert(id, Subscription { feed_ids, slot });
 

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -79,7 +79,6 @@ pub struct LazerSourceConfig {
     api_token: RedactedString,
     channel: Channel,
     max_payload_age: Duration,
-    idle_timeout: Duration,
 }
 
 #[derive(Debug, Clone)]
@@ -110,7 +109,6 @@ impl LazerSourceConfig {
             api_token,
             channel,
             max_payload_age,
-            idle_timeout: STREAM_IDLE_TIMEOUT,
         })
     }
 
@@ -127,16 +125,7 @@ impl LazerSourceConfig {
             api_token: RedactedString::from("test-token"),
             channel: parse_channel("fixed_rate@200ms".to_owned()).expect("valid channel"),
             max_payload_age,
-            idle_timeout: STREAM_IDLE_TIMEOUT,
         }
-    }
-
-    /// Test-only: shorten the idle timeout so a silent-stream test needn't wait
-    /// [`STREAM_IDLE_TIMEOUT`].
-    #[cfg(test)]
-    pub(crate) fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
-        self.idle_timeout = idle_timeout;
-        self
     }
 }
 
@@ -219,9 +208,24 @@ impl Drop for TaskGuard {
 
 impl LazerPayloadSource {
     pub fn spawn(config: LazerSourceConfig) -> Self {
+        Self::spawn_with(config, STREAM_IDLE_TIMEOUT)
+    }
+
+    /// Test-only: shorten silence detection so a silent-stream test needn't wait
+    /// [`STREAM_IDLE_TIMEOUT`]. Kept off [`LazerSourceConfig`], which carries only what
+    /// production configures.
+    #[cfg(test)]
+    pub(crate) fn spawn_with_idle_timeout(
+        config: LazerSourceConfig,
+        idle_timeout: Duration,
+    ) -> Self {
+        Self::spawn_with(config, idle_timeout)
+    }
+
+    fn spawn_with(config: LazerSourceConfig, idle_timeout: Duration) -> Self {
         let max_payload_age = config.max_payload_age;
         let (subscribe_tx, subscribe_rx) = mpsc::channel(32);
-        let task = tokio::spawn(StreamTask::new(config).run(subscribe_rx));
+        let task = tokio::spawn(StreamTask::new(config, idle_timeout).run(subscribe_rx));
         Self {
             max_payload_age,
             subscribe_tx,
@@ -312,6 +316,7 @@ struct StreamTask {
     subscriptions: BTreeMap<SubscriptionId, Subscription>,
     next_id: u64,
     backoff: Duration,
+    idle_timeout: Duration,
 }
 
 struct Subscription {
@@ -337,12 +342,13 @@ enum StreamEnd {
 }
 
 impl StreamTask {
-    fn new(config: LazerSourceConfig) -> Self {
+    fn new(config: LazerSourceConfig, idle_timeout: Duration) -> Self {
         Self {
             config,
             subscriptions: BTreeMap::new(),
             next_id: 1,
             backoff: INITIAL_RECONNECT_BACKOFF,
+            idle_timeout,
         }
     }
 
@@ -411,7 +417,7 @@ impl StreamTask {
         // Rebuilding a `timeout(..., stream.next())` each iteration would restart the
         // idle timer every time the request branch won, so a steady trickle of fetches
         // would hide a silent, dead socket indefinitely.
-        let idle = tokio::time::sleep(self.config.idle_timeout);
+        let idle = tokio::time::sleep(self.idle_timeout);
         tokio::pin!(idle);
 
         loop {
@@ -426,7 +432,7 @@ impl StreamTask {
                     return Err(LazerClientError::Request("websocket idle timeout".to_owned()));
                 }
                 message = stream.next() => {
-                    idle.as_mut().reset(Instant::now() + self.config.idle_timeout);
+                    idle.as_mut().reset(Instant::now() + self.idle_timeout);
                     let Some(message) = message else {
                         return Err(LazerClientError::Request("websocket closed".to_owned()));
                     };

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -39,20 +39,26 @@ const MAX_ACTIVE_SUBSCRIPTIONS: usize = 128;
 /// on the slowest (`fixed_rate@1000ms`) — so this much silence means the socket is dead.
 /// A socket can go silent while staying open, and nothing else detects that.
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
-/// How long [`LazerPayloadSource::fetch_payload`] waits for a payload covering its
-/// feeds. Distinct from `max_payload_age`, which bounds how old an already-cached
-/// payload may be when it is served.
-const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+/// Headroom, within [`FETCH_TIMEOUT`], for the reconnect itself: TLS handshake,
+/// subscription replay, and the first payload off the new stream.
+const RECONNECT_LATENCY_BUDGET: Duration = Duration::from_secs(4);
 
-/// A fetch must outlive one silent-socket recovery, or it expires before the stream task
-/// notices the socket is dead: detect (`STREAM_IDLE_TIMEOUT`) + backoff (reset to
-/// `INITIAL_RECONNECT_BACKOFF` by the last payload) + reconnect, replay, and first
-/// payload. Roughly 5s + 1s + <1s against a 10s deadline.
-const _: () = assert!(
-    STREAM_IDLE_TIMEOUT.as_millis() + INITIAL_RECONNECT_BACKOFF.as_millis()
-        < FETCH_TIMEOUT.as_millis(),
-    "FETCH_TIMEOUT must leave room to detect a silent socket and reconnect",
-);
+/// How long [`LazerPayloadSource::fetch_payload`] waits for a payload covering its feeds.
+/// Distinct from `max_payload_age`, which bounds how old an already-cached payload may be
+/// when it is served.
+///
+/// Summed, not chosen: a fetch has to outlive one recovery from a socket that fell silent
+/// while healthy — notice the silence, sleep the backoff, reconnect, replay, receive. Any
+/// smaller value would expire before the stream task even noticed the socket was dead.
+///
+/// *While healthy* is the precondition, and [`StreamTask::cache_payload`] establishes it:
+/// a payload resets the backoff, so the first reconnect after one sleeps exactly
+/// [`INITIAL_RECONNECT_BACKOFF`]. A larger backoff means no payload has arrived since the
+/// last disconnect — the stream is degraded, and expiring the fetch is then the intended
+/// answer rather than holding a caller's request open for [`MAX_RECONNECT_BACKOFF`].
+const FETCH_TIMEOUT: Duration = STREAM_IDLE_TIMEOUT
+    .saturating_add(INITIAL_RECONNECT_BACKOFF)
+    .saturating_add(RECONNECT_LATENCY_BUDGET);
 
 #[cfg(test)]
 mod config_tests;

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -35,27 +35,20 @@ use crate::lazer_wire::{
 const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
 const MAX_ACTIVE_SUBSCRIPTIONS: usize = 128;
-/// A subscribed stream delivers at least once per channel interval — once a second even
-/// on the slowest (`fixed_rate@1000ms`) — so this much silence means the socket is dead.
-/// A socket can go silent while staying open, and nothing else detects that.
+/// A subscribed stream delivers once per channel interval — 1s on the slowest — so this
+/// much silence means a socket that is open but dead.
 const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
-/// Headroom, within [`FETCH_TIMEOUT`], for the reconnect itself: TLS handshake,
-/// subscription replay, and the first payload off the new stream.
+/// Headroom in [`FETCH_TIMEOUT`] for the reconnect itself: handshake, replay, first payload.
 const RECONNECT_LATENCY_BUDGET: Duration = Duration::from_secs(4);
 
-/// How long [`LazerPayloadSource::fetch_payload`] waits for a payload covering its feeds.
-/// Distinct from `max_payload_age`, which bounds how old an already-cached payload may be
-/// when it is served.
+/// How long [`LazerPayloadSource::fetch_payload`] waits for a covering payload. Distinct
+/// from `max_payload_age`, which bounds the age of an already-cached one.
 ///
-/// Summed, not chosen: a fetch has to outlive one recovery from a socket that fell silent
-/// while healthy — notice the silence, sleep the backoff, reconnect, replay, receive. Any
-/// smaller value would expire before the stream task even noticed the socket was dead.
-///
-/// *While healthy* is the precondition, and [`StreamTask::cache_payload`] establishes it:
-/// a payload resets the backoff, so the first reconnect after one sleeps exactly
-/// [`INITIAL_RECONNECT_BACKOFF`]. A larger backoff means no payload has arrived since the
-/// last disconnect — the stream is degraded, and expiring the fetch is then the intended
-/// answer rather than holding a caller's request open for [`MAX_RECONNECT_BACKOFF`].
+/// Summed, not chosen, so a fetch outlives one recovery from a socket that fell silent
+/// while healthy. [`StreamTask::cache_payload`] resets the backoff on every payload, so
+/// that first reconnect sleeps [`INITIAL_RECONNECT_BACKOFF`]; a larger backoff means the
+/// stream is degraded, and expiring the fetch beats holding a caller open for
+/// [`MAX_RECONNECT_BACKOFF`].
 const FETCH_TIMEOUT: Duration = STREAM_IDLE_TIMEOUT
     .saturating_add(INITIAL_RECONNECT_BACKOFF)
     .saturating_add(RECONNECT_LATENCY_BUDGET);
@@ -254,11 +247,10 @@ impl OraclePayloadSource for LazerPayloadSource {
         }
         let feed_ids: BTreeSet<u32> = price_ids.iter().copied().collect();
 
-        // One deadline over both halves: the stream task may be mid-connect when the request
-        // arrives, so waiting for it to answer is as unbounded as waiting for a payload.
+        // One deadline over both halves: the task may be mid-connect, so waiting for its
+        // reply is as unbounded as waiting for a payload.
         timeout(FETCH_TIMEOUT, async {
-            // Sending the request also wakes the stream task out of any reconnect backoff, so
-            // a fetch never waits on a sleep it could have cancelled.
+            // This send also wakes the task out of any reconnect backoff.
             let mut slot = self.subscribe(feed_ids.clone()).await?;
             await_payload(&mut slot, &feed_ids, self.max_payload_age).await
         })
@@ -296,23 +288,24 @@ fn ready_payload(
         {
             Some(Ok(cached.payload.clone()))
         }
-        // A stale or not-yet-covering payload is not a failure: on a live stream the
-        // next one is a channel interval away. Wait for it rather than erroring.
+        // Stale or not-yet-covering is not a failure: the next frame is a channel interval
+        // away. This cannot stall — a `fixed_rate` frame carries every feed the server
+        // subscribed us to, and a feed it won't serve fails the slot at subscribe time.
+        //
+        // Coverage stays a hard requirement: the payload goes verbatim to the adapter's
+        // `update_price_feeds`, so a frame missing a feed would never refresh that price.
         Slot::Waiting | Slot::Ready(_) => None,
     }
 }
 
-/// The background task that owns the websocket and every subscription on it. Callers
-/// reach it only by message, so the subscription set needs no lock and cannot be observed
-/// mid-update.
+/// Owns the websocket and every subscription on it; callers reach it only by message, so
+/// the subscription set needs no lock.
 ///
-/// Not an `actix::Actor`: this is a plain tokio task owning a long-lived resource, so it
-/// stays usable from the lock-free `templar-gateway-client` path, which runs no actix
-/// `System`. The gateway's actix actors are request/response mailboxes at the RPC edge.
+/// Not an `actix::Actor`: a plain tokio task, so the source stays usable from the
+/// `templar-gateway-client` path, which runs no actix `System`.
 struct StreamTask {
     config: LazerSourceConfig,
-    /// Keyed by a monotonically increasing id, so the first key is the oldest
-    /// subscription — which is the one eviction takes.
+    /// Ids increase monotonically, so the first key is the oldest — the one eviction takes.
     subscriptions: BTreeMap<SubscriptionId, Subscription>,
     next_id: u64,
     backoff: Duration,
@@ -354,13 +347,9 @@ impl StreamTask {
 
     async fn run(mut self, mut requests: mpsc::Receiver<SubscribeRequest>) {
         loop {
-            // With no subscription there is nothing to stream, and the server closes a
-            // subscription-less connection after 60s — an idle connection is just a
-            // reconnect loop. Hold none, and wait for demand instead.
-            //
-            // Keep waiting rather than connecting once: an abandoned request registers
-            // nothing, and connecting for it would open a websocket with no subscription
-            // on it — and stall a real fetch behind that connect.
+            // A connection exists exactly while a subscription does: the server closes a
+            // subscription-less socket after 60s. `while`, not `if` — an abandoned request
+            // registers nothing, and connecting for it would open an empty socket.
             while self.subscriptions.is_empty() {
                 let Some(request) = requests.recv().await else {
                     return;
@@ -370,8 +359,7 @@ impl StreamTask {
 
             match self.connect_and_stream(&mut requests).await {
                 Ok(StreamEnd::Shutdown) => return,
-                // Nothing left to stream: loop back around and park, rather than
-                // hold a connection the server would close anyway.
+                // Nothing left to stream: park rather than hold a doomed connection.
                 Ok(StreamEnd::NoSubscriptions) => continue,
                 Err(error) => tracing::warn!(
                     %error,
@@ -413,16 +401,14 @@ impl StreamTask {
         let mut stream = self.connect().await?;
         self.replay_subscriptions(&mut stream).await?;
 
-        // One deadline for the whole connection, reset only by traffic from the server.
-        // Rebuilding a `timeout(..., stream.next())` each iteration would restart the
-        // idle timer every time the request branch won, so a steady trickle of fetches
-        // would hide a silent, dead socket indefinitely.
+        // One deadline per connection, reset only by traffic. A `timeout(.., stream.next())`
+        // rebuilt each `select!` iteration would restart whenever the request branch won,
+        // so a trickle of fetches would hide a silent socket.
         let idle = tokio::time::sleep(self.idle_timeout);
         tokio::pin!(idle);
 
         loop {
-            // Every subscription was rejected: drop the connection instead of letting
-            // it idle. A connection exists exactly while a subscription does.
+            // Every subscription was rejected; the connection has no purpose.
             if self.subscriptions.is_empty() {
                 return Ok(StreamEnd::NoSubscriptions);
             }
@@ -482,12 +468,10 @@ impl StreamTask {
         Ok(stream)
     }
 
-    /// Resubscribe every live subscription on a fresh connection. A request that
-    /// arrived while disconnected is already registered, so it is replayed here too —
-    /// there is no queued frame that could subscribe the same id twice.
-    ///
-    /// Cached payloads survive the reconnect: `max_payload_age` already decides whether
-    /// one is still servable, so a brief reconnect need not stall a fetch.
+    /// Resubscribe every live subscription on a fresh connection. A request that arrived
+    /// while disconnected is already registered, so it replays here too — no queued frame
+    /// can subscribe the same id twice. Cached payloads survive; `max_payload_age` already
+    /// decides whether one is still servable.
     async fn replay_subscriptions(&self, stream: &mut LazerStream) -> LazerResult<()> {
         for (id, subscription) in &self.subscriptions {
             let frame =
@@ -516,13 +500,10 @@ impl StreamTask {
         Ok(())
     }
 
-    /// Hand the caller the slot of a subscription covering `feed_ids`, creating one if
-    /// no live subscription already does.
-    ///
-    /// A requester that timed out or was cancelled has dropped its receiver. Hand the
-    /// slot over *before* touching any state, so an abandoned request cannot evict a
-    /// live subscription or strand one that nothing is waiting on — which would also
-    /// hold the connection open forever.
+    /// Hand the caller the slot of a subscription covering `feed_ids`, creating one if none
+    /// does. Hand it over *before* mutating state: a requester that timed out has dropped
+    /// its receiver, and registering for it would strand a subscription nothing waits on
+    /// (holding the connection open) or evict a live one at capacity.
     fn register(&mut self, request: SubscribeRequest) -> Registration {
         let SubscribeRequest { feed_ids, slot_tx } = request;
 
@@ -552,7 +533,6 @@ impl StreamTask {
         }
     }
 
-    /// Ids increase monotonically, so the first key is the oldest subscription.
     fn evict_to_fit(&mut self) -> Vec<SubscriptionId> {
         let mut evicted = Vec::new();
         while self.subscriptions.len() >= MAX_ACTIVE_SUBSCRIPTIONS {
@@ -617,8 +597,7 @@ impl StreamTask {
         }));
     }
 
-    /// Drop a subscription and wake its waiters with the reason. Terminal, so it is
-    /// removed rather than left to be replayed on the next connect.
+    /// Drop a subscription and wake its waiters. Terminal, so it is not replayed.
     fn fail(&mut self, subscription_id: SubscriptionId, error: String) {
         if let Some(subscription) = self.subscriptions.remove(&subscription_id) {
             subscription.slot.send_replace(Slot::Failed(error));

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashSet, VecDeque},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
     time::Duration,
 };
@@ -10,7 +10,8 @@ use pyth_lazer_protocol::api::{Channel, SubscriptionId};
 use templar_gateway_core::{OraclePayloadSource, RedactedString};
 use thiserror::Error;
 use tokio::{
-    sync::{mpsc, oneshot, watch, RwLock},
+    net::TcpStream,
+    sync::{mpsc, oneshot, watch},
     task::JoinHandle,
     time::{timeout, Instant},
 };
@@ -22,22 +23,39 @@ use tokio_tungstenite::{
         protocol::WebSocketConfig,
         Message,
     },
+    MaybeTlsStream, WebSocketStream,
 };
 use url::Url;
 
 use crate::lazer_wire::{
-    decode_stream_message, subscription_frame_for_feeds, unsubscription_frame, LazerStreamEvent,
-    MAX_STREAM_JSON_MESSAGE_BYTES,
+    decode_stream_message, subscription_frame_for_feeds, unsubscription_frame, DecodedLazerPayload,
+    LazerStreamEvent, MAX_STREAM_JSON_MESSAGE_BYTES,
 };
 
+const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
 const MAX_ACTIVE_SUBSCRIPTIONS: usize = 128;
-const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
+/// A subscribed stream delivers at least once per channel interval, so prolonged
+/// silence means the connection is dead. Stays well under the 60s after which the
+/// server closes a connection, so our own timeout can't race theirs.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
+/// How long [`LazerPayloadSource::fetch_payload`] waits for a payload covering its
+/// feeds — long enough to absorb a reconnect. Distinct from `max_payload_age`, which
+/// bounds how old an already-cached payload may be when it is served.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[cfg(test)]
 mod config_tests;
 #[cfg(test)]
+mod fixtures;
+#[cfg(test)]
+mod lifecycle_tests;
+#[cfg(test)]
+mod mock_server;
+#[cfg(test)]
 mod tests;
+
+type LazerStream = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 #[derive(Debug, Clone)]
 pub struct LazerSourceConfig {
@@ -81,6 +99,18 @@ impl LazerSourceConfig {
     pub(crate) fn channel(&self) -> Channel {
         self.channel
     }
+
+    /// Test-only: point the source at the in-process mock server, which speaks
+    /// plaintext `ws://`. Production configs must be `wss://` — see [`Self::new`].
+    #[cfg(test)]
+    pub(crate) fn for_mock_server(ws_url: Url, max_payload_age: Duration) -> Self {
+        Self {
+            ws_url,
+            api_token: RedactedString::from("test-token"),
+            channel: parse_channel("fixed_rate@200ms".to_owned()).expect("valid channel"),
+            max_payload_age,
+        }
+    }
 }
 
 fn parse_channel(channel: String) -> LazerResult<Channel> {
@@ -106,63 +136,28 @@ pub enum LazerClientError {
     Decode(String),
     #[error("Pyth Lazer solana payload exceeds size limit")]
     PayloadTooLarge,
-    #[error("Pyth Lazer cache does not yet contain a payload")]
-    CacheMiss,
     #[error("Pyth Lazer payload request must include at least one feed id")]
     EmptyRequest,
-    #[error("Pyth Lazer cached payload is stale")]
-    StalePayload,
-    #[error("Pyth Lazer cached payload does not cover requested feeds")]
-    FeedNotCovered,
+    #[error("timed out waiting for a Pyth Lazer payload")]
+    Timeout,
     #[error("Pyth Lazer subscription failed: {0}")]
     SubscriptionFailed(String),
 }
 
 pub type LazerResult<T> = Result<T, LazerClientError>;
 
+fn source_stopped() -> LazerClientError {
+    LazerClientError::Request("Pyth Lazer source task stopped".to_owned())
+}
+
+/// The latest state of one subscription, published to every waiting `fetch_payload`.
 #[derive(Debug, Clone)]
-pub struct LazerPayloadSource {
-    inner: Arc<LazerPayloadSourceInner>,
-    subscribe_tx: mpsc::Sender<SubscribeRequest>,
-    _task: Arc<TaskGuard>,
-}
-
-#[derive(Debug)]
-struct LazerPayloadSourceInner {
-    config: LazerSourceConfig,
-    subscriptions: RwLock<SubscriptionState>,
-}
-
-#[derive(Debug)]
-struct SubscriptionState {
-    active: BTreeMap<SubscriptionId, SubscriptionInfo>,
-    pending: BTreeMap<SubscriptionId, PendingSubscription>,
-    fifo: VecDeque<SubscriptionId>,
-    next_id: u64,
-}
-
-impl Default for SubscriptionState {
-    fn default() -> Self {
-        Self {
-            active: BTreeMap::new(),
-            pending: BTreeMap::new(),
-            fifo: VecDeque::new(),
-            next_id: 1,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-struct SubscriptionInfo {
-    feed_ids: BTreeSet<u32>,
-    cache: watch::Receiver<Option<CachedPayload>>,
-    cache_tx: Arc<watch::Sender<Option<CachedPayload>>>,
-}
-
-#[derive(Debug)]
-struct TaskGuard {
-    /// `None` only for the `#[cfg(test)] from_cached` seam, which runs no background task.
-    task: Option<JoinHandle<()>>,
+enum Slot {
+    /// Subscribed, but no payload has arrived yet.
+    Waiting,
+    /// The server rejected the subscription. Terminal: invalid feeds never become valid.
+    Failed(String),
+    Ready(CachedPayload),
 }
 
 #[derive(Debug, Clone)]
@@ -172,65 +167,48 @@ struct CachedPayload {
     received_at: Instant,
 }
 
+/// Ask the stream task for the slot of a subscription covering `feed_ids`, creating one if needed.
 #[derive(Debug)]
-struct PendingSubscription {
-    response_tx: oneshot::Sender<LazerResult<SubscriptionId>>,
+struct SubscribeRequest {
+    feed_ids: BTreeSet<u32>,
+    slot_tx: oneshot::Sender<watch::Receiver<Slot>>,
 }
 
-struct SubscribeRequest {
-    subscription_id: SubscriptionId,
-    feed_ids: BTreeSet<u32>,
-    evicted_ids: Vec<SubscriptionId>,
+#[derive(Debug, Clone)]
+pub struct LazerPayloadSource {
+    max_payload_age: Duration,
+    subscribe_tx: mpsc::Sender<SubscribeRequest>,
+    _task: Arc<TaskGuard>,
+}
+
+#[derive(Debug)]
+struct TaskGuard(JoinHandle<()>);
+
+impl Drop for TaskGuard {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 impl LazerPayloadSource {
     pub fn spawn(config: LazerSourceConfig) -> Self {
-        let inner = Arc::new(LazerPayloadSourceInner {
-            config,
-            subscriptions: RwLock::new(SubscriptionState::default()),
-        });
+        let max_payload_age = config.max_payload_age;
         let (subscribe_tx, subscribe_rx) = mpsc::channel(32);
-        let task_inner = Arc::clone(&inner);
-        let handle = tokio::spawn(async move { task_inner.run(subscribe_rx).await });
+        let task = tokio::spawn(StreamTask::new(config).run(subscribe_rx));
         Self {
-            inner,
+            max_payload_age,
             subscribe_tx,
-            _task: Arc::new(TaskGuard { task: Some(handle) }),
+            _task: Arc::new(TaskGuard(task)),
         }
     }
 
-    #[cfg(test)]
-    fn from_cached(config: LazerSourceConfig, payload: Option<CachedPayload>) -> Self {
-        let (subscribe_tx, _) = mpsc::channel(32);
-        let mut subscriptions = SubscriptionState::default();
-        let (cache_tx, cache_rx) = watch::channel(payload.clone());
-        let feed_ids = payload.map(|p| p.feed_ids).unwrap_or_default();
-        subscriptions.active.insert(
-            SubscriptionId(1),
-            SubscriptionInfo {
-                feed_ids,
-                cache: cache_rx,
-                cache_tx: Arc::new(cache_tx),
-            },
-        );
-        subscriptions.fifo.push_back(SubscriptionId(1));
-        subscriptions.next_id = 2;
-        Self {
-            inner: Arc::new(LazerPayloadSourceInner {
-                config,
-                subscriptions: RwLock::new(subscriptions),
-            }),
-            subscribe_tx,
-            _task: Arc::new(TaskGuard { task: None }),
-        }
-    }
-}
-
-impl Drop for TaskGuard {
-    fn drop(&mut self) {
-        if let Some(task) = &self.task {
-            task.abort();
-        }
+    async fn subscribe(&self, feed_ids: BTreeSet<u32>) -> LazerResult<watch::Receiver<Slot>> {
+        let (slot_tx, slot_rx) = oneshot::channel();
+        self.subscribe_tx
+            .send(SubscribeRequest { feed_ids, slot_tx })
+            .await
+            .map_err(|_| source_stopped())?;
+        slot_rx.await.map_err(|_| source_stopped())
     }
 }
 
@@ -243,195 +221,196 @@ impl OraclePayloadSource for LazerPayloadSource {
         if price_ids.is_empty() {
             return Err(LazerClientError::EmptyRequest);
         }
+        let feed_ids: BTreeSet<u32> = price_ids.iter().copied().collect();
 
-        let requested_feeds: BTreeSet<u32> = price_ids.iter().copied().collect();
-
-        let subscription_id = self.ensure_subscription(requested_feeds.clone()).await?;
-
-        let mut cache_rx = self.cache_receiver(subscription_id).await?;
-        if let Some(payload) = self.payload_from_cache(&cache_rx, &requested_feeds)? {
-            return Ok(payload);
-        }
-
-        let wait_for_payload = async {
-            loop {
-                cache_rx
-                    .changed()
-                    .await
-                    .map_err(|_| LazerClientError::CacheMiss)?;
-                if let Some(payload) = self.payload_from_cache(&cache_rx, &requested_feeds)? {
-                    return Ok(payload);
-                }
-            }
-        };
-
-        timeout(self.inner.config.max_payload_age, wait_for_payload)
-            .await
-            .map_err(|_| LazerClientError::CacheMiss)?
+        // One deadline over both halves: the stream task may be mid-connect when the request
+        // arrives, so waiting for it to answer is as unbounded as waiting for a payload.
+        timeout(FETCH_TIMEOUT, async {
+            // Sending the request also wakes the stream task out of any reconnect backoff, so
+            // a fetch never waits on a sleep it could have cancelled.
+            let mut slot = self.subscribe(feed_ids.clone()).await?;
+            await_payload(&mut slot, &feed_ids, self.max_payload_age).await
+        })
+        .await
+        .map_err(|_| LazerClientError::Timeout)?
     }
 }
 
-impl LazerPayloadSource {
-    async fn cache_receiver(
-        &self,
-        subscription_id: SubscriptionId,
-    ) -> LazerResult<watch::Receiver<Option<CachedPayload>>> {
-        let subscriptions = self.inner.subscriptions.read().await;
-        subscriptions
-            .active
-            .get(&subscription_id)
-            .map(|subscription| subscription.cache.clone())
-            .ok_or(LazerClientError::CacheMiss)
-    }
-
-    fn payload_from_cache(
-        &self,
-        cache_rx: &watch::Receiver<Option<CachedPayload>>,
-        requested_feeds: &BTreeSet<u32>,
-    ) -> LazerResult<Option<Vec<u8>>> {
-        let Some(cached) = cache_rx.borrow().clone() else {
-            return Ok(None);
-        };
-
-        if cached.received_at.elapsed() > self.inner.config.max_payload_age {
-            return Err(LazerClientError::StalePayload);
+async fn await_payload(
+    slot: &mut watch::Receiver<Slot>,
+    feed_ids: &BTreeSet<u32>,
+    max_payload_age: Duration,
+) -> LazerResult<Vec<u8>> {
+    loop {
+        // Scope the borrow: a `watch::Ref` must not be held across an await.
+        let settled = ready_payload(&slot.borrow_and_update(), feed_ids, max_payload_age);
+        if let Some(result) = settled {
+            return result;
         }
-
-        if !requested_feeds.is_subset(&cached.feed_ids) {
-            return Err(LazerClientError::FeedNotCovered);
-        }
-
-        Ok(Some(cached.payload))
-    }
-
-    async fn ensure_subscription(&self, feed_ids: BTreeSet<u32>) -> LazerResult<SubscriptionId> {
-        {
-            let subscriptions = self.inner.subscriptions.read().await;
-            for (id, info) in &subscriptions.active {
-                if !subscriptions.pending.contains_key(id) && feed_ids.is_subset(&info.feed_ids) {
-                    return Ok(*id);
-                }
-            }
-        }
-
-        let (response_tx, response_rx) = oneshot::channel();
-        let (subscription_id, evicted_ids) = self
-            .inner
-            .register_pending_subscription(feed_ids.clone(), response_tx)
-            .await;
-        if self
-            .subscribe_tx
-            .send(SubscribeRequest {
-                subscription_id,
-                feed_ids,
-                evicted_ids,
-            })
-            .await
-            .is_err()
-        {
-            self.inner
-                .fail_pending_subscription(
-                    subscription_id,
-                    "subscription channel closed".to_owned(),
-                )
-                .await;
-            return Err(LazerClientError::Request(
-                "subscription channel closed".to_owned(),
-            ));
-        }
-
-        match timeout(self.inner.config.max_payload_age, response_rx).await {
-            Ok(Ok(result)) => result,
-            Ok(Err(_)) => Err(LazerClientError::Request(
-                "subscription response channel closed".to_owned(),
-            )),
-            Err(_) => {
-                self.inner
-                    .fail_pending_subscription(
-                        subscription_id,
-                        "subscription acknowledgement timed out".to_owned(),
-                    )
-                    .await;
-                Err(LazerClientError::SubscriptionFailed(
-                    "subscription acknowledgement timed out".to_owned(),
-                ))
-            }
-        }
+        slot.changed().await.map_err(|_| source_stopped())?;
     }
 }
 
-impl LazerPayloadSourceInner {
-    async fn register_pending_subscription(
-        &self,
-        feed_ids: BTreeSet<u32>,
-        response_tx: oneshot::Sender<LazerResult<SubscriptionId>>,
-    ) -> (SubscriptionId, Vec<SubscriptionId>) {
-        let mut subscriptions = self.subscriptions.write().await;
-        let subscription_id = SubscriptionId(subscriptions.next_id);
-        subscriptions.next_id += 1;
-
-        let mut evicted_ids = Vec::new();
-        while subscriptions.active.len() >= MAX_ACTIVE_SUBSCRIPTIONS {
-            let Some(evicted_id) = subscriptions.fifo.pop_front() else {
-                break;
-            };
-            subscriptions.active.remove(&evicted_id);
-            if let Some(pending) = subscriptions.pending.remove(&evicted_id) {
-                let _ = pending
-                    .response_tx
-                    .send(Err(LazerClientError::SubscriptionFailed(
-                        "subscription evicted before acknowledgement".to_owned(),
-                    )));
-            }
-            evicted_ids.push(evicted_id);
+/// `None` while the subscription has yet to produce a payload we can serve.
+fn ready_payload(
+    slot: &Slot,
+    feed_ids: &BTreeSet<u32>,
+    max_payload_age: Duration,
+) -> Option<LazerResult<Vec<u8>>> {
+    match slot {
+        Slot::Failed(error) => Some(Err(LazerClientError::SubscriptionFailed(error.clone()))),
+        Slot::Ready(cached)
+            if cached.received_at.elapsed() <= max_payload_age
+                && feed_ids.is_subset(&cached.feed_ids) =>
+        {
+            Some(Ok(cached.payload.clone()))
         }
+        // A stale or not-yet-covering payload is not a failure: on a live stream the
+        // next one is a channel interval away. Wait for it rather than erroring.
+        Slot::Waiting | Slot::Ready(_) => None,
+    }
+}
 
-        let (cache_tx, cache_rx) = watch::channel(None);
-        subscriptions.active.insert(
-            subscription_id,
-            SubscriptionInfo {
-                feed_ids,
-                cache: cache_rx,
-                cache_tx: Arc::new(cache_tx),
-            },
-        );
-        subscriptions.fifo.push_back(subscription_id);
-        subscriptions
-            .pending
-            .insert(subscription_id, PendingSubscription { response_tx });
+/// The background task that owns the websocket and every subscription on it. Callers
+/// reach it only by message, so the subscription set needs no lock and cannot be observed
+/// mid-update.
+///
+/// Not an `actix::Actor`: this is a plain tokio task owning a long-lived resource, so it
+/// stays usable from the lock-free `templar-gateway-client` path, which runs no actix
+/// `System`. The gateway's actix actors are request/response mailboxes at the RPC edge.
+struct StreamTask {
+    config: LazerSourceConfig,
+    /// Keyed by a monotonically increasing id, so the first key is the oldest
+    /// subscription — which is the one eviction takes.
+    subscriptions: BTreeMap<SubscriptionId, Subscription>,
+    next_id: u64,
+    backoff: Duration,
+}
 
-        (subscription_id, evicted_ids)
+struct Subscription {
+    feed_ids: BTreeSet<u32>,
+    slot: watch::Sender<Slot>,
+}
+
+/// What [`StreamTask::register`] changed, and therefore which frames the stream owes the
+/// server. Empty when an existing subscription already covered the request.
+#[derive(Debug, Default)]
+struct Registration {
+    new_subscription: Option<SubscriptionId>,
+    evicted: Vec<SubscriptionId>,
+}
+
+/// A stream that ended without an error, and so without a reconnect.
+#[derive(Debug)]
+enum StreamEnd {
+    /// Every `LazerPayloadSource` was dropped.
+    Shutdown,
+    /// The last subscription went away, so the connection has no purpose.
+    NoSubscriptions,
+}
+
+impl StreamTask {
+    fn new(config: LazerSourceConfig) -> Self {
+        Self {
+            config,
+            subscriptions: BTreeMap::new(),
+            next_id: 1,
+            backoff: INITIAL_RECONNECT_BACKOFF,
+        }
     }
 
-    async fn run(self: Arc<Self>, mut subscribe_rx: mpsc::Receiver<SubscribeRequest>) {
-        let mut backoff = Duration::from_secs(1);
+    async fn run(mut self, mut requests: mpsc::Receiver<SubscribeRequest>) {
         loop {
-            match self
-                .connect_and_stream(&mut subscribe_rx, &mut backoff)
-                .await
-            {
-                // The subscribe channel closed: the `LazerPayloadSource` was dropped, so shut the
-                // task down cleanly rather than reconnecting.
-                Ok(()) => break,
-                Err(error) => {
-                    self.fail_pending_subscriptions("websocket disconnected")
-                        .await;
-                    tracing::warn!(%error, "Pyth Lazer stream disconnected");
-                    tokio::time::sleep(backoff).await;
-                    backoff = (backoff * 2).min(MAX_RECONNECT_BACKOFF);
+            // With no subscription there is nothing to stream, and the server closes a
+            // subscription-less connection after 60s — an idle connection is just a
+            // reconnect loop. Hold none, and wait for demand instead.
+            if self.subscriptions.is_empty() {
+                let Some(request) = requests.recv().await else {
+                    return;
+                };
+                self.register(request);
+            }
+
+            match self.connect_and_stream(&mut requests).await {
+                Ok(StreamEnd::Shutdown) => return,
+                // Nothing left to stream: loop back around and park, rather than
+                // hold a connection the server would close anyway.
+                Ok(StreamEnd::NoSubscriptions) => continue,
+                Err(error) => tracing::warn!(
+                    %error,
+                    subscriptions = self.subscriptions.len(),
+                    "Pyth Lazer stream disconnected",
+                ),
+            }
+
+            if !self.wait_before_reconnect(&mut requests).await {
+                return;
+            }
+        }
+    }
+
+    /// Sleep out the reconnect backoff, waking early for a subscribe request. Returns
+    /// `false` once every sender is gone, which is the shutdown signal.
+    async fn wait_before_reconnect(
+        &mut self,
+        requests: &mut mpsc::Receiver<SubscribeRequest>,
+    ) -> bool {
+        let sleep = self.backoff;
+        self.backoff = (self.backoff * 2).min(MAX_RECONNECT_BACKOFF);
+        tokio::select! {
+            () = tokio::time::sleep(sleep) => true,
+            request = requests.recv() => match request {
+                // Registered now, subscribed by the replay on the next connect.
+                Some(request) => { self.register(request); true }
+                None => false,
+            },
+        }
+    }
+
+    /// Streams until the connection ends. `Ok` is an orderly end (see [`StreamEnd`]);
+    /// every disconnect is an `Err`, which the caller retries after a backoff.
+    async fn connect_and_stream(
+        &mut self,
+        requests: &mut mpsc::Receiver<SubscribeRequest>,
+    ) -> LazerResult<StreamEnd> {
+        let mut stream = self.connect().await?;
+        self.replay_subscriptions(&mut stream).await?;
+
+        loop {
+            // Every subscription was rejected: drop the connection instead of letting
+            // it idle. A connection exists exactly while a subscription does.
+            if self.subscriptions.is_empty() {
+                return Ok(StreamEnd::NoSubscriptions);
+            }
+
+            tokio::select! {
+                message = timeout(STREAM_IDLE_TIMEOUT, stream.next()) => {
+                    let message = message
+                        .map_err(|_| LazerClientError::Request("websocket idle timeout".to_owned()))?;
+                    let Some(message) = message else {
+                        return Err(LazerClientError::Request("websocket closed".to_owned()));
+                    };
+                    let message = message.map_err(|error| LazerClientError::Request(error.to_string()))?;
+                    let Message::Text(text) = message else {
+                        continue;
+                    };
+                    match decode_stream_message(text.as_ref()) {
+                        Ok(event) => self.handle_event(event),
+                        Err(error) => tracing::warn!(%error, "ignored invalid Pyth Lazer stream message"),
+                    }
+                }
+                request = requests.recv() => {
+                    let Some(request) = request else {
+                        return Ok(StreamEnd::Shutdown);
+                    };
+                    let registration = self.register(request);
+                    self.send_registration(&mut stream, &registration).await?;
                 }
             }
         }
     }
 
-    /// Connect, stream, and dispatch until the connection ends. Returns `Ok(())` only when the
-    /// subscribe channel closes (graceful shutdown); every disconnect/error returns `Err`, which
-    /// the caller treats as a reconnect trigger.
-    async fn connect_and_stream(
-        &self,
-        subscribe_rx: &mut mpsc::Receiver<SubscribeRequest>,
-        backoff: &mut Duration,
-    ) -> LazerResult<()> {
+    async fn connect(&self) -> LazerResult<LazerStream> {
         let mut request = self
             .config
             .ws_url
@@ -443,7 +422,7 @@ impl LazerPayloadSourceInner {
                 .map_err(|error| LazerClientError::Request(error.to_string()))?;
         request.headers_mut().insert(AUTHORIZATION, authorization);
 
-        let (mut stream, _) = connect_async_with_config(
+        let (stream, _) = connect_async_with_config(
             request,
             Some(
                 WebSocketConfig::default()
@@ -454,249 +433,148 @@ impl LazerPayloadSourceInner {
         )
         .await
         .map_err(|error| LazerClientError::Request(error.to_string()))?;
-
-        // Replay all active subscriptions after reconnect. Any `SubscribeRequest` still
-        // queued for one of these ids (registered while the task was reconnecting) is now
-        // redundant — the replay already (re)sent its frame — so those queued requests must
-        // be skipped below to avoid subscribing the same id twice.
-        let replayed = self.replay_active_subscriptions(&mut stream).await?;
-
-        loop {
-            tokio::select! {
-                message = timeout(STREAM_IDLE_TIMEOUT, stream.next()) => {
-                    let message = message.map_err(|_| LazerClientError::Request("websocket idle timeout".to_owned()))?;
-                    let Some(message) = message else {
-                        break;
-                    };
-                    let message = message.map_err(|error| LazerClientError::Request(error.to_string()))?;
-                    let Message::Text(text) = message else {
-                        continue;
-                    };
-                    match decode_stream_message(text.as_ref()) {
-                        Ok(event) => self.handle_stream_event(event, backoff).await,
-                        Err(error) => tracing::warn!(%error, "ignored invalid Pyth Lazer stream message"),
-                    }
-                }
-                req = subscribe_rx.recv() => {
-                    let Some(req) = req else {
-                        // All senders dropped: the source is shutting down.
-                        return Ok(());
-                    };
-                    self.handle_subscribe_request(&mut stream, req, &replayed).await?;
-                }
-            }
-        }
-        Err(LazerClientError::Request("websocket closed".to_owned()))
+        Ok(stream)
     }
 
-    /// Resubscribe every active subscription after a reconnect. Returns the ids that were
-    /// replayed so [`Self::handle_subscribe_request`] can drop any queued request for the
-    /// same id (a subscription registered during the reconnect is both `active` and still
-    /// has its `SubscribeRequest` queued, and must not be subscribed twice).
-    async fn replay_active_subscriptions(
-        &self,
-        stream: &mut tokio_tungstenite::WebSocketStream<
-            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-        >,
-    ) -> LazerResult<HashSet<SubscriptionId>> {
-        let active = {
-            let subscriptions = self.subscriptions.read().await;
-            subscriptions
-                .active
-                .iter()
-                .map(|(id, info)| (*id, info.feed_ids.clone(), Arc::clone(&info.cache_tx)))
-                .collect::<Vec<_>>()
-        };
-
-        let mut replayed = HashSet::with_capacity(active.len());
-        for (id, feed_ids, cache_tx) in active {
-            let frame = subscription_frame_for_feeds(&self.config, id, feed_ids)?;
-            stream
-                .send(Message::Text(frame.into()))
-                .await
-                .map_err(|error| LazerClientError::Request(error.to_string()))?;
-            let _ = cache_tx.send(None);
-            replayed.insert(id);
-        }
-        Ok(replayed)
-    }
-
-    async fn handle_subscribe_request(
-        &self,
-        stream: &mut tokio_tungstenite::WebSocketStream<
-            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-        >,
-        req: SubscribeRequest,
-        replayed: &HashSet<SubscriptionId>,
-    ) -> LazerResult<()> {
-        // Skip a request whose subscription was just resubscribed by the reconnect replay:
-        // sending it again would subscribe the same id twice and a duplicate-subscription
-        // error could tear down the live subscription. Ids are never reused, so a replayed
-        // subscription never legitimately needs a second subscribe frame.
-        if replayed.contains(&req.subscription_id)
-            || !self.subscription_is_pending(req.subscription_id).await
-        {
-            return Ok(());
-        }
-
-        for evicted_id in req.evicted_ids {
-            let frame = unsubscription_frame(evicted_id)?;
-            stream
-                .send(Message::Text(frame.into()))
-                .await
-                .map_err(|error| LazerClientError::Request(error.to_string()))?;
-        }
-
-        let frame =
-            subscription_frame_for_feeds(&self.config, req.subscription_id, req.feed_ids.clone())?;
-        if let Err(error) = stream.send(Message::Text(frame.into())).await {
-            let message = error.to_string();
-            self.fail_pending_subscription(req.subscription_id, message.clone())
-                .await;
-            return Err(LazerClientError::Request(message));
+    /// Resubscribe every live subscription on a fresh connection. A request that
+    /// arrived while disconnected is already registered, so it is replayed here too —
+    /// there is no queued frame that could subscribe the same id twice.
+    ///
+    /// Cached payloads survive the reconnect: `max_payload_age` already decides whether
+    /// one is still servable, so a brief reconnect need not stall a fetch.
+    async fn replay_subscriptions(&self, stream: &mut LazerStream) -> LazerResult<()> {
+        for (id, subscription) in &self.subscriptions {
+            let frame =
+                subscription_frame_for_feeds(&self.config, *id, subscription.feed_ids.clone())?;
+            send_frame(stream, frame).await?;
         }
         Ok(())
     }
 
-    async fn subscription_is_pending(&self, subscription_id: SubscriptionId) -> bool {
-        let subscriptions = self.subscriptions.read().await;
-        subscriptions.pending.contains_key(&subscription_id)
+    async fn send_registration(
+        &self,
+        stream: &mut LazerStream,
+        registration: &Registration,
+    ) -> LazerResult<()> {
+        for id in &registration.evicted {
+            send_frame(stream, unsubscription_frame(*id)?).await?;
+        }
+        if let Some(id) = registration.new_subscription {
+            let Some(subscription) = self.subscriptions.get(&id) else {
+                return Ok(());
+            };
+            let frame =
+                subscription_frame_for_feeds(&self.config, id, subscription.feed_ids.clone())?;
+            send_frame(stream, frame).await?;
+        }
+        Ok(())
     }
 
-    async fn handle_stream_event(&self, event: LazerStreamEvent, backoff: &mut Duration) {
+    /// Hand the caller the slot of a subscription covering `feed_ids`, creating one if
+    /// no live subscription already does.
+    fn register(&mut self, request: SubscribeRequest) -> Registration {
+        let SubscribeRequest { feed_ids, slot_tx } = request;
+
+        if let Some(subscription) = self
+            .subscriptions
+            .values()
+            .find(|subscription| feed_ids.is_subset(&subscription.feed_ids))
+        {
+            let _ = slot_tx.send(subscription.slot.subscribe());
+            return Registration::default();
+        }
+
+        let evicted = self.evict_to_fit();
+        let id = SubscriptionId(self.next_id);
+        self.next_id += 1;
+        let (slot, slot_rx) = watch::channel(Slot::Waiting);
+        let _ = slot_tx.send(slot_rx);
+        self.subscriptions
+            .insert(id, Subscription { feed_ids, slot });
+
+        Registration {
+            new_subscription: Some(id),
+            evicted,
+        }
+    }
+
+    /// Ids increase monotonically, so the first key is the oldest subscription.
+    fn evict_to_fit(&mut self) -> Vec<SubscriptionId> {
+        let mut evicted = Vec::new();
+        while self.subscriptions.len() >= MAX_ACTIVE_SUBSCRIPTIONS {
+            let Some(&oldest) = self.subscriptions.keys().next() else {
+                break;
+            };
+            self.fail(oldest, "subscription evicted".to_owned());
+            evicted.push(oldest);
+        }
+        evicted
+    }
+
+    fn handle_event(&mut self, event: LazerStreamEvent) {
         match event {
-            LazerStreamEvent::Payload(payload) => {
-                *backoff = Duration::from_secs(1);
-                self.update_subscription_cache(payload).await;
-            }
-            LazerStreamEvent::Subscribed { subscription_id } => {
-                self.acknowledge_subscription(subscription_id).await;
-            }
+            LazerStreamEvent::Payload(payload) => self.cache_payload(payload),
+            // Nothing to do: a fetch waits for the payload, not for the acknowledgement.
+            LazerStreamEvent::Subscribed { .. } => {}
             LazerStreamEvent::SubscribedWithInvalidFeedIdsIgnored {
                 subscription_id,
                 subscribed_feed_ids,
             } => {
-                self.acknowledge_partial_subscription(subscription_id, subscribed_feed_ids)
-                    .await;
+                let covered =
+                    self.subscriptions
+                        .get(&subscription_id)
+                        .is_some_and(|subscription| {
+                            subscription.feed_ids.is_subset(&subscribed_feed_ids)
+                        });
+                if !covered {
+                    self.fail(
+                        subscription_id,
+                        "subscription ignored requested feed ids".to_owned(),
+                    );
+                }
             }
             LazerStreamEvent::SubscriptionError {
                 subscription_id,
                 error,
-            } => {
-                self.fail_pending_subscription(subscription_id, error).await;
-            }
-            LazerStreamEvent::Unsubscribed { subscription_id } => {
-                tracing::debug!(
-                    subscription_id = subscription_id.0,
-                    "Pyth Lazer subscription removed"
-                );
-            }
+            } => self.fail(subscription_id, error),
+            LazerStreamEvent::Unsubscribed { subscription_id } => tracing::debug!(
+                subscription_id = subscription_id.0,
+                "Pyth Lazer subscription removed"
+            ),
             LazerStreamEvent::Error { error } => {
                 tracing::warn!(%error, "Pyth Lazer stream returned an error response");
             }
         }
     }
 
-    async fn acknowledge_subscription(&self, subscription_id: SubscriptionId) {
-        let pending = {
-            let mut subscriptions = self.subscriptions.write().await;
-            subscriptions.pending.remove(&subscription_id)
-        };
-        if let Some(pending) = pending {
-            let _ = pending.response_tx.send(Ok(subscription_id));
-        }
-    }
-
-    async fn acknowledge_partial_subscription(
-        &self,
-        subscription_id: SubscriptionId,
-        subscribed_feed_ids: BTreeSet<u32>,
-    ) {
-        let result = {
-            let mut subscriptions = self.subscriptions.write().await;
-            let covers_requested = subscriptions
-                .active
-                .get(&subscription_id)
-                .is_some_and(|info| info.feed_ids.is_subset(&subscribed_feed_ids));
-            if covers_requested {
-                subscriptions
-                    .pending
-                    .remove(&subscription_id)
-                    .map(|pending| (pending, Ok(subscription_id)))
-            } else {
-                subscriptions.active.remove(&subscription_id);
-                subscriptions.fifo.retain(|id| *id != subscription_id);
-                subscriptions
-                    .pending
-                    .remove(&subscription_id)
-                    .map(|pending| {
-                        (
-                            pending,
-                            Err(LazerClientError::SubscriptionFailed(
-                                "subscription ignored requested feed ids".to_owned(),
-                            )),
-                        )
-                    })
-            }
-        };
-
-        if let Some((pending, result)) = result {
-            let _ = pending.response_tx.send(result);
-        }
-    }
-
-    async fn fail_pending_subscription(&self, subscription_id: SubscriptionId, error: String) {
-        let pending = {
-            let mut subscriptions = self.subscriptions.write().await;
-            subscriptions.active.remove(&subscription_id);
-            subscriptions.fifo.retain(|id| *id != subscription_id);
-            subscriptions.pending.remove(&subscription_id)
-        };
-        if let Some(pending) = pending {
-            let _ = pending
-                .response_tx
-                .send(Err(LazerClientError::SubscriptionFailed(error)));
-        }
-    }
-
-    async fn fail_pending_subscriptions(&self, error: &str) {
-        let pending = {
-            let mut subscriptions = self.subscriptions.write().await;
-            let ids = subscriptions.pending.keys().copied().collect::<Vec<_>>();
-            for id in &ids {
-                subscriptions.active.remove(id);
-            }
-            subscriptions
-                .fifo
-                .retain(|queued_id| !ids.contains(queued_id));
-            std::mem::take(&mut subscriptions.pending)
-                .into_values()
-                .collect::<Vec<_>>()
-        };
-
-        for pending in pending {
-            let _ = pending
-                .response_tx
-                .send(Err(LazerClientError::SubscriptionFailed(error.to_owned())));
-        }
-    }
-
-    async fn update_subscription_cache(&self, payload: crate::lazer_wire::DecodedLazerPayload) {
-        let subscriptions = self.subscriptions.read().await;
-        let Some(info) = subscriptions.active.get(&payload.subscription_id) else {
+    fn cache_payload(&mut self, payload: DecodedLazerPayload) {
+        self.backoff = INITIAL_RECONNECT_BACKOFF;
+        let Some(subscription) = self.subscriptions.get(&payload.subscription_id) else {
             tracing::warn!(
                 subscription_id = payload.subscription_id.0,
                 "ignored Pyth Lazer payload for unknown subscription"
             );
             return;
         };
-        let cached = CachedPayload {
+        subscription.slot.send_replace(Slot::Ready(CachedPayload {
             payload: payload.bytes,
             feed_ids: payload.feed_ids,
             received_at: Instant::now(),
-        };
-        if let Err(error) = info.cache_tx.send(Some(cached)) {
-            tracing::warn!(subscription_id = payload.subscription_id.0, %error, "failed to update subscription cache");
+        }));
+    }
+
+    /// Drop a subscription and wake its waiters with the reason. Terminal, so it is
+    /// removed rather than left to be replayed on the next connect.
+    fn fail(&mut self, subscription_id: SubscriptionId, error: String) {
+        if let Some(subscription) = self.subscriptions.remove(&subscription_id) {
+            subscription.slot.send_replace(Slot::Failed(error));
         }
     }
+}
+
+async fn send_frame(stream: &mut LazerStream, frame: String) -> LazerResult<()> {
+    stream
+        .send(Message::Text(frame.into()))
+        .await
+        .map_err(|error| LazerClientError::Request(error.to_string()))
 }

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -347,6 +347,9 @@ impl StreamTask {
 
     async fn run(mut self, mut requests: mpsc::Receiver<SubscribeRequest>) {
         loop {
+            // Disconnected, so there is nothing to unsubscribe from.
+            self.prune_abandoned();
+
             // A connection exists exactly while a subscription does: the server closes a
             // subscription-less socket after 60s. `while`, not `if` — an abandoned request
             // registers nothing, and connecting for it would open an empty socket.
@@ -408,7 +411,11 @@ impl StreamTask {
         tokio::pin!(idle);
 
         loop {
-            // Every subscription was rejected; the connection has no purpose.
+            for id in self.prune_abandoned() {
+                send_frame(&mut stream, unsubscription_frame(id)?).await?;
+            }
+
+            // Every subscription was rejected or abandoned; the connection has no purpose.
             if self.subscriptions.is_empty() {
                 return Ok(StreamEnd::NoSubscriptions);
             }
@@ -531,6 +538,24 @@ impl StreamTask {
             new_subscription: Some(id),
             evicted,
         }
+    }
+
+    /// Drop the subscriptions worth nothing to anyone, returning the ids to unsubscribe:
+    /// a fetch that timed out before its first payload dropped its receiver, and its
+    /// subscription would otherwise hold the connection open for a caller that is gone.
+    /// A cached payload keeps its subscription — that is the warm cache for the next fetch,
+    /// whose own receiver is likewise long dropped.
+    fn prune_abandoned(&mut self) -> Vec<SubscriptionId> {
+        let mut pruned = Vec::new();
+        self.subscriptions.retain(|id, subscription| {
+            let keep = subscription.slot.receiver_count() > 0
+                || matches!(*subscription.slot.borrow(), Slot::Ready(_));
+            if !keep {
+                pruned.push(*id);
+            }
+            keep
+        });
+        pruned
     }
 
     fn evict_to_fit(&mut self) -> Vec<SubscriptionId> {

--- a/gateway/oracle-updates-dispatch/src/lazer_client.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client.rs
@@ -35,14 +35,24 @@ use crate::lazer_wire::{
 const INITIAL_RECONNECT_BACKOFF: Duration = Duration::from_secs(1);
 const MAX_RECONNECT_BACKOFF: Duration = Duration::from_secs(30);
 const MAX_ACTIVE_SUBSCRIPTIONS: usize = 128;
-/// A subscribed stream delivers at least once per channel interval, so prolonged
-/// silence means the connection is dead. Stays well under the 60s after which the
-/// server closes a connection, so our own timeout can't race theirs.
-const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(15);
+/// A subscribed stream delivers at least once per channel interval — once a second even
+/// on the slowest (`fixed_rate@1000ms`) — so this much silence means the socket is dead.
+/// A socket can go silent while staying open, and nothing else detects that.
+const STREAM_IDLE_TIMEOUT: Duration = Duration::from_secs(5);
 /// How long [`LazerPayloadSource::fetch_payload`] waits for a payload covering its
-/// feeds — long enough to absorb a reconnect. Distinct from `max_payload_age`, which
-/// bounds how old an already-cached payload may be when it is served.
+/// feeds. Distinct from `max_payload_age`, which bounds how old an already-cached
+/// payload may be when it is served.
 const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// A fetch must outlive one silent-socket recovery, or it expires before the stream task
+/// notices the socket is dead: detect (`STREAM_IDLE_TIMEOUT`) + backoff (reset to
+/// `INITIAL_RECONNECT_BACKOFF` by the last payload) + reconnect, replay, and first
+/// payload. Roughly 5s + 1s + <1s against a 10s deadline.
+const _: () = assert!(
+    STREAM_IDLE_TIMEOUT.as_millis() + INITIAL_RECONNECT_BACKOFF.as_millis()
+        < FETCH_TIMEOUT.as_millis(),
+    "FETCH_TIMEOUT must leave room to detect a silent socket and reconnect",
+);
 
 #[cfg(test)]
 mod config_tests;
@@ -335,7 +345,11 @@ impl StreamTask {
             // With no subscription there is nothing to stream, and the server closes a
             // subscription-less connection after 60s — an idle connection is just a
             // reconnect loop. Hold none, and wait for demand instead.
-            if self.subscriptions.is_empty() {
+            //
+            // Keep waiting rather than connecting once: an abandoned request registers
+            // nothing, and connecting for it would open a websocket with no subscription
+            // on it — and stall a real fetch behind that connect.
+            while self.subscriptions.is_empty() {
                 let Some(request) = requests.recv().await else {
                     return;
                 };

--- a/gateway/oracle-updates-dispatch/src/lazer_client/fixtures.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/fixtures.rs
@@ -17,9 +17,8 @@ pub(crate) fn fixture_bytes() -> Vec<u8> {
         .expect("fixture should be base64")
 }
 
-/// Build a `streamUpdated` frame from the protocol's own response types, serialized by their serde
-/// impls — so the wire tags (`type`/`streamUpdated`/`solana`/`encoding`) come from the protocol
-/// shape rather than hand-written strings, and a protocol change surfaces here at compile time.
+/// Built from the protocol's own response types, so the wire tags come from the protocol
+/// shape rather than hand-written strings and a protocol change fails to compile.
 pub(crate) fn stream_message(subscription_id: SubscriptionId, solana: JsonBinaryData) -> String {
     serde_json::to_string(&stream_response(subscription_id, solana))
         .expect("protocol response serializes")

--- a/gateway/oracle-updates-dispatch/src/lazer_client/fixtures.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/fixtures.rs
@@ -1,0 +1,53 @@
+//! A captured Pyth Lazer `streamUpdated` payload, shared by the wire-decoding
+//! tests and the connection-lifecycle tests.
+
+use base64::Engine as _;
+use pyth_lazer_protocol::api::{
+    JsonBinaryData, JsonBinaryEncoding, JsonUpdate, StreamUpdatedResponse, SubscriptionId,
+    WsResponse,
+};
+
+pub(crate) const PAYLOAD_001: &str = "uQEagohEipEVyTiNYf6VaHJFux40+GmgzXaVUuzszi4nJMWpoMH4WZB0W3SMzUM41gQlkeJYJDydLouwjUDVBbksHwqA78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHk0AKB5JsVAYAAwUHAAAABgD4hPUFAAAAAAUwKwAAAAAAAAT4/wqlkfUFAAAAAAsGNgAAAAAAAAwBQAoHkmxUBgAIAAAABgAvcfQFAAAAAAVeLAAAAAAAAAT4/wpWYvQFAAAAAAt1NwAAAAAAAAwBQAoHkmxUBgABAAAABgAqfglX/QUAAAV2rg9cAQAAAAT4/wqgFefA+wUAAAv8FrtEAQAAAAwBQAoHkmxUBgAbAAAABgC9d+INAAAAAAU27QEAAAAAAAT4/wqQi9sNAAAAAAu07wAAAAAAAAwBQAoHkmxUBgAXAAAABgDQwVgBAAAAAAWSGAAAAAAAAAT4/wqs8FYBAAAAAAvgGAAAAAAAAAwBQAoHkmxUBgA=";
+pub(crate) const EXPECTED_FEEDS: [u32; 5] = [7, 8, 1, 27, 23];
+pub(crate) const PAYLOAD_001_TIMESTAMP_US: u64 = 1_781_675_143_400_000;
+
+pub(crate) fn fixture_bytes() -> Vec<u8> {
+    base64::engine::general_purpose::STANDARD
+        .decode(PAYLOAD_001)
+        .expect("fixture should be base64")
+}
+
+/// Build a `streamUpdated` frame from the protocol's own response types, serialized by their serde
+/// impls — so the wire tags (`type`/`streamUpdated`/`solana`/`encoding`) come from the protocol
+/// shape rather than hand-written strings, and a protocol change surfaces here at compile time.
+pub(crate) fn stream_message(subscription_id: SubscriptionId, solana: JsonBinaryData) -> String {
+    serde_json::to_string(&stream_response(subscription_id, solana))
+        .expect("protocol response serializes")
+}
+
+pub(crate) fn stream_response(
+    subscription_id: SubscriptionId,
+    solana: JsonBinaryData,
+) -> WsResponse {
+    WsResponse::StreamUpdated(StreamUpdatedResponse {
+        subscription_id,
+        payload: JsonUpdate {
+            parsed: None,
+            evm: None,
+            solana: Some(solana),
+            le_ecdsa: None,
+            le_unsigned: None,
+        },
+    })
+}
+
+/// The captured payload as a `streamUpdated` response for `subscription_id`.
+pub(crate) fn fixture_response(subscription_id: SubscriptionId) -> WsResponse {
+    stream_response(
+        subscription_id,
+        JsonBinaryData {
+            encoding: JsonBinaryEncoding::Base64,
+            data: PAYLOAD_001.to_owned(),
+        },
+    )
+}

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -380,3 +380,35 @@ async fn a_fetch_survives_a_silent_socket() {
 
     assert_eq!(payload, fixture_bytes());
 }
+
+/// `FETCH_TIMEOUT` is summed on the assumption that the first reconnect after a payload
+/// sleeps only `INITIAL_RECONNECT_BACKOFF`. That assumption lives here, in the reset
+/// `cache_payload` performs — without it the derived deadline no longer covers a
+/// silent-socket recovery.
+#[test]
+fn a_payload_resets_the_reconnect_backoff() {
+    let mut task = StreamTask::new(LazerSourceConfig::for_mock_server(
+        "ws://127.0.0.1:1/v1/stream".parse().expect("valid url"),
+        Duration::from_secs(5),
+    ));
+    let (slot_tx, _slot_rx) = oneshot::channel();
+    let subscription_id = task
+        .register(SubscribeRequest {
+            feed_ids: [FIXTURE_FEED].into_iter().collect(),
+            slot_tx,
+        })
+        .new_subscription
+        .expect("a live requester registers a subscription");
+
+    task.backoff = MAX_RECONNECT_BACKOFF;
+    task.cache_payload(DecodedLazerPayload {
+        subscription_id,
+        bytes: fixture_bytes(),
+        feed_ids: [FIXTURE_FEED].into_iter().collect(),
+    });
+
+    assert_eq!(
+        task.backoff, INITIAL_RECONNECT_BACKOFF,
+        "a payload must reset the backoff, or FETCH_TIMEOUT's budget is wrong"
+    );
+}

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -11,7 +11,10 @@ use std::time::Duration;
 use futures::StreamExt as _;
 use pyth_lazer_protocol::api::{SubscriptionErrorResponse, SubscriptionId, WsResponse};
 use templar_gateway_core::OraclePayloadSource;
-use tokio::time::{timeout, Instant};
+use tokio::{
+    task::JoinHandle,
+    time::{timeout, Instant},
+};
 
 use super::*;
 use crate::lazer_client::{
@@ -21,6 +24,9 @@ use crate::lazer_client::{
 
 /// A feed carried by the captured fixture payload.
 const FIXTURE_FEED: u32 = 7;
+
+/// Generous enough that a failure means "never happened", not "was slow".
+const PATIENCE: Duration = Duration::from_secs(5);
 
 fn source_for(server: &MockLazer, max_payload_age: Duration) -> LazerPayloadSource {
     LazerPayloadSource::spawn(LazerSourceConfig::for_mock_server(
@@ -34,10 +40,38 @@ fn source_with_idle_timeout(
     max_payload_age: Duration,
     idle_timeout: Duration,
 ) -> LazerPayloadSource {
-    LazerPayloadSource::spawn(
-        LazerSourceConfig::for_mock_server(server.url(), max_payload_age)
-            .with_idle_timeout(idle_timeout),
+    LazerPayloadSource::spawn_with_idle_timeout(
+        LazerSourceConfig::for_mock_server(server.url(), max_payload_age),
+        idle_timeout,
     )
+}
+
+/// A task pointed at a port nothing listens on: for the tests that drive `register` /
+/// `cache_payload` directly and never connect.
+fn offline_task() -> StreamTask {
+    StreamTask::new(
+        LazerSourceConfig::for_mock_server(
+            "ws://127.0.0.1:1/v1/stream".parse().expect("valid url"),
+            Duration::from_secs(5),
+        ),
+        STREAM_IDLE_TIMEOUT,
+    )
+}
+
+/// A fetch for `FIXTURE_FEED`, off the current task so the test can drive the server
+/// while it is in flight.
+fn spawn_fetch(source: &LazerPayloadSource) -> JoinHandle<LazerResult<Vec<u8>>> {
+    let probe = source.clone();
+    tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await })
+}
+
+/// Unwrap a spawned fetch through all three of its failure modes.
+async fn payload_of(fetch: JoinHandle<LazerResult<Vec<u8>>>) -> Vec<u8> {
+    timeout(PATIENCE, fetch)
+        .await
+        .expect("fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("fetch should return a payload")
 }
 
 /// Accept a connection, expect a subscribe frame for `FIXTURE_FEED`, and answer
@@ -47,6 +81,15 @@ async fn accept_and_serve(server: &mut MockLazer) -> ServerConn {
     let feed_ids = next_subscribed_feed_ids(&mut connection).await;
     assert_eq!(feed_ids, vec![FIXTURE_FEED]);
     send(&mut connection, &fixture_response(SubscriptionId(1))).await;
+    connection
+}
+
+/// Drive the source to one live subscription with a payload cached, and hand back the
+/// connection serving it — the starting state for every test about what happens *next*.
+async fn warm_up(source: &LazerPayloadSource, server: &mut MockLazer) -> ServerConn {
+    let fetch = spawn_fetch(source);
+    let connection = accept_and_serve(server).await;
+    payload_of(fetch).await;
     connection
 }
 
@@ -71,16 +114,10 @@ async fn first_fetch_connects_subscribes_and_returns_the_payload() {
     let mut server = MockLazer::start().await;
     let source = source_for(&server, Duration::from_secs(5));
 
-    let fetch = tokio::spawn(async move { source.fetch_payload(&[FIXTURE_FEED]).await });
+    let fetch = spawn_fetch(&source);
     let _connection = accept_and_serve(&mut server).await;
 
-    let payload = timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("fetch should return the payload");
-
-    assert_eq!(payload, fixture_bytes());
+    assert_eq!(payload_of(fetch).await, fixture_bytes());
 }
 
 /// A fetch arriving while the source sleeps in reconnect backoff must connect
@@ -92,15 +129,7 @@ async fn fetch_during_reconnect_backoff_connects_immediately() {
     // A short freshness bound so the cached payload is stale by the time the
     // second fetch runs, forcing it to wait on the stream rather than the cache.
     let source = source_for(&server, Duration::from_millis(200));
-
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
-    let connection = accept_and_serve(&mut server).await;
-    timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("first fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("first fetch should return the payload");
+    let connection = warm_up(&source, &mut server).await;
 
     // Server-side close, twice: backoff grows to ~2s.
     drop(connection);
@@ -109,17 +138,11 @@ async fn fetch_during_reconnect_backoff_connects_immediately() {
 
     tokio::time::sleep(Duration::from_millis(300)).await;
 
-    let probe = source.clone();
     let started = Instant::now();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let fetch = spawn_fetch(&source);
     let _connection = accept_and_serve(&mut server).await;
     let reconnect_delay = started.elapsed();
-
-    timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("fetch should return the payload");
+    payload_of(fetch).await;
 
     assert!(
         reconnect_delay < Duration::from_millis(700),
@@ -133,15 +156,7 @@ async fn fetch_during_reconnect_backoff_connects_immediately() {
 async fn reconnect_replays_active_subscriptions() {
     let mut server = MockLazer::start().await;
     let source = source_for(&server, Duration::from_secs(5));
-
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
-    let connection = accept_and_serve(&mut server).await;
-    timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("fetch should return the payload");
+    let connection = warm_up(&source, &mut server).await;
 
     drop(connection);
 
@@ -162,8 +177,7 @@ async fn subscription_error_fails_the_fetch() {
     let mut server = MockLazer::start().await;
     let source = source_for(&server, Duration::from_secs(5));
 
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let fetch = spawn_fetch(&source);
     let mut connection = server.accept().await;
     let _ = next_subscribed_feed_ids(&mut connection).await;
     send(
@@ -207,24 +221,16 @@ async fn subscription_error_fails_the_fetch() {
 #[tokio::test]
 async fn stale_cached_payload_waits_for_a_fresh_one() {
     let mut server = MockLazer::start().await;
+    // Production idle timeout: the socket stays up for the whole test, so the fetch
+    // must wait on the *stream*, not on a reconnect.
     let source = source_for(&server, Duration::from_millis(200));
-
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
-    let mut connection = accept_and_serve(&mut server).await;
-    timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("first fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("first fetch should return the payload");
+    let mut connection = warm_up(&source, &mut server).await;
 
     tokio::time::sleep(Duration::from_millis(400)).await;
 
-    let probe = source.clone();
-    let mut fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
-
+    let mut fetch = spawn_fetch(&source);
     assert!(
-        timeout(Duration::from_millis(200), &mut fetch)
+        timeout(Duration::from_millis(100), &mut fetch)
             .await
             .is_err(),
         "a stale cached payload must not be returned, and must not fail the fetch"
@@ -232,13 +238,7 @@ async fn stale_cached_payload_waits_for_a_fresh_one() {
 
     send(&mut connection, &fixture_response(SubscriptionId(1))).await;
 
-    let payload = timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("fetch should return once a fresh payload arrives")
-        .expect("fetch task should not panic")
-        .expect("fetch should return the payload");
-
-    assert_eq!(payload, fixture_bytes());
+    assert_eq!(payload_of(fetch).await, fixture_bytes());
 }
 
 /// A silent websocket must trip the idle timeout even while fetches keep arriving.
@@ -253,21 +253,12 @@ async fn silent_stream_reconnects_despite_fetch_traffic() {
         Duration::from_millis(100),
         Duration::from_millis(500),
     );
-
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
     // Held open, then silent forever: the server never sends another frame.
-    let _connection = accept_and_serve(&mut server).await;
-    timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("first fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("first fetch should return the payload");
+    let _silent = warm_up(&source, &mut server).await;
 
     let poller = tokio::spawn(async move {
         for _ in 0..40_u32 {
-            let probe = source.clone();
-            tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+            spawn_fetch(&source);
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     });
@@ -281,30 +272,28 @@ async fn silent_stream_reconnects_despite_fetch_traffic() {
     );
 }
 
-/// A requester that timed out or was cancelled has dropped its receiver before the
-/// task handles its request. Registering it anyway would strand a subscription that
-/// nothing waits on — holding the connection open forever — and, at capacity, evict a
-/// live one to make room for it.
-#[test]
-fn an_abandoned_request_registers_nothing() {
-    let mut task = StreamTask::new(LazerSourceConfig::for_mock_server(
-        "ws://127.0.0.1:1/v1/stream".parse().expect("valid url"),
-        Duration::from_secs(5),
-    ));
-    let (slot_tx, slot_rx) = oneshot::channel();
-    drop(slot_rx);
-
-    let registration = task.register(SubscribeRequest {
-        feed_ids: [FIXTURE_FEED].into_iter().collect(),
-        slot_tx,
-    });
-
-    assert!(registration.new_subscription.is_none());
-    assert!(registration.evicted.is_empty());
-    assert!(
-        task.subscriptions.is_empty(),
-        "an abandoned request must not leave a subscription behind"
+/// A subscribed socket that goes silent without closing must be detected, reconnected,
+/// and replayed inside a single fetch's deadline — otherwise `FETCH_TIMEOUT` expires
+/// first and the fetch fails spuriously. In production that headroom comes from
+/// `FETCH_TIMEOUT` being summed over the recovery it must cover.
+#[tokio::test]
+async fn a_fetch_survives_a_silent_socket() {
+    let mut server = MockLazer::start().await;
+    let source = source_with_idle_timeout(
+        &server,
+        Duration::from_millis(100),
+        Duration::from_millis(300),
     );
+    let _silent = warm_up(&source, &mut server).await;
+
+    // Let the cached payload go stale while the socket stays open and silent.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let fetch = spawn_fetch(&source);
+    // The idle timer fires, the task reconnects and replays; serve the fetch there.
+    let _reconnected = accept_and_serve(&mut server).await;
+
+    assert_eq!(payload_of(fetch).await, fixture_bytes());
 }
 
 /// An abandoned request registers nothing, so the task must keep waiting for demand
@@ -315,10 +304,10 @@ async fn an_abandoned_first_request_does_not_connect() {
     let mut server = MockLazer::start().await;
     let (requests_tx, requests_rx) = mpsc::channel(4);
     let task = tokio::spawn(
-        StreamTask::new(LazerSourceConfig::for_mock_server(
-            server.url(),
-            Duration::from_secs(5),
-        ))
+        StreamTask::new(
+            LazerSourceConfig::for_mock_server(server.url(), Duration::from_secs(5)),
+            STREAM_IDLE_TIMEOUT,
+        )
         .run(requests_rx),
     );
 
@@ -341,44 +330,27 @@ async fn an_abandoned_first_request_does_not_connect() {
     );
 }
 
-/// A subscribed socket that goes silent without closing must be detected, reconnected,
-/// and replayed inside a single fetch's deadline — otherwise `FETCH_TIMEOUT` expires
-/// first and the fetch fails spuriously. Guarded for production values by the
-/// `STREAM_IDLE_TIMEOUT + INITIAL_RECONNECT_BACKOFF < FETCH_TIMEOUT` assertion.
-#[tokio::test]
-async fn a_fetch_survives_a_silent_socket() {
-    let mut server = MockLazer::start().await;
-    let source = source_with_idle_timeout(
-        &server,
-        Duration::from_millis(100),
-        Duration::from_millis(300),
+/// A requester that timed out or was cancelled has dropped its receiver before the
+/// task handles its request. Registering it anyway would strand a subscription that
+/// nothing waits on — holding the connection open forever — and, at capacity, evict a
+/// live one to make room for it.
+#[test]
+fn an_abandoned_request_registers_nothing() {
+    let mut task = offline_task();
+    let (slot_tx, slot_rx) = oneshot::channel();
+    drop(slot_rx);
+
+    let registration = task.register(SubscribeRequest {
+        feed_ids: [FIXTURE_FEED].into_iter().collect(),
+        slot_tx,
+    });
+
+    assert!(registration.new_subscription.is_none());
+    assert!(registration.evicted.is_empty());
+    assert!(
+        task.subscriptions.is_empty(),
+        "an abandoned request must not leave a subscription behind"
     );
-
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
-    let _silent = accept_and_serve(&mut server).await;
-    timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("first fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("first fetch should return the payload");
-
-    // Let the cached payload go stale while the socket stays open and silent.
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    let probe = source.clone();
-    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
-
-    // The idle timer fires, the task reconnects and replays; serve the fetch there.
-    let _reconnected = accept_and_serve(&mut server).await;
-
-    let payload = timeout(Duration::from_secs(5), fetch)
-        .await
-        .expect("fetch should not time out")
-        .expect("fetch task should not panic")
-        .expect("a fetch must survive a silent socket, not expire waiting on it");
-
-    assert_eq!(payload, fixture_bytes());
 }
 
 /// `FETCH_TIMEOUT` is summed on the assumption that the first reconnect after a payload
@@ -387,10 +359,7 @@ async fn a_fetch_survives_a_silent_socket() {
 /// silent-socket recovery.
 #[test]
 fn a_payload_resets_the_reconnect_backoff() {
-    let mut task = StreamTask::new(LazerSourceConfig::for_mock_server(
-        "ws://127.0.0.1:1/v1/stream".parse().expect("valid url"),
-        Duration::from_secs(5),
-    ));
+    let mut task = offline_task();
     let (slot_tx, _slot_rx) = oneshot::channel();
     let subscription_id = task
         .register(SubscribeRequest {

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -29,6 +29,17 @@ fn source_for(server: &MockLazer, max_payload_age: Duration) -> LazerPayloadSour
     ))
 }
 
+fn source_with_idle_timeout(
+    server: &MockLazer,
+    max_payload_age: Duration,
+    idle_timeout: Duration,
+) -> LazerPayloadSource {
+    LazerPayloadSource::spawn(
+        LazerSourceConfig::for_mock_server(server.url(), max_payload_age)
+            .with_idle_timeout(idle_timeout),
+    )
+}
+
 /// Accept a connection, expect a subscribe frame for `FIXTURE_FEED`, and answer
 /// with the fixture payload.
 async fn accept_and_serve(server: &mut MockLazer) -> ServerConn {
@@ -228,4 +239,70 @@ async fn stale_cached_payload_waits_for_a_fresh_one() {
         .expect("fetch should return the payload");
 
     assert_eq!(payload, fixture_bytes());
+}
+
+/// A silent websocket must trip the idle timeout even while fetches keep arriving.
+/// Every fetch messages the task, including one for an already-covered subscription,
+/// so an idle timer rebuilt per `select!` iteration would be reset forever and the
+/// dead socket would never be detected.
+#[tokio::test]
+async fn silent_stream_reconnects_despite_fetch_traffic() {
+    let mut server = MockLazer::start().await;
+    let source = source_with_idle_timeout(
+        &server,
+        Duration::from_millis(100),
+        Duration::from_millis(500),
+    );
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    // Held open, then silent forever: the server never sends another frame.
+    let _connection = accept_and_serve(&mut server).await;
+    timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("first fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("first fetch should return the payload");
+
+    let poller = tokio::spawn(async move {
+        for _ in 0..40_u32 {
+            let probe = source.clone();
+            tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    });
+
+    let reconnected = server.accept_within(Duration::from_secs(3)).await;
+    poller.abort();
+
+    assert!(
+        reconnected.is_some(),
+        "a silent stream must trip the idle timeout and reconnect, even under fetch traffic"
+    );
+}
+
+/// A requester that timed out or was cancelled has dropped its receiver before the
+/// task handles its request. Registering it anyway would strand a subscription that
+/// nothing waits on — holding the connection open forever — and, at capacity, evict a
+/// live one to make room for it.
+#[test]
+fn an_abandoned_request_registers_nothing() {
+    let mut task = StreamTask::new(LazerSourceConfig::for_mock_server(
+        "ws://127.0.0.1:1/v1/stream".parse().expect("valid url"),
+        Duration::from_secs(5),
+    ));
+    let (slot_tx, slot_rx) = oneshot::channel();
+    drop(slot_rx);
+
+    let registration = task.register(SubscribeRequest {
+        feed_ids: [FIXTURE_FEED].into_iter().collect(),
+        slot_tx,
+    });
+
+    assert!(registration.new_subscription.is_none());
+    assert!(registration.evicted.is_empty());
+    assert!(
+        task.subscriptions.is_empty(),
+        "an abandoned request must not leave a subscription behind"
+    );
 }

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -1,10 +1,6 @@
-//! Connection-lifecycle tests for [`LazerPayloadSource`], driven against the
-//! in-process [`mock_server`].
-//!
-//! The production Lazer endpoint closes any connection carrying no subscription
-//! after exactly 60s. A source that connects before anything subscribes therefore
-//! reconnects forever, and a fetch arriving while it sleeps in reconnect backoff
-//! is starved. Both properties are asserted here.
+//! Connection-lifecycle tests for [`LazerPayloadSource`], driven against the in-process
+//! [`mock_server`]. The live endpoint closes a subscription-less connection after 60s, so
+//! when the source connects is a correctness question, not a detail.
 
 use std::time::Duration;
 
@@ -46,8 +42,7 @@ fn source_with_idle_timeout(
     )
 }
 
-/// A task pointed at a port nothing listens on: for the tests that drive `register` /
-/// `cache_payload` directly and never connect.
+/// Pointed at a port nothing listens on: for tests that drive the task directly.
 fn offline_task() -> StreamTask {
     StreamTask::new(
         LazerSourceConfig::for_mock_server(
@@ -58,8 +53,7 @@ fn offline_task() -> StreamTask {
     )
 }
 
-/// A fetch for `FIXTURE_FEED`, off the current task so the test can drive the server
-/// while it is in flight.
+/// Off the current task, so the test can drive the server while the fetch is in flight.
 fn spawn_fetch(source: &LazerPayloadSource) -> JoinHandle<LazerResult<Vec<u8>>> {
     let probe = source.clone();
     tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await })
@@ -84,8 +78,8 @@ async fn accept_and_serve(server: &mut MockLazer) -> ServerConn {
     connection
 }
 
-/// Drive the source to one live subscription with a payload cached, and hand back the
-/// connection serving it — the starting state for every test about what happens *next*.
+/// Drive the source to one live subscription with a payload cached, returning the
+/// connection serving it.
 async fn warm_up(source: &LazerPayloadSource, server: &mut MockLazer) -> ServerConn {
     let fetch = spawn_fetch(source);
     let connection = accept_and_serve(server).await;
@@ -93,9 +87,8 @@ async fn warm_up(source: &LazerPayloadSource, server: &mut MockLazer) -> ServerC
     connection
 }
 
-/// The source must not hold a websocket open before anything subscribes: the
-/// live endpoint reaps a subscription-less connection after 60s, so an eager
-/// connect becomes a permanent reconnect loop.
+/// An eager connect becomes a permanent reconnect loop against the live endpoint's
+/// 60s reap of subscription-less connections.
 #[tokio::test]
 async fn does_not_connect_until_a_payload_is_requested() {
     let mut server = MockLazer::start().await;
@@ -120,9 +113,8 @@ async fn first_fetch_connects_subscribes_and_returns_the_payload() {
     assert_eq!(payload_of(fetch).await, fixture_bytes());
 }
 
-/// A fetch arriving while the source sleeps in reconnect backoff must connect
-/// immediately rather than waiting out the sleep. Two disconnects push the
-/// backoff to ~2s; the reconnect must beat that by a wide margin.
+/// A fetch arriving during reconnect backoff must cancel the sleep. Two disconnects push
+/// the backoff to ~2s; the reconnect must beat that by a wide margin.
 #[tokio::test]
 async fn fetch_during_reconnect_backoff_connects_immediately() {
     let mut server = MockLazer::start().await;
@@ -150,8 +142,7 @@ async fn fetch_during_reconnect_backoff_connects_immediately() {
     );
 }
 
-/// After a server-side close the source must resubscribe every live
-/// subscription, without any new fetch prompting it.
+/// A server-side close must resubscribe every live subscription, unprompted.
 #[tokio::test]
 async fn reconnect_replays_active_subscriptions() {
     let mut server = MockLazer::start().await;
@@ -170,8 +161,7 @@ async fn reconnect_replays_active_subscriptions() {
     );
 }
 
-/// A server-side subscription rejection must surface as an error, not as a
-/// silent wait that expires on the fetch timeout.
+/// A rejection must surface as an error, not a wait that expires on the fetch timeout.
 #[tokio::test]
 async fn subscription_error_fails_the_fetch() {
     let mut server = MockLazer::start().await;
@@ -200,10 +190,8 @@ async fn subscription_error_fails_the_fetch() {
         "expected the server's rejection detail, got {error:?}"
     );
 
-    // The rejection left no subscription, so the connection has no purpose: the
-    // source must drop it rather than idle until the server closes it. `source`
-    // stays alive here, so the close can only come from that invariant and not
-    // from the task guard aborting a dropped source.
+    // No subscription left, so the connection must be dropped. `source` stays alive, so
+    // the close cannot come from the task guard aborting a dropped source.
     let closed = timeout(Duration::from_secs(2), connection.next())
         .await
         .expect("source should drop a connection with no subscriptions");
@@ -215,14 +203,12 @@ async fn subscription_error_fails_the_fetch() {
     drop(source);
 }
 
-/// A cached payload older than `max_payload_age` must not be returned, and must
-/// not fail the fetch either: the next payload is ~200ms away on a live stream,
-/// so the fetch waits for it.
+/// A payload older than `max_payload_age` must neither be returned nor fail the fetch:
+/// the next one is a channel interval away, so the fetch waits.
 #[tokio::test]
 async fn stale_cached_payload_waits_for_a_fresh_one() {
     let mut server = MockLazer::start().await;
-    // Production idle timeout: the socket stays up for the whole test, so the fetch
-    // must wait on the *stream*, not on a reconnect.
+    // Production idle timeout: the socket stays up, so the fetch waits on the stream.
     let source = source_for(&server, Duration::from_millis(200));
     let mut connection = warm_up(&source, &mut server).await;
 
@@ -241,10 +227,8 @@ async fn stale_cached_payload_waits_for_a_fresh_one() {
     assert_eq!(payload_of(fetch).await, fixture_bytes());
 }
 
-/// A silent websocket must trip the idle timeout even while fetches keep arriving.
-/// Every fetch messages the task, including one for an already-covered subscription,
-/// so an idle timer rebuilt per `select!` iteration would be reset forever and the
-/// dead socket would never be detected.
+/// A silent websocket must trip the idle timeout even under fetch traffic: every fetch
+/// messages the task, so a timer rebuilt per `select!` iteration would reset forever.
 #[tokio::test]
 async fn silent_stream_reconnects_despite_fetch_traffic() {
     let mut server = MockLazer::start().await;
@@ -272,10 +256,8 @@ async fn silent_stream_reconnects_despite_fetch_traffic() {
     );
 }
 
-/// A subscribed socket that goes silent without closing must be detected, reconnected,
-/// and replayed inside a single fetch's deadline — otherwise `FETCH_TIMEOUT` expires
-/// first and the fetch fails spuriously. In production that headroom comes from
-/// `FETCH_TIMEOUT` being summed over the recovery it must cover.
+/// A socket that goes silent without closing must be detected, reconnected, and replayed
+/// inside one fetch's deadline, or the fetch fails spuriously.
 #[tokio::test]
 async fn a_fetch_survives_a_silent_socket() {
     let mut server = MockLazer::start().await;
@@ -296,9 +278,8 @@ async fn a_fetch_survives_a_silent_socket() {
     assert_eq!(payload_of(fetch).await, fixture_bytes());
 }
 
-/// An abandoned request registers nothing, so the task must keep waiting for demand
-/// rather than connect. A websocket with no subscription on it is the very thing
-/// connect-on-demand exists to prevent, and the connect would stall a real fetch.
+/// An abandoned request registers nothing, so the task must keep waiting rather than open
+/// a subscription-less websocket — and stall a real fetch behind that connect.
 #[tokio::test]
 async fn an_abandoned_first_request_does_not_connect() {
     let mut server = MockLazer::start().await;
@@ -330,10 +311,8 @@ async fn an_abandoned_first_request_does_not_connect() {
     );
 }
 
-/// A requester that timed out or was cancelled has dropped its receiver before the
-/// task handles its request. Registering it anyway would strand a subscription that
-/// nothing waits on — holding the connection open forever — and, at capacity, evict a
-/// live one to make room for it.
+/// A requester that timed out has dropped its receiver. Registering it anyway would strand
+/// a subscription nothing waits on, and at capacity evict a live one to make room.
 #[test]
 fn an_abandoned_request_registers_nothing() {
     let mut task = offline_task();
@@ -353,10 +332,8 @@ fn an_abandoned_request_registers_nothing() {
     );
 }
 
-/// `FETCH_TIMEOUT` is summed on the assumption that the first reconnect after a payload
-/// sleeps only `INITIAL_RECONNECT_BACKOFF`. That assumption lives here, in the reset
-/// `cache_payload` performs — without it the derived deadline no longer covers a
-/// silent-socket recovery.
+/// `FETCH_TIMEOUT` is summed assuming the first reconnect after a payload sleeps only
+/// `INITIAL_RECONNECT_BACKOFF`. That assumption is this reset.
 #[test]
 fn a_payload_resets_the_reconnect_backoff() {
     let mut task = offline_task();

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -306,3 +306,77 @@ fn an_abandoned_request_registers_nothing() {
         "an abandoned request must not leave a subscription behind"
     );
 }
+
+/// An abandoned request registers nothing, so the task must keep waiting for demand
+/// rather than connect. A websocket with no subscription on it is the very thing
+/// connect-on-demand exists to prevent, and the connect would stall a real fetch.
+#[tokio::test]
+async fn an_abandoned_first_request_does_not_connect() {
+    let mut server = MockLazer::start().await;
+    let (requests_tx, requests_rx) = mpsc::channel(4);
+    let task = tokio::spawn(
+        StreamTask::new(LazerSourceConfig::for_mock_server(
+            server.url(),
+            Duration::from_secs(5),
+        ))
+        .run(requests_rx),
+    );
+
+    let (slot_tx, slot_rx) = oneshot::channel();
+    drop(slot_rx);
+    requests_tx
+        .send(SubscribeRequest {
+            feed_ids: [FIXTURE_FEED].into_iter().collect(),
+            slot_tx,
+        })
+        .await
+        .expect("stream task should accept the request");
+
+    let connection = server.accept_within(Duration::from_millis(500)).await;
+    task.abort();
+
+    assert!(
+        connection.is_none(),
+        "an abandoned request must not open a subscription-less websocket"
+    );
+}
+
+/// A subscribed socket that goes silent without closing must be detected, reconnected,
+/// and replayed inside a single fetch's deadline — otherwise `FETCH_TIMEOUT` expires
+/// first and the fetch fails spuriously. Guarded for production values by the
+/// `STREAM_IDLE_TIMEOUT + INITIAL_RECONNECT_BACKOFF < FETCH_TIMEOUT` assertion.
+#[tokio::test]
+async fn a_fetch_survives_a_silent_socket() {
+    let mut server = MockLazer::start().await;
+    let source = source_with_idle_timeout(
+        &server,
+        Duration::from_millis(100),
+        Duration::from_millis(300),
+    );
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let _silent = accept_and_serve(&mut server).await;
+    timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("first fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("first fetch should return the payload");
+
+    // Let the cached payload go stale while the socket stays open and silent.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+
+    // The idle timer fires, the task reconnects and replays; serve the fetch there.
+    let _reconnected = accept_and_serve(&mut server).await;
+
+    let payload = timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("a fetch must survive a silent socket, not expire waiting on it");
+
+    assert_eq!(payload, fixture_bytes());
+}

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -1,0 +1,231 @@
+//! Connection-lifecycle tests for [`LazerPayloadSource`], driven against the
+//! in-process [`mock_server`].
+//!
+//! The production Lazer endpoint closes any connection carrying no subscription
+//! after exactly 60s. A source that connects before anything subscribes therefore
+//! reconnects forever, and a fetch arriving while it sleeps in reconnect backoff
+//! is starved. Both properties are asserted here.
+
+use std::time::Duration;
+
+use futures::StreamExt as _;
+use pyth_lazer_protocol::api::{SubscriptionErrorResponse, SubscriptionId, WsResponse};
+use templar_gateway_core::OraclePayloadSource;
+use tokio::time::{timeout, Instant};
+
+use super::*;
+use crate::lazer_client::{
+    fixtures::{fixture_bytes, fixture_response},
+    mock_server::{next_subscribed_feed_ids, send, MockLazer, ServerConn},
+};
+
+/// A feed carried by the captured fixture payload.
+const FIXTURE_FEED: u32 = 7;
+
+fn source_for(server: &MockLazer, max_payload_age: Duration) -> LazerPayloadSource {
+    LazerPayloadSource::spawn(LazerSourceConfig::for_mock_server(
+        server.url(),
+        max_payload_age,
+    ))
+}
+
+/// Accept a connection, expect a subscribe frame for `FIXTURE_FEED`, and answer
+/// with the fixture payload.
+async fn accept_and_serve(server: &mut MockLazer) -> ServerConn {
+    let mut connection = server.accept().await;
+    let feed_ids = next_subscribed_feed_ids(&mut connection).await;
+    assert_eq!(feed_ids, vec![FIXTURE_FEED]);
+    send(&mut connection, &fixture_response(SubscriptionId(1))).await;
+    connection
+}
+
+/// The source must not hold a websocket open before anything subscribes: the
+/// live endpoint reaps a subscription-less connection after 60s, so an eager
+/// connect becomes a permanent reconnect loop.
+#[tokio::test]
+async fn does_not_connect_until_a_payload_is_requested() {
+    let mut server = MockLazer::start().await;
+    let _source = source_for(&server, Duration::from_secs(5));
+
+    let connection = server.accept_within(Duration::from_millis(500)).await;
+
+    assert!(
+        connection.is_none(),
+        "source must not connect until a payload is requested"
+    );
+}
+
+#[tokio::test]
+async fn first_fetch_connects_subscribes_and_returns_the_payload() {
+    let mut server = MockLazer::start().await;
+    let source = source_for(&server, Duration::from_secs(5));
+
+    let fetch = tokio::spawn(async move { source.fetch_payload(&[FIXTURE_FEED]).await });
+    let _connection = accept_and_serve(&mut server).await;
+
+    let payload = timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("fetch should return the payload");
+
+    assert_eq!(payload, fixture_bytes());
+}
+
+/// A fetch arriving while the source sleeps in reconnect backoff must connect
+/// immediately rather than waiting out the sleep. Two disconnects push the
+/// backoff to ~2s; the reconnect must beat that by a wide margin.
+#[tokio::test]
+async fn fetch_during_reconnect_backoff_connects_immediately() {
+    let mut server = MockLazer::start().await;
+    // A short freshness bound so the cached payload is stale by the time the
+    // second fetch runs, forcing it to wait on the stream rather than the cache.
+    let source = source_for(&server, Duration::from_millis(200));
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let connection = accept_and_serve(&mut server).await;
+    timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("first fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("first fetch should return the payload");
+
+    // Server-side close, twice: backoff grows to ~2s.
+    drop(connection);
+    let connection = server.accept().await;
+    drop(connection);
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let probe = source.clone();
+    let started = Instant::now();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let _connection = accept_and_serve(&mut server).await;
+    let reconnect_delay = started.elapsed();
+
+    timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("fetch should return the payload");
+
+    assert!(
+        reconnect_delay < Duration::from_millis(700),
+        "a fetch during backoff must cancel the sleep and connect at once, took {reconnect_delay:?}"
+    );
+}
+
+/// After a server-side close the source must resubscribe every live
+/// subscription, without any new fetch prompting it.
+#[tokio::test]
+async fn reconnect_replays_active_subscriptions() {
+    let mut server = MockLazer::start().await;
+    let source = source_for(&server, Duration::from_secs(5));
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let connection = accept_and_serve(&mut server).await;
+    timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("fetch should return the payload");
+
+    drop(connection);
+
+    let mut reconnected = server.accept().await;
+    let feed_ids = next_subscribed_feed_ids(&mut reconnected).await;
+
+    assert_eq!(
+        feed_ids,
+        vec![FIXTURE_FEED],
+        "reconnect must replay the live subscription"
+    );
+}
+
+/// A server-side subscription rejection must surface as an error, not as a
+/// silent wait that expires on the fetch timeout.
+#[tokio::test]
+async fn subscription_error_fails_the_fetch() {
+    let mut server = MockLazer::start().await;
+    let source = source_for(&server, Duration::from_secs(5));
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let mut connection = server.accept().await;
+    let _ = next_subscribed_feed_ids(&mut connection).await;
+    send(
+        &mut connection,
+        &WsResponse::SubscriptionError(SubscriptionErrorResponse {
+            subscription_id: SubscriptionId(1),
+            error: "unknown feed id".to_owned(),
+        }),
+    )
+    .await;
+
+    let error = timeout(Duration::from_secs(2), fetch)
+        .await
+        .expect("a rejected subscription must fail fast, not wait for the fetch timeout")
+        .expect("fetch task should not panic")
+        .expect_err("a rejected subscription must fail the fetch");
+
+    assert!(
+        matches!(error, LazerClientError::SubscriptionFailed(ref message) if message.contains("unknown feed id")),
+        "expected the server's rejection detail, got {error:?}"
+    );
+
+    // The rejection left no subscription, so the connection has no purpose: the
+    // source must drop it rather than idle until the server closes it. `source`
+    // stays alive here, so the close can only come from that invariant and not
+    // from the task guard aborting a dropped source.
+    let closed = timeout(Duration::from_secs(2), connection.next())
+        .await
+        .expect("source should drop a connection with no subscriptions");
+    assert!(
+        matches!(closed, None | Some(Err(_))),
+        "expected the connection to close, got {closed:?}"
+    );
+
+    drop(source);
+}
+
+/// A cached payload older than `max_payload_age` must not be returned, and must
+/// not fail the fetch either: the next payload is ~200ms away on a live stream,
+/// so the fetch waits for it.
+#[tokio::test]
+async fn stale_cached_payload_waits_for_a_fresh_one() {
+    let mut server = MockLazer::start().await;
+    let source = source_for(&server, Duration::from_millis(200));
+
+    let probe = source.clone();
+    let fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+    let mut connection = accept_and_serve(&mut server).await;
+    timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("first fetch should not time out")
+        .expect("fetch task should not panic")
+        .expect("first fetch should return the payload");
+
+    tokio::time::sleep(Duration::from_millis(400)).await;
+
+    let probe = source.clone();
+    let mut fetch = tokio::spawn(async move { probe.fetch_payload(&[FIXTURE_FEED]).await });
+
+    assert!(
+        timeout(Duration::from_millis(200), &mut fetch)
+            .await
+            .is_err(),
+        "a stale cached payload must not be returned, and must not fail the fetch"
+    );
+
+    send(&mut connection, &fixture_response(SubscriptionId(1))).await;
+
+    let payload = timeout(Duration::from_secs(5), fetch)
+        .await
+        .expect("fetch should return once a fresh payload arrives")
+        .expect("fetch task should not panic")
+        .expect("fetch should return the payload");
+
+    assert_eq!(payload, fixture_bytes());
+}

--- a/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/lifecycle_tests.rs
@@ -5,7 +5,7 @@
 use std::time::Duration;
 
 use futures::StreamExt as _;
-use pyth_lazer_protocol::api::{SubscriptionErrorResponse, SubscriptionId, WsResponse};
+use pyth_lazer_protocol::api::{SubscriptionErrorResponse, SubscriptionId, WsRequest, WsResponse};
 use templar_gateway_core::OraclePayloadSource;
 use tokio::{
     task::JoinHandle,
@@ -15,7 +15,7 @@ use tokio::{
 use super::*;
 use crate::lazer_client::{
     fixtures::{fixture_bytes, fixture_response},
-    mock_server::{next_subscribed_feed_ids, send, MockLazer, ServerConn},
+    mock_server::{next_request, next_subscribed_feed_ids, send, MockLazer, ServerConn},
 };
 
 /// A feed carried by the captured fixture payload.
@@ -356,5 +356,128 @@ fn a_payload_resets_the_reconnect_backoff() {
     assert_eq!(
         task.backoff, INITIAL_RECONNECT_BACKOFF,
         "a payload must reset the backoff, or FETCH_TIMEOUT's budget is wrong"
+    );
+}
+
+/// A fetch that timed out before its first payload has dropped its receiver. Its
+/// subscription must go with it, or the task reconnects forever for a caller that is gone.
+#[test]
+fn a_timed_out_fetch_prunes_its_subscription() {
+    let mut task = offline_task();
+    let (slot_tx, mut slot_rx) = oneshot::channel();
+    let subscription_id = task
+        .register(SubscribeRequest {
+            feed_ids: [FIXTURE_FEED].into_iter().collect(),
+            slot_tx,
+        })
+        .new_subscription
+        .expect("a live requester registers a subscription");
+    let slot = slot_rx.try_recv().expect("register hands the slot over");
+
+    assert!(
+        task.prune_abandoned().is_empty(),
+        "a fetch is still waiting on this subscription"
+    );
+
+    drop(slot);
+
+    assert_eq!(
+        task.prune_abandoned(),
+        vec![subscription_id],
+        "an abandoned subscription must be unsubscribed"
+    );
+    assert!(task.subscriptions.is_empty());
+}
+
+/// The warm cache: a subscription holding a payload outlives the fetch that created it,
+/// which also dropped its receiver on the way out.
+#[test]
+fn a_cached_payload_outlives_its_fetch() {
+    let mut task = offline_task();
+    let (slot_tx, mut slot_rx) = oneshot::channel();
+    let subscription_id = task
+        .register(SubscribeRequest {
+            feed_ids: [FIXTURE_FEED].into_iter().collect(),
+            slot_tx,
+        })
+        .new_subscription
+        .expect("a live requester registers a subscription");
+    let slot = slot_rx.try_recv().expect("register hands the slot over");
+
+    task.cache_payload(DecodedLazerPayload {
+        subscription_id,
+        bytes: fixture_bytes(),
+        feed_ids: [FIXTURE_FEED].into_iter().collect(),
+    });
+    drop(slot);
+
+    assert!(task.prune_abandoned().is_empty());
+    assert_eq!(
+        task.subscriptions.len(),
+        1,
+        "a cached payload must outlive its fetch, or every fetch reconnects"
+    );
+}
+
+/// Pruning the last subscription ends the connection: unsubscribe, close, and park.
+#[tokio::test]
+async fn an_abandoned_subscription_closes_the_connection() {
+    let mut server = MockLazer::start().await;
+    let source = source_for(&server, Duration::from_secs(5));
+
+    let slot = source
+        .subscribe([FIXTURE_FEED].into_iter().collect())
+        .await
+        .expect("the task should answer a subscribe request");
+    let mut connection = server.accept().await;
+    assert_eq!(
+        next_subscribed_feed_ids(&mut connection).await,
+        vec![FIXTURE_FEED]
+    );
+
+    drop(slot);
+    // Any frame drives the task's loop, which prunes before it streams.
+    send(
+        &mut connection,
+        &WsResponse::SubscriptionError(SubscriptionErrorResponse {
+            subscription_id: SubscriptionId(u64::MAX),
+            error: "for a subscription this task never held".to_owned(),
+        }),
+    )
+    .await;
+
+    match next_request(&mut connection).await {
+        WsRequest::Unsubscribe(request) => assert_eq!(request.subscription_id, SubscriptionId(1)),
+        other @ WsRequest::Subscribe(_) => panic!("expected an unsubscribe request, got {other:?}"),
+    }
+    assert!(
+        server.accept_within(PATIENCE).await.is_none(),
+        "the task must park once its last subscription is pruned, not reconnect"
+    );
+}
+
+/// And a disconnect does not resurrect it: the task parks rather than reconnecting to
+/// replay a subscription nobody waits on.
+#[tokio::test]
+async fn an_abandoned_subscription_is_not_reconnected_for() {
+    let mut server = MockLazer::start().await;
+    let source = source_for(&server, Duration::from_secs(5));
+
+    let slot = source
+        .subscribe([FIXTURE_FEED].into_iter().collect())
+        .await
+        .expect("the task should answer a subscribe request");
+    let mut connection = server.accept().await;
+    assert_eq!(
+        next_subscribed_feed_ids(&mut connection).await,
+        vec![FIXTURE_FEED]
+    );
+
+    drop(slot);
+    drop(connection);
+
+    assert!(
+        server.accept_within(PATIENCE).await.is_none(),
+        "the task must park, not reconnect for an abandoned subscription"
     );
 }

--- a/gateway/oracle-updates-dispatch/src/lazer_client/mock_server.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/mock_server.rs
@@ -1,11 +1,7 @@
-//! A minimal in-process stand-in for the Pyth Lazer stream, so the payload
-//! source's connection lifecycle is testable without the live endpoint.
-//!
-//! The production endpoint closes any connection that carries no subscription
-//! after 60s, which is what makes "when does the source connect?" a correctness
-//! question rather than a detail. Tests drive the accepted [`ServerConn`]
-//! directly: read the client's frames, answer with protocol responses, or drop
-//! the connection to simulate a server-side close.
+//! An in-process stand-in for the Pyth Lazer stream, so the source's connection
+//! lifecycle is testable without the live endpoint. Tests drive the accepted
+//! [`ServerConn`] directly: read frames, answer with protocol responses, or drop
+//! it to simulate a server-side close.
 
 use std::time::Duration;
 
@@ -76,8 +72,7 @@ impl MockLazer {
             .expect("source should have connected")
     }
 
-    /// Wait up to `within` for a connection. `None` means the source did not
-    /// connect — which is the assertion for the idle case.
+    /// `None` means the source did not connect — the assertion for the idle case.
     pub(crate) async fn accept_within(&mut self, within: Duration) -> Option<ServerConn> {
         timeout(within, self.connections.recv())
             .await

--- a/gateway/oracle-updates-dispatch/src/lazer_client/mock_server.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/mock_server.rs
@@ -1,0 +1,123 @@
+//! A minimal in-process stand-in for the Pyth Lazer stream, so the payload
+//! source's connection lifecycle is testable without the live endpoint.
+//!
+//! The production endpoint closes any connection that carries no subscription
+//! after 60s, which is what makes "when does the source connect?" a correctness
+//! question rather than a detail. Tests drive the accepted [`ServerConn`]
+//! directly: read the client's frames, answer with protocol responses, or drop
+//! the connection to simulate a server-side close.
+
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use pyth_lazer_protocol::api::{WsRequest, WsResponse};
+use tokio::{
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+    task::JoinHandle,
+    time::timeout,
+};
+use tokio_tungstenite::{accept_async, tungstenite::Message, WebSocketStream};
+use url::Url;
+
+/// One accepted client connection, driven directly by the test.
+pub(crate) type ServerConn = WebSocketStream<TcpStream>;
+
+pub(crate) struct MockLazer {
+    url: Url,
+    connections: mpsc::UnboundedReceiver<ServerConn>,
+    accept_task: JoinHandle<()>,
+}
+
+impl Drop for MockLazer {
+    fn drop(&mut self) {
+        self.accept_task.abort();
+    }
+}
+
+impl MockLazer {
+    pub(crate) async fn start() -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("mock server should bind a loopback port");
+        let addr = listener
+            .local_addr()
+            .expect("bound listener should have an address");
+        let (connection_tx, connections) = mpsc::unbounded_channel();
+
+        let accept_task = tokio::spawn(async move {
+            while let Ok((stream, _)) = listener.accept().await {
+                let Ok(websocket) = accept_async(stream).await else {
+                    continue;
+                };
+                if connection_tx.send(websocket).is_err() {
+                    break;
+                }
+            }
+        });
+
+        Self {
+            url: format!("ws://{addr}/v1/stream")
+                .parse()
+                .expect("loopback address should form a valid ws:// url"),
+            connections,
+            accept_task,
+        }
+    }
+
+    pub(crate) fn url(&self) -> Url {
+        self.url.clone()
+    }
+
+    /// Wait for the source to connect, failing the test if it does not.
+    pub(crate) async fn accept(&mut self) -> ServerConn {
+        self.accept_within(Duration::from_secs(5))
+            .await
+            .expect("source should have connected")
+    }
+
+    /// Wait up to `within` for a connection. `None` means the source did not
+    /// connect — which is the assertion for the idle case.
+    pub(crate) async fn accept_within(&mut self, within: Duration) -> Option<ServerConn> {
+        timeout(within, self.connections.recv())
+            .await
+            .ok()
+            .flatten()
+    }
+}
+
+/// Read the next client frame, decoded as a protocol request.
+pub(crate) async fn next_request(connection: &mut ServerConn) -> WsRequest {
+    let message = timeout(Duration::from_secs(5), connection.next())
+        .await
+        .expect("client should send a frame")
+        .expect("stream should not end")
+        .expect("frame should not error");
+    let Message::Text(text) = message else {
+        panic!("expected a text frame, got {message:?}");
+    };
+    serde_json::from_str(text.as_ref()).expect("client frame should be a protocol request")
+}
+
+/// The feed ids of the next `subscribe` frame, failing on any other request.
+pub(crate) async fn next_subscribed_feed_ids(connection: &mut ServerConn) -> Vec<u32> {
+    match next_request(connection).await {
+        WsRequest::Subscribe(request) => request
+            .params
+            .price_feed_ids
+            .clone()
+            .expect("subscribe frame should carry price feed ids")
+            .into_iter()
+            .map(|feed| feed.0)
+            .collect(),
+        other @ WsRequest::Unsubscribe(_) => panic!("expected a subscribe request, got {other:?}"),
+    }
+}
+
+pub(crate) async fn send(connection: &mut ServerConn, response: &WsResponse) {
+    let text = serde_json::to_string(response).expect("response should serialize");
+    connection
+        .send(Message::Text(text.into()))
+        .await
+        .expect("mock server should send a frame");
+}

--- a/gateway/oracle-updates-dispatch/src/lazer_client/tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/tests.rs
@@ -1,11 +1,10 @@
 use std::time::Duration;
 
-use base64::Engine as _;
 use ed25519_dalek::{Signature, VerifyingKey};
 use pyth_lazer_protocol::api::{
-    ErrorResponse, InvalidFeedSubscriptionDetails, JsonBinaryData, JsonBinaryEncoding, JsonUpdate,
-    StreamUpdatedResponse, SubscribedResponse, SubscribedWithInvalidFeedIdsIgnoredResponse,
-    SubscriptionErrorResponse, UnsubscribedResponse, WsResponse,
+    ErrorResponse, InvalidFeedSubscriptionDetails, JsonBinaryData, JsonBinaryEncoding,
+    SubscribedResponse, SubscribedWithInvalidFeedIdsIgnoredResponse, SubscriptionErrorResponse,
+    UnsubscribedResponse, WsResponse,
 };
 use pyth_lazer_protocol::message::SolanaMessage;
 use pyth_lazer_protocol::PriceFeedId;
@@ -48,9 +47,9 @@ fn live_config_from_env() -> (LazerSourceConfig, Vec<u32>) {
     (config, feed_ids)
 }
 
-const PAYLOAD_001: &str = "uQEagohEipEVyTiNYf6VaHJFux40+GmgzXaVUuzszi4nJMWpoMH4WZB0W3SMzUM41gQlkeJYJDydLouwjUDVBbksHwqA78H0gMVhWvP7Zz1CKH6ZPan7w1BrbkHfoylQggwubBwBddPHk0AKB5JsVAYAAwUHAAAABgD4hPUFAAAAAAUwKwAAAAAAAAT4/wqlkfUFAAAAAAsGNgAAAAAAAAwBQAoHkmxUBgAIAAAABgAvcfQFAAAAAAVeLAAAAAAAAAT4/wpWYvQFAAAAAAt1NwAAAAAAAAwBQAoHkmxUBgABAAAABgAqfglX/QUAAAV2rg9cAQAAAAT4/wqgFefA+wUAAAv8FrtEAQAAAAwBQAoHkmxUBgAbAAAABgC9d+INAAAAAAU27QEAAAAAAAT4/wqQi9sNAAAAAAu07wAAAAAAAAwBQAoHkmxUBgAXAAAABgDQwVgBAAAAAAWSGAAAAAAAAAT4/wqs8FYBAAAAAAvgGAAAAAAAAAwBQAoHkmxUBgA=";
-const EXPECTED_FEEDS: [u32; 5] = [7, 8, 1, 27, 23];
-const PAYLOAD_001_TIMESTAMP_US: u64 = 1_781_675_143_400_000;
+use crate::lazer_client::fixtures::{
+    fixture_bytes, stream_message, EXPECTED_FEEDS, PAYLOAD_001, PAYLOAD_001_TIMESTAMP_US,
+};
 
 struct TestCrypto;
 
@@ -76,34 +75,11 @@ fn test_config(max_payload_age: Duration) -> LazerSourceConfig {
     .expect("valid config")
 }
 
-/// Build a `streamUpdated` frame from the protocol's own response types, serialized by their serde
-/// impls — so the wire tags (`type`/`streamUpdated`/`solana`/`encoding`) come from the protocol
-/// shape rather than hand-written strings, and a protocol change surfaces here at compile time.
-fn stream_message(solana: JsonBinaryData) -> String {
-    let response = WsResponse::StreamUpdated(StreamUpdatedResponse {
-        subscription_id: SubscriptionId(1),
-        payload: JsonUpdate {
-            parsed: None,
-            evm: None,
-            solana: Some(solana),
-            le_ecdsa: None,
-            le_unsigned: None,
-        },
-    });
-    serde_json::to_string(&response).expect("protocol response serializes")
-}
-
 fn decoded_payload(message: &str) -> DecodedLazerPayload {
     match decode_stream_message(message).expect("message should decode") {
         LazerStreamEvent::Payload(payload) => payload,
         event => panic!("expected streamUpdated payload event, got {event:?}"),
     }
-}
-
-fn fixture_bytes() -> Vec<u8> {
-    base64::engine::general_purpose::STANDARD
-        .decode(PAYLOAD_001)
-        .expect("fixture should be base64")
 }
 
 fn signer_of(raw: &[u8]) -> [u8; 32] {
@@ -138,14 +114,20 @@ fn decodes_captured_stream_updated_fixture() {
 #[test]
 fn decodes_explicit_hex_and_base64() {
     let fixture = fixture_bytes();
-    let hex_payload = decoded_payload(&stream_message(JsonBinaryData {
-        encoding: JsonBinaryEncoding::Hex,
-        data: hex::encode(&fixture),
-    }));
-    let base64_payload = decoded_payload(&stream_message(JsonBinaryData {
-        encoding: JsonBinaryEncoding::Base64,
-        data: PAYLOAD_001.to_owned(),
-    }));
+    let hex_payload = decoded_payload(&stream_message(
+        SubscriptionId(1),
+        JsonBinaryData {
+            encoding: JsonBinaryEncoding::Hex,
+            data: hex::encode(&fixture),
+        },
+    ));
+    let base64_payload = decoded_payload(&stream_message(
+        SubscriptionId(1),
+        JsonBinaryData {
+            encoding: JsonBinaryEncoding::Base64,
+            data: PAYLOAD_001.to_owned(),
+        },
+    ));
 
     assert_eq!(hex_payload.bytes, fixture);
     assert_eq!(
@@ -156,10 +138,13 @@ fn decodes_explicit_hex_and_base64() {
 
 #[test]
 fn oversized_payload_returns_error_before_decode() {
-    let message = stream_message(JsonBinaryData {
-        encoding: JsonBinaryEncoding::Hex,
-        data: "00".repeat(1_048_577),
-    });
+    let message = stream_message(
+        SubscriptionId(1),
+        JsonBinaryData {
+            encoding: JsonBinaryEncoding::Hex,
+            data: "00".repeat(1_048_577),
+        },
+    );
 
     let error = decode_stream_message(&message).expect_err("oversized payload should fail");
 
@@ -169,10 +154,13 @@ fn oversized_payload_returns_error_before_decode() {
 #[test]
 fn decoded_fixture_is_accepted_by_pyth_lazer_verifier() {
     let raw = fixture_bytes();
-    let message = stream_message(JsonBinaryData {
-        encoding: JsonBinaryEncoding::Base64,
-        data: PAYLOAD_001.to_owned(),
-    });
+    let message = stream_message(
+        SubscriptionId(1),
+        JsonBinaryData {
+            encoding: JsonBinaryEncoding::Base64,
+            data: PAYLOAD_001.to_owned(),
+        },
+    );
     let decoded = decoded_payload(&message);
     let trusted_signers = [TrustedSigner {
         public_key: signer_of(&raw),
@@ -271,68 +259,12 @@ fn decodes_partial_subscription_acknowledgement() {
     );
 }
 
-#[tokio::test]
-async fn cache_miss_returns_error() {
-    let source = LazerPayloadSource::from_cached(test_config(Duration::from_secs(5)), None);
-
-    let error = source
-        .fetch_payload(&[7])
-        .await
-        .expect_err("empty cache should miss");
-
-    // With dynamic subscriptions, when there's no background task running,
-    // attempting to subscribe will fail with a request error
-    assert!(matches!(error, LazerClientError::Request(_)));
-}
-
-#[tokio::test]
-async fn stale_cache_returns_error() {
-    let source = LazerPayloadSource::from_cached(
-        test_config(Duration::from_secs(5)),
-        Some(CachedPayload {
-            payload: vec![1, 2, 3],
-            feed_ids: [7, 8].into_iter().collect(),
-            received_at: Instant::now() - Duration::from_secs(6),
-        }),
-    );
-
-    let error = source
-        .fetch_payload(&[7])
-        .await
-        .expect_err("stale payload should fail");
-
-    assert!(matches!(error, LazerClientError::StalePayload));
-}
-
-#[tokio::test]
-async fn fresh_cache_returns_payload_for_covered_feeds() {
-    let source = LazerPayloadSource::from_cached(
-        test_config(Duration::from_secs(5)),
-        Some(CachedPayload {
-            payload: vec![1, 2, 3],
-            feed_ids: [7, 8].into_iter().collect(),
-            received_at: Instant::now(),
-        }),
-    );
-
-    let payload = source
-        .fetch_payload(&[7, 8])
-        .await
-        .expect("fresh payload should be returned");
-
-    assert_eq!(payload, vec![1, 2, 3]);
-}
-
+/// Rejected before the source is consulted, so it needs no stream. Cache
+/// freshness, feed coverage, and subscription failures are covered against the
+/// mock server in `actor_tests`.
 #[tokio::test]
 async fn empty_request_returns_error() {
-    let source = LazerPayloadSource::from_cached(
-        test_config(Duration::from_secs(5)),
-        Some(CachedPayload {
-            payload: vec![1, 2, 3],
-            feed_ids: [7, 8].into_iter().collect(),
-            received_at: Instant::now(),
-        }),
-    );
+    let source = LazerPayloadSource::spawn(test_config(Duration::from_secs(5)));
 
     let error = source
         .fetch_payload(&[])
@@ -447,22 +379,19 @@ async fn capture_live_stream_updated_fixture() {
 /// Live end-to-end smoke test of the production `LazerPayloadSource`: spawn the
 /// actor and confirm it fetches a non-empty payload for the requested feeds against
 /// the real Pyth Lazer stream. Ignored by default (needs credentials + network).
+///
+/// The first fetch must succeed on its own: it connects, subscribes, and waits for
+/// the payload. A retry loop here would only mask a source that connects late.
 #[tokio::test]
 #[ignore = "requires PYTH_LAZER_API_KEY and PYTH_LAZER_FEED_IDS"]
 async fn requires_network_fetches_production_lazer_payload() {
     let (config, feed_ids) = live_config_from_env();
     let source = LazerPayloadSource::spawn(config);
 
-    let deadline = Instant::now() + Duration::from_secs(20);
-    loop {
-        if let Ok(payload) = source.fetch_payload(&feed_ids).await {
-            assert!(!payload.is_empty());
-            break;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "timed out waiting for Pyth Lazer payload"
-        );
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
+    let payload = source
+        .fetch_payload(&feed_ids)
+        .await
+        .expect("the first fetch should connect, subscribe, and return a payload");
+
+    assert!(!payload.is_empty());
 }

--- a/gateway/oracle-updates-dispatch/src/lazer_client/tests.rs
+++ b/gateway/oracle-updates-dispatch/src/lazer_client/tests.rs
@@ -8,6 +8,7 @@ use pyth_lazer_protocol::api::{
 };
 use pyth_lazer_protocol::message::SolanaMessage;
 use pyth_lazer_protocol::PriceFeedId;
+use rstest::rstest;
 use templar_gateway_core::OraclePayloadSource;
 use templar_pyth_lazer_verifier::{verify_solana_update, Crypto, TrustedSigner, VerifyParams};
 use tokio::time::Instant;
@@ -184,51 +185,38 @@ fn decoded_fixture_is_accepted_by_pyth_lazer_verifier() {
     );
 }
 
-#[test]
-fn decodes_subscription_events_with_ids() {
-    let cases = [
-        (
-            WsResponse::Subscribed(SubscribedResponse {
-                subscription_id: SubscriptionId(3),
-            }),
-            LazerStreamEvent::Subscribed {
-                subscription_id: SubscriptionId(3),
-            },
-        ),
-        (
-            WsResponse::Unsubscribed(UnsubscribedResponse {
-                subscription_id: SubscriptionId(4),
-            }),
-            LazerStreamEvent::Unsubscribed {
-                subscription_id: SubscriptionId(4),
-            },
-        ),
-        (
-            WsResponse::SubscriptionError(SubscriptionErrorResponse {
-                subscription_id: SubscriptionId(5),
-                error: "denied".to_owned(),
-            }),
-            LazerStreamEvent::SubscriptionError {
-                subscription_id: SubscriptionId(5),
-                error: "denied".to_owned(),
-            },
-        ),
-        (
-            WsResponse::Error(ErrorResponse {
-                error: "bad request".to_owned(),
-            }),
-            LazerStreamEvent::Error {
-                error: "bad request".to_owned(),
-            },
-        ),
-    ];
+#[rstest]
+#[case::subscribed(
+    WsResponse::Subscribed(SubscribedResponse { subscription_id: SubscriptionId(3) }),
+    LazerStreamEvent::Subscribed { subscription_id: SubscriptionId(3) },
+)]
+#[case::unsubscribed(
+    WsResponse::Unsubscribed(UnsubscribedResponse { subscription_id: SubscriptionId(4) }),
+    LazerStreamEvent::Unsubscribed { subscription_id: SubscriptionId(4) },
+)]
+#[case::subscription_error(
+    WsResponse::SubscriptionError(SubscriptionErrorResponse {
+        subscription_id: SubscriptionId(5),
+        error: "denied".to_owned(),
+    }),
+    LazerStreamEvent::SubscriptionError {
+        subscription_id: SubscriptionId(5),
+        error: "denied".to_owned(),
+    },
+)]
+#[case::stream_error(
+    WsResponse::Error(ErrorResponse { error: "bad request".to_owned() }),
+    LazerStreamEvent::Error { error: "bad request".to_owned() },
+)]
+fn decodes_subscription_events_with_ids(
+    #[case] response: WsResponse,
+    #[case] expected: LazerStreamEvent,
+) {
+    let message = serde_json::to_string(&response).expect("protocol response serializes");
 
-    for (response, expected) in cases {
-        let message = serde_json::to_string(&response).expect("protocol response serializes");
-        let event = decode_stream_message(&message).expect("event should decode");
+    let event = decode_stream_message(&message).expect("event should decode");
 
-        assert_eq!(event, expected);
-    }
+    assert_eq!(event, expected);
 }
 
 #[test]


### PR DESCRIPTION
Closes ENG-452.

## The bug

`LazerPayloadSource::spawn` opened the Pyth Lazer websocket at context-build time, before anything subscribed. Pyth reaps a subscription-less connection at **exactly 60s** (verified against the live endpoint: `CLOSE code=1006`, no close frame, no server pings; a connection with one subscribe frame streamed for 150s+ untouched). `backoff` only reset on a received payload, which cannot happen without a subscription, so it saturated at 30s and the source reconnected every 60 + 30 = **90 seconds**, forever.

The log noise was the symptom, not the cost. `run()` did not poll `subscribe_rx` while sleeping in backoff, so a fetch arriving in that 30s window waited out `max_payload_age` (5s) for a subscription ack that could never come. `/update_prices` for a Lazer-backed market failed with `subscription acknowledgement timed out` for roughly **one in three cold pushes after a restart**. It self-healed after the first success — the subscription kept the stream busy — which is why a warm relayer looked healthy.

Confirmed in production: the warning appears only after a relayer restart, and stops permanently once `/update_prices` is hit for the first time.

## The fix

Not a patch to the loop — a removal of the structure the bug lived in.

Subscriptions were tracked by two parallel mechanisms behind a shared `RwLock`: a `oneshot` ack channel (`pending`) and a `watch` payload channel (`active`). Every defect lived at that seam. A single `StreamTask` now owns the subscription set outright and callers reach it only by message, collapsing both channels into one `watch<Slot>`:

- park on `subscribe_rx.recv()` when nothing is subscribed, and drop the connection when the last subscription goes away — **a websocket exists exactly while a subscription does**
- `select!` the backoff sleep against `recv()`, so an arriving fetch cancels the sleep
- one `FETCH_TIMEOUT` over both halves of a fetch; `max_payload_age` goes back to bounding only the age of a served payload
- a stale or not-yet-covering payload waits for the next one (~200ms on a live stream) instead of erroring

Deletes `pending`, `PendingSubscription`, `subscription_is_pending`, `acknowledge_subscription`, `acknowledge_partial_subscription`, `fail_pending_subscription(s)`, the `replayed` double-subscribe guard, the `RwLock`, the `fifo` (ids are monotonic, so a `BTreeMap`'s first key is the oldest), the `from_cached` test seam, and three error variants.

Not an `actix::Actor` deliberately: this is a plain tokio task owning a long-lived resource, so it stays usable from the lock-free `templar-gateway-client` path, which runs no actix `System`. The gateway's actix actors are request/response mailboxes at the RPC edge.

## Review rounds

Three rounds of review found four further defects, each **introduced by the previous round's fix** in code that fix had made reachable. Worth reading the commits individually:

- `9635c7d7` — the idle timer was rebuilt inside `select!` every iteration, so a steady trickle of fetches restarted it forever and a silent-but-open socket would never be detected. Latent before; routing every fetch through the task (which is how a fetch now cancels the backoff) made it live. Also, `register` evicted and inserted *before* handing the slot to the requester, so an abandoned request stranded a subscription — holding the connection open forever against the invariant above.
- `1092e10a` — `run()` parked with an `if` and fell through to `connect_and_stream` unconditionally; once `register` could legitimately register nothing, that opened a subscription-less socket. And `STREAM_IDLE_TIMEOUT` (15s) exceeded `FETCH_TIMEOUT` (10s), so a fetch could never survive a silent socket: it expired 5s before the task noticed.
- `18af64c7` — the `const` assertion guarding those timeouts constrained `INITIAL_RECONNECT_BACKOFF` while the code sleeps `self.backoff`. An assertion over constants cannot bound a runtime value. `FETCH_TIMEOUT` is now *derived* as the sum of the recovery it must cover, so it cannot be set below its budget or drift from its terms.

## Verification

- **Six lifecycle tests** against a new in-process mock Lazer websocket server, covering behaviour that previously had **no coverage at all**: the idle connection, the starved fetch, replay on reconnect, a rejected subscription closing the connection, a silent socket under fetch traffic, and a fetch surviving a silent-socket episode.
- Every fix was **mutation-checked**: reverting it makes its test fail, restoring it makes it pass. Restoring the old timeout values fails to compile against the derived constant.
- The live smoke test drops its 20s retry loop — which was masking this bug — and now returns on the **first** fetch against the real Pyth endpoint in ~2s.
- 29 tests pass (stable across repeated runs), clippy clean at `-D warnings`, `templar-gateway-service` and `templar-relayer` both compile.

## Blast radius

Production code net **−127 lines**. `LazerPayloadSource::spawn`'s signature is unchanged, so no consumer wiring moves. Three `LazerClientError` variants are gone; `service/gateway`'s `FakeLazerSource` has its own independent error enum and is unaffected.

Unblocks ENG-448 (whose stated main design decision is this eager-source problem) and ENG-436 (the liquidator's pre-liquidation refresh is a cold fetch by definition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/502)
<!-- Reviewable:end -->
