### PR TITLE
fix(relayer): fold account provisioning into lock_pending

### DIFF
--- a/service/relayer/src/app/mod.rs
+++ b/service/relayer/src/app/mod.rs
@@ -646,9 +646,13 @@ impl App {
     /// `account_id` is the account charged for the operation; `signer_account_id`
     /// is the relayer-controlled account that signs and pays (relay or UA).
     ///
+    /// A first-seen account is provisioned with the starting allowance as part
+    /// of the lock; callers gating on prior existence must check first.
+    ///
     /// # Errors
     ///
     /// - Locking or settling the allowance in the database
+    /// - The account being denied allowance
     /// - Gateway execution
     /// - The operation completing without producing a transaction
     #[tracing::instrument(skip(self, body), fields(
@@ -672,9 +676,6 @@ impl App {
     {
         tracing::info!("Submitting and accounting for transaction");
         let operation_key = Uuid::new_v4();
-        self.database
-            .create_account(&account_id, self.args.relay.starting_allowance_yocto)
-            .await?;
 
         self.database
             .lock_pending(
@@ -682,6 +683,7 @@ impl App {
                 gas_cost_estimate,
                 spend_within_transaction,
                 operation_key,
+                self.args.relay.starting_allowance_yocto,
             )
             .await?;
 

--- a/service/relayer/src/client/database.rs
+++ b/service/relayer/src/client/database.rs
@@ -46,12 +46,6 @@ pub mod error {
     use thiserror::Error;
 
     #[derive(Debug, Error)]
-    #[error("Account \"{account_id}\" does not exist in database")]
-    pub struct AccountDoesNotExistError {
-        pub account_id: AccountId,
-    }
-
-    #[derive(Debug, Error)]
     #[error("Account \"{account_id}\" has insufficient allowance: {actual} < {required}")]
     pub struct InsufficientAllowanceError {
         pub account_id: AccountId,
@@ -68,8 +62,6 @@ pub mod error {
     /// Failure to lock allowance for a new charge.
     #[derive(Debug, Error)]
     pub enum LockError {
-        #[error(transparent)]
-        AccountDoesNotExist(#[from] AccountDoesNotExistError),
         #[error(transparent)]
         InsufficientAllowance(#[from] InsufficientAllowanceError),
         #[error(transparent)]
@@ -160,32 +152,17 @@ LIMIT
             .collect())
     }
 
-    /// # Errors
-    ///
-    /// - Query errors
-    pub async fn get_available_allowance_or_create(
-        &self,
-        account_id: &AccountIdRef,
-        default_allowance: NearToken,
-    ) -> Result<NearToken, sqlx::Error> {
-        let available = self.get_available_allowance(account_id).await?;
-        if let Some(available) = available {
-            Ok(available)
-        } else {
-            self.create_account(account_id, default_allowance).await?;
-            Ok(default_allowance)
-        }
-    }
-
     /// Lock allowance for a charge the relayer is about to submit, keyed by the
     /// gateway idempotency key (`operation_key`). Records gas and inner-spend
     /// reservations so concurrent gateway operations cannot overdraw the account;
     /// the actual gas cost is read back from the gateway at settlement.
     ///
+    /// A first-seen account is provisioned with `starting_allowance` in the same
+    /// transaction rather than failing the lock.
+    ///
     /// # Errors
     ///
-    /// - Query errors
-    /// - Account does not exist
+    /// - Query errors (a denied account surfaces as an opaque row-not-found)
     /// - Insufficient allowance
     #[tracing::instrument(skip(self), fields(
         account_id = %account_id,
@@ -199,10 +176,26 @@ LIMIT
         gas_estimate: NearToken,
         inner_spend: NearToken,
         operation_key: Uuid,
+        starting_allowance: NearToken,
     ) -> Result<(), error::LockError> {
         tracing::debug!("Locking allowance for charge");
         let mut tx = self.connection.begin().await?;
 
+        // Provision a first-seen account before locking its row.
+        sqlx::query!(
+            r#"
+INSERT INTO
+    account (account_id, allowance)
+VALUES
+    ($1, $2) ON CONFLICT (account_id) DO NOTHING
+"#,
+            account_id.as_str(),
+            Decimal::from(starting_allowance.as_yoctonear()),
+        )
+        .execute(&mut *tx)
+        .await?;
+
+        // Denied accounts are filtered out, surfacing as an opaque row-not-found.
         let account = sqlx::query!(
             r#"
 SELECT
@@ -217,15 +210,8 @@ FOR UPDATE
 "#,
             account_id.to_string(),
         )
-        .fetch_optional(&mut *tx)
+        .fetch_one(&mut *tx)
         .await?;
-
-        let Some(account) = account else {
-            return Err(error::AccountDoesNotExistError {
-                account_id: account_id.to_owned(),
-            }
-            .into());
-        };
 
         let required = gas_estimate.saturating_add(inner_spend);
 
@@ -570,7 +556,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
         assert_eq!(allowance(&db, &account).await, 85);
@@ -587,7 +573,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
         db.settle(&account, key, near(8), false).await.unwrap();
@@ -603,13 +589,13 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
         db.release_pending(&account, key).await.unwrap();
         assert_eq!(allowance(&db, &account).await, 100);
 
-        db.lock_pending(&account, near(10), near(0), Uuid::new_v4())
+        db.lock_pending(&account, near(10), near(0), Uuid::new_v4(), near(100))
             .await
             .unwrap();
     }
@@ -623,7 +609,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
         db.settle(&account, key, near(8), true).await.unwrap();
@@ -641,7 +627,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
 
@@ -663,7 +649,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
 
@@ -685,7 +671,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
 
@@ -696,7 +682,7 @@ mod tests {
         assert_eq!(status, AccountedStatus::Succeeded);
         // The no-op spent nothing, so the locked deposit is not billed.
         assert_eq!(allowance(&db, &account).await, 100);
-        db.lock_pending(&account, near(10), near(0), Uuid::new_v4())
+        db.lock_pending(&account, near(10), near(0), Uuid::new_v4(), near(100))
             .await
             .unwrap();
     }
@@ -710,7 +696,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
 
@@ -720,7 +706,7 @@ mod tests {
             .unwrap();
         assert_eq!(status, AccountedStatus::Failed);
         assert_eq!(allowance(&db, &account).await, 100);
-        db.lock_pending(&account, near(10), near(0), Uuid::new_v4())
+        db.lock_pending(&account, near(10), near(0), Uuid::new_v4(), near(100))
             .await
             .unwrap();
     }
@@ -735,14 +721,14 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
 
         let status = db.resolve_charge(&account, key, None).await.unwrap();
         assert_eq!(status, AccountedStatus::Failed);
         assert_eq!(allowance(&db, &account).await, 100);
-        db.lock_pending(&account, near(10), near(0), Uuid::new_v4())
+        db.lock_pending(&account, near(10), near(0), Uuid::new_v4(), near(100))
             .await
             .unwrap();
     }
@@ -757,10 +743,10 @@ mod tests {
         let first = Uuid::new_v4();
         let second = Uuid::new_v4();
 
-        db.lock_pending(&account, near(10), near(5), first)
+        db.lock_pending(&account, near(10), near(5), first, near(100))
             .await
             .unwrap();
-        db.lock_pending(&account, near(20), near(7), second)
+        db.lock_pending(&account, near(20), near(7), second, near(100))
             .await
             .unwrap();
 
@@ -789,7 +775,7 @@ mod tests {
         db.create_account(&account, near(10)).await.unwrap();
 
         let err = db
-            .lock_pending(&account, near(8), near(5), Uuid::new_v4())
+            .lock_pending(&account, near(8), near(5), Uuid::new_v4(), near(100))
             .await
             .unwrap_err();
         assert!(matches!(err, error::LockError::InsufficientAllowance(_)));
@@ -802,12 +788,12 @@ mod tests {
         let account = acct("a.near");
         db.create_account(&account, near(30)).await.unwrap();
 
-        db.lock_pending(&account, near(10), near(5), Uuid::new_v4())
+        db.lock_pending(&account, near(10), near(5), Uuid::new_v4(), near(100))
             .await
             .unwrap();
 
         let err = db
-            .lock_pending(&account, near(12), near(4), Uuid::new_v4())
+            .lock_pending(&account, near(12), near(4), Uuid::new_v4(), near(100))
             .await
             .unwrap_err();
         assert!(matches!(err, error::LockError::InsufficientAllowance(_)));
@@ -821,10 +807,10 @@ mod tests {
         let account = acct("a.near");
         db.create_account(&account, near(100)).await.unwrap();
 
-        db.lock_pending(&account, near(10), near(5), Uuid::new_v4())
+        db.lock_pending(&account, near(10), near(5), Uuid::new_v4(), near(100))
             .await
             .unwrap();
-        db.lock_pending(&account, near(20), near(7), Uuid::new_v4())
+        db.lock_pending(&account, near(20), near(7), Uuid::new_v4(), near(100))
             .await
             .unwrap();
 
@@ -840,10 +826,10 @@ mod tests {
 
         let settled = Uuid::new_v4();
         let released = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), settled)
+        db.lock_pending(&account, near(10), near(5), settled, near(100))
             .await
             .unwrap();
-        db.lock_pending(&account, near(20), near(7), released)
+        db.lock_pending(&account, near(20), near(7), released, near(100))
             .await
             .unwrap();
 
@@ -871,7 +857,7 @@ mod tests {
         db.create_account(&account, near(100)).await.unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(0), key)
+        db.lock_pending(&account, near(10), near(0), key, near(100))
             .await
             .unwrap();
 
@@ -914,7 +900,7 @@ mod tests {
             .unwrap();
 
         let key = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(5), key)
+        db.lock_pending(&account, near(10), near(5), key, near(100))
             .await
             .unwrap();
 
@@ -937,10 +923,10 @@ mod tests {
 
         let stale = Uuid::new_v4();
         let fresh = Uuid::new_v4();
-        db.lock_pending(&account, near(10), near(0), stale)
+        db.lock_pending(&account, near(10), near(0), stale, near(100))
             .await
             .unwrap();
-        db.lock_pending(&account, near(10), near(0), fresh)
+        db.lock_pending(&account, near(10), near(0), fresh, near(100))
             .await
             .unwrap();
 

--- a/service/relayer/src/route/relay/mod.rs
+++ b/service/relayer/src/route/relay/mod.rs
@@ -96,10 +96,12 @@ pub async fn relay(
         };
     };
 
+    // Read-only pre-check; execute_and_account provisions a first-seen account.
     let available_allowance = match app
         .database
-        .get_available_allowance_or_create(&account_id, app.args.relay.starting_allowance_yocto)
+        .get_available_allowance(&account_id)
         .await
+        .map(|a| a.unwrap_or(app.args.relay.starting_allowance_yocto))
     {
         Ok(available) => available,
         Err(e) => {

--- a/service/relayer/src/route/universal_account/create.rs
+++ b/service/relayer/src/route/universal_account/create.rs
@@ -28,7 +28,7 @@ use templar_universal_account::{
 
 use crate::{
     app::{to_gateway_hash, App, SubmitError},
-    client::database::AccountedStatus,
+    client::database::{error::LockError, AccountedStatus},
     route::{universal_account::public_key_to_account_id_slug, SimpleResponse},
 };
 
@@ -340,14 +340,25 @@ pub async fn create(
         .await
     {
         Ok(execution) => execution,
-        // Lock failures are pre-submit; a Database error is post-submit
-        // settlement, where the deploy may already have landed.
-        Err(e @ SubmitError::Lock(_)) => {
-            tracing::error!("Failed to create account in database: {e}");
-            return SimpleResponse::Failure {
-                error: "Failed to create account in database".to_string(),
+        // Lock failures are all pre-submit: nothing was deployed.
+        Err(SubmitError::Lock(lock)) => {
+            return match lock {
+                LockError::InsufficientAllowance(_) => SimpleResponse::Rejected {
+                    reason: "Insufficient allowance".to_string(),
+                },
+                LockError::PendingCharge(_) => SimpleResponse::Rejected {
+                    reason: "Account creation already in progress".to_string(),
+                },
+                LockError::Sql(e) => {
+                    tracing::error!("Failed to create account in database: {e}");
+                    SimpleResponse::Failure {
+                        error: "Failed to create account in database".to_string(),
+                    }
+                }
             };
         }
+        // Gateway/NoTransaction, or a Database error from post-submit settlement:
+        // the deploy may already have landed.
         Err(e) => {
             tracing::error!("Failed to deploy universal account: {e}");
             return SimpleResponse::Failure {

--- a/service/relayer/src/route/universal_account/create.rs
+++ b/service/relayer/src/route/universal_account/create.rs
@@ -27,7 +27,7 @@ use templar_universal_account::{
 };
 
 use crate::{
-    app::{to_gateway_hash, App},
+    app::{to_gateway_hash, App, SubmitError},
     client::database::AccountedStatus,
     route::{universal_account::public_key_to_account_id_slug, SimpleResponse},
 };
@@ -340,6 +340,14 @@ pub async fn create(
         .await
     {
         Ok(execution) => execution,
+        // Lock failures are pre-submit; a Database error is post-submit
+        // settlement, where the deploy may already have landed.
+        Err(e @ SubmitError::Lock(_)) => {
+            tracing::error!("Failed to create account in database: {e}");
+            return SimpleResponse::Failure {
+                error: "Failed to create account in database".to_string(),
+            };
+        }
         Err(e) => {
             tracing::error!("Failed to deploy universal account: {e}");
             return SimpleResponse::Failure {

--- a/service/relayer/src/route/universal_account/create.rs
+++ b/service/relayer/src/route/universal_account/create.rs
@@ -27,8 +27,8 @@ use templar_universal_account::{
 };
 
 use crate::{
-    app::{to_gateway_hash, App, SubmitError},
-    client::database::{error::LockError, AccountedStatus},
+    app::{to_gateway_hash, App},
+    client::database::AccountedStatus,
     route::{universal_account::public_key_to_account_id_slug, SimpleResponse},
 };
 
@@ -340,25 +340,6 @@ pub async fn create(
         .await
     {
         Ok(execution) => execution,
-        // Lock failures are all pre-submit: nothing was deployed.
-        Err(SubmitError::Lock(lock)) => {
-            return match lock {
-                LockError::InsufficientAllowance(_) => SimpleResponse::Rejected {
-                    reason: "Insufficient allowance".to_string(),
-                },
-                LockError::PendingCharge(_) => SimpleResponse::Rejected {
-                    reason: "Account creation already in progress".to_string(),
-                },
-                LockError::Sql(e) => {
-                    tracing::error!("Failed to create account in database: {e}");
-                    SimpleResponse::Failure {
-                        error: "Failed to create account in database".to_string(),
-                    }
-                }
-            };
-        }
-        // Gateway/NoTransaction, or a Database error from post-submit settlement:
-        // the deploy may already have landed.
         Err(e) => {
             tracing::error!("Failed to deploy universal account: {e}");
             return SimpleResponse::Failure {

--- a/service/relayer/tests/relayer.rs
+++ b/service/relayer/tests/relayer.rs
@@ -665,6 +665,8 @@ async fn assert_storage_deposit_planning_failure(app: &App, payer: &AccountId) {
     );
 }
 
+/// A planning failure releases the reservation immediately: a first-seen account
+/// keeps the full starting allowance, an existing account its prior balance.
 #[rstest]
 #[tokio::test]
 async fn planning_failure_creates_missing_account_without_resetting_existing_account(


### PR DESCRIPTION
Follow-up to #511, addressing review findings on the merged change.

#511 provisioned a missing account with a separate `create_account` call inside `execute_and_account`, immediately before `lock_pending` opened its own transaction and took `SELECT ... FOR UPDATE` on the same row — a non-atomic extra round-trip.

## Changes
- **Atomic provisioning**: move provisioning into `lock_pending` via `INSERT ... ON CONFLICT DO NOTHING` in the same transaction as the row lock, taking `starting_allowance` as a parameter. Drop the redundant `create_account` call site in `execute_and_account`.
- **Accurate denied-account error**: a banned (`always_deny`) account is filtered out of the `SELECT` and surfaces as an opaque row-not-found rather than the misleading "account does not exist" error, without leaking the mark to the API consumer. Remove the now-unreachable `AccountDoesNotExistError`.
- **Drop dead code**: the relay route uses read-only `get_available_allowance` for its pre-lock check (`execute_and_account` now provisions); delete the dead `get_available_allowance_or_create`.
- **UA create error clarity**: distinguish a pre-submit database/lock failure ("Failed to create account in database") from an actual deploy failure in the response.

## Not addressed
- Routes surface raw `SubmitError`/`StorageDepositError` text in responses (schema/RPC details). Pre-existing and consistent across every relayer route; deferred.

## Testing
- `cargo fmt`, `cargo check -p templar-relayer --tests` (SQLX_OFFLINE), clippy `-D warnings` — clean.
- The `#[sqlx::test]` DB-backed tests require a live Postgres and were not run locally; no new SQL strings were introduced, so the `.sqlx` offline cache is unchanged. CI exercises them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/512)
<!-- Reviewable:end -->
