### PR TITLE
Add plan rendering to tmplrmgr writes (ENG-506)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13399,6 +13399,7 @@ name = "templar-manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "clap",
  "dirs 6.0.0",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12186,6 +12186,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sputnikdao2"
+version = "2.3.1"
+source = "git+https://github.com/near-daos/sputnik-dao-contract?rev=5434a59dec23ee0c49df8c8c4350c208a7e75b0b#5434a59dec23ee0c49df8c8c4350c208a7e75b0b"
+dependencies = [
+ "hex",
+ "near-contract-standards",
+ "near-sdk",
+]
+
+[[package]]
 name = "sqlx"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13408,6 +13418,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "sputnikdao2",
  "templar-common",
  "templar-contract-artifacts",
  "templar-gateway-client",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13399,7 +13399,6 @@ name = "templar-manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.22.1",
  "clap",
  "dirs 6.0.0",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ sqlx = { version = "0.8", features = [
 ] }
 sha2 = "0.10.9"
 solana-sdk = "3.0.0"
+sputnikdao2 = { git = "https://github.com/near-daos/sputnik-dao-contract", rev = "5434a59dec23ee0c49df8c8c4350c208a7e75b0b" }
 stellar-strkey = { version = "0.0.16", default-features = false }
 strum = { version = "0.27", features = ["derive"] }
 templar-common = { path = "./common" }

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -25,6 +25,7 @@ near-api.workspace = true
 near-sdk = { workspace = true, features = ["unit-testing", "non-contract-usage"] }
 serde.workspace = true
 serde_json.workspace = true
+sputnikdao2.workspace = true
 templar-common.workspace = true
 templar-contract-artifacts.workspace = true
 templar-gateway-client = { workspace = true, features = ["clap"] }

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -11,7 +11,6 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
-base64.workspace = true
 clap.workspace = true
 dirs.workspace = true
 hex.workspace = true

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+base64.workspace = true
 clap.workspace = true
 dirs.workspace = true
 hex.workspace = true

--- a/tools/manager/src/commands/deploy_common.rs
+++ b/tools/manager/src/commands/deploy_common.rs
@@ -30,15 +30,19 @@ impl DeployCommonArgs {
     /// Build the registry deploy spec from these shared flags and the caller's
     /// init-args bytes, granting the operator's full access keys (the signer's
     /// `signer_public_key` by default) so it retains control of the new account.
-    pub fn into_deploy(self, signer_public_key: PublicKey, init_args: Vec<u8>) -> spec::Deploy {
-        let full_access_keys = self.full_access_keys.resolve(signer_public_key);
-        spec::Deploy {
+    pub fn into_deploy(
+        self,
+        signer_public_key: impl FnOnce() -> anyhow::Result<PublicKey>,
+        init_args: Vec<u8>,
+    ) -> anyhow::Result<spec::Deploy> {
+        let full_access_keys = self.full_access_keys.resolve(signer_public_key)?;
+        Ok(spec::Deploy {
             registry_id: self.registry_id,
             name: self.name,
             version_key: self.version_key,
             init_args: Base64Bytes(init_args),
             full_access_keys: Some(full_access_keys),
             deposit: self.deposit,
-        }
+        })
     }
 }

--- a/tools/manager/src/commands/full_access_key.rs
+++ b/tools/manager/src/commands/full_access_key.rs
@@ -17,12 +17,15 @@ pub struct FullAccessKeyArgs {
 }
 
 impl FullAccessKeyArgs {
-    /// Resolve the keys granted to the new account: `signer_public_key` by default
-    /// (unless suppressed), plus the explicit extras, de-duplicated.
-    pub fn resolve(&self, signer_public_key: PublicKey) -> Vec<PublicKey> {
+    /// Resolve the keys granted to the new account: the lazily-provided signer
+    /// key by default (unless suppressed), plus explicit extras, de-duplicated.
+    pub fn resolve(
+        &self,
+        signer_public_key: impl FnOnce() -> anyhow::Result<PublicKey>,
+    ) -> anyhow::Result<Vec<PublicKey>> {
         let mut keys = Vec::with_capacity(self.with_full_access_key.len() + 1);
         if !self.no_signer_full_access_key {
-            keys.push(signer_public_key);
+            keys.push(signer_public_key()?);
         }
         for key in &self.with_full_access_key {
             let key = PublicKey::from(*key);
@@ -30,7 +33,7 @@ impl FullAccessKeyArgs {
                 keys.push(key);
             }
         }
-        keys
+        Ok(keys)
     }
 }
 
@@ -62,15 +65,28 @@ mod tests {
         // The signer's key is granted on every deploy — the operator must retain
         // control of the new account.
         let signer = signer_key();
-        assert_eq!(args(false, &[]).resolve(signer.clone()), vec![signer]);
+        assert_eq!(
+            args(false, &[])
+                .resolve(|| Ok(signer.clone()))
+                .expect("signer key"),
+            vec![signer]
+        );
     }
 
     #[test]
-    fn no_signer_flag_drops_signer_key() {
-        assert!(args(true, &[]).resolve(signer_key()).is_empty());
+    fn no_signer_flag_drops_signer_key_without_resolving_it() {
+        assert!(args(true, &[])
+            .resolve(|| unreachable!("signer key must stay lazy"))
+            .expect("no signer key needed")
+            .is_empty());
         // With extras and --no-signer, only the extras are granted.
         let key_b = PublicKey::from(KEY_B.parse::<CliPublicKey>().unwrap());
-        assert_eq!(args(true, &[KEY_B]).resolve(signer_key()), vec![key_b]);
+        assert_eq!(
+            args(true, &[KEY_B])
+                .resolve(|| unreachable!("signer key must stay lazy"))
+                .expect("no signer key needed"),
+            vec![key_b]
+        );
     }
 
     #[test]
@@ -78,7 +94,9 @@ mod tests {
         let signer = signer_key();
         let signer_str = signer.0.to_string();
         // Extras that repeat the signer key or each other are dropped.
-        let keys = args(false, &[&signer_str, KEY_B, KEY_B]).resolve(signer.clone());
+        let keys = args(false, &[&signer_str, KEY_B, KEY_B])
+            .resolve(|| Ok(signer.clone()))
+            .expect("signer key");
         let key_b = PublicKey::from(KEY_B.parse::<CliPublicKey>().unwrap());
         assert_eq!(keys, vec![signer, key_b]);
     }

--- a/tools/manager/src/commands/full_access_key.rs
+++ b/tools/manager/src/commands/full_access_key.rs
@@ -75,10 +75,6 @@ mod tests {
 
     #[test]
     fn no_signer_flag_drops_signer_key_without_resolving_it() {
-        assert!(args(true, &[])
-            .resolve(|| unreachable!("signer key must stay lazy"))
-            .expect("no signer key needed")
-            .is_empty());
         // With extras and --no-signer, only the extras are granted.
         let key_b = PublicKey::from(KEY_B.parse::<CliPublicKey>().unwrap());
         assert_eq!(

--- a/tools/manager/src/commands/market/create.rs
+++ b/tools/manager/src/commands/market/create.rs
@@ -42,7 +42,7 @@ struct MarketInitArgs {
 
 impl Create {
     pub fn try_into_spec(self) -> anyhow::Result<spec::Create> {
-        let full_access_keys = self.full_access_keys.resolve(self.signer.public_key()?);
+        let full_access_keys = self.full_access_keys.resolve(|| self.signer.public_key())?;
         let file = std::fs::File::open(&self.init_args_file).with_context(|| {
             format!(
                 "open market init args from {}",

--- a/tools/manager/src/commands/proxy_oracle/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/create.rs
@@ -64,7 +64,7 @@ impl Create {
             check_owner_id_is_honored(&self.version_key, owner_id)?;
         }
 
-        let full_access_keys = self.full_access_keys.resolve(self.signer.public_key()?);
+        let full_access_keys = self.full_access_keys.resolve(|| self.signer.public_key())?;
 
         Ok(spec::Create {
             registry_id: self.registry_id,

--- a/tools/manager/src/commands/proxy_oracle/governance/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/create.rs
@@ -50,7 +50,6 @@ struct GovernanceInit {
 
 impl GovernanceCreate {
     pub fn try_into_spec(self) -> anyhow::Result<registry_spec::Deploy> {
-        let signer_public_key = self.signer.public_key()?;
         let ttls = match self.ttls_file {
             Some(path) => load_json_file(&path).context("parse TtlConfig")?,
             None => uniform_ttls(self.ttl_default),
@@ -63,6 +62,7 @@ impl GovernanceCreate {
         };
         let init_args = serde_json::to_vec(&init).context("encode governance init args")?;
 
-        Ok(self.common.into_deploy(signer_public_key, init_args))
+        let signer = self.signer;
+        self.common.into_deploy(|| signer.public_key(), init_args)
     }
 }

--- a/tools/manager/src/commands/proxy_oracle/governance/create_proposal.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/create_proposal.rs
@@ -36,7 +36,7 @@ pub struct CreateProposal {
     requested_ttl: Nanoseconds,
     /// After creating, wait for the proposal's TTL to elapse, then execute it.
     /// Blocks for the full (effective) TTL, so it is only practical for short ones.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "print")]
     execute_when_ready: bool,
     #[command(flatten)]
     pub(crate) signer: SignerArgs,

--- a/tools/manager/src/commands/proxy_oracle/governance/execute_proposal.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/execute_proposal.rs
@@ -14,7 +14,7 @@ pub struct ExecuteProposalArgs {
     id: u32,
     /// Wait for the proposal's TTL to elapse before executing, instead of
     /// failing if it has not yet matured.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "print")]
     when_ready: bool,
     #[command(flatten)]
     pub(crate) signer: SignerArgs,

--- a/tools/manager/src/commands/proxy_oracle/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/mod.rs
@@ -26,7 +26,7 @@ pub enum ProxyOracleNs {
     /// Deploy a proxy oracle from a registry, optionally owned by `--owner-id`.
     Create(Create),
     /// Administer a proxy oracle through its governance contract.
-    #[command(subcommand, visible_aliases = ["gov", "g"])]
+    #[command(subcommand, visible_alias = "gov")]
     Governance(ProxyOracleGovernanceNs),
     /// Read a single price feed's proxy configuration.
     GetProxy(GetProxy),

--- a/tools/manager/src/commands/proxy_oracle/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/mod.rs
@@ -26,7 +26,7 @@ pub enum ProxyOracleNs {
     /// Deploy a proxy oracle from a registry, optionally owned by `--owner-id`.
     Create(Create),
     /// Administer a proxy oracle through its governance contract.
-    #[command(subcommand, visible_alias = "gov")]
+    #[command(subcommand, visible_aliases = ["gov", "g"])]
     Governance(ProxyOracleGovernanceNs),
     /// Read a single price feed's proxy configuration.
     GetProxy(GetProxy),

--- a/tools/manager/src/commands/redstone/create.rs
+++ b/tools/manager/src/commands/redstone/create.rs
@@ -89,7 +89,6 @@ impl Create {
     }
 
     pub fn try_into_spec(self) -> anyhow::Result<registry_spec::Deploy> {
-        let signer_public_key = self.signer.public_key()?;
         let init_args = if let Some(preset) = self.preset {
             let config = match preset {
                 Preset::Prod => config::prod(),
@@ -105,7 +104,8 @@ impl Create {
         } else {
             bail!("provide --preset, --init-args, or --init-args-file");
         };
-        let deploy = self.common.into_deploy(signer_public_key, init_args);
+        let signer = self.signer;
+        let deploy = self.common.into_deploy(|| signer.public_key(), init_args)?;
 
         check_new_requires_admin_id(&deploy.version_key)?;
 

--- a/tools/manager/src/commands/registry/deploy.rs
+++ b/tools/manager/src/commands/registry/deploy.rs
@@ -33,7 +33,6 @@ pub struct Deploy {
 
 impl Deploy {
     pub fn try_into_spec(self) -> anyhow::Result<spec::Deploy> {
-        let signer_public_key = self.signer.public_key()?;
         // clap's required, mutually-exclusive `init` group guarantees exactly one
         // source is present.
         let init_bytes = match (self.init_args, self.init_args_file) {
@@ -46,6 +45,7 @@ impl Deploy {
                 .with_context(|| format!("read init args from {}", path.display()))?,
             (None, None) => unreachable!("clap requires one of --init-args / --init-args-file"),
         };
-        Ok(self.common.into_deploy(signer_public_key, init_bytes))
+        let signer = self.signer;
+        self.common.into_deploy(|| signer.public_key(), init_bytes)
     }
 }

--- a/tools/manager/src/commands/registry/remove_version.rs
+++ b/tools/manager/src/commands/registry/remove_version.rs
@@ -16,7 +16,7 @@ pub struct RemoveVersion {
     #[arg(long, value_name = "KEY")]
     version_key: Option<String>,
     /// Remove every version currently in the registry.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "print")]
     all: bool,
     #[command(flatten)]
     pub(crate) signer: SignerArgs,

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -3,25 +3,30 @@
 //! parser: a write with no credentials can't parse, and credentials on a read are
 //! an unexpected argument — enforcement lives in clap, not a runtime check.
 
-use std::fmt;
+use std::{ffi::OsStr, fmt};
 
-use clap::Args;
+use clap::{builder::TypedValueParser, error::ErrorKind, Args, ValueEnum};
 use near_account_id::AccountId;
-use near_api::SecretKey;
+use near_api::{PublicKey as CliPublicKey, SecretKey};
 use templar_gateway_types::{primitive::PublicKey, ManagedAccountId};
 
 /// Placeholder for the secret key in `Debug` output, so `{:?}` on a command that
 /// flattens these args never echoes credentials.
 const REDACTED: &str = "<redacted>";
 
-/// The account that signs a write and its secret key — both required. Flatten
-/// into every write command's args so the pairing is structural: neither half
-/// can be supplied without the other.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+pub(crate) enum PrintFormat {
+    Json,
+    Sputnik,
+}
+
+/// The account authorizing a write and either its execution credential or its
+/// plan-only output format. Clap enforces the credential-mode split.
 ///
 /// `Debug` is hand-written to redact `secret_key`; do not derive it.
 #[derive(Args, Clone)]
 pub struct SignerArgs {
-    /// Account that signs the transaction.
+    /// Account that signs the transaction, or the DAO account that will execute a plan.
     #[arg(long, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
     signer_id: AccountId,
     /// Private key for `--signer-id`, in `ed25519:…` form.
@@ -29,16 +34,32 @@ pub struct SignerArgs {
         long,
         env = "SECRET_KEY",
         hide_env_values = true,
-        value_name = "SECRET_KEY"
+        value_name = "SECRET_KEY",
+        required_unless_present = "print",
+        conflicts_with = "print",
+        value_parser = SecretKeyParser
     )]
-    secret_key: String,
+    secret_key: Option<Box<SecretKey>>,
+    /// Plan the write without executing it, then print the selected representation.
+    #[arg(long, value_enum, value_name = "FORMAT")]
+    print: Option<PrintFormat>,
+    /// Public key embedded by deploy/create writes in plan-only mode.
+    #[arg(
+        long,
+        value_name = "PUBLIC_KEY",
+        requires = "print",
+        conflicts_with = "secret_key"
+    )]
+    public_key: Option<CliPublicKey>,
 }
 
 impl fmt::Debug for SignerArgs {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("SignerArgs")
+            .field("secret_key", &self.secret_key.as_ref().map(|_| REDACTED))
             .field("signer_id", &self.signer_id)
-            .field("secret_key", &REDACTED)
+            .field("print", &self.print)
+            .field("public_key", &self.public_key)
             .finish()
     }
 }
@@ -49,9 +70,22 @@ impl SignerArgs {
         ManagedAccountId::from(self.signer_id.clone())
     }
 
+    /// The requested plan-only output format.
+    pub const fn print(&self) -> Option<PrintFormat> {
+        self.print
+    }
+
     /// The signer's public key, used by from-registry deploys that grant it a
     /// full access key on the new account.
     pub fn public_key(&self) -> anyhow::Result<PublicKey> {
+        if let Some(public_key) = &self.public_key {
+            return Ok(PublicKey::from(*public_key));
+        }
+        if self.print.is_some() {
+            anyhow::bail!(
+                "--public-key is required with --print for writes that embed the signer's key"
+            );
+        }
         Ok(PublicKey::from(self.secret()?.public_key()))
     }
 
@@ -61,7 +95,13 @@ impl SignerArgs {
     }
 
     fn secret(&self) -> anyhow::Result<SecretKey> {
-        parse_secret_key(&self.secret_key)
+        if self.print.is_some() {
+            anyhow::bail!("--print is not supported for this orchestrated write");
+        }
+        self.secret_key
+            .as_deref()
+            .cloned()
+            .ok_or_else(|| anyhow::anyhow!("missing --secret-key"))
     }
 }
 
@@ -77,9 +117,10 @@ pub struct SecretKeyArgs {
         long,
         env = "SECRET_KEY",
         hide_env_values = true,
-        value_name = "SECRET_KEY"
+        value_name = "SECRET_KEY",
+        value_parser = SecretKeyParser
     )]
-    secret_key: String,
+    secret_key: Box<SecretKey>,
 }
 
 impl fmt::Debug for SecretKeyArgs {
@@ -92,16 +133,34 @@ impl fmt::Debug for SecretKeyArgs {
 
 impl SecretKeyArgs {
     /// The parsed secret key.
-    pub fn secret(&self) -> anyhow::Result<SecretKey> {
-        parse_secret_key(&self.secret_key)
+    pub fn secret(&self) -> SecretKey {
+        self.secret_key.as_ref().clone()
     }
 }
 
-/// Parse a secret key without echoing the input in the error (it is a secret).
-fn parse_secret_key(secret_key: &str) -> anyhow::Result<SecretKey> {
-    secret_key
-        .parse::<SecretKey>()
-        .map_err(|_| anyhow::anyhow!("invalid --secret-key"))
+/// Parse a secret key at the clap boundary without placing its source text in
+/// the validation error.
+#[derive(Clone)]
+struct SecretKeyParser;
+
+impl TypedValueParser for SecretKeyParser {
+    type Value = Box<SecretKey>;
+
+    fn parse_ref(
+        &self,
+        command: &clap::Command,
+        _argument: Option<&clap::Arg>,
+        value: &OsStr,
+    ) -> Result<Self::Value, clap::Error> {
+        value
+            .to_str()
+            .and_then(|value| value.parse().ok())
+            .map(Box::new)
+            .ok_or_else(|| {
+                clap::Error::raw(ErrorKind::ValueValidation, "invalid --secret-key")
+                    .with_cmd(command)
+            })
+    }
 }
 
 #[cfg(test)]
@@ -110,6 +169,7 @@ mod tests {
     use clap::Parser;
 
     const SECRET: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
+    const PUBLIC: &str = "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w";
 
     #[derive(Parser)]
     struct Harness {
@@ -141,5 +201,76 @@ mod tests {
             rendered.contains("signer.testnet"),
             "signer id missing: {rendered}"
         );
+    }
+
+    #[test]
+    fn invalid_secret_key_is_rejected_without_echoing_it() {
+        let invalid = "ed25519:sensitive-but-invalid";
+        let error = Harness::try_parse_from([
+            "tmplrmgr",
+            "--signer-id",
+            "signer.testnet",
+            "--secret-key",
+            invalid,
+        ])
+        .err()
+        .expect("invalid secret should fail at the clap boundary");
+        let rendered = error.to_string();
+        assert!(rendered.contains("invalid --secret-key"), "{rendered}");
+        assert!(!rendered.contains(invalid), "secret leaked: {rendered}");
+    }
+
+    #[test]
+    fn plan_public_key_is_explicit_and_never_resolves_credentials() {
+        let public_key: CliPublicKey = PUBLIC.parse().expect("valid public key");
+        let signer = SignerArgs {
+            signer_id: "dao.near".parse().expect("valid account"),
+            secret_key: None,
+            print: Some(PrintFormat::Sputnik),
+            public_key: Some(public_key),
+        };
+
+        assert_eq!(
+            signer.public_key().expect("explicit plan key"),
+            PublicKey::from(public_key)
+        );
+        assert_eq!(signer.print(), Some(PrintFormat::Sputnik));
+        assert_eq!(
+            signer
+                .resolve()
+                .expect_err("plan mode has no execution credentials")
+                .to_string(),
+            "--print is not supported for this orchestrated write"
+        );
+    }
+
+    #[test]
+    fn plan_write_that_embeds_a_key_requires_public_key() {
+        let signer = SignerArgs {
+            signer_id: "dao.near".parse().expect("valid account"),
+            secret_key: None,
+            print: Some(PrintFormat::Json),
+            public_key: None,
+        };
+
+        assert!(signer
+            .public_key()
+            .expect_err("plan must not invent a public key")
+            .to_string()
+            .contains("--public-key"));
+    }
+
+    #[test]
+    fn execution_public_key_is_derived_from_typed_secret() {
+        let secret_key: SecretKey = SECRET.parse().expect("valid secret");
+        let expected = PublicKey::from(secret_key.public_key());
+        let signer = SignerArgs {
+            signer_id: "signer.testnet".parse().expect("valid account"),
+            secret_key: Some(Box::new(secret_key)),
+            print: None,
+            public_key: None,
+        };
+
+        assert_eq!(signer.public_key().expect("derived public key"), expected);
     }
 }

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -1,7 +1,7 @@
-//! Signer credentials as structural, per-operation arguments. Flattening these
-//! into a write command's args makes the invalid states unrepresentable at the
-//! parser: a write with no credentials can't parse, and credentials on a read are
-//! an unexpected argument — enforcement lives in clap, not a runtime check.
+//! Per-operation signer inputs. Clap selects either execution credentials or a
+//! plan-only output format on every write; reads reject signer arguments.
+//! Dispatch rejects print mode only for orchestrated writes that cannot produce
+//! one transaction without performing execution steps.
 
 use std::{ffi::OsStr, fmt};
 
@@ -91,16 +91,15 @@ impl SignerArgs {
 
     /// The signing account together with its secret key.
     pub fn resolve(&self) -> anyhow::Result<(ManagedAccountId, SecretKey)> {
-        Ok((self.account_id(), self.secret()?))
+        Ok((self.account_id(), self.secret()?.clone()))
     }
 
-    fn secret(&self) -> anyhow::Result<SecretKey> {
+    fn secret(&self) -> anyhow::Result<&SecretKey> {
         if self.print.is_some() {
             anyhow::bail!("--print is not supported for this orchestrated write");
         }
         self.secret_key
             .as_deref()
-            .cloned()
             .ok_or_else(|| anyhow::anyhow!("missing --secret-key"))
     }
 }
@@ -169,7 +168,6 @@ mod tests {
     use clap::Parser;
 
     const SECRET: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
-    const PUBLIC: &str = "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w";
 
     #[derive(Parser)]
     struct Harness {
@@ -204,37 +202,14 @@ mod tests {
     }
 
     #[test]
-    fn invalid_secret_key_is_rejected_without_echoing_it() {
-        let invalid = "ed25519:sensitive-but-invalid";
-        let error = Harness::try_parse_from([
-            "tmplrmgr",
-            "--signer-id",
-            "signer.testnet",
-            "--secret-key",
-            invalid,
-        ])
-        .err()
-        .expect("invalid secret should fail at the clap boundary");
-        let rendered = error.to_string();
-        assert!(rendered.contains("invalid --secret-key"), "{rendered}");
-        assert!(!rendered.contains(invalid), "secret leaked: {rendered}");
-    }
-
-    #[test]
-    fn plan_public_key_is_explicit_and_never_resolves_credentials() {
-        let public_key: CliPublicKey = PUBLIC.parse().expect("valid public key");
+    fn plan_mode_rejects_credential_resolution() {
         let signer = SignerArgs {
             signer_id: "dao.near".parse().expect("valid account"),
             secret_key: None,
             print: Some(PrintFormat::Sputnik),
-            public_key: Some(public_key),
+            public_key: None,
         };
 
-        assert_eq!(
-            signer.public_key().expect("explicit plan key"),
-            PublicKey::from(public_key)
-        );
-        assert_eq!(signer.print(), Some(PrintFormat::Sputnik));
         assert_eq!(
             signer
                 .resolve()

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -1,6 +1,6 @@
 //! CLI gateway context and the shared helpers for reading, planning, executing,
-//! reporting, and printing. Credentials remain on each write command rather than
-//! in this context.
+//! reporting, and printing. Execution credentials and plan output selection
+//! remain on each write command rather than in this context.
 
 use anyhow::Context as _;
 use near_api::{types::transaction::actions::Action, NetworkConfig, SecretKey};
@@ -37,9 +37,9 @@ pub(crate) struct CliContext {
 
 impl CliContext {
     /// Build a single-signer client for `account_id` from `secret_key`. Each
-    /// write signs with credentials carried by its own command, and teardown
-    /// flows (e.g. `registry clear-deployments`) sign many discovered accounts
-    /// with one authorized key.
+    /// executed write signs with credentials carried by its own command, and
+    /// teardown flows (e.g. `registry clear-deployments`) sign many discovered
+    /// accounts with one authorized key.
     pub(crate) fn signing_client(
         &self,
         account_id: impl Into<ManagedAccountId>,
@@ -250,24 +250,22 @@ fn sputnik_function_call(
             let Action::FunctionCall(action) = action else {
                 anyhow::bail!("--print sputnik supports FunctionCall actions only");
             };
-            Ok(serde_json::json!({
+            // `ActionCall` is public but its fields are private, so construct
+            // each action through the contract's JSON boundary.
+            serde_json::from_value(serde_json::json!({
                 "method_name": action.method_name,
                 "args": Base64VecU8(action.args),
                 "deposit": action.deposit,
                 "gas": action.gas,
             }))
+            .context("build Sputnik FunctionCall action")
         })
-        .collect::<anyhow::Result<Vec<_>>>()?;
+        .collect::<anyhow::Result<Vec<sputnikdao2::proposals::ActionCall>>>()?;
 
-    // Sputnik's canonical `ActionCall` fields are private, so construct its
-    // public `ProposalKind` through the same JSON boundary the contract uses.
-    serde_json::from_value(serde_json::json!({
-        "FunctionCall": {
-            "receiver_id": transaction.receiver_id,
-            "actions": actions,
-        }
-    }))
-    .context("build Sputnik FunctionCall proposal kind")
+    Ok(sputnikdao2::ProposalKind::FunctionCall {
+        receiver_id: transaction.receiver_id,
+        actions,
+    })
 }
 
 /// Serialize `output` as a single line of JSON to stdout — the machine-readable

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -4,11 +4,17 @@
 //! context's whole surface lives together rather than scattered across dispatch.
 
 use anyhow::Context as _;
-use near_api::{NetworkConfig, SecretKey};
-use serde::Serialize;
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use near_account_id::AccountId;
+use near_api::{types::transaction::actions::Action, NetworkConfig, SecretKey};
+use near_sdk::json_types::{U128, U64};
+use serde::{Serialize, Serializer};
 use std::io::Write as _;
 use templar_gateway_client::{Client, NetworkConfigBuilder};
-use templar_gateway_core::{DispatchRead, GatewayContext, GatewayContextBuilder, PlanWrite};
+use templar_gateway_core::{
+    DispatchRead, GatewayContext, GatewayContextBuilder, OperationPlan, PlanWrite,
+    PlannedTransaction,
+};
 use templar_gateway_methods_dispatch::Dispatch;
 use templar_gateway_oracle_updates_dispatch::{
     build_oracle_updates_context, Dispatch as OracleUpdatesDispatch,
@@ -16,12 +22,13 @@ use templar_gateway_oracle_updates_dispatch::{
     RedStoneSourceArgs, WithLazerSource, WithRedStoneSource,
 };
 use templar_gateway_types::{
-    common::WriteOperationResult, operation::ReceiptStatus, ManagedAccountId, MethodSpec,
-    OperationStatus,
+    common::{WriteOperationResult, WriteRequest},
+    operation::ReceiptStatus,
+    ManagedAccountId, MethodSpec, OperationStatus,
 };
 
 use crate::cli::Cli;
-use crate::commands::signer::SignerArgs;
+use crate::commands::signer::{PrintFormat, SignerArgs};
 
 pub(crate) struct CliContext {
     /// An unsigned client for reads. Writes build a per-operation signing client
@@ -57,25 +64,33 @@ impl CliContext {
         print_json(&output)
     }
 
-    /// Execute a write signed by `signer`, report the tx link, print the JSON
-    /// result, then fail unless the operation succeeded on chain.
+    /// Plan and print a write when `signer` selects a format; otherwise execute
+    /// it, report the tx link, print the result, and require on-chain success.
     pub(crate) async fn write<S>(&self, signer: SignerArgs, body: S) -> anyhow::Result<()>
     where
         S: MethodSpec<Output = WriteOperationResult>,
         Dispatch: PlanWrite<S, GatewayContext>,
     {
+        if let Some(format) = signer.print() {
+            let plan = self
+                .client
+                .plan_request(WriteRequest {
+                    signer_account_id: signer.account_id(),
+                    idempotency_key: None,
+                    body,
+                })
+                .await?;
+            return print_plan(format, &plan);
+        }
+
         let (account_id, secret_key) = signer.resolve()?;
         let client = self.signing_client(account_id.clone(), secret_key)?;
         let output = client.execute_as(account_id, body).await?;
         self.finish_write(&output)
     }
 
-    /// Execute an `oracle.*` write through [`OracleUpdatesDispatch`], whose context must
-    /// carry the in-process payload sources that method fetches from. `layer_sources`
-    /// builds that context from the base one, so each method constructs only the sources
-    /// its `PlanWrite` bound names — `oracle.updateRedStone` needs no Lazer token, and
-    /// `oracle.updatePyth`, whose VAA arrives in the request body, passes `Ok` to plan
-    /// against the bare [`GatewayContext`].
+    /// Plan or execute an `oracle.*` write through [`OracleUpdatesDispatch`],
+    /// whose context carries the in-process payload sources the method fetches.
     pub(crate) async fn oracle_write<S, Ctx>(
         &self,
         signer: SignerArgs,
@@ -87,13 +102,31 @@ impl CliContext {
         Ctx: Clone,
         OracleUpdatesDispatch: PlanWrite<S, Ctx>,
     {
-        let (account_id, secret_key) = signer.resolve()?;
-        let (base_context, driver, signer_account_ids) = Client::builder(self.network.clone())
-            .secret_key(account_id.clone(), secret_key)?
-            .build_parts()
-            .context("build oracle-updates client")?;
+        let account_id = signer.account_id();
+        let builder = Client::builder(self.network.clone());
+        let (base_context, driver, signer_account_ids) = if signer.print().is_some() {
+            builder.build_parts()
+        } else {
+            let (_, secret_key) = signer.resolve()?;
+            builder
+                .secret_key(account_id.clone(), secret_key)?
+                .build_parts()
+        }
+        .context("build oracle-updates client")?;
         let client: Client<OracleUpdatesDispatch, Ctx> =
             Client::from_parts(layer_sources(base_context)?, driver, signer_account_ids);
+
+        if let Some(format) = signer.print() {
+            let plan = client
+                .plan_request(WriteRequest {
+                    signer_account_id: account_id,
+                    idempotency_key: None,
+                    body,
+                })
+                .await?;
+            return print_plan(format, &plan);
+        }
+
         let output = client.execute_as(account_id, body).await?;
         self.finish_write(&output)
     }
@@ -196,6 +229,77 @@ pub(crate) fn check_operation_status(result: &WriteOperationResult) -> anyhow::R
     }
 }
 
+fn print_plan(format: PrintFormat, plan: &OperationPlan) -> anyhow::Result<()> {
+    let transaction = single_transaction(plan)?;
+    match format {
+        PrintFormat::Json => print_json(transaction),
+        PrintFormat::Sputnik => print_json(&sputnik_function_call(transaction)?),
+    }
+}
+
+fn single_transaction(plan: &OperationPlan) -> anyhow::Result<&PlannedTransaction> {
+    match plan.steps.as_slice() {
+        [transaction] => Ok(transaction),
+        steps => anyhow::bail!(
+            "--print requires exactly one planned transaction; planned {}",
+            steps.len()
+        ),
+    }
+}
+
+#[derive(Serialize)]
+enum SputnikProposalKind<'a> {
+    FunctionCall {
+        receiver_id: &'a AccountId,
+        actions: Vec<SputnikAction<'a>>,
+    },
+}
+
+#[derive(Serialize)]
+struct SputnikAction<'a> {
+    method_name: &'a str,
+    args: Base64<'a>,
+    deposit: U128,
+    gas: U64,
+}
+
+#[derive(Clone, Copy)]
+struct Base64<'a>(&'a [u8]);
+
+impl Serialize for Base64<'_> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&BASE64_STANDARD.encode(self.0))
+    }
+}
+
+fn sputnik_function_call(
+    transaction: &PlannedTransaction,
+) -> anyhow::Result<SputnikProposalKind<'_>> {
+    let actions = transaction
+        .actions
+        .iter()
+        .map(|action| {
+            let Action::FunctionCall(action) = action else {
+                anyhow::bail!("--print sputnik supports FunctionCall actions only");
+            };
+            Ok(SputnikAction {
+                method_name: &action.method_name,
+                args: Base64(&action.args),
+                deposit: U128(action.deposit.as_yoctonear()),
+                gas: U64(action.gas.as_gas()),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    Ok(SputnikProposalKind::FunctionCall {
+        receiver_id: &transaction.receiver_id,
+        actions,
+    })
+}
+
 /// Serialize `output` as a single line of JSON to stdout — the machine-readable
 /// result channel (diagnostics go to stderr via tracing).
 pub(crate) fn print_json(output: &impl Serialize) -> anyhow::Result<()> {
@@ -225,9 +329,14 @@ pub(crate) fn build_context(cli: &Cli) -> anyhow::Result<CliContext> {
 
 #[cfg(test)]
 mod tests {
-    use super::check_operation_status;
+    use super::{check_operation_status, single_transaction, sputnik_function_call};
+    use near_account_id::AccountId;
+    use near_api::types::transaction::actions::{Action, FunctionCallAction, TransferAction};
     use serde_json::json;
-    use templar_gateway_types::common::WriteOperationResult;
+    use templar_gateway_core::{OperationPlan, PlannedTransaction};
+    use templar_gateway_types::{
+        common::WriteOperationResult, ManagedAccountId, NearGas, NearToken,
+    };
 
     /// A single-step write result with the given operation status and a reverted
     /// step whose first receipt has `receipt_status`.
@@ -255,6 +364,97 @@ mod tests {
             }
         }))
         .expect("valid WriteOperationResult json")
+    }
+
+    fn function_call_transaction() -> PlannedTransaction {
+        PlannedTransaction::single_action(
+            ManagedAccountId::from("dao.near".parse::<AccountId>().expect("valid signer")),
+            "governance.testnet".parse().expect("valid receiver"),
+            Action::FunctionCall(Box::new(FunctionCallAction {
+                method_name: "execute_proposal".to_owned(),
+                args: br#"{"id":4}"#.to_vec(),
+                gas: NearGas::from_tgas(300),
+                deposit: NearToken::from_yoctonear(1),
+            })),
+        )
+    }
+
+    #[test]
+    fn sputnik_renders_paste_ready_function_call_kind() {
+        let transaction = function_call_transaction();
+        let value = serde_json::to_value(
+            sputnik_function_call(&transaction).expect("FunctionCall plan should render"),
+        )
+        .expect("Sputnik kind should serialize");
+
+        assert_eq!(
+            value,
+            json!({
+                "FunctionCall": {
+                    "receiver_id": "governance.testnet",
+                    "actions": [{
+                        "method_name": "execute_proposal",
+                        "args": "eyJpZCI6NH0=",
+                        "deposit": "1",
+                        "gas": "300000000000000"
+                    }]
+                }
+            })
+        );
+        assert!(
+            value.get("signer_account_id").is_none(),
+            "Sputnik kind must discard the planning signer"
+        );
+    }
+
+    #[test]
+    fn sputnik_rejects_non_function_call_actions() {
+        let transaction = PlannedTransaction::single_action(
+            ManagedAccountId::from("dao.near".parse::<AccountId>().expect("valid signer")),
+            "receiver.testnet".parse().expect("valid receiver"),
+            Action::Transfer(TransferAction {
+                deposit: NearToken::from_yoctonear(1),
+            }),
+        );
+
+        let error = sputnik_function_call(&transaction)
+            .err()
+            .expect("Sputnik FunctionCall cannot represent a transfer");
+        assert_eq!(
+            error.to_string(),
+            "--print sputnik supports FunctionCall actions only"
+        );
+        assert!(
+            serde_json::to_value(&transaction).is_ok(),
+            "the same transaction remains valid JSON output"
+        );
+    }
+
+    #[test]
+    fn print_requires_exactly_one_planned_transaction() {
+        let transaction = function_call_transaction();
+        assert_eq!(
+            single_transaction(&OperationPlan::single(transaction.clone()))
+                .expect("single step")
+                .receiver_id,
+            transaction.receiver_id
+        );
+
+        for plan in [
+            OperationPlan { steps: vec![] },
+            OperationPlan {
+                steps: vec![transaction.clone(), transaction.clone()],
+            },
+        ] {
+            let error =
+                single_transaction(&plan).expect_err("non-single plan must not be rendered");
+            assert!(
+                error
+                    .to_string()
+                    .starts_with("--print requires exactly one planned transaction"),
+                "{error}"
+            );
+        }
     }
 
     #[test]

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -3,9 +3,8 @@
 //! in this context.
 
 use anyhow::Context as _;
-use near_account_id::AccountId;
 use near_api::{types::transaction::actions::Action, NetworkConfig, SecretKey};
-use near_sdk::json_types::{U128, U64};
+use near_sdk::json_types::Base64VecU8;
 use serde::Serialize;
 use std::io::Write as _;
 use templar_gateway_client::{Client, NetworkConfigBuilder};
@@ -22,7 +21,6 @@ use templar_gateway_oracle_updates_dispatch::{
 use templar_gateway_types::{
     common::{WriteOperationResult, WriteRequest},
     operation::ReceiptStatus,
-    primitive::Base64Bytes,
     ManagedAccountId, MethodSpec, OperationStatus,
 };
 
@@ -242,23 +240,9 @@ fn single_transaction(plan: OperationPlan) -> anyhow::Result<PlannedTransaction>
     Ok(transaction)
 }
 
-#[derive(Serialize)]
-enum SputnikProposalKind {
-    FunctionCall {
-        receiver_id: AccountId,
-        actions: Vec<SputnikAction>,
-    },
-}
-
-#[derive(Serialize)]
-struct SputnikAction {
-    method_name: String,
-    args: Base64Bytes,
-    deposit: U128,
-    gas: U64,
-}
-
-fn sputnik_function_call(transaction: PlannedTransaction) -> anyhow::Result<SputnikProposalKind> {
+fn sputnik_function_call(
+    transaction: PlannedTransaction,
+) -> anyhow::Result<sputnikdao2::ProposalKind> {
     let actions = transaction
         .actions
         .into_iter()
@@ -266,19 +250,24 @@ fn sputnik_function_call(transaction: PlannedTransaction) -> anyhow::Result<Sput
             let Action::FunctionCall(action) = action else {
                 anyhow::bail!("--print sputnik supports FunctionCall actions only");
             };
-            Ok(SputnikAction {
-                method_name: action.method_name,
-                args: Base64Bytes(action.args),
-                deposit: U128(action.deposit.as_yoctonear()),
-                gas: U64(action.gas.as_gas()),
-            })
+            Ok(serde_json::json!({
+                "method_name": action.method_name,
+                "args": Base64VecU8(action.args),
+                "deposit": action.deposit,
+                "gas": action.gas,
+            }))
         })
         .collect::<anyhow::Result<Vec<_>>>()?;
 
-    Ok(SputnikProposalKind::FunctionCall {
-        receiver_id: transaction.receiver_id,
-        actions,
-    })
+    // Sputnik's canonical `ActionCall` fields are private, so construct its
+    // public `ProposalKind` through the same JSON boundary the contract uses.
+    serde_json::from_value(serde_json::json!({
+        "FunctionCall": {
+            "receiver_id": transaction.receiver_id,
+            "actions": actions,
+        }
+    }))
+    .context("build Sputnik FunctionCall proposal kind")
 }
 
 /// Serialize `output` as a single line of JSON to stdout — the machine-readable
@@ -395,9 +384,9 @@ mod tests {
         );
 
         let json_serializes = serde_json::to_value(&transaction).is_ok();
-        let error = sputnik_function_call(transaction)
-            .err()
-            .expect("Sputnik FunctionCall cannot represent a transfer");
+        let Err(error) = sputnik_function_call(transaction) else {
+            panic!("Sputnik FunctionCall cannot represent a transfer");
+        };
         assert_eq!(
             error.to_string(),
             "--print sputnik supports FunctionCall actions only"

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -1,14 +1,12 @@
-//! The CLI execution context: a gateway [`Client`] plus the resolved signer and
-//! presentation settings, and the small set of helpers every dispatch path uses
-//! to read, write, report, and print. Keeping this in one place means the
-//! context's whole surface lives together rather than scattered across dispatch.
+//! CLI gateway context and the shared helpers for reading, planning, executing,
+//! reporting, and printing. Credentials remain on each write command rather than
+//! in this context.
 
 use anyhow::Context as _;
-use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use near_account_id::AccountId;
 use near_api::{types::transaction::actions::Action, NetworkConfig, SecretKey};
 use near_sdk::json_types::{U128, U64};
-use serde::{Serialize, Serializer};
+use serde::Serialize;
 use std::io::Write as _;
 use templar_gateway_client::{Client, NetworkConfigBuilder};
 use templar_gateway_core::{
@@ -24,6 +22,7 @@ use templar_gateway_oracle_updates_dispatch::{
 use templar_gateway_types::{
     common::{WriteOperationResult, WriteRequest},
     operation::ReceiptStatus,
+    primitive::Base64Bytes,
     ManagedAccountId, MethodSpec, OperationStatus,
 };
 
@@ -31,8 +30,8 @@ use crate::cli::Cli;
 use crate::commands::signer::{PrintFormat, SignerArgs};
 
 pub(crate) struct CliContext {
-    /// An unsigned client for reads. Writes build a per-operation signing client
-    /// from the command's own credentials (see [`CliContext::signing_client`]).
+    /// An unsigned client for reads and ordinary write plans. Executed writes
+    /// build a per-operation signing client from their command's credentials.
     pub(crate) client: Client,
     network: NetworkConfig,
     transaction_url_prefix: String,
@@ -80,7 +79,7 @@ impl CliContext {
                     body,
                 })
                 .await?;
-            return print_plan(format, &plan);
+            return print_plan(format, plan);
         }
 
         let (account_id, secret_key) = signer.resolve()?;
@@ -102,31 +101,27 @@ impl CliContext {
         Ctx: Clone,
         OracleUpdatesDispatch: PlanWrite<S, Ctx>,
     {
-        let account_id = signer.account_id();
-        let builder = Client::builder(self.network.clone());
-        let (base_context, driver, signer_account_ids) = if signer.print().is_some() {
-            builder.build_parts()
-        } else {
-            let (_, secret_key) = signer.resolve()?;
-            builder
-                .secret_key(account_id.clone(), secret_key)?
-                .build_parts()
-        }
-        .context("build oracle-updates client")?;
-        let client: Client<OracleUpdatesDispatch, Ctx> =
-            Client::from_parts(layer_sources(base_context)?, driver, signer_account_ids);
-
         if let Some(format) = signer.print() {
-            let plan = client
-                .plan_request(WriteRequest {
-                    signer_account_id: account_id,
+            let context = layer_sources(GatewayContext::new(self.network.clone())?)?;
+            let plan = <OracleUpdatesDispatch as PlanWrite<S, Ctx>>::plan(
+                WriteRequest {
+                    signer_account_id: signer.account_id(),
                     idempotency_key: None,
                     body,
-                })
-                .await?;
-            return print_plan(format, &plan);
+                },
+                context,
+            )
+            .await?;
+            return print_plan(format, plan);
         }
 
+        let (account_id, secret_key) = signer.resolve()?;
+        let (base_context, driver, signer_account_ids) = Client::builder(self.network.clone())
+            .secret_key(account_id.clone(), secret_key)?
+            .build_parts()
+            .context("build oracle-updates client")?;
+        let client: Client<OracleUpdatesDispatch, Ctx> =
+            Client::from_parts(layer_sources(base_context)?, driver, signer_account_ids);
         let output = client.execute_as(account_id, body).await?;
         self.finish_write(&output)
     }
@@ -229,65 +224,51 @@ pub(crate) fn check_operation_status(result: &WriteOperationResult) -> anyhow::R
     }
 }
 
-fn print_plan(format: PrintFormat, plan: &OperationPlan) -> anyhow::Result<()> {
+fn print_plan(format: PrintFormat, plan: OperationPlan) -> anyhow::Result<()> {
     let transaction = single_transaction(plan)?;
     match format {
-        PrintFormat::Json => print_json(transaction),
+        PrintFormat::Json => print_json(&transaction),
         PrintFormat::Sputnik => print_json(&sputnik_function_call(transaction)?),
     }
 }
 
-fn single_transaction(plan: &OperationPlan) -> anyhow::Result<&PlannedTransaction> {
-    match plan.steps.as_slice() {
-        [transaction] => Ok(transaction),
-        steps => anyhow::bail!(
+fn single_transaction(plan: OperationPlan) -> anyhow::Result<PlannedTransaction> {
+    let [transaction] = plan.steps.try_into().map_err(|steps: Vec<_>| {
+        anyhow::anyhow!(
             "--print requires exactly one planned transaction; planned {}",
             steps.len()
-        ),
-    }
+        )
+    })?;
+    Ok(transaction)
 }
 
 #[derive(Serialize)]
-enum SputnikProposalKind<'a> {
+enum SputnikProposalKind {
     FunctionCall {
-        receiver_id: &'a AccountId,
-        actions: Vec<SputnikAction<'a>>,
+        receiver_id: AccountId,
+        actions: Vec<SputnikAction>,
     },
 }
 
 #[derive(Serialize)]
-struct SputnikAction<'a> {
-    method_name: &'a str,
-    args: Base64<'a>,
+struct SputnikAction {
+    method_name: String,
+    args: Base64Bytes,
     deposit: U128,
     gas: U64,
 }
 
-#[derive(Clone, Copy)]
-struct Base64<'a>(&'a [u8]);
-
-impl Serialize for Base64<'_> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(&BASE64_STANDARD.encode(self.0))
-    }
-}
-
-fn sputnik_function_call(
-    transaction: &PlannedTransaction,
-) -> anyhow::Result<SputnikProposalKind<'_>> {
+fn sputnik_function_call(transaction: PlannedTransaction) -> anyhow::Result<SputnikProposalKind> {
     let actions = transaction
         .actions
-        .iter()
+        .into_iter()
         .map(|action| {
             let Action::FunctionCall(action) = action else {
                 anyhow::bail!("--print sputnik supports FunctionCall actions only");
             };
             Ok(SputnikAction {
-                method_name: &action.method_name,
-                args: Base64(&action.args),
+                method_name: action.method_name,
+                args: Base64Bytes(action.args),
                 deposit: U128(action.deposit.as_yoctonear()),
                 gas: U64(action.gas.as_gas()),
             })
@@ -295,7 +276,7 @@ fn sputnik_function_call(
         .collect::<anyhow::Result<Vec<_>>>()?;
 
     Ok(SputnikProposalKind::FunctionCall {
-        receiver_id: &transaction.receiver_id,
+        receiver_id: transaction.receiver_id,
         actions,
     })
 }
@@ -310,9 +291,9 @@ pub(crate) fn print_json(output: &impl Serialize) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Build the execution context from parsed CLI args: the network and an unsigned
-/// gateway client (backed by a transient in-memory operation store) for reads.
-/// Writes sign per-operation with credentials carried by their own command.
+/// Build the CLI context: the selected network and an unsigned gateway client
+/// backed by a transient in-memory operation store. Reads and ordinary plans use
+/// that client; executed writes build a signing client per operation.
 pub(crate) fn build_context(cli: &Cli) -> anyhow::Result<CliContext> {
     let network = NetworkConfigBuilder::new(cli.network)
         .rpc_url(cli.rpc_url.as_deref())
@@ -383,7 +364,7 @@ mod tests {
     fn sputnik_renders_paste_ready_function_call_kind() {
         let transaction = function_call_transaction();
         let value = serde_json::to_value(
-            sputnik_function_call(&transaction).expect("FunctionCall plan should render"),
+            sputnik_function_call(transaction).expect("FunctionCall plan should render"),
         )
         .expect("Sputnik kind should serialize");
 
@@ -401,10 +382,6 @@ mod tests {
                 }
             })
         );
-        assert!(
-            value.get("signer_account_id").is_none(),
-            "Sputnik kind must discard the planning signer"
-        );
     }
 
     #[test]
@@ -417,7 +394,8 @@ mod tests {
             }),
         );
 
-        let error = sputnik_function_call(&transaction)
+        let json_serializes = serde_json::to_value(&transaction).is_ok();
+        let error = sputnik_function_call(transaction)
             .err()
             .expect("Sputnik FunctionCall cannot represent a transfer");
         assert_eq!(
@@ -425,7 +403,7 @@ mod tests {
             "--print sputnik supports FunctionCall actions only"
         );
         assert!(
-            serde_json::to_value(&transaction).is_ok(),
+            json_serializes,
             "the same transaction remains valid JSON output"
         );
     }
@@ -434,7 +412,7 @@ mod tests {
     fn print_requires_exactly_one_planned_transaction() {
         let transaction = function_call_transaction();
         assert_eq!(
-            single_transaction(&OperationPlan::single(transaction.clone()))
+            single_transaction(OperationPlan::single(transaction.clone()))
                 .expect("single step")
                 .receiver_id,
             transaction.receiver_id
@@ -446,8 +424,7 @@ mod tests {
                 steps: vec![transaction.clone(), transaction.clone()],
             },
         ] {
-            let error =
-                single_transaction(&plan).expect_err("non-single plan must not be rendered");
+            let error = single_transaction(plan).expect_err("non-single plan must not be rendered");
             assert!(
                 error
                     .to_string()

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -1,6 +1,6 @@
-//! Governance proposal orchestration: creating a proposal (with id and
-//! breaker-id auto-resolution, and optional wait-then-execute) and executing one
-//! after it matures.
+//! Governance proposal planning and orchestration: resolving proposal inputs,
+//! rendering plans, creating proposals, and optionally waiting for maturity
+//! before execution.
 
 use anyhow::Context as _;
 use near_account_id::AccountId;
@@ -13,11 +13,12 @@ use templar_gateway_types::{common::WriteOperationResult, ManagedAccountId};
 use crate::commands::proxy_oracle::{CreateProposal, ExecuteProposalArgs};
 use crate::context::{print_json, CliContext};
 
-/// Create a governance proposal. Resolves the proposal id (fetching the
+/// Plan or create a governance proposal. Resolves the proposal id (fetching the
 /// governance contract's next id when `--id` was omitted) and, for an
 /// `add-circuit-breaker` proposal without `--breaker-id`, the set's next breaker
-/// id. Always emits the resolved proposal id so scripts can learn it. With
-/// `--execute-when-ready`, waits for the proposal's TTL to elapse and executes.
+/// id. Print mode emits the selected plan representation without sending.
+/// Execution mode logs the resolved id, and `--execute-when-ready` waits for the
+/// proposal's TTL to elapse before executing it.
 pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow::Result<()> {
     let execute_when_ready = args.execute_when_ready();
     let signer_args = args.signer.clone();
@@ -74,9 +75,9 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
     })
 }
 
-/// Execute a governance proposal. With `--when-ready`, wait for its TTL to
-/// elapse first, so an early call blocks instead of failing on an immature
-/// proposal.
+/// Plan or execute a governance proposal. In execution mode, `--when-ready`
+/// waits for its TTL to elapse, so an early call blocks instead of failing on
+/// an immature proposal.
 pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyhow::Result<()> {
     let governance_id = args.target.resolve(&ctx).await?;
     if args.when_ready() {
@@ -136,9 +137,9 @@ async fn next_breaker_id(
     Ok(set.map_or(0, |set| set.next_id()))
 }
 
-/// Machine-readable result of a `create-proposal` run. `id` is always present
-/// (resolved even when auto-fetched); `execute` is present only when the
-/// proposal was executed via `--execute-when-ready`.
+/// Machine-readable result of an execution-mode `create-proposal` run. `id` is
+/// always present (resolved even when auto-fetched); `execute` is present only
+/// when the proposal was executed via `--execute-when-ready`.
 #[derive(Serialize)]
 struct CreateProposalOutput {
     id: u32,

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -19,10 +19,12 @@ use crate::context::{print_json, CliContext};
 /// id. Always emits the resolved proposal id so scripts can learn it. With
 /// `--execute-when-ready`, waits for the proposal's TTL to elapse and executes.
 pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow::Result<()> {
-    let (signer, secret_key) = args.signer.resolve()?;
-    let client = ctx.signing_client(signer.clone(), secret_key)?;
-    let governance_id = args.target.resolve(&ctx).await?;
     let execute_when_ready = args.execute_when_ready();
+    if execute_when_ready && args.signer.print().is_some() {
+        anyhow::bail!("--print is not supported with --execute-when-ready");
+    }
+    let signer_args = args.signer.clone();
+    let governance_id = args.target.resolve(&ctx).await?;
 
     // Auto-fill the next breaker id for add-circuit-breaker, resolving the proxy
     // oracle (whose set holds the breakers) through the governance contract. This
@@ -46,12 +48,14 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
         }
     };
 
-    let create = client
-        .execute_as(
-            signer.clone(),
-            args.try_into_spec(governance_id.clone(), id)?,
-        )
-        .await?;
+    let create_spec = args.try_into_spec(governance_id.clone(), id)?;
+    if signer_args.print().is_some() {
+        return ctx.write(signer_args, create_spec).await;
+    }
+
+    let (signer, secret_key) = signer_args.resolve()?;
+    let client = ctx.signing_client(signer.clone(), secret_key)?;
+    let create = client.execute_as(signer.clone(), create_spec).await?;
     // Fail fast if the create reverted, before waiting on / executing a proposal
     // that was never created.
     ctx.report_checked(&create)?;
@@ -77,6 +81,9 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
 /// elapse first, so an early call blocks instead of failing on an immature
 /// proposal.
 pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyhow::Result<()> {
+    if args.when_ready() && args.signer.print().is_some() {
+        anyhow::bail!("--print is not supported with --when-ready");
+    }
     let governance_id = args.target.resolve(&ctx).await?;
     if args.when_ready() {
         wait_for_maturity(&ctx, &governance_id, args.id()).await?;

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -20,9 +20,6 @@ use crate::context::{print_json, CliContext};
 /// `--execute-when-ready`, waits for the proposal's TTL to elapse and executes.
 pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow::Result<()> {
     let execute_when_ready = args.execute_when_ready();
-    if execute_when_ready && args.signer.print().is_some() {
-        anyhow::bail!("--print is not supported with --execute-when-ready");
-    }
     let signer_args = args.signer.clone();
     let governance_id = args.target.resolve(&ctx).await?;
 
@@ -81,9 +78,6 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
 /// elapse first, so an early call blocks instead of failing on an immature
 /// proposal.
 pub(super) async fn execute(ctx: CliContext, args: ExecuteProposalArgs) -> anyhow::Result<()> {
-    if args.when_ready() && args.signer.print().is_some() {
-        anyhow::bail!("--print is not supported with --when-ready");
-    }
     let governance_id = args.target.resolve(&ctx).await?;
     if args.when_ready() {
         wait_for_maturity(&ctx, &governance_id, args.id()).await?;

--- a/tools/manager/src/dispatch/teardown.rs
+++ b/tools/manager/src/dispatch/teardown.rs
@@ -141,7 +141,7 @@ pub(super) async fn clear_deployments(
     let beneficiary = args.beneficiary_id();
     let force = args.force();
     // One authorized key signs every discovered market's self-removal.
-    let secret_key = args.signer.secret()?;
+    let secret_key = args.signer.secret();
     // Only markets are torn down here (removal reads a market configuration), so
     // filter by kind rather than trying `remove_market` on every deployment.
     let accounts = ctx

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -126,6 +126,20 @@ const CREDS: [&str; 4] = [
     TEST_SECRET_KEY,
 ];
 
+fn try_parse_write<'a>(args: impl IntoIterator<Item = &'a str>) -> Result<Cli, clap::Error> {
+    Cli::try_parse_from(
+        [
+            "tmplrmgr",
+            "write",
+            "registry.removeVersion",
+            "--json",
+            r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+        ]
+        .into_iter()
+        .chain(args),
+    )
+}
+
 fn try_parse_governance<'a>(
     args: impl IntoIterator<Item = &'a str>,
 ) -> Result<ProxyOracleGovernanceNs, clap::Error> {
@@ -160,18 +174,7 @@ fn parse_create_proposal<'a>(args: impl IntoIterator<Item = &'a str>) -> CreateP
 
 #[test]
 fn parses_write_fallback_with_json() {
-    let cli = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-        "--signer-id",
-        "signer.testnet",
-        "--secret-key",
-        TEST_SECRET_KEY,
-    ])
-    .expect("write fallback should parse");
+    let cli = try_parse_write(CREDS).expect("write fallback should parse");
 
     match cli.command {
         super::cli::Command::Write(call) => {
@@ -209,20 +212,7 @@ fn write_fallback_does_not_require_a_lazer_key() {
 fn write_command_requires_credentials() {
     // With credentials structural on the write, omitting them is a parse error —
     // no build or network work is reachable.
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
-
-    let result = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-    ]);
-
-    // Restore before asserting: a panic here must not leak cleared env vars into
-    // later tests sharing this process.
-    restore();
+    let result = with_cleared_credential_env(|| try_parse_write([]));
     let error = result.expect_err("a write with no credentials should fail to parse");
     assert_eq!(
         error.kind(),
@@ -232,44 +222,19 @@ fn write_command_requires_credentials() {
 
 #[test]
 fn write_command_accepts_print_without_secret() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
-
-    let result = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "sputnik",
-    ]);
-
-    restore();
+    let result = with_cleared_credential_env(|| {
+        try_parse_write(["--signer-id", "dao.near", "--print", "sputnik"])
+    });
     let cli = result.expect("plan-only write should parse without a secret");
     let Command::Write(call) = cli.command else {
         panic!("expected Write variant");
     };
     assert_eq!(call.signer.print(), Some(PrintFormat::Sputnik));
-    assert_eq!(
-        call.signer
-            .resolve()
-            .expect_err("plan mode must not resolve signing credentials")
-            .to_string(),
-        "--print is not supported for this orchestrated write"
-    );
 }
 
 #[test]
 fn print_conflicts_with_secret_key() {
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+    let error = try_parse_write([
         "--signer-id",
         "dao.near",
         "--print",
@@ -287,17 +252,7 @@ fn print_conflicts_with_secret_key_from_environment() {
     let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
     let original_secret = std::env::var_os("SECRET_KEY");
     std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
-    let result = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-    ]);
+    let result = try_parse_write(["--signer-id", "dao.near", "--print", "json"]);
     restore_env("SECRET_KEY", original_secret);
 
     let error = result.expect_err("environment secret must conflict with --print");
@@ -306,12 +261,7 @@ fn print_conflicts_with_secret_key_from_environment() {
 
 #[test]
 fn public_key_requires_print_mode() {
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+    let error = try_parse_write([
         "--signer-id",
         "signer.testnet",
         "--secret-key",
@@ -344,18 +294,8 @@ fn read_command_rejects_credentials() {
 #[test]
 fn invalid_secret_key_error_does_not_echo_input() {
     let secret = "not-a-real-secret-key";
-    let error = Cli::try_parse_from([
-        "tmplrmgr",
-        "write",
-        "registry.removeVersion",
-        "--json",
-        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-        "--signer-id",
-        "signer.testnet",
-        "--secret-key",
-        secret,
-    ])
-    .expect_err("invalid secret key should fail at the clap boundary");
+    let error = try_parse_write(["--signer-id", "signer.testnet", "--secret-key", secret])
+        .expect_err("invalid secret key should fail at the clap boundary");
 
     let message = error.to_string();
     assert!(message.contains("invalid --secret-key"), "{message}");
@@ -373,14 +313,7 @@ fn signer_env_satisfies_write_credentials() {
     std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
 
     let result = (|| {
-        let cli = Cli::try_parse_from([
-            "tmplrmgr",
-            "write",
-            "registry.removeVersion",
-            "--json",
-            r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
-        ])
-        .map_err(|error| anyhow::anyhow!(error.to_string()))?;
+        let cli = try_parse_write([]).map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
         match cli.command {
             super::cli::Command::Write(call) => call.signer.resolve().map(|_| ()),
@@ -394,18 +327,18 @@ fn signer_env_satisfies_write_credentials() {
     result.expect("env-provided credentials should satisfy a write command");
 }
 
-/// Clear the credential env vars (under `ENV_LOCK`) so a "missing credentials"
-/// parse test isn't satisfied by an ambient `SIGNER_ID`/`SECRET_KEY`. Returns a
-/// closure that restores the originals.
-fn clear_credential_env() -> impl FnOnce() {
+/// Run `f` with ambient signer credentials cleared and environment mutation
+/// serialized, then restore the original values.
+fn with_cleared_credential_env<T>(f: impl FnOnce() -> T) -> T {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
     let original_signer = std::env::var_os("SIGNER_ID");
     let original_secret = std::env::var_os("SECRET_KEY");
     std::env::remove_var("SIGNER_ID");
     std::env::remove_var("SECRET_KEY");
-    move || {
-        restore_env("SIGNER_ID", original_signer);
-        restore_env("SECRET_KEY", original_secret);
-    }
+    let result = f();
+    restore_env("SIGNER_ID", original_signer);
+    restore_env("SECRET_KEY", original_secret);
+    result
 }
 
 fn restore_env(key: &str, original: Option<std::ffi::OsString>) {

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -4,6 +4,7 @@ use clap::{CommandFactory, Parser};
 
 use super::cli::{Cli, Command};
 use super::commands::proxy_oracle::{CreateProposal, ProxyOracleGovernanceNs, ProxyOracleNs};
+use super::commands::signer::PrintFormat;
 
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
@@ -230,6 +231,100 @@ fn write_command_requires_credentials() {
 }
 
 #[test]
+fn write_command_accepts_print_without_secret() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+
+    let result = Cli::try_parse_from([
+        "tmplrmgr",
+        "write",
+        "registry.removeVersion",
+        "--json",
+        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "sputnik",
+    ]);
+
+    restore();
+    let cli = result.expect("plan-only write should parse without a secret");
+    let Command::Write(call) = cli.command else {
+        panic!("expected Write variant");
+    };
+    assert_eq!(call.signer.print(), Some(PrintFormat::Sputnik));
+    assert_eq!(
+        call.signer
+            .resolve()
+            .expect_err("plan mode must not resolve signing credentials")
+            .to_string(),
+        "--print is not supported for this orchestrated write"
+    );
+}
+
+#[test]
+fn print_conflicts_with_secret_key() {
+    let error = Cli::try_parse_from([
+        "tmplrmgr",
+        "write",
+        "registry.removeVersion",
+        "--json",
+        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "--secret-key",
+        TEST_SECRET_KEY,
+    ])
+    .expect_err("plan and execution credentials must be mutually exclusive");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn print_conflicts_with_secret_key_from_environment() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let original_secret = std::env::var_os("SECRET_KEY");
+    std::env::set_var("SECRET_KEY", TEST_SECRET_KEY);
+    let result = Cli::try_parse_from([
+        "tmplrmgr",
+        "write",
+        "registry.removeVersion",
+        "--json",
+        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ]);
+    restore_env("SECRET_KEY", original_secret);
+
+    let error = result.expect_err("environment secret must conflict with --print");
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
+fn public_key_requires_print_mode() {
+    let error = Cli::try_parse_from([
+        "tmplrmgr",
+        "write",
+        "registry.removeVersion",
+        "--json",
+        r#"{"registry_id":"registry.testnet","version_key":"v1"}"#,
+        "--signer-id",
+        "signer.testnet",
+        "--secret-key",
+        TEST_SECRET_KEY,
+        "--public-key",
+        "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w",
+    ])
+    .expect_err("--public-key is plan-only");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+}
+
+#[test]
 fn read_command_rejects_credentials() {
     // Reads don't flatten the signer, so credentials are an unexpected argument.
     let error = Cli::try_parse_from([
@@ -249,7 +344,7 @@ fn read_command_rejects_credentials() {
 #[test]
 fn invalid_secret_key_error_does_not_echo_input() {
     let secret = "not-a-real-secret-key";
-    let cli = Cli::try_parse_from([
+    let error = Cli::try_parse_from([
         "tmplrmgr",
         "write",
         "registry.removeVersion",
@@ -260,19 +355,11 @@ fn invalid_secret_key_error_does_not_echo_input() {
         "--secret-key",
         secret,
     ])
-    .expect("secret key should parse as an opaque string at the clap boundary");
-
-    let error = match cli.command {
-        super::cli::Command::Write(call) => call
-            .signer
-            .resolve()
-            .expect_err("invalid secret key should be rejected"),
-        _ => panic!("expected Write variant"),
-    };
+    .expect_err("invalid secret key should fail at the clap boundary");
 
     let message = error.to_string();
-    assert_eq!(message, "invalid --secret-key");
-    assert!(!message.contains(secret));
+    assert!(message.contains("invalid --secret-key"), "{message}");
+    assert!(!message.contains(secret), "secret leaked: {message}");
 }
 
 #[test]

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -209,11 +209,11 @@ fn write_fallback_does_not_require_a_lazer_key() {
 }
 
 #[test]
-fn write_command_requires_credentials() {
-    // With credentials structural on the write, omitting them is a parse error —
-    // no build or network work is reachable.
-    let result = with_cleared_credential_env(|| try_parse_write([]));
-    let error = result.expect_err("a write with no credentials should fail to parse");
+fn write_requires_secret_key_or_print() {
+    // Omitting both execution credentials and plan mode is a parse error, so no
+    // build or network work is reachable.
+    let result = with_cleared_credential_env(|| try_parse_write(["--signer-id", "dao.near"]));
+    let error = result.expect_err("a write needs --secret-key or --print");
     assert_eq!(
         error.kind(),
         clap::error::ErrorKind::MissingRequiredArgument
@@ -261,17 +261,21 @@ fn print_conflicts_with_secret_key_from_environment() {
 
 #[test]
 fn public_key_requires_print_mode() {
-    let error = try_parse_write([
-        "--signer-id",
-        "signer.testnet",
-        "--secret-key",
-        TEST_SECRET_KEY,
-        "--public-key",
-        "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w",
-    ])
+    let error = with_cleared_credential_env(|| {
+        try_parse_write([
+            "--signer-id",
+            "signer.testnet",
+            "--public-key",
+            "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w",
+        ])
+    })
     .expect_err("--public-key is plan-only");
 
-    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
+    assert_eq!(
+        error.kind(),
+        clap::error::ErrorKind::MissingRequiredArgument
+    );
+    assert!(error.to_string().contains("--print <FORMAT>"));
 }
 
 #[test]

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -6,9 +6,15 @@ use serde_json::{json, Value};
 use near_sdk::json_types::{Base58CryptoHash, Base64VecU8, U128};
 use near_sdk::Gas;
 
-use super::{parse_create_proposal, parse_governance, CREDS};
+use super::{
+    clear_credential_env, parse_create_proposal, parse_governance, try_parse_governance, CREDS,
+    ENV_LOCK,
+};
 use crate::cli::{Cli, Command};
-use crate::commands::proxy_oracle::{ProxyOracleGovernanceNs, ProxyOracleNs};
+use crate::commands::{
+    proxy_oracle::{ProxyOracleGovernanceNs, ProxyOracleNs},
+    signer::PrintFormat,
+};
 use templar_common::upgrade::UpgradeSource;
 use templar_common::Nanoseconds;
 use templar_primitives::Decimal;
@@ -40,8 +46,8 @@ fn create_proposal(
 }
 
 #[test]
-fn governance_and_gov_parse_into_the_nested_command() {
-    for alias in ["governance", "gov"] {
+fn governance_aliases_parse_into_the_nested_command() {
+    for alias in ["governance", "gov", "g"] {
         let cli = Cli::try_parse_from([
             "tmplrmgr",
             "proxy-oracle",
@@ -59,10 +65,6 @@ fn governance_and_gov_parse_into_the_nested_command() {
             _ => panic!("expected nested governance command"),
         }
     }
-
-    let error = Cli::try_parse_from(["tmplrmgr", "proxy-oracle", "g"])
-        .expect_err("removed single-letter alias should be rejected");
-    assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
 }
 
 /// The typed `operation` a `create-proposal` invocation parses into.
@@ -484,6 +486,106 @@ fn execute_proposal_when_ready_flag() {
             _ => panic!("expected execute-proposal"),
         }
     }
+}
+
+#[test]
+fn governance_write_commands_accept_print_mode() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+    let execute = try_parse_governance([
+        "execute-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "2",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "sputnik",
+    ]);
+    let create = try_parse_governance([
+        "create-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "0",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "admin-function-call",
+        "--method",
+        "own_accept_owner",
+        "--deposit",
+        "1 yoctoNEAR",
+    ]);
+    restore();
+
+    let ProxyOracleGovernanceNs::ExecuteProposal(execute) =
+        execute.expect("immediate execution should support planning")
+    else {
+        panic!("expected execute-proposal");
+    };
+    assert_eq!(execute.signer.print(), Some(PrintFormat::Sputnik));
+
+    let ProxyOracleGovernanceNs::CreateProposal(create) =
+        create.expect("single-write proposal creation should support planning")
+    else {
+        panic!("expected create-proposal");
+    };
+    assert_eq!(create.signer.print(), Some(PrintFormat::Json));
+}
+
+#[test]
+fn proposal_orchestration_flags_parse_with_print_for_runtime_rejection() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+    let execute = try_parse_governance([
+        "execute-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "2",
+        "--when-ready",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ]);
+    let create = try_parse_governance([
+        "create-proposal",
+        "--governance-id",
+        "gov.testnet",
+        "--id",
+        "0",
+        "--execute-when-ready",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "admin-function-call",
+        "--method",
+        "own_accept_owner",
+        "--deposit",
+        "1 yoctoNEAR",
+    ]);
+    restore();
+
+    let ProxyOracleGovernanceNs::ExecuteProposal(execute) =
+        execute.expect("runtime guard should own the orchestration diagnostic")
+    else {
+        panic!("expected execute-proposal");
+    };
+    assert!(execute.when_ready());
+    assert_eq!(execute.signer.print(), Some(PrintFormat::Json));
+
+    let ProxyOracleGovernanceNs::CreateProposal(create) =
+        create.expect("runtime guard should own the orchestration diagnostic")
+    else {
+        panic!("expected create-proposal");
+    };
+    assert!(create.execute_when_ready());
+    assert_eq!(create.signer.print(), Some(PrintFormat::Json));
 }
 
 #[test]

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -7,8 +7,8 @@ use near_sdk::json_types::{Base58CryptoHash, Base64VecU8, U128};
 use near_sdk::Gas;
 
 use super::{
-    clear_credential_env, parse_create_proposal, parse_governance, try_parse_governance, CREDS,
-    ENV_LOCK,
+    parse_create_proposal, parse_governance, try_parse_governance, with_cleared_credential_env,
+    CREDS,
 };
 use crate::cli::{Cli, Command};
 use crate::commands::{
@@ -490,36 +490,37 @@ fn execute_proposal_when_ready_flag() {
 
 #[test]
 fn governance_write_commands_accept_print_mode() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
-    let execute = try_parse_governance([
-        "execute-proposal",
-        "--governance-id",
-        "gov.testnet",
-        "--id",
-        "2",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "sputnik",
-    ]);
-    let create = try_parse_governance([
-        "create-proposal",
-        "--governance-id",
-        "gov.testnet",
-        "--id",
-        "0",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-        "admin-function-call",
-        "--method",
-        "own_accept_owner",
-        "--deposit",
-        "1 yoctoNEAR",
-    ]);
-    restore();
+    let (execute, create) = with_cleared_credential_env(|| {
+        (
+            try_parse_governance([
+                "execute-proposal",
+                "--governance-id",
+                "gov.testnet",
+                "--id",
+                "2",
+                "--signer-id",
+                "dao.near",
+                "--print",
+                "sputnik",
+            ]),
+            try_parse_governance([
+                "create-proposal",
+                "--governance-id",
+                "gov.testnet",
+                "--id",
+                "0",
+                "--signer-id",
+                "dao.near",
+                "--print",
+                "json",
+                "admin-function-call",
+                "--method",
+                "own_accept_owner",
+                "--deposit",
+                "1 yoctoNEAR",
+            ]),
+        )
+    });
 
     let ProxyOracleGovernanceNs::ExecuteProposal(execute) =
         execute.expect("immediate execution should support planning")
@@ -538,54 +539,48 @@ fn governance_write_commands_accept_print_mode() {
 
 #[test]
 fn proposal_orchestration_flags_parse_with_print_for_runtime_rejection() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
-    let execute = try_parse_governance([
-        "execute-proposal",
-        "--governance-id",
-        "gov.testnet",
-        "--id",
-        "2",
-        "--when-ready",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-    ]);
-    let create = try_parse_governance([
-        "create-proposal",
-        "--governance-id",
-        "gov.testnet",
-        "--id",
-        "0",
-        "--execute-when-ready",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-        "admin-function-call",
-        "--method",
-        "own_accept_owner",
-        "--deposit",
-        "1 yoctoNEAR",
-    ]);
-    restore();
+    let (execute, create) = with_cleared_credential_env(|| {
+        (
+            try_parse_governance([
+                "execute-proposal",
+                "--governance-id",
+                "gov.testnet",
+                "--id",
+                "2",
+                "--when-ready",
+                "--signer-id",
+                "dao.near",
+                "--print",
+                "json",
+            ]),
+            try_parse_governance([
+                "create-proposal",
+                "--governance-id",
+                "gov.testnet",
+                "--id",
+                "0",
+                "--execute-when-ready",
+                "--signer-id",
+                "dao.near",
+                "--print",
+                "json",
+                "admin-function-call",
+                "--method",
+                "own_accept_owner",
+                "--deposit",
+                "1 yoctoNEAR",
+            ]),
+        )
+    });
 
-    let ProxyOracleGovernanceNs::ExecuteProposal(execute) =
-        execute.expect("runtime guard should own the orchestration diagnostic")
-    else {
-        panic!("expected execute-proposal");
-    };
-    assert!(execute.when_ready());
-    assert_eq!(execute.signer.print(), Some(PrintFormat::Json));
-
-    let ProxyOracleGovernanceNs::CreateProposal(create) =
-        create.expect("runtime guard should own the orchestration diagnostic")
-    else {
-        panic!("expected create-proposal");
-    };
-    assert!(create.execute_when_ready());
-    assert_eq!(create.signer.print(), Some(PrintFormat::Json));
+    assert!(matches!(
+        execute.expect("runtime guard should own the orchestration diagnostic"),
+        ProxyOracleGovernanceNs::ExecuteProposal(_)
+    ));
+    assert!(matches!(
+        create.expect("runtime guard should own the orchestration diagnostic"),
+        ProxyOracleGovernanceNs::CreateProposal(_)
+    ));
 }
 
 #[test]

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -545,7 +545,7 @@ fn governance_write_commands_accept_print_mode() {
 }
 
 #[test]
-fn proposal_orchestration_flags_parse_with_print_for_runtime_rejection() {
+fn proposal_orchestration_flags_conflict_with_print() {
     let (execute, create) = with_cleared_credential_env(|| {
         (
             try_parse_governance([
@@ -580,14 +580,18 @@ fn proposal_orchestration_flags_parse_with_print_for_runtime_rejection() {
         )
     });
 
-    assert!(matches!(
-        execute.expect("runtime guard should own the orchestration diagnostic"),
-        ProxyOracleGovernanceNs::ExecuteProposal(_)
-    ));
-    assert!(matches!(
-        create.expect("runtime guard should own the orchestration diagnostic"),
-        ProxyOracleGovernanceNs::CreateProposal(_)
-    ));
+    assert_eq!(
+        execute
+            .expect_err("--when-ready must conflict with --print")
+            .kind(),
+        clap::error::ErrorKind::ArgumentConflict
+    );
+    assert_eq!(
+        create
+            .expect_err("--execute-when-ready must conflict with --print")
+            .kind(),
+        clap::error::ErrorKind::ArgumentConflict
+    );
 }
 
 #[test]

--- a/tools/manager/src/tests/proxy_oracle.rs
+++ b/tools/manager/src/tests/proxy_oracle.rs
@@ -46,8 +46,8 @@ fn create_proposal(
 }
 
 #[test]
-fn governance_aliases_parse_into_the_nested_command() {
-    for alias in ["governance", "gov", "g"] {
+fn governance_and_gov_parse_into_the_nested_command() {
+    for alias in ["governance", "gov"] {
         let cli = Cli::try_parse_from([
             "tmplrmgr",
             "proxy-oracle",
@@ -65,6 +65,13 @@ fn governance_aliases_parse_into_the_nested_command() {
             _ => panic!("expected nested governance command"),
         }
     }
+}
+
+#[test]
+fn g_alias_is_rejected() {
+    let error = Cli::try_parse_from(["tmplrmgr", "proxy-oracle", "g"])
+        .expect_err("single-letter governance alias must stay unsupported");
+    assert_eq!(error.kind(), clap::error::ErrorKind::InvalidSubcommand);
 }
 
 /// The typed `operation` a `create-proposal` invocation parses into.

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use serde_json::json;
 use templar_common::registry::DeployMode;
 
-use super::{CREDS, TEST_SECRET_KEY};
+use super::{clear_credential_env, CREDS, ENV_LOCK, TEST_SECRET_KEY};
 use crate::cli::{Cli, Command};
 use crate::commands::registry::RegistryNs;
 
@@ -364,6 +364,91 @@ fn add_version_requires_a_contract_source() {
 }
 
 #[test]
+fn deploy_plan_uses_explicit_public_key() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+    let public_key = "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w";
+    let result = Cli::try_parse_from([
+        "tmplrmgr",
+        "registry",
+        "deploy",
+        "--registry-id",
+        "registry.testnet",
+        "--name",
+        "market",
+        "--version-key",
+        "market@1",
+        "--deposit",
+        "1 NEAR",
+        "--init-args",
+        "null",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+        "--public-key",
+        public_key,
+    ]);
+    restore();
+    let cli = result.expect("plan-only deploy should parse");
+    let Command::Registry {
+        command: RegistryNs::Deploy(cmd),
+    } = cli.command
+    else {
+        panic!("expected registry deploy");
+    };
+
+    let spec = cmd
+        .try_into_spec()
+        .expect("explicit public key builds spec");
+    let keys = spec.full_access_keys.expect("full-access keys");
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].0.to_string(), public_key);
+}
+
+#[test]
+fn deploy_plan_without_signer_grant_needs_no_public_key() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+    let result = Cli::try_parse_from([
+        "tmplrmgr",
+        "registry",
+        "deploy",
+        "--registry-id",
+        "registry.testnet",
+        "--name",
+        "market",
+        "--version-key",
+        "market@1",
+        "--deposit",
+        "1 NEAR",
+        "--init-args",
+        "null",
+        "--no-signer-full-access-key",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ]);
+    restore();
+    let cli = result.expect("plan-only deploy should parse");
+    let Command::Registry {
+        command: RegistryNs::Deploy(cmd),
+    } = cli.command
+    else {
+        panic!("expected registry deploy");
+    };
+
+    let spec = cmd
+        .try_into_spec()
+        .expect("suppressed signer grant must not resolve a key");
+    assert!(
+        spec.full_access_keys.expect("full-access keys").is_empty(),
+        "no signer key should be embedded"
+    );
+}
+
+#[test]
 fn remove_version_single_builds_spec() {
     let cli = Cli::try_parse_from(
         [
@@ -414,6 +499,39 @@ fn remove_version_all_has_no_single_spec() {
         panic!("expected remove-version");
     };
     assert!(cmd.single().is_none());
+}
+#[test]
+fn remove_version_all_rejects_print_credentials() {
+    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
+    let restore = clear_credential_env();
+    let result = Cli::try_parse_from([
+        "tmplrmgr",
+        "registry",
+        "remove-version",
+        "--registry-id",
+        "registry.testnet",
+        "--all",
+        "--signer-id",
+        "dao.near",
+        "--print",
+        "json",
+    ]);
+    restore();
+    let cli = result.expect("print mode should parse before orchestration rejects it");
+    let Command::Registry {
+        command: RegistryNs::RemoveVersion(cmd),
+    } = cli.command
+    else {
+        panic!("expected remove-version");
+    };
+
+    assert_eq!(
+        cmd.signer
+            .resolve()
+            .expect_err("multi-version removal is orchestrated")
+            .to_string(),
+        "--print is not supported for this orchestrated write"
+    );
 }
 
 #[test]

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -499,8 +499,8 @@ fn remove_version_all_has_no_single_spec() {
     assert!(cmd.single().is_none());
 }
 #[test]
-fn remove_version_all_accepts_print_for_runtime_rejection() {
-    let result = with_cleared_credential_env(|| {
+fn remove_version_all_conflicts_with_print() {
+    let error = with_cleared_credential_env(|| {
         Cli::try_parse_from([
             "tmplrmgr",
             "registry",
@@ -513,14 +513,10 @@ fn remove_version_all_accepts_print_for_runtime_rejection() {
             "--print",
             "json",
         ])
-    });
-    let cli = result.expect("print mode should parse before orchestration rejects it");
-    assert!(matches!(
-        cli.command,
-        Command::Registry {
-            command: RegistryNs::RemoveVersion(_)
-        }
-    ));
+    })
+    .expect_err("--all must conflict with --print");
+
+    assert_eq!(error.kind(), clap::error::ErrorKind::ArgumentConflict);
 }
 
 #[test]

--- a/tools/manager/src/tests/registry.rs
+++ b/tools/manager/src/tests/registry.rs
@@ -4,7 +4,7 @@ use clap::Parser;
 use serde_json::json;
 use templar_common::registry::DeployMode;
 
-use super::{clear_credential_env, CREDS, ENV_LOCK, TEST_SECRET_KEY};
+use super::{with_cleared_credential_env, CREDS, TEST_SECRET_KEY};
 use crate::cli::{Cli, Command};
 use crate::commands::registry::RegistryNs;
 
@@ -365,31 +365,30 @@ fn add_version_requires_a_contract_source() {
 
 #[test]
 fn deploy_plan_uses_explicit_public_key() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
     let public_key = "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w";
-    let result = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "deploy",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "market",
-        "--version-key",
-        "market@1",
-        "--deposit",
-        "1 NEAR",
-        "--init-args",
-        "null",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-        "--public-key",
-        public_key,
-    ]);
-    restore();
+    let result = with_cleared_credential_env(|| {
+        Cli::try_parse_from([
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "market",
+            "--version-key",
+            "market@1",
+            "--deposit",
+            "1 NEAR",
+            "--init-args",
+            "null",
+            "--signer-id",
+            "dao.near",
+            "--print",
+            "json",
+            "--public-key",
+            public_key,
+        ])
+    });
     let cli = result.expect("plan-only deploy should parse");
     let Command::Registry {
         command: RegistryNs::Deploy(cmd),
@@ -408,29 +407,28 @@ fn deploy_plan_uses_explicit_public_key() {
 
 #[test]
 fn deploy_plan_without_signer_grant_needs_no_public_key() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
-    let result = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "deploy",
-        "--registry-id",
-        "registry.testnet",
-        "--name",
-        "market",
-        "--version-key",
-        "market@1",
-        "--deposit",
-        "1 NEAR",
-        "--init-args",
-        "null",
-        "--no-signer-full-access-key",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-    ]);
-    restore();
+    let result = with_cleared_credential_env(|| {
+        Cli::try_parse_from([
+            "tmplrmgr",
+            "registry",
+            "deploy",
+            "--registry-id",
+            "registry.testnet",
+            "--name",
+            "market",
+            "--version-key",
+            "market@1",
+            "--deposit",
+            "1 NEAR",
+            "--init-args",
+            "null",
+            "--no-signer-full-access-key",
+            "--signer-id",
+            "dao.near",
+            "--print",
+            "json",
+        ])
+    });
     let cli = result.expect("plan-only deploy should parse");
     let Command::Registry {
         command: RegistryNs::Deploy(cmd),
@@ -501,37 +499,28 @@ fn remove_version_all_has_no_single_spec() {
     assert!(cmd.single().is_none());
 }
 #[test]
-fn remove_version_all_rejects_print_credentials() {
-    let _guard = ENV_LOCK.lock().expect("env lock should not be poisoned");
-    let restore = clear_credential_env();
-    let result = Cli::try_parse_from([
-        "tmplrmgr",
-        "registry",
-        "remove-version",
-        "--registry-id",
-        "registry.testnet",
-        "--all",
-        "--signer-id",
-        "dao.near",
-        "--print",
-        "json",
-    ]);
-    restore();
+fn remove_version_all_accepts_print_for_runtime_rejection() {
+    let result = with_cleared_credential_env(|| {
+        Cli::try_parse_from([
+            "tmplrmgr",
+            "registry",
+            "remove-version",
+            "--registry-id",
+            "registry.testnet",
+            "--all",
+            "--signer-id",
+            "dao.near",
+            "--print",
+            "json",
+        ])
+    });
     let cli = result.expect("print mode should parse before orchestration rejects it");
-    let Command::Registry {
-        command: RegistryNs::RemoveVersion(cmd),
-    } = cli.command
-    else {
-        panic!("expected remove-version");
-    };
-
-    assert_eq!(
-        cmd.signer
-            .resolve()
-            .expect_err("multi-version removal is orchestrated")
-            .to_string(),
-        "--print is not supported for this orchestrated write"
-    );
+    assert!(matches!(
+        cli.command,
+        Command::Registry {
+            command: RegistryNs::RemoveVersion(_)
+        }
+    ));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add plan-only `--print json|sputnik` support to every `tmplrmgr` write carrying `SignerArgs`
- parse and redact typed signing credentials at the clap boundary while preserving normal execution
- render single-transaction JSON plans and paste-ready Sputnik `FunctionCall` proposal kinds without submitting transactions
- reject unsupported multi-step orchestration and non-FunctionCall Sputnik plans before partial output
- support explicit or suppressed signer full-access keys for plan-only deploy/create commands

## Verification

- `cargo test -p templar-manager` — 141 passed
- `cargo fmt --all --check`
- `cargo clippy -p templar-manager --all-targets -- -D warnings`
- Sputnik acceptance smoke test against an unreachable RPC endpoint
- JSON generic-write, oracle-plan, deploy-key, credential-conflict, and orchestration rejection smoke tests
- zero-finding adversarial review after fixes

Linear: https://linear.app/templar-protocol/issue/ENG-506/add-print-jsonsputnik-to-render-a-tmplrmgr-write-as-a-plan

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/523)
<!-- Reviewable:end -->
