### PR TITLE
Add `--market-id` as an alternative contract selector in tmplrmgr (ENG-505)

### DIFF
--- a/tools/manager/src/commands/proxy_oracle/get_proxy.rs
+++ b/tools/manager/src/commands/proxy_oracle/get_proxy.rs
@@ -4,21 +4,21 @@ use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use super::parse_price_identifier;
+use crate::resolve::OracleTarget;
 
 #[derive(Args, Debug)]
 pub struct GetProxy {
-    /// Proxy-oracle account to query.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: OracleTarget,
     /// Price identifier (32-byte hex, optional `0x` prefix).
     #[arg(long, value_name = "HEX", value_parser = parse_price_identifier)]
     price_id: PriceIdentifier,
 }
 
 impl GetProxy {
-    pub fn into_spec(self) -> spec::GetProxy {
+    pub fn into_spec(self, oracle_id: AccountId) -> spec::GetProxy {
         spec::GetProxy {
-            oracle_id: self.oracle_id,
+            oracle_id,
             id: self.price_id,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/get_proxy_circuit_breaker_set.rs
+++ b/tools/manager/src/commands/proxy_oracle/get_proxy_circuit_breaker_set.rs
@@ -4,21 +4,21 @@ use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use super::parse_price_identifier;
+use crate::resolve::OracleTarget;
 
 #[derive(Args, Debug)]
 pub struct GetProxyCircuitBreakerSet {
-    /// Proxy-oracle account to query.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: OracleTarget,
     /// Price identifier (32-byte hex, optional `0x` prefix).
     #[arg(long, value_name = "HEX", value_parser = parse_price_identifier)]
     price_id: PriceIdentifier,
 }
 
 impl GetProxyCircuitBreakerSet {
-    pub fn into_spec(self) -> spec::GetProxyCircuitBreakerSet {
+    pub fn into_spec(self, oracle_id: AccountId) -> spec::GetProxyCircuitBreakerSet {
         spec::GetProxyCircuitBreakerSet {
-            oracle_id: self.oracle_id,
+            oracle_id,
             id: self.price_id,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/governance/create_proposal.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/create_proposal.rs
@@ -21,12 +21,12 @@ use crate::commands::duration::parse_duration;
 use crate::commands::proxy_oracle::parse_price_identifier;
 use crate::commands::signer::SignerArgs;
 use crate::proxy::load_proxy_file;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Args, Debug)]
 pub struct CreateProposal {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Proposal id; fetched from the governance contract's next id when omitted
     #[arg(long, value_name = "ID")]
     id: Option<u32>,
@@ -44,10 +44,6 @@ pub struct CreateProposal {
 }
 
 impl CreateProposal {
-    pub fn governance_id(&self) -> &AccountId {
-        &self.governance_id
-    }
-
     /// The explicit `--id`, or `None` when it should be auto-fetched.
     pub fn id(&self) -> Option<u32> {
         self.id
@@ -74,10 +70,14 @@ impl CreateProposal {
         }
     }
 
-    /// Build the gateway spec with the resolved proposal id.
-    pub fn try_into_spec(self, id: u32) -> anyhow::Result<spec::CreateProposal> {
+    /// Build the gateway spec with the resolved governance account and proposal id.
+    pub fn try_into_spec(
+        self,
+        governance_id: AccountId,
+        id: u32,
+    ) -> anyhow::Result<spec::CreateProposal> {
         Ok(spec::CreateProposal {
-            governance_id: self.governance_id,
+            governance_id,
             id,
             operation: self.operation.into_operation()?,
             requested_ttl: self.requested_ttl,

--- a/tools/manager/src/commands/proxy_oracle/governance/execute_proposal.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/execute_proposal.rs
@@ -3,12 +3,12 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
 use crate::commands::signer::SignerArgs;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Args, Debug)]
 pub struct ExecuteProposalArgs {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Proposal id to execute.
     #[arg(long, value_name = "ID")]
     id: u32,
@@ -21,18 +21,15 @@ pub struct ExecuteProposalArgs {
 }
 
 impl ExecuteProposalArgs {
-    pub fn governance_id(&self) -> &AccountId {
-        &self.governance_id
-    }
     pub fn id(&self) -> u32 {
         self.id
     }
     pub fn when_ready(&self) -> bool {
         self.when_ready
     }
-    pub fn into_spec(self) -> spec::ExecuteProposal {
+    pub fn into_spec(self, governance_id: AccountId) -> spec::ExecuteProposal {
         spec::ExecuteProposal {
-            governance_id: self.governance_id,
+            governance_id,
             id: self.id,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/governance/get_operation_ttl.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/get_operation_ttl.rs
@@ -3,21 +3,21 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
 use super::OperationKind;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Args, Debug)]
 pub struct GetOperationTtl {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Operation kind to read the TTL for.
     #[arg(long, value_enum)]
     kind: OperationKind,
 }
 
 impl GetOperationTtl {
-    pub fn into_spec(self) -> spec::GetOperationTtl {
+    pub fn into_spec(self, governance_id: AccountId) -> spec::GetOperationTtl {
         spec::GetOperationTtl {
-            governance_id: self.governance_id,
+            governance_id,
             kind: self.kind,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/governance/get_roles.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/get_roles.rs
@@ -2,20 +2,21 @@ use clap::Args;
 use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
+use crate::resolve::GovernanceTarget;
+
 #[derive(Args, Debug)]
 pub struct GetRoles {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Account to query.
     #[arg(long, value_name = "ACCOUNT_ID")]
     account_id: AccountId,
 }
 
 impl GetRoles {
-    pub fn into_spec(self) -> spec::GetRoles {
+    pub fn into_spec(self, governance_id: AccountId) -> spec::GetRoles {
         spec::GetRoles {
-            governance_id: self.governance_id,
+            governance_id,
             account_id: self.account_id,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/governance/has_role.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/has_role.rs
@@ -3,12 +3,12 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
 use super::Role;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Args, Debug)]
 pub struct HasRole {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Account to query.
     #[arg(long, value_name = "ACCOUNT_ID")]
     account_id: AccountId,
@@ -18,9 +18,9 @@ pub struct HasRole {
 }
 
 impl HasRole {
-    pub fn into_spec(self) -> spec::HasRole {
+    pub fn into_spec(self, governance_id: AccountId) -> spec::HasRole {
         spec::HasRole {
-            governance_id: self.governance_id,
+            governance_id,
             account_id: self.account_id,
             role: self.role,
         }

--- a/tools/manager/src/commands/proxy_oracle/governance/list_proposals.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/list_proposals.rs
@@ -3,20 +3,20 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
 use crate::commands::pagination::PaginationArgs;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Args, Debug)]
 pub struct ListProposals {
-    /// Governance contract to list proposals from.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     #[command(flatten)]
     pagination: PaginationArgs,
 }
 
 impl ListProposals {
-    pub fn into_spec(self) -> spec::ListProposals {
+    pub fn into_spec(self, governance_id: AccountId) -> spec::ListProposals {
         spec::ListProposals {
-            governance_id: self.governance_id,
+            governance_id,
             offset: self.pagination.offset,
             count: self.pagination.count,
         }

--- a/tools/manager/src/commands/proxy_oracle/governance/list_role.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/list_role.rs
@@ -4,12 +4,12 @@ use templar_gateway_methods_spec::proxy_oracle_governance as spec;
 
 use super::Role;
 use crate::commands::pagination::PaginationArgs;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Args, Debug)]
 pub struct ListRole {
-    /// Governance contract to query.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Role whose members to list.
     #[arg(long, value_enum)]
     role: Role,
@@ -18,9 +18,9 @@ pub struct ListRole {
 }
 
 impl ListRole {
-    pub fn into_spec(self) -> spec::ListRole {
+    pub fn into_spec(self, governance_id: AccountId) -> spec::ListRole {
         spec::ListRole {
-            governance_id: self.governance_id,
+            governance_id,
             role: self.role,
             offset: self.pagination.offset,
             count: self.pagination.count,

--- a/tools/manager/src/commands/proxy_oracle/governance/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/mod.rs
@@ -29,6 +29,7 @@ use templar_proxy_oracle_near_governance_common::TtlConfig;
 pub use templar_proxy_oracle_near_governance_common::{OperationKind, Role};
 
 use crate::commands::signer::SignerArgs;
+use crate::resolve::GovernanceTarget;
 
 #[derive(Subcommand, Debug)]
 #[command(rename_all = "kebab-case")]
@@ -46,13 +47,13 @@ pub enum ProxyOracleGovernanceNs {
     /// List the governance contract's proposals.
     ListProposals(ListProposals),
     /// Read the id the next proposal will use.
-    NextProposalId(GovernanceIdArgs),
+    NextProposalId(GovernanceTarget),
     /// Read the total number of proposals.
-    ProposalCount(GovernanceIdArgs),
+    ProposalCount(GovernanceTarget),
     /// Read the configured TTL for an operation kind.
     GetOperationTtl(GetOperationTtl),
     /// Read the proxy-oracle account this contract governs.
-    GetProxyOracleId(GovernanceIdArgs),
+    GetProxyOracleId(GovernanceTarget),
     /// Check whether an account holds a role.
     HasRole(HasRole),
     /// List the accounts holding a role.
@@ -65,18 +66,17 @@ pub enum ProxyOracleGovernanceNs {
 /// `get-proposal`.
 #[derive(Args, Debug)]
 pub struct ProposalRef {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: GovernanceTarget,
     /// Proposal id.
     #[arg(long, value_name = "ID")]
     id: u32,
 }
 
 impl ProposalRef {
-    pub fn get(self) -> spec::GetProposal {
+    pub fn get(self, governance_id: AccountId) -> spec::GetProposal {
         spec::GetProposal {
-            governance_id: self.governance_id,
+            governance_id,
             id: self.id,
         }
     }
@@ -88,43 +88,16 @@ impl ProposalRef {
 #[derive(Args, Debug)]
 pub struct CancelProposal {
     #[command(flatten)]
-    proposal: ProposalRef,
+    pub(crate) proposal: ProposalRef,
     #[command(flatten)]
     pub(crate) signer: SignerArgs,
 }
 
 impl CancelProposal {
-    pub fn cancel(self) -> spec::CancelProposal {
+    pub fn cancel(self, governance_id: AccountId) -> spec::CancelProposal {
         spec::CancelProposal {
-            governance_id: self.proposal.governance_id,
+            governance_id,
             id: self.proposal.id,
-        }
-    }
-}
-
-/// Argument keyed only by the governance account — shared by the reads that take
-/// no other input (`next-proposal-id`, `proposal-count`, `get-proxy-oracle-id`).
-#[derive(Args, Debug)]
-pub struct GovernanceIdArgs {
-    /// Governance contract account.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    governance_id: AccountId,
-}
-
-impl GovernanceIdArgs {
-    pub fn next_proposal_id(self) -> spec::NextProposalId {
-        spec::NextProposalId {
-            governance_id: self.governance_id,
-        }
-    }
-    pub fn proposal_count(self) -> spec::ProposalCount {
-        spec::ProposalCount {
-            governance_id: self.governance_id,
-        }
-    }
-    pub fn get_proxy_oracle_id(self) -> spec::GetProxyOracleId {
-        spec::GetProxyOracleId {
-            governance_id: self.governance_id,
         }
     }
 }

--- a/tools/manager/src/commands/proxy_oracle/list_proxies.rs
+++ b/tools/manager/src/commands/proxy_oracle/list_proxies.rs
@@ -3,20 +3,20 @@ use near_account_id::AccountId;
 use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use crate::commands::pagination::PaginationArgs;
+use crate::resolve::OracleTarget;
 
 #[derive(Args, Debug)]
 pub struct ListProxies {
-    /// Proxy-oracle account to list price feeds from.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: OracleTarget,
     #[command(flatten)]
     pagination: PaginationArgs,
 }
 
 impl ListProxies {
-    pub fn into_spec(self) -> spec::ListProxies {
+    pub fn into_spec(self, oracle_id: AccountId) -> spec::ListProxies {
         spec::ListProxies {
-            oracle_id: self.oracle_id,
+            oracle_id,
             offset: self.pagination.offset,
             count: self.pagination.count,
         }

--- a/tools/manager/src/commands/proxy_oracle/price_feed_exists.rs
+++ b/tools/manager/src/commands/proxy_oracle/price_feed_exists.rs
@@ -4,21 +4,21 @@ use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use super::parse_price_identifier;
+use crate::resolve::OracleTarget;
 
 #[derive(Args, Debug)]
 pub struct PriceFeedExists {
-    /// Proxy-oracle account to query.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: OracleTarget,
     /// Price identifier (32-byte hex, optional `0x` prefix).
     #[arg(long, value_name = "HEX", value_parser = parse_price_identifier)]
     price_id: PriceIdentifier,
 }
 
 impl PriceFeedExists {
-    pub fn into_spec(self) -> spec::PriceFeedExists {
+    pub fn into_spec(self, oracle_id: AccountId) -> spec::PriceFeedExists {
         spec::PriceFeedExists {
-            oracle_id: self.oracle_id,
+            oracle_id,
             price_identifier: self.price_id,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/update_prices.rs
+++ b/tools/manager/src/commands/proxy_oracle/update_prices.rs
@@ -5,12 +5,12 @@ use templar_gateway_methods_spec::proxy_oracle as spec;
 
 use super::parse_price_identifier;
 use crate::commands::signer::SignerArgs;
+use crate::resolve::OracleTarget;
 
 #[derive(Args, Debug)]
 pub struct UpdatePrices {
-    /// Proxy-oracle account to refresh.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: OracleTarget,
     /// Price identifier (32-byte hex) to refresh; repeat the flag per feed.
     #[arg(long = "price-id", value_name = "HEX", value_parser = parse_price_identifier, required = true)]
     price_ids: Vec<PriceIdentifier>,
@@ -19,9 +19,9 @@ pub struct UpdatePrices {
 }
 
 impl UpdatePrices {
-    pub fn into_spec(self) -> spec::UpdatePrices {
+    pub fn into_spec(self, oracle_id: AccountId) -> spec::UpdatePrices {
         spec::UpdatePrices {
-            oracle_id: self.oracle_id,
+            oracle_id,
             price_ids: self.price_ids,
         }
     }

--- a/tools/manager/src/commands/proxy_oracle/upgrade.rs
+++ b/tools/manager/src/commands/proxy_oracle/upgrade.rs
@@ -7,13 +7,13 @@ use templar_gateway_methods_spec::proxy_oracle as spec;
 use templar_gateway_types::Base64Bytes;
 
 use crate::commands::signer::SignerArgs;
+use crate::resolve::OracleTarget;
 
 /// Upgrade a proxy oracle from a local WASM file.
 #[derive(Args, Debug)]
 pub struct Upgrade {
-    /// Proxy-oracle account to upgrade.
-    #[arg(long, value_name = "ACCOUNT_ID")]
-    oracle_id: AccountId,
+    #[command(flatten)]
+    pub(crate) target: OracleTarget,
     /// Audited WASM file for the target proxy-oracle release.
     #[arg(long, value_name = "PATH")]
     wasm: PathBuf,
@@ -38,11 +38,11 @@ impl From<MigrationArg> for spec::Migration {
 }
 
 impl Upgrade {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::Upgrade> {
+    pub fn try_into_spec(self, oracle_id: AccountId) -> anyhow::Result<spec::Upgrade> {
         let wasm = std::fs::read(&self.wasm)
             .with_context(|| format!("read WASM from {}", self.wasm.display()))?;
         Ok(spec::Upgrade {
-            oracle_id: self.oracle_id,
+            oracle_id,
             wasm: Base64Bytes(wasm),
             migration: self.migration.into(),
         })

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -101,12 +101,31 @@ async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
 async fn proxy_oracle(ctx: CliContext, ns: ProxyOracleNs) -> anyhow::Result<()> {
     match ns {
         ProxyOracleNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
-        ProxyOracleNs::GetProxy(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleNs::ListProxies(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleNs::PriceFeedExists(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleNs::GetProxyCircuitBreakerSet(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleNs::UpdatePrices(a) => ctx.write(a.signer.clone(), a.into_spec()).await,
-        ProxyOracleNs::Upgrade(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        ProxyOracleNs::GetProxy(a) => {
+            let oracle_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(oracle_id)).await
+        }
+        ProxyOracleNs::ListProxies(a) => {
+            let oracle_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(oracle_id)).await
+        }
+        ProxyOracleNs::PriceFeedExists(a) => {
+            let oracle_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(oracle_id)).await
+        }
+        ProxyOracleNs::GetProxyCircuitBreakerSet(a) => {
+            let oracle_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(oracle_id)).await
+        }
+        ProxyOracleNs::UpdatePrices(a) => {
+            let oracle_id = a.target.resolve(&ctx).await?;
+            ctx.write(a.signer.clone(), a.into_spec(oracle_id)).await
+        }
+        ProxyOracleNs::Upgrade(a) => {
+            let oracle_id = a.target.resolve(&ctx).await?;
+            ctx.write(a.signer.clone(), a.try_into_spec(oracle_id)?)
+                .await
+        }
         ProxyOracleNs::Governance(a) => proxy_oracle_governance(ctx, a).await,
     }
 }
@@ -161,20 +180,52 @@ async fn proxy_oracle_governance(
     ctx: CliContext,
     ns: ProxyOracleGovernanceNs,
 ) -> anyhow::Result<()> {
+    use templar_gateway_methods_spec::proxy_oracle_governance as gov;
+
     match ns {
         ProxyOracleGovernanceNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         ProxyOracleGovernanceNs::CreateProposal(a) => proposals::create(ctx, a).await,
-        ProxyOracleGovernanceNs::CancelProposal(a) => ctx.write(a.signer.clone(), a.cancel()).await,
+        ProxyOracleGovernanceNs::CancelProposal(a) => {
+            let governance_id = a.proposal.target.resolve(&ctx).await?;
+            ctx.write(a.signer.clone(), a.cancel(governance_id)).await
+        }
         ProxyOracleGovernanceNs::ExecuteProposal(a) => proposals::execute(ctx, a).await,
-        ProxyOracleGovernanceNs::GetProposal(a) => ctx.read(a.get()).await,
-        ProxyOracleGovernanceNs::ListProposals(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleGovernanceNs::NextProposalId(a) => ctx.read(a.next_proposal_id()).await,
-        ProxyOracleGovernanceNs::ProposalCount(a) => ctx.read(a.proposal_count()).await,
-        ProxyOracleGovernanceNs::GetOperationTtl(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleGovernanceNs::GetProxyOracleId(a) => ctx.read(a.get_proxy_oracle_id()).await,
-        ProxyOracleGovernanceNs::HasRole(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleGovernanceNs::ListRole(a) => ctx.read(a.into_spec()).await,
-        ProxyOracleGovernanceNs::GetRoles(a) => ctx.read(a.into_spec()).await,
+        ProxyOracleGovernanceNs::GetProposal(a) => {
+            let governance_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.get(governance_id)).await
+        }
+        ProxyOracleGovernanceNs::ListProposals(a) => {
+            let governance_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(governance_id)).await
+        }
+        ProxyOracleGovernanceNs::NextProposalId(a) => {
+            let governance_id = a.resolve(&ctx).await?;
+            ctx.read(gov::NextProposalId { governance_id }).await
+        }
+        ProxyOracleGovernanceNs::ProposalCount(a) => {
+            let governance_id = a.resolve(&ctx).await?;
+            ctx.read(gov::ProposalCount { governance_id }).await
+        }
+        ProxyOracleGovernanceNs::GetOperationTtl(a) => {
+            let governance_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(governance_id)).await
+        }
+        ProxyOracleGovernanceNs::GetProxyOracleId(a) => {
+            let governance_id = a.resolve(&ctx).await?;
+            ctx.read(gov::GetProxyOracleId { governance_id }).await
+        }
+        ProxyOracleGovernanceNs::HasRole(a) => {
+            let governance_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(governance_id)).await
+        }
+        ProxyOracleGovernanceNs::ListRole(a) => {
+            let governance_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(governance_id)).await
+        }
+        ProxyOracleGovernanceNs::GetRoles(a) => {
+            let governance_id = a.target.resolve(&ctx).await?;
+            ctx.read(a.into_spec(governance_id)).await
+        }
     }
 }
 

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -21,7 +21,7 @@ use crate::context::{print_json, CliContext};
 pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow::Result<()> {
     let (signer, secret_key) = args.signer.resolve()?;
     let client = ctx.signing_client(signer.clone(), secret_key)?;
-    let governance_id = args.governance_id().clone();
+    let governance_id = args.target.resolve(&ctx).await?;
     let execute_when_ready = args.execute_when_ready();
 
     // Auto-fill the next breaker id for add-circuit-breaker, resolving the proxy
@@ -47,7 +47,10 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
     };
 
     let create = client
-        .execute_as(signer.clone(), args.try_into_spec(id)?)
+        .execute_as(
+            signer.clone(),
+            args.try_into_spec(governance_id.clone(), id)?,
+        )
         .await?;
     // Fail fast if the create reverted, before waiting on / executing a proposal
     // that was never created.
@@ -74,10 +77,12 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
 /// elapse first, so an early call blocks instead of failing on an immature
 /// proposal.
 pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyhow::Result<()> {
+    let governance_id = args.target.resolve(&ctx).await?;
     if args.when_ready() {
-        wait_for_maturity(&ctx, args.governance_id(), args.id()).await?;
+        wait_for_maturity(&ctx, &governance_id, args.id()).await?;
     }
-    ctx.write(args.signer.clone(), args.into_spec()).await
+    ctx.write(args.signer.clone(), args.into_spec(governance_id))
+        .await
 }
 
 /// Execute proposal `id` on its own (no idempotency key), signed as `signer`

--- a/tools/manager/src/lib.rs
+++ b/tools/manager/src/lib.rs
@@ -3,6 +3,7 @@ mod commands;
 mod context;
 mod dispatch;
 mod proxy;
+mod resolve;
 
 #[cfg(test)]
 mod tests;

--- a/tools/manager/src/resolve.rs
+++ b/tools/manager/src/resolve.rs
@@ -1,12 +1,13 @@
-//! `--market-id` target resolution: turn a market account into the concrete
-//! oracle or governance account a command operates on, asserting the resolved
-//! contract is the expected kind before any write is planned.
+//! Target resolution for `proxy-oracle`/`proxy-oracle gov` commands: turn a
+//! `--market-id` (or, for governance, an `--oracle-id`) into the concrete oracle
+//! or governance account a command operates on, asserting the resolved contract
+//! is the expected kind before any write is planned.
 //!
 //! Each resolution is a handful of extra view calls — fine for an ops CLI. The
-//! kind assertions are hard errors, not warnings: a wrong-target admin write is
-//! the failure mode this prevents, so a market whose oracle isn't a proxy oracle
-//! (or a proxy oracle not owned by a governance contract) fails with a
-//! diagnostic naming the resolution step that broke.
+//! assertions are hard errors, not warnings: a wrong-target admin write is the
+//! failure mode this prevents, so a market whose oracle isn't a proxy oracle (or
+//! a proxy oracle not owned by a governance contract) fails with a diagnostic
+//! naming the resolution step that broke.
 
 use anyhow::{bail, Context as _};
 use clap::{ArgGroup, Args};
@@ -35,7 +36,7 @@ impl OracleTarget {
     pub(crate) async fn resolve(&self, ctx: &CliContext) -> anyhow::Result<AccountId> {
         match (&self.oracle_id, &self.market_id) {
             (Some(oracle_id), _) => Ok(oracle_id.clone()),
-            (_, Some(market_id)) => resolve_oracle_from_market(ctx, market_id.clone()).await,
+            (_, Some(market_id)) => resolve_oracle_from_market(ctx, market_id).await,
             (None, None) => bail!("either --oracle-id or --market-id is required"),
         }
     }
@@ -67,8 +68,8 @@ impl GovernanceTarget {
     pub(crate) async fn resolve(&self, ctx: &CliContext) -> anyhow::Result<AccountId> {
         match (&self.governance_id, &self.oracle_id, &self.market_id) {
             (Some(governance_id), _, _) => Ok(governance_id.clone()),
-            (_, Some(oracle_id), _) => resolve_governance_from_oracle(ctx, oracle_id.clone()).await,
-            (_, _, Some(market_id)) => resolve_governance_from_market(ctx, market_id.clone()).await,
+            (_, Some(oracle_id), _) => resolve_governance_from_oracle(ctx, oracle_id).await,
+            (_, _, Some(market_id)) => resolve_governance_from_market(ctx, market_id).await,
             (None, None, None) => {
                 bail!("one of --governance-id, --oracle-id, or --market-id is required")
             }
@@ -76,12 +77,9 @@ impl GovernanceTarget {
     }
 }
 
-/// Read a market's configured oracle and assert it is a proxy oracle.
-async fn resolve_oracle_from_market(
-    ctx: &CliContext,
-    market_id: AccountId,
-) -> anyhow::Result<AccountId> {
-    let oracle_id = ctx
+/// Read a market's configured price-oracle account (no kind assertion).
+async fn read_market_oracle(ctx: &CliContext, market_id: &AccountId) -> anyhow::Result<AccountId> {
+    Ok(ctx
         .client
         .read(market::GetConfiguration {
             market_id: market_id.clone(),
@@ -89,7 +87,16 @@ async fn resolve_oracle_from_market(
         .await
         .with_context(|| format!("read market.getConfiguration for {market_id}"))?
         .price_oracle_configuration
-        .account_id;
+        .account_id)
+}
+
+/// Read a market's configured oracle and assert it is a proxy oracle. Used on the
+/// `--market-id` proxy-oracle path, which has no later round-trip to prove it.
+async fn resolve_oracle_from_market(
+    ctx: &CliContext,
+    market_id: &AccountId,
+) -> anyhow::Result<AccountId> {
+    let oracle_id = read_market_oracle(ctx, market_id).await?;
 
     let kind = ctx
         .client
@@ -104,21 +111,23 @@ async fn resolve_oracle_from_market(
     Ok(oracle_id)
 }
 
-/// Resolve a market's governance contract: resolve the market's proxy oracle,
-/// then the governance contract that owns it.
+/// Resolve a market's governance contract: read the market's oracle, then the
+/// governance contract that owns it. No proxy-oracle `getKind` assertion here —
+/// the `getProxyOracleId` round-trip in [`resolve_governance_from_oracle`] is
+/// itself proof the oracle is a proxy oracle governed by that account.
 async fn resolve_governance_from_market(
     ctx: &CliContext,
-    market_id: AccountId,
+    market_id: &AccountId,
 ) -> anyhow::Result<AccountId> {
-    let oracle_id = resolve_oracle_from_market(ctx, market_id).await?;
-    resolve_governance_from_oracle(ctx, oracle_id).await
+    let oracle_id = read_market_oracle(ctx, market_id).await?;
+    resolve_governance_from_oracle(ctx, &oracle_id).await
 }
 
 /// Resolve a proxy oracle's governance contract: read the oracle's owner, then
 /// confirm it governs that oracle by round-tripping `getProxyOracleId`.
 async fn resolve_governance_from_oracle(
     ctx: &CliContext,
-    oracle_id: AccountId,
+    oracle_id: &AccountId,
 ) -> anyhow::Result<AccountId> {
     let owner = ctx
         .client
@@ -128,7 +137,7 @@ async fn resolve_governance_from_oracle(
         .await
         .with_context(|| format!("read owner.getOwner for oracle {oracle_id}"))?
         .owner;
-    let governance_id = ensure_owner_present(owner, &oracle_id)?;
+    let governance_id = ensure_owner_present(owner, oracle_id)?;
 
     let governed = ctx
         .client
@@ -140,7 +149,7 @@ async fn resolve_governance_from_oracle(
             format!("read proxyOracleGovernance.getProxyOracleId for {governance_id}")
         })?
         .proxy_oracle_id;
-    ensure_governs(&oracle_id, &governance_id, &governed)?;
+    ensure_governs(oracle_id, &governance_id, &governed)?;
 
     Ok(governance_id)
 }

--- a/tools/manager/src/resolve.rs
+++ b/tools/manager/src/resolve.rs
@@ -1,0 +1,236 @@
+//! `--market-id` target resolution: turn a market account into the concrete
+//! oracle or governance account a command operates on, asserting the resolved
+//! contract is the expected kind before any write is planned.
+//!
+//! Each resolution is a handful of extra view calls — fine for an ops CLI. The
+//! kind assertions are hard errors, not warnings: a wrong-target admin write is
+//! the failure mode this prevents, so a market whose oracle isn't a proxy oracle
+//! (or a proxy oracle not owned by a governance contract) fails with a
+//! diagnostic naming the resolution step that broke.
+
+use anyhow::{bail, Context as _};
+use clap::{ArgGroup, Args};
+use near_account_id::AccountId;
+use templar_gateway_methods_spec::{contract, market, owner, proxy_oracle_governance as gov};
+use templar_gateway_types::contract::ContractKind;
+
+use crate::context::CliContext;
+
+/// Target for `proxy-oracle` commands: an explicit proxy-oracle account, or a
+/// market whose configured oracle is resolved and asserted to be a proxy oracle.
+#[derive(Args, Debug)]
+#[command(group(ArgGroup::new("proxy_oracle_target").required(true).args(["oracle_id", "market_id"])))]
+pub(crate) struct OracleTarget {
+    /// Proxy-oracle account to target.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    oracle_id: Option<AccountId>,
+    /// Market whose configured proxy oracle is the target.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    market_id: Option<AccountId>,
+}
+
+impl OracleTarget {
+    /// The proxy-oracle account: `--oracle-id` verbatim, or the oracle resolved
+    /// from `--market-id`.
+    pub(crate) async fn resolve(&self, ctx: &CliContext) -> anyhow::Result<AccountId> {
+        match (&self.oracle_id, &self.market_id) {
+            (Some(oracle_id), _) => Ok(oracle_id.clone()),
+            (_, Some(market_id)) => resolve_oracle_from_market(ctx, market_id.clone()).await,
+            (None, None) => bail!("either --oracle-id or --market-id is required"),
+        }
+    }
+}
+
+/// Target for `proxy-oracle gov` commands: an explicit governance account, the
+/// governance contract that owns a proxy oracle, or the one reached through a
+/// market's proxy oracle. Each indirect path confirms the resolved contract
+/// actually governs that oracle.
+#[derive(Args, Debug)]
+#[command(group(ArgGroup::new("governance_target").required(true).args(["governance_id", "oracle_id", "market_id"])))]
+#[allow(clippy::struct_field_names)]
+pub(crate) struct GovernanceTarget {
+    /// Governance contract account to target.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    governance_id: Option<AccountId>,
+    /// Proxy oracle whose governance contract is the target.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    oracle_id: Option<AccountId>,
+    /// Market whose proxy oracle's governance contract is the target.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    market_id: Option<AccountId>,
+}
+
+impl GovernanceTarget {
+    /// The governance account: `--governance-id` verbatim, the governance
+    /// contract owning `--oracle-id`, or the one reached via `--market-id`'s
+    /// proxy oracle.
+    pub(crate) async fn resolve(&self, ctx: &CliContext) -> anyhow::Result<AccountId> {
+        match (&self.governance_id, &self.oracle_id, &self.market_id) {
+            (Some(governance_id), _, _) => Ok(governance_id.clone()),
+            (_, Some(oracle_id), _) => resolve_governance_from_oracle(ctx, oracle_id.clone()).await,
+            (_, _, Some(market_id)) => resolve_governance_from_market(ctx, market_id.clone()).await,
+            (None, None, None) => {
+                bail!("one of --governance-id, --oracle-id, or --market-id is required")
+            }
+        }
+    }
+}
+
+/// Read a market's configured oracle and assert it is a proxy oracle.
+async fn resolve_oracle_from_market(
+    ctx: &CliContext,
+    market_id: AccountId,
+) -> anyhow::Result<AccountId> {
+    let oracle_id = ctx
+        .client
+        .read(market::GetConfiguration {
+            market_id: market_id.clone(),
+        })
+        .await
+        .with_context(|| format!("read market.getConfiguration for {market_id}"))?
+        .price_oracle_configuration
+        .account_id;
+
+    let kind = ctx
+        .client
+        .read(contract::GetKind {
+            contract_id: oracle_id.clone(),
+        })
+        .await
+        .with_context(|| format!("read contract.getKind for oracle {oracle_id}"))?
+        .kind;
+    ensure_proxy_oracle(kind, &oracle_id)?;
+
+    Ok(oracle_id)
+}
+
+/// Resolve a market's governance contract: resolve the market's proxy oracle,
+/// then the governance contract that owns it.
+async fn resolve_governance_from_market(
+    ctx: &CliContext,
+    market_id: AccountId,
+) -> anyhow::Result<AccountId> {
+    let oracle_id = resolve_oracle_from_market(ctx, market_id).await?;
+    resolve_governance_from_oracle(ctx, oracle_id).await
+}
+
+/// Resolve a proxy oracle's governance contract: read the oracle's owner, then
+/// confirm it governs that oracle by round-tripping `getProxyOracleId`.
+async fn resolve_governance_from_oracle(
+    ctx: &CliContext,
+    oracle_id: AccountId,
+) -> anyhow::Result<AccountId> {
+    let owner = ctx
+        .client
+        .read(owner::GetOwner {
+            contract_id: oracle_id.clone(),
+        })
+        .await
+        .with_context(|| format!("read owner.getOwner for oracle {oracle_id}"))?
+        .owner;
+    let governance_id = ensure_owner_present(owner, &oracle_id)?;
+
+    let governed = ctx
+        .client
+        .read(gov::GetProxyOracleId {
+            governance_id: governance_id.clone(),
+        })
+        .await
+        .with_context(|| {
+            format!("read proxyOracleGovernance.getProxyOracleId for {governance_id}")
+        })?
+        .proxy_oracle_id;
+    ensure_governs(&oracle_id, &governance_id, &governed)?;
+
+    Ok(governance_id)
+}
+
+/// Assert `oracle_id` is a proxy oracle, naming the failed step otherwise.
+fn ensure_proxy_oracle(kind: ContractKind, oracle_id: &AccountId) -> anyhow::Result<()> {
+    if kind == ContractKind::ProxyOracle {
+        return Ok(());
+    }
+    bail!(
+        "resolution step 'assert proxy oracle' failed: the market's configured oracle \
+         {oracle_id} is a {kind:?}, not a proxy oracle"
+    );
+}
+
+/// Take a proxy oracle's owner as its governance contract, failing when the
+/// oracle has no owner.
+fn ensure_owner_present(
+    owner: Option<AccountId>,
+    oracle_id: &AccountId,
+) -> anyhow::Result<AccountId> {
+    owner.with_context(|| {
+        format!(
+            "resolution step 'read oracle owner' failed: proxy oracle {oracle_id} has no owner, \
+             so no governance contract can be resolved"
+        )
+    })
+}
+
+/// Confirm the resolved governance contract governs the resolved oracle, naming
+/// the failed step otherwise.
+fn ensure_governs(
+    oracle_id: &AccountId,
+    governance_id: &AccountId,
+    governed: &AccountId,
+) -> anyhow::Result<()> {
+    if governed == oracle_id {
+        return Ok(());
+    }
+    bail!(
+        "resolution step 'confirm governance' failed: {governance_id} governs {governed}, \
+         not the resolved oracle {oracle_id}"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ensure_governs, ensure_owner_present, ensure_proxy_oracle};
+    use near_account_id::AccountId;
+    use templar_gateway_types::contract::ContractKind;
+
+    fn account(id: &str) -> AccountId {
+        id.parse().expect("valid account id")
+    }
+
+    #[test]
+    fn proxy_oracle_kind_passes_others_fail_by_step() {
+        let oracle = account("oracle.testnet");
+        ensure_proxy_oracle(ContractKind::ProxyOracle, &oracle).expect("proxy oracle passes");
+
+        let error = ensure_proxy_oracle(ContractKind::PythOracle, &oracle)
+            .expect_err("a non-proxy oracle must fail");
+        let message = error.to_string();
+        assert!(message.contains("assert proxy oracle"), "{message}");
+        assert!(message.contains("oracle.testnet"), "{message}");
+    }
+
+    #[test]
+    fn missing_owner_fails_naming_the_step() {
+        let oracle = account("oracle.testnet");
+        let governance = ensure_owner_present(Some(account("gov.testnet")), &oracle)
+            .expect("an owner resolves to the governance account");
+        assert_eq!(governance.as_str(), "gov.testnet");
+
+        let error = ensure_owner_present(None, &oracle).expect_err("an unowned oracle must fail");
+        let message = error.to_string();
+        assert!(message.contains("read oracle owner"), "{message}");
+        assert!(message.contains("oracle.testnet"), "{message}");
+    }
+
+    #[test]
+    fn governance_must_govern_the_resolved_oracle() {
+        let oracle = account("oracle.testnet");
+        let governance = account("gov.testnet");
+        ensure_governs(&oracle, &governance, &oracle).expect("a matching round-trip passes");
+
+        let error = ensure_governs(&oracle, &governance, &account("other.testnet"))
+            .expect_err("governing a different oracle must fail");
+        let message = error.to_string();
+        assert!(message.contains("confirm governance"), "{message}");
+        assert!(message.contains("other.testnet"), "{message}");
+    }
+}

--- a/tools/manager/src/tests/deploy_script.rs
+++ b/tools/manager/src/tests/deploy_script.rs
@@ -258,7 +258,12 @@ fn governance_create_proposal_reshapes_legacy_proxy_file() {
         "--proxy-file",
         proxy_file.to_str().expect("fixture path is unicode"),
     ]);
-    let params = cmd.try_into_spec(0).expect("create-proposal should build");
+    let params = cmd
+        .try_into_spec(
+            "proxy.registry.testnet".parse().expect("valid account id"),
+            0,
+        )
+        .expect("create-proposal should build");
 
     std::fs::remove_file(&proxy_file).expect("remove proxy fixture");
 
@@ -286,7 +291,9 @@ fn governance_execute_proposal_typed_args_parse() {
         .into_iter()
         .chain(CREDS),
     ) {
-        ProxyOracleGovernanceNs::ExecuteProposal(cmd) => cmd.into_spec(),
+        ProxyOracleGovernanceNs::ExecuteProposal(cmd) => {
+            cmd.into_spec("proxy.registry.testnet".parse().expect("valid account id"))
+        }
         _ => panic!("expected execute-proposal"),
     };
 

--- a/tools/manager/src/tests/plan.rs
+++ b/tools/manager/src/tests/plan.rs
@@ -206,7 +206,9 @@ async fn governance_cancel_proposal_plans_cancel_action() {
         .into_iter()
         .chain(CREDS),
     ) {
-        ProxyOracleGovernanceNs::CancelProposal(a) => a.cancel(),
+        ProxyOracleGovernanceNs::CancelProposal(a) => {
+            a.cancel("proxy.registry.testnet".parse().expect("valid account id"))
+        }
         _ => panic!("expected cancel-proposal"),
     };
 

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -18,13 +18,19 @@ impl Drop for RemoveFileOnDrop<'_> {
     }
 }
 
+/// A stand-in resolved governance account for the offline spec-building tests
+/// (these pass `--governance-id gov.testnet`, so no resolution is exercised).
+fn gov_account() -> near_account_id::AccountId {
+    "gov.testnet".parse().expect("valid account id")
+}
+
 /// Parse a `create-proposal` invocation and return the built gateway spec.
 fn create_proposal(
     args: &[&str],
 ) -> anyhow::Result<templar_gateway_methods_spec::proxy_oracle_governance::CreateProposal> {
     let cmd = parse_create_proposal(args.iter().copied());
     let id = cmd.id().expect("these tests pass --id explicitly");
-    cmd.try_into_spec(id)
+    cmd.try_into_spec(gov_account(), id)
 }
 
 #[test]
@@ -122,7 +128,9 @@ fn upgrade_reads_local_wasm_and_carries_the_migration() {
     let spec = match cli.command {
         Command::ProxyOracle {
             command: ProxyOracleNs::Upgrade(cmd),
-        } => cmd.try_into_spec().expect("read WASM"),
+        } => cmd
+            .try_into_spec("oracle.testnet".parse().expect("valid account id"))
+            .expect("read WASM"),
         _ => panic!("expected proxy-oracle upgrade"),
     };
     std::fs::remove_file(&path).ok();
@@ -372,10 +380,11 @@ fn create_proposal_id_is_optional_for_auto_fetch() {
     ]);
     assert_eq!(cmd.id(), None);
     assert!(!cmd.execute_when_ready());
-    assert_eq!(cmd.governance_id().as_str(), "gov.testnet");
-    // A resolved id flows through to the spec.
-    let spec = cmd.try_into_spec(7).expect("into spec");
-    assert_eq!(serde_json::to_value(&spec).unwrap()["id"], json!(7));
+    // A resolved governance account and id flow through to the spec.
+    let spec = cmd.try_into_spec(gov_account(), 7).expect("into spec");
+    let json = serde_json::to_value(&spec).unwrap();
+    assert_eq!(json["id"], json!(7));
+    assert_eq!(json["governance_id"], json!("gov.testnet"));
 }
 
 #[test]
@@ -478,7 +487,7 @@ fn governance_role_reads_parse() {
         "--count",
         "10",
     ]) {
-        ProxyOracleGovernanceNs::ListRole(cmd) => cmd.into_spec(),
+        ProxyOracleGovernanceNs::ListRole(cmd) => cmd.into_spec(gov_account()),
         _ => panic!("expected list-role"),
     };
     assert_eq!(
@@ -514,7 +523,7 @@ fn oracle_update_prices_collects_repeated_ids() {
     let spec = match cli.command {
         Command::ProxyOracle {
             command: ProxyOracleNs::UpdatePrices(cmd),
-        } => cmd.into_spec(),
+        } => cmd.into_spec("proxy.testnet".parse().expect("valid account id")),
         _ => panic!("expected update-prices"),
     };
     assert_eq!(spec.price_ids.len(), 2);
@@ -556,7 +565,7 @@ fn add_circuit_breaker_breaker_id_is_optional_and_resolvable() {
     let expected = crate::commands::proxy_oracle::parse_price_identifier(PRICE_ID).unwrap();
     assert_eq!(unresolved.unresolved_breaker_price_id(), Some(expected));
     let error = unresolved
-        .try_into_spec(0)
+        .try_into_spec(gov_account(), 0)
         .expect_err("building a spec must reject an unresolved breaker id");
     assert!(
         error.to_string().contains("breaker id must be resolved"),
@@ -568,7 +577,7 @@ fn add_circuit_breaker_breaker_id_is_optional_and_resolvable() {
     // Once resolved, it is no longer flagged for auto-fetch.
     assert_eq!(resolved.unresolved_breaker_price_id(), None);
     let spec = resolved
-        .try_into_spec(0)
+        .try_into_spec(gov_account(), 0)
         .expect("resolved breaker id should build");
     let operation =
         serde_json::to_value(spec).expect("serialize proposal spec")["operation"].clone();
@@ -589,4 +598,66 @@ fn add_circuit_breaker_breaker_id_is_optional_and_resolvable() {
         "/does/not/need/to/exist.json",
     ]);
     assert_eq!(explicit.unresolved_breaker_price_id(), None);
+}
+
+/// A `proxy-oracle` command takes exactly one of `--oracle-id` / `--market-id`.
+#[test]
+fn oracle_target_requires_exactly_one_selector() {
+    let base = [
+        "tmplrmgr",
+        "proxy-oracle",
+        "get-proxy",
+        "--price-id",
+        PRICE_ID,
+    ];
+
+    // Neither selector: the required group is unsatisfied.
+    Cli::try_parse_from(base).expect_err("a target selector is required");
+
+    // Both selectors: they are mutually exclusive.
+    Cli::try_parse_from(base.into_iter().chain([
+        "--oracle-id",
+        "oracle.testnet",
+        "--market-id",
+        "market.testnet",
+    ]))
+    .expect_err("--oracle-id and --market-id are mutually exclusive");
+
+    // Either alone parses.
+    for selector in [
+        ["--oracle-id", "oracle.testnet"],
+        ["--market-id", "market.testnet"],
+    ] {
+        Cli::try_parse_from(base.into_iter().chain(selector))
+            .expect("exactly one selector should parse");
+    }
+}
+
+/// A `proxy-oracle gov` command takes exactly one of `--governance-id` /
+/// `--oracle-id` / `--market-id`.
+#[test]
+fn governance_target_requires_exactly_one_selector() {
+    let base = ["tmplrmgr", "proxy-oracle", "gov", "get-proxy-oracle-id"];
+
+    // Neither selector: the required group is unsatisfied.
+    Cli::try_parse_from(base).expect_err("a target selector is required");
+
+    // Two selectors: mutually exclusive.
+    Cli::try_parse_from(base.into_iter().chain([
+        "--governance-id",
+        "gov.testnet",
+        "--oracle-id",
+        "oracle.testnet",
+    ]))
+    .expect_err("governance selectors are mutually exclusive");
+
+    // Each alone parses.
+    for selector in [
+        ["--governance-id", "gov.testnet"],
+        ["--oracle-id", "oracle.testnet"],
+        ["--market-id", "market.testnet"],
+    ] {
+        Cli::try_parse_from(base.into_iter().chain(selector))
+            .expect("exactly one selector should parse");
+    }
 }


### PR DESCRIPTION
Let admins target `tmplrmgr` proxy-oracle commands by market instead of hand-looking-up the oracle/governance account. A pre-dispatch resolver, mutually exclusive with the explicit id arg via a required-one clap `ArgGroup`, resolves the concrete account from the market config and asserts the target is the expected kind (hard errors, not warnings).

## Selectors

- **`proxy-oracle` commands** accept `--oracle-id` **or** `--market-id`.
- **`proxy-oracle gov` commands** accept `--governance-id`, `--oracle-id`, **or** `--market-id`.
- The abstract, contract-agnostic **`owner`** namespace is intentionally left on `--contract-id` only — a market→contract mapping is ill-defined there, and changing that interface is out of scope.

## Resolution

- `--market-id` reads `market.getConfiguration` → `price_oracle_configuration.account_id` (the oracle).
- On the proxy-oracle path, the oracle is asserted to be a proxy oracle via `contract.getKind`.
- On the governance paths, the oracle's owner (`owner.getOwner`) is read and confirmed to govern that oracle by round-tripping `proxyOracleGovernance.getProxyOracleId`. This round-trip is the authoritative proof, so the market→governance path skips the redundant `getKind`, keeping each resolution to ~2–4 view calls.
- Assertions are hard errors whose diagnostics name the failed resolution step.

Resolution runs in the dispatcher, so each command's `into_spec` stays a pure `(args, resolved id) → spec` function the offline unit tests exercise without a live client.

## Notes

The issue suggested asserting proxy-oracle-ness via a NEP-330 version probe (`ProxyOracleClient::version::<ProxyOracle>()`). That was substituted with `contract.getKind` == `ContractKind::ProxyOracle`: `Version<ProxyOracle>` is a phantom-tagged semver that parses for any versioned contract (so it wouldn't actually assert proxy-oracle-ness), and the core client isn't reachable from the CLI's gateway `Client`. `contract.getKind` is the CLI-reachable interface probe. No new gateway methods → no `METHODS.md` change.

## Testing

- `cargo nextest run -p templar-manager` — 124/124 pass, including new `ArgGroup` mutual-exclusivity/required-one tests for both selectors and pure-guard diagnostic tests.
- `cargo clippy -p templar-manager --tests -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/521)
<!-- Reviewable:end -->
