### PR TITLE
fix(curator-proxy): decode foreign vault errors safely

### DIFF
--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -733,7 +733,7 @@ pub(crate) fn invoke_vault_execute(
     let vault_address = read_vault_address(env)?;
     let command = command.into_wire()?;
     let payload = Bytes::from_slice(env, &command.encode());
-    let result = env.try_invoke_contract::<Bytes, ContractError>(
+    let result = env.try_invoke_contract::<Bytes, InvokeError>(
         &vault_address,
         &Symbol::new(env, "execute"),
         (&payload,).into_val(env),
@@ -742,13 +742,8 @@ pub(crate) fn invoke_vault_execute(
     let bytes = match result {
         Ok(Ok(bytes)) => bytes,
         Ok(Err(_)) => return Err(ContractError::VaultError),
-        Err(Ok(error)) => return Err(error),
-        Err(Err(invoke_error)) => {
-            return Err(match invoke_error {
-                InvokeError::Abort => ContractError::VaultError,
-                InvokeError::Contract(code) => ContractError::from_vault_error_code(code),
-            })
-        }
+        Err(Ok(invoke_error)) => return Err(map_vault_invoke_error(invoke_error)),
+        Err(Err(invoke_error)) => return Err(map_vault_invoke_error(invoke_error)),
     };
 
     Ok(bytes)
@@ -761,7 +756,7 @@ fn call_proxy_view_full(
     shares: i128,
 ) -> Result<ProxyViewFields, ContractError> {
     let vault_address = read_vault_address(env)?;
-    let result = env.try_invoke_contract::<ProxyViewResponse, ContractError>(
+    let result = env.try_invoke_contract::<ProxyViewResponse, InvokeError>(
         &vault_address,
         &Symbol::new(env, "proxy_view"),
         (owner.clone(), assets, shares).into_val(env),
@@ -770,11 +765,15 @@ fn call_proxy_view_full(
     match result {
         Ok(Ok(response)) => Ok(response.into()),
         Ok(Err(_)) => Err(ContractError::VaultError),
-        Err(Ok(error)) => Err(error),
-        Err(Err(invoke_error)) => Err(match invoke_error {
-            InvokeError::Abort => ContractError::VaultError,
-            InvokeError::Contract(code) => ContractError::from_vault_error_code(code),
-        }),
+        Err(Ok(invoke_error)) => Err(map_vault_invoke_error(invoke_error)),
+        Err(Err(invoke_error)) => Err(map_vault_invoke_error(invoke_error)),
+    }
+}
+
+fn map_vault_invoke_error(error: InvokeError) -> ContractError {
+    match error {
+        InvokeError::Abort => ContractError::VaultError,
+        InvokeError::Contract(code) => ContractError::from_vault_error_code(code),
     }
 }
 

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -777,6 +777,15 @@ fn map_vault_invoke_error(error: InvokeError) -> ContractError {
     }
 }
 
+#[cfg(test)]
+#[test]
+fn abort_vault_invoke_error_maps_to_vault_error() {
+    assert_eq!(
+        map_vault_invoke_error(InvokeError::Abort),
+        ContractError::VaultError
+    );
+}
+
 fn vault_view_from_response(response: ProxyViewFields) -> VaultView {
     let core = response.core;
     let policy = response.policy;

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -215,6 +215,9 @@ impl SorobanCuratorProxyContract {
             AllocationDelta::Supply(market, amount) => (market, amount, true),
             AllocationDelta::Withdraw(market, amount) => (market, amount, false),
         };
+        if amount <= 0 {
+            return Err(ContractError::InvalidInput);
+        }
         expect_i128_result(invoke_vault_execute(
             &env,
             VaultCommand::Allocate {

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -772,8 +772,7 @@ fn call_proxy_view_full(
 
 pub(crate) fn map_vault_invoke_error(error: InvokeError) -> ContractError {
     match error {
-        InvokeError::Abort => ContractError::VaultError,
-        InvokeError::Contract(code) => ContractError::from_vault_error_code(code),
+        InvokeError::Abort | InvokeError::Contract(_) => ContractError::VaultError,
     }
 }
 

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -770,20 +770,11 @@ fn call_proxy_view_full(
     }
 }
 
-fn map_vault_invoke_error(error: InvokeError) -> ContractError {
+pub(crate) fn map_vault_invoke_error(error: InvokeError) -> ContractError {
     match error {
         InvokeError::Abort => ContractError::VaultError,
         InvokeError::Contract(code) => ContractError::from_vault_error_code(code),
     }
-}
-
-#[cfg(test)]
-#[test]
-fn abort_vault_invoke_error_maps_to_vault_error() {
-    assert_eq!(
-        map_vault_invoke_error(InvokeError::Abort),
-        ContractError::VaultError
-    );
 }
 
 fn vault_view_from_response(response: ProxyViewFields) -> VaultView {

--- a/contract/vault/soroban/curator-proxy/src/error.rs
+++ b/contract/vault/soroban/curator-proxy/src/error.rs
@@ -2,9 +2,7 @@
 
 use soroban_sdk::contracterror;
 
-use templar_soroban_shared_types::{
-    CodecError, VAULT_ERR_ALREADY_INITIALIZED, VAULT_ERR_INVALID_INPUT,
-};
+use templar_soroban_shared_types::CodecError;
 
 #[contracterror]
 #[repr(u32)]
@@ -22,15 +20,5 @@ pub enum ContractError {
 impl From<CodecError> for ContractError {
     fn from(_: CodecError) -> Self {
         Self::InvalidInput
-    }
-}
-
-impl ContractError {
-    pub(crate) const fn from_vault_error_code(code: u32) -> Self {
-        match code {
-            VAULT_ERR_INVALID_INPUT => Self::InvalidInput,
-            VAULT_ERR_ALREADY_INITIALIZED => Self::AlreadyInitialized,
-            _ => Self::VaultError,
-        }
     }
 }

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -1,9 +1,9 @@
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{contract, contractimpl, contracttype, Address, Bytes, Env, Vec};
+use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Vec};
 use templar_soroban_runtime::ContractError as VaultContractError;
 use templar_soroban_shared_types::{
-    EmptyReceipt, I128Receipt, VaultCommand as WireVaultCommand, VAULT_ERR_ALREADY_INITIALIZED,
-    VAULT_ERR_INVALID_INPUT,
+    EmptyReceipt, I128Receipt, ProxyViewResponse, VaultCommand as WireVaultCommand,
+    VAULT_ERR_ALREADY_INITIALIZED, VAULT_ERR_INVALID_INPUT,
 };
 
 use crate::{
@@ -54,6 +54,33 @@ impl MockVaultContract {
         };
 
         Bytes::from_slice(&env, &receipt)
+    }
+}
+
+#[contracterror]
+#[repr(u32)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+enum MockForeignVaultError {
+    CollidesWithNotInitialized = 1,
+    CollidesWithNotImplemented = 6,
+}
+
+#[contract]
+struct MockFailingVaultContract;
+
+#[contractimpl]
+impl MockFailingVaultContract {
+    pub fn execute(_env: Env, _payload: Bytes) -> Result<Bytes, MockForeignVaultError> {
+        Err(MockForeignVaultError::CollidesWithNotImplemented)
+    }
+
+    pub fn proxy_view(
+        _env: Env,
+        _owner: Address,
+        _assets: i128,
+        _shares: i128,
+    ) -> Result<ProxyViewResponse, MockForeignVaultError> {
+        Err(MockForeignVaultError::CollidesWithNotInitialized)
     }
 }
 
@@ -502,6 +529,36 @@ fn supply_market_encodes_allocate_command() {
             supply: true,
         }
     );
+}
+
+#[test]
+fn vault_error_codes_do_not_decode_as_curator_proxy_errors() {
+    let fixture = Fixture::new();
+    let failing_vault = fixture.env.register(MockFailingVaultContract, ());
+    let caller = Address::generate(&fixture.env);
+
+    fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::initialize(
+            fixture.env.clone(),
+            failing_vault,
+            fixture.governance.clone(),
+        )
+        .expect("initialize succeeds");
+    });
+
+    let execute_result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::allocate(
+            fixture.env.clone(),
+            caller,
+            AllocationDelta::Withdraw(0, 1),
+        )
+    });
+    let view_result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::vault_view(fixture.env.clone())
+    });
+
+    assert_eq!(execute_result, Err(ContractError::VaultError));
+    assert!(matches!(view_result, Err(ContractError::VaultError)));
 }
 
 #[test]
@@ -1026,6 +1083,12 @@ fn vault_error_code_mapping_matches_runtime_discriminants() {
         ContractError::from_vault_error_code(VAULT_ERR_ALREADY_INITIALIZED),
         ContractError::AlreadyInitialized
     );
+    for colliding_code in [1, 2, 4, 5, 6, 7] {
+        assert_eq!(
+            ContractError::from_vault_error_code(colliding_code),
+            ContractError::VaultError
+        );
+    }
     assert_eq!(
         ContractError::from_vault_error_code(u32::MAX),
         ContractError::VaultError

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -2,10 +2,8 @@ use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, InvokeError, Vec,
 };
-use templar_soroban_runtime::ContractError as VaultContractError;
 use templar_soroban_shared_types::{
     EmptyReceipt, I128Receipt, ProxyViewResponse, VaultCommand as WireVaultCommand,
-    VAULT_ERR_ALREADY_INITIALIZED, VAULT_ERR_INVALID_INPUT,
 };
 
 use crate::{
@@ -1069,33 +1067,13 @@ fn timelocks_from_scalar_kind_values_preserves_every_field() {
 }
 
 #[test]
-fn vault_error_code_mapping_matches_runtime_discriminants() {
-    assert_eq!(
-        VAULT_ERR_INVALID_INPUT,
-        VaultContractError::InvalidInput as u32
-    );
-    assert_eq!(
-        VAULT_ERR_ALREADY_INITIALIZED,
-        VaultContractError::AlreadyInitialized as u32
-    );
-    assert_eq!(
-        ContractError::from_vault_error_code(VAULT_ERR_INVALID_INPUT),
-        ContractError::InvalidInput
-    );
-    assert_eq!(
-        ContractError::from_vault_error_code(VAULT_ERR_ALREADY_INITIALIZED),
-        ContractError::AlreadyInitialized
-    );
-    for colliding_code in [1, 2, 4, 5, 6, 7] {
+fn vault_contract_error_codes_map_to_vault_error() {
+    for code in [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, u32::MAX] {
         assert_eq!(
-            ContractError::from_vault_error_code(colliding_code),
+            map_vault_invoke_error(InvokeError::Contract(code)),
             ContractError::VaultError
         );
     }
-    assert_eq!(
-        ContractError::from_vault_error_code(u32::MAX),
-        ContractError::VaultError
-    );
 }
 
 #[test]

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -533,6 +533,27 @@ fn supply_market_encodes_allocate_command() {
 }
 
 #[test]
+fn allocate_rejects_nonpositive_amounts_before_vault_call() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+    let caller = Address::generate(&fixture.env);
+
+    for delta in [
+        AllocationDelta::Supply(0, 0),
+        AllocationDelta::Supply(0, -1),
+        AllocationDelta::Withdraw(0, 0),
+        AllocationDelta::Withdraw(0, -1),
+    ] {
+        let result = fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::allocate(fixture.env.clone(), caller.clone(), delta)
+        });
+        assert_eq!(result, Err(ContractError::InvalidInput));
+    }
+
+    assert_eq!(fixture.recorded_payloads().len(), 0);
+}
+
+#[test]
 fn vault_error_codes_do_not_decode_as_curator_proxy_errors() {
     let fixture = Fixture::new();
     let failing_vault = fixture.env.register(MockFailingVaultContract, ());

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -1,5 +1,7 @@
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, Vec};
+use soroban_sdk::{
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, InvokeError, Vec,
+};
 use templar_soroban_runtime::ContractError as VaultContractError;
 use templar_soroban_shared_types::{
     EmptyReceipt, I128Receipt, ProxyViewResponse, VaultCommand as WireVaultCommand,
@@ -8,7 +10,8 @@ use templar_soroban_shared_types::{
 
 use crate::{
     contract::{
-        timelocks_from_kind_values, AllocationDelta, ProxyDataKey, SorobanCuratorProxyContract,
+        map_vault_invoke_error, timelocks_from_kind_values, AllocationDelta, ProxyDataKey,
+        SorobanCuratorProxyContract,
     },
     error::ContractError,
     governance_abi::{
@@ -1091,6 +1094,14 @@ fn vault_error_code_mapping_matches_runtime_discriminants() {
     }
     assert_eq!(
         ContractError::from_vault_error_code(u32::MAX),
+        ContractError::VaultError
+    );
+}
+
+#[test]
+fn abort_vault_invoke_error_maps_to_vault_error() {
+    assert_eq!(
+        map_vault_invoke_error(InvokeError::Abort),
         ContractError::VaultError
     );
 }


### PR DESCRIPTION
## Summary

- decode vault `execute` and `proxy_view` failures as raw `InvokeError` values before mapping them into the curator proxy error domain
- keep only the explicit runtime mappings for `InvalidInput` (code 3) and `AlreadyInitialized` (code 8); all other foreign or nested contract codes surface as `VaultError`
- add regression coverage for execute/view collisions and for proxy-local codes 1, 2, 4, 5, 6, and 7

## Root cause

The curator proxy passed its own `ContractError` type to `try_invoke_contract` when calling the vault. Soroban therefore decoded a foreign numeric contract error as a curator-proxy variant whenever the discriminants collided.

For example:

- custodial adapter `InsufficientReturnedLiquidity = 6` surfaced as curator proxy `NotImplemented = 6`
- vault runtime `Unauthorized = 1` surfaced as curator proxy `NotInitialized = 1`

The ERC-4626 proxy already uses the safe raw-`InvokeError` pattern; this applies the same boundary handling to the curator proxy.

## Safety and impact

The underlying calls already fail atomically, so this bug does not commit partial vault or adapter accounting. The audit also found no production contract logic that branches on these curator-proxy error variants; frontend consumers use them for display. This change fixes misleading diagnostics without changing success-path behavior or the public error ABI.

The currently deployed curator proxy is immutable and has no upgrade entrypoint, so affected deployments will need a replacement proxy after this source fix is released.

## Verification

- `cargo test -p templar-curator-proxy-soroban -- --nocapture`
- `stellar contract build --manifest-path Cargo.toml --package templar-curator-proxy-soroban --optimize --out-dir target/wasm32-unknown-unknown/release-soroban`
- post-commit Soroban size budget check: 129255 bytes
- `cargo fmt --all -- --check`
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/516)
<!-- Reviewable:end -->
