### PR TITLE
ENG-484: require explicit Soroban adapter admin selection

### DIFF
--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -345,8 +345,14 @@ Blend integration lives in the dedicated crate `contract/vault/soroban/blend-ada
 Use recipes in [contract/vault/soroban/justfile](./justfile):
 
 - `just build-blend-adapter`
-- `just deploy-blend-adapter <BLEND_POOL_ADDRESS>`
-- `just deploy-all-with-blend <BLEND_POOL_ADDRESS>`
+- `SOROBAN_ADAPTER_ADMIN=G... just deploy-blend-adapter <BLEND_POOL_ADDRESS>`
+- `SOROBAN_ADAPTER_ADMIN=G... just deploy-all-with-blend <BLEND_POOL_ADDRESS>`
+
+**Breaking change:** adapter deployment no longer defaults the admin to governance. Set
+`SOROBAN_ADAPTER_ADMIN` to an explicit Soroban account or contract address. The literal value
+`vault` is accepted only when the deployed vault's `version()` response advertises
+companion-contract upgrade routing (`0x40`). The current default runtime mask is `0x1f`, so it
+rejects `SOROBAN_ADAPTER_ADMIN=vault`.
 
 After deployment, register the adapter as a vault market before allocation.
 
@@ -373,8 +379,8 @@ NAV revision and must increase by one from the current value.
 Use recipes in [contract/vault/soroban/justfile](./justfile):
 
 - `just build-custodial-adapter`
-- `just deploy-custodial-adapter <CUSTODIAN_OR_MULTISIG_ADDRESS>`
-- `just deploy-all-with-custodial <CUSTODIAN_OR_MULTISIG_ADDRESS>`
+- `SOROBAN_ADAPTER_ADMIN=G... just deploy-custodial-adapter <CUSTODIAN_OR_MULTISIG_ADDRESS>`
+- `SOROBAN_ADAPTER_ADMIN=G... just deploy-all-with-custodial <CUSTODIAN_OR_MULTISIG_ADDRESS>`
 - `just custodial-adapter-status`
 - `just custodial-adapter-reported-at <ASSET_ADDRESS>`
 - `just custodial-adapter-set-reported-assets <CALLER_ADDRESS> <ASSET_ADDRESS> <EXPECTED_CURRENT> <RAW_AMOUNT> <REPORT_NONCE>`
@@ -387,6 +393,8 @@ the next successful explicit report. Rollout still requires upgrade authority ov
 WASM. Adapters
 whose admin is the governance contract cannot currently be upgraded through the shipped governance
 actions; adding that authority or migrating those routes to replacement adapters is separate work.
+The vault CLI and justfile recipes therefore require an explicit adapter admin and apply the same
+`0x40` capability gate before accepting the vault itself.
 
 ### Custodial Runbook Checks
 

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -12,7 +12,7 @@ set dotenv-load := false
 #
 # WITH BLEND INTEGRATION (for yield):
 #   1. just setup
-#   2. just deploy-all-with-blend <BLEND_POOL_ADDRESS>
+#   2. SOROBAN_ADAPTER_ADMIN=G... just deploy-all-with-blend <BLEND_POOL_ADDRESS>
 #   3. just demo-deposit
 #
 # PREREQUISITES:
@@ -34,7 +34,7 @@ set dotenv-load := false
 #   SOROBAN_VIRTUAL_ASSETS   Initial virtual assets offset (default: 0)
 #   BLEND_ADAPTER_ID         Deployed Blend adapter contract ID
 #   BLEND_POOL_ID            Blend pool address
-#   SOROBAN_ADAPTER_ADMIN    Adapter admin contract/address (default: governance, then vault)
+#   SOROBAN_ADAPTER_ADMIN    Adapter admin address, or "vault" with capability 0x40 (required for deployment)
 #   CUSTODIAL_ADAPTER_ID     Deployed custodial adapter contract ID
 #   CUSTODIAL_ADDRESS        Custodian/multisig receiving allocated funds
 #
@@ -58,6 +58,7 @@ share_token_wasm := wasm_dir + "/templar_soroban_share_token.wasm"
 payload_script := justfile_directory() + "/scripts/vault_payload.py"
 custodial_adapter_abi_script := justfile_directory() + "/scripts/check_custodial_adapter_release_abi.py"
 release_abi_script := justfile_directory() + "/scripts/check_release_abi.py"
+runtime_feature_script := justfile_directory() + "/scripts/require_runtime_feature.py"
 default_friendbot := "https://friendbot.stellar.org"
 default_network := "testnet"
 default_rpc := "https://soroban-testnet.stellar.org"
@@ -87,8 +88,8 @@ deploy-all: _ensure-setup build deploy-test-token deploy deploy-share-token depl
 	@echo "  Asset Token: $(cat {{state_dir}}/asset_token_id 2>/dev/null || echo 'not found')"
 	@echo ""
 	@echo "Run: just demo-deposit"
-	@echo "For Blend integration: just deploy-blend-adapter"
-	@echo "For custodial integration: just deploy-custodial-adapter <custodian>"
+	@echo "For Blend integration: SOROBAN_ADAPTER_ADMIN=<address|vault> just deploy-blend-adapter <pool>"
+	@echo "For custodial integration: SOROBAN_ADAPTER_ADMIN=<address|vault> just deploy-custodial-adapter <custodian>"
 
 # Deploy everything including Blend adapter for yield strategies.
 # NOTE: Blend integration requires allowed-adapter and supply-queue governance after deployment.
@@ -625,8 +626,46 @@ extend-ttl ledgers="100000":
 #
 # =============================================================================
 
+# Resolve the required adapter admin. Selecting the vault is fail-closed until the
+# deployed runtime advertises companion-contract upgrade routing (feature bit 0x40).
+_resolve-adapter-admin:
+	@admin="${SOROBAN_ADAPTER_ADMIN:-}"; \
+	vault_id="${SOROBAN_ADAPTER_VAULT_ID:-}"; \
+	if [ -z "$admin" ]; then \
+		echo "Error: SOROBAN_ADAPTER_ADMIN is required; set it to a Soroban address or 'vault'." >&2; \
+		exit 1; \
+	fi; \
+	if [ "$admin" = "vault" ]; then \
+		if [ -z "$vault_id" ]; then \
+			echo "Error: cannot resolve SOROBAN_ADAPTER_ADMIN=vault without a deployed vault ID." >&2; \
+			exit 1; \
+		fi; \
+		admin="$vault_id"; \
+	fi; \
+	if [ -n "$vault_id" ] && [ "$admin" = "$vault_id" ]; then \
+		network="${SOROBAN_NETWORK:-{{default_network}}}"; \
+		source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
+		if ! version_response=$(stellar contract invoke \
+			--id "$vault_id" \
+			--network "$network" \
+			--source-account "$source" \
+			--send no \
+			-- version); then \
+			echo "Error: cannot use vault $vault_id as adapter admin because version() capability detection failed." >&2; \
+			exit 1; \
+		fi; \
+		if ! printf '%s\n' "$version_response" | python3 "{{runtime_feature_script}}" \
+			--feature-bit 0x40 \
+			--feature-name companion-upgrade \
+			--contract "vault $vault_id"; then \
+			exit 1; \
+		fi; \
+	fi; \
+	printf '%s\n' "$admin"
+
 # Deploy the Blend adapter contract.
-# Requires: vault must be deployed first, pool_address is the Blend pool to use.
+# Requires: vault must be deployed first, pool_address is the Blend pool to use, and
+# SOROBAN_ADAPTER_ADMIN must be an explicit address or capability-gated "vault".
 deploy-blend-adapter pool_address:
 	@wasm="${BLEND_ADAPTER_WASM:-{{blend_adapter_wasm}}}"; \
 	if [ ! -f "$wasm" ]; then \
@@ -639,9 +678,8 @@ deploy-blend-adapter pool_address:
 		echo "Error: Vault not deployed. Run 'just deploy' first."; \
 		exit 1; \
 	fi; \
-	admin="${SOROBAN_ADAPTER_ADMIN:-$(cat {{state_dir}}/governance_id 2>/dev/null)}"; \
-	if [ -z "$admin" ]; then \
-		admin="$vault_id"; \
+	if ! admin=$(SOROBAN_ADAPTER_VAULT_ID="$vault_id" just -f "{{justfile_directory()}}/justfile" _resolve-adapter-admin); then \
+		exit 1; \
 	fi; \
 	network="${SOROBAN_NETWORK:-{{default_network}}}"; \
 	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
@@ -667,7 +705,8 @@ deploy-blend-adapter pool_address:
 	echo "{{pool_address}}" > "{{state_dir}}/blend_pool_id"
 
 # Deploy the custodial adapter contract.
-# Requires: vault must be deployed first, custodian is the multisig/address receiving allocated funds.
+# Requires: vault must be deployed first, custodian is the multisig/address receiving allocated
+# funds, and SOROBAN_ADAPTER_ADMIN must be an explicit address or capability-gated "vault".
 deploy-custodial-adapter custodian:
 	@wasm="${CUSTODIAL_ADAPTER_WASM:-{{custodial_adapter_wasm}}}"; \
 	if [ ! -f "$wasm" ]; then \
@@ -685,9 +724,8 @@ deploy-custodial-adapter custodian:
 		echo "Error: No asset token. Run 'just deploy-test-token' first or set SOROBAN_ASSET_TOKEN"; \
 		exit 1; \
 	fi; \
-	admin="${SOROBAN_ADAPTER_ADMIN:-$(cat {{state_dir}}/governance_id 2>/dev/null)}"; \
-	if [ -z "$admin" ]; then \
-		admin="$vault_id"; \
+	if ! admin=$(SOROBAN_ADAPTER_VAULT_ID="$vault_id" just -f "{{justfile_directory()}}/justfile" _resolve-adapter-admin); then \
+		exit 1; \
 	fi; \
 	network="${SOROBAN_NETWORK:-{{default_network}}}"; \
 	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
@@ -1410,8 +1448,8 @@ help:
 	@echo "QUICK START:"
 	@echo "  just setup                    Full setup (build, network, keys, fund)"
 	@echo "  just deploy-all               Deploy vault + share token + governance + test token, initialize"
-	@echo "  just deploy-all-with-blend <pool>  Deploy with Blend adapter"
-	@echo "  just deploy-all-with-custodial <custodian>  Deploy with custodial adapter"
+	@echo "  SOROBAN_ADAPTER_ADMIN=<address|vault> just deploy-all-with-blend <pool>"
+	@echo "  SOROBAN_ADAPTER_ADMIN=<address|vault> just deploy-all-with-custodial <custodian>"
 	@echo "  just demo-deposit             Run deposit demonstration"
 	@echo "  just demo-withdraw            Run withdrawal demonstration"
 	@echo "  just demo-e2e-full            Run full e2e flow"
@@ -1444,7 +1482,7 @@ help:
 	@echo "  just extend-ttl               Extend contract TTL"
 	@echo ""
 	@echo "BLEND ADAPTER:"
-	@echo "  just deploy-blend-adapter <pool>  Deploy adapter for Blend pool"
+	@echo "  SOROBAN_ADAPTER_ADMIN=<address|vault> just deploy-blend-adapter <pool>"
 	@echo "  just blend-adapter-status        Show adapter status"
 	@echo "  just blend-adapter-total-assets <asset>  Query pool position"
 	@echo "  just allocate-supply <mkt> <amt>  Supply to market via adapter"
@@ -1454,7 +1492,7 @@ help:
 	@echo "  just demo-e2e-blend              Full Blend integration e2e"
 	@echo ""
 	@echo "CUSTODIAL ADAPTER:"
-	@echo "  just deploy-custodial-adapter <custodian>  Deploy adapter for offchain custody route"
+	@echo "  SOROBAN_ADAPTER_ADMIN=<address|vault> just deploy-custodial-adapter <custodian>"
 	@echo "  just custodial-adapter-status              Show adapter status"
 	@echo "  just custodial-adapter-total-assets <asset>  Query reported position"
 	@echo "  just custodial-adapter-reported-at <asset>   Query latest explicit report timestamp"

--- a/contract/vault/soroban/scripts/require_runtime_feature.py
+++ b/contract/vault/soroban/scripts/require_runtime_feature.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Require a feature bit in a Stellar runtime version response read from stdin."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+def parse_response(payload: Any) -> tuple[str, int]:
+    if not isinstance(payload, list) or len(payload) != 2:
+        raise ValueError("expected [version, feature_flags]")
+    version, feature_flags = payload
+    if not isinstance(version, str):
+        raise ValueError("version must be a string")
+    if isinstance(feature_flags, bool) or not isinstance(feature_flags, int):
+        raise ValueError("feature_flags must be an integer")
+    if not 0 <= feature_flags <= (1 << 64) - 1:
+        raise ValueError("feature_flags must fit u64")
+    return version, feature_flags
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--feature-bit", required=True, type=lambda value: int(value, 0))
+    parser.add_argument("--feature-name", required=True)
+    parser.add_argument("--contract", required=True)
+    args = parser.parse_args()
+
+    if args.feature_bit <= 0 or args.feature_bit > (1 << 64) - 1:
+        parser.error("--feature-bit must be a nonzero u64 value")
+
+    try:
+        version, feature_flags = parse_response(json.load(sys.stdin))
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        print(
+            f"cannot use {args.contract}: invalid runtime version response: {error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if feature_flags & args.feature_bit == 0:
+        print(
+            f"cannot use {args.contract}: version {version} does not advertise "
+            f"{args.feature_name} capability {args.feature_bit:#x} "
+            f"(feature mask {feature_flags:#x})",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -70,13 +70,20 @@ flow. The manifest stores these as `custodial_adapter_0`, `custodial_adapter_1`,
 the `admin`, `vault`, `custodian`, and bound `asset` constructor args recorded for reconciliation
 and status. Custodial adapters are single-asset; `deploy adapters --custodian ...` requires
 `asset_token` in the manifest or `--asset-token`.
+Every deployment that requests a Blend or custodial adapter must also pass
+`--adapter-admin <address|vault>` (or `SOROBAN_ADAPTER_ADMIN`). Governance is never selected
+implicitly. The `vault` alias, and an explicit address equal to the vault, are accepted only after
+the CLI calls `vault.version()` and detects companion-upgrade capability `0x40`. The current default
+runtime does not advertise that capability, so use an independently controlled account or contract
+until companion upgrades are implemented.
 
 ```sh
 tmplr-soroban-vault deploy stack \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
   --blend-pool CPOOL2... \
-  --custodian G...
+  --custodian G... \
+  --adapter-admin GADAPTERADMIN...
 ```
 
 To add adapters later without redeploying the stack, use `deploy adapters`. If the manifest already
@@ -90,7 +97,8 @@ tmplr-soroban-vault deploy adapters \
   --governance CGOV... \
   --asset-token CASSET... \
   --blend-pool CPOOL... \
-  --custodian G...
+  --custodian G... \
+  --adapter-admin GADAPTERADMIN...
 ```
 
 To deploy only a fresh curator proxy for an existing vault, use `deploy curator-proxy`. Vault and
@@ -132,13 +140,15 @@ manifest changes:
 tmplr-soroban-vault deploy plan stack \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
-  --custodian G...
+  --custodian G... \
+  --adapter-admin GADAPTERADMIN...
 
 tmplr-soroban-vault deploy plan adapters \
   --vault CVAULT... \
   --governance CGOV... \
   --blend-pool CPOOL... \
-  --custodian G...
+  --custodian G... \
+  --adapter-admin GADAPTERADMIN...
 ```
 
 Recover an interrupted deployment by reconciling first, then resuming if the repair plan reports
@@ -151,7 +161,8 @@ tmplr-soroban-vault deploy repair --json
 tmplr-soroban-vault deploy resume \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
-  --custodian G...
+  --custodian G... \
+  --adapter-admin GADAPTERADMIN...
 ```
 
 The CLI validates Soroban account and contract addresses at parse time for operational commands.
@@ -319,7 +330,8 @@ the simplest testnet or custodial setup.
 tmplr-soroban-vault deploy stack \
   --admin GCURATOR... \
   --governance-timelock-ns 86400000000000 \
-  --blend-pool CPOOL...
+  --blend-pool CPOOL... \
+  --adapter-admin GCURATOR...
 
 tmplr-soroban-vault governance submit-set-allowed-adapters \
   --admin GCURATOR... \
@@ -381,7 +393,8 @@ governance caller, while the Stellar source account supplies the transaction env
 tmplr-soroban-vault deploy stack \
   --admin CMULTISIG... \
   --governance-timelock-ns 86400000000000 \
-  --blend-pool CPOOL...
+  --blend-pool CPOOL... \
+  --adapter-admin CMULTISIG...
 
 tmplr-soroban-vault governance plan-submit-set-supply-queue \
   --admin CMULTISIG... \
@@ -499,7 +512,8 @@ tmplr-soroban-vault deploy stack \
   --admin GCURATOR_OR_MULTISIG... \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
-  --custodian GCUSTODIAN...
+  --custodian GCUSTODIAN... \
+  --adapter-admin GADAPTERADMIN...
 
 tmplr-soroban-vault governance submit-set-sentinel \
   --admin GCURATOR_OR_MULTISIG... \
@@ -549,7 +563,8 @@ accounting views. `curator allocate-supply` observes adapter `total_assets` afte
 `curator allocate-withdraw` verifies the realized token balance delta and subtracts that amount from
 stored principal; it does not refresh route NAV.
 
-For custodial adapters, use `deploy adapters --custodian <address>` to append custodial routes,
+For custodial adapters, use
+`deploy adapters --custodian <address> --adapter-admin <address|vault>` to append custodial routes,
 then allow the deployed adapter, set a nonzero market cap, refresh reported NAV, and add it to the
 supply queue before allocating to it. Each custodial adapter is bound to the manifest asset token at
 deployment and rejects calls for any other asset. The custodian, adapter admin, or vault can
@@ -573,6 +588,7 @@ stellar contract invoke \
 
 - Mainnet write commands require `--allow-mainnet-write`.
 - Zero governance timelocks require `--allow-zero-timelock`.
+- Adapter deployment requires an explicit `--adapter-admin`; selecting the vault fails closed unless runtime capability `0x40` is detected first.
 - `--dry-run` prints the `stellar` commands with source-account environment overrides redacted, returns planned contract ids in the response, and never writes the manifest.
 - `--json` emits stable machine-readable envelopes with `type`, `ok`, `network`, `manifest`, `commands`, `tx_hashes`, `warnings`, and command-specific `data`.
 - `--json-lines` emits the same envelope format as newline-delimited JSON for long-running automation.

--- a/tools/soroban-vault-cli/src/cli.rs
+++ b/tools/soroban-vault-cli/src/cli.rs
@@ -4,8 +4,8 @@ use clap::{Args, Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 
 use crate::types::{
-    AddressStr, DecimalAmount, GovernanceActionKindArg, RestrictionModeArg, ShareDecimalsArg,
-    SourceAccount, SupplyQueueEntryArg, TimelockKindArg, WasmHash,
+    AdapterAdminArg, AddressStr, DecimalAmount, GovernanceActionKindArg, RestrictionModeArg,
+    ShareDecimalsArg, SourceAccount, SupplyQueueEntryArg, TimelockKindArg, WasmHash,
 };
 
 pub const DEFAULT_CONTRACT_SOURCE_REPO: &str = "github:Templar-Protocol/contracts";
@@ -277,6 +277,10 @@ pub struct DeployStackArgs {
     #[arg(long = "custodian", env = "CUSTODIAL_ADDRESS", value_delimiter = ',')]
     pub custodians: Vec<AddressStr>,
 
+    /// Admin for every newly deployed Blend or custodial adapter. Required when adapters are requested. Use `vault` only when the runtime advertises companion-upgrade support.
+    #[arg(long, env = "SOROBAN_ADAPTER_ADMIN")]
+    pub adapter_admin: Option<AdapterAdminArg>,
+
     /// Rebuild missing artifacts before upload/deploy
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub build: bool,
@@ -307,6 +311,10 @@ pub struct DeployAdaptersArgs {
     /// Custodian or multisig address. Repeat the flag, or provide comma-separated CUSTODIAL_ADDRESS values, to append multiple custodial adapters.
     #[arg(long = "custodian", env = "CUSTODIAL_ADDRESS", value_delimiter = ',')]
     pub custodians: Vec<AddressStr>,
+
+    /// Admin for every newly deployed Blend or custodial adapter. Required for this command. Use `vault` only when the runtime advertises companion-upgrade support.
+    #[arg(long, env = "SOROBAN_ADAPTER_ADMIN")]
+    pub adapter_admin: AdapterAdminArg,
 
     /// Rebuild adapter artifacts before upload/deploy
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
@@ -1148,6 +1156,8 @@ mod tests {
             POOL,
             "--custodian",
             ADMIN,
+            "--adapter-admin",
+            ADMIN,
         ])
         .expect("parse cli");
 
@@ -1161,6 +1171,14 @@ mod tests {
                     assert_eq!(stack.governance_timelock_ns, Some(1000));
                     assert_eq!(stack.blend_pools.len(), 2);
                     assert_eq!(stack.custodians.len(), 1);
+                    assert_eq!(
+                        stack
+                            .adapter_admin
+                            .as_ref()
+                            .map(ToString::to_string)
+                            .as_deref(),
+                        Some(ADMIN)
+                    );
                 }
                 DeployCommand::Plan(_)
                 | DeployCommand::Resume(_)
@@ -1183,6 +1201,8 @@ mod tests {
             ADMIN,
             "--custodian",
             &format!("{ADMIN},{POOL}"),
+            "--adapter-admin",
+            "vault",
         ])
         .expect("parse cli");
 
@@ -1195,6 +1215,10 @@ mod tests {
                         .map(ToString::to_string)
                         .collect::<Vec<_>>();
                     assert_eq!(custodians, vec![ADMIN, POOL]);
+                    assert_eq!(
+                        stack.adapter_admin.as_ref().map(ToString::to_string),
+                        Some("vault".to_string())
+                    );
                 }
                 DeployCommand::Plan(_)
                 | DeployCommand::Resume(_)
@@ -1223,6 +1247,8 @@ mod tests {
             POOL,
             "--custodian",
             ADMIN,
+            "--adapter-admin",
+            ADMIN,
         ])
         .expect("parse cli");
 
@@ -1235,6 +1261,7 @@ mod tests {
                     );
                     assert_eq!(args.blend_pools.len(), 1);
                     assert_eq!(args.custodians.len(), 1);
+                    assert_eq!(args.adapter_admin.to_string(), ADMIN);
                 }
                 DeployCommand::Plan(_)
                 | DeployCommand::Stack(_)
@@ -1245,6 +1272,24 @@ mod tests {
             },
             _ => panic!("expected deploy command"),
         }
+    }
+
+    #[test]
+    fn deploy_adapters_rejects_missing_explicit_admin() {
+        let error = Cli::try_parse_from([
+            "tmplr-soroban-vault",
+            "deploy",
+            "adapters",
+            "--vault",
+            POOL,
+            "--governance",
+            POOL,
+            "--blend-pool",
+            POOL,
+        ])
+        .expect_err("adapter admin must be required");
+
+        assert!(error.to_string().contains("--adapter-admin"));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -12,7 +12,9 @@ use clap::CommandFactory;
 use indicatif::{ProgressBar, ProgressStyle};
 use serde::Serialize;
 use templar_curator_proxy_soroban::AllocationDelta;
-use templar_soroban_shared_types::VaultCommand as WireVaultCommand;
+use templar_soroban_shared_types::{
+    VaultCommand as WireVaultCommand, RUNTIME_FEATURE_COMPANION_UPGRADE,
+};
 use tracing::{debug, info};
 
 use crate::{
@@ -27,7 +29,7 @@ use crate::{
     profile,
     stellar::{CommandExecutor, CommandOutput, Stellar},
     types::{
-        AddressStr, DecimalAmount, FeeParamsArg, ShareDecimalsArg, SourceAccount,
+        AdapterAdminArg, AddressStr, DecimalAmount, FeeParamsArg, ShareDecimalsArg, SourceAccount,
         SupplyQueueEntryArg,
     },
 };
@@ -632,13 +634,17 @@ fn deploy_stack<E: CommandExecutor>(
         anyhow::bail!("zero governance timelock requires --allow-zero-timelock");
     }
 
+    let include_blend = !args.blend_pools.is_empty();
+    let include_custodial = !args.custodians.is_empty();
+    let requested_adapter_admin = if include_blend || include_custodial {
+        Some(require_adapter_admin(args.adapter_admin.as_ref())?)
+    } else {
+        None
+    };
     let admin = match &args.admin {
         Some(admin) => admin.to_string(),
         None => stellar.keys_address_source_account()?,
     };
-
-    let include_blend = !args.blend_pools.is_empty();
-    let include_custodial = !args.custodians.is_empty();
     let progress = DeploymentProgress::stack(
         cli,
         stack_progress_steps(
@@ -873,7 +879,8 @@ fn deploy_stack<E: CommandExecutor>(
                 stellar,
                 manifest,
                 &wasm_hashes["blend_adapter"],
-                &governance,
+                requested_adapter_admin
+                    .context("adapter deployment requires --adapter-admin <address|vault>")?,
                 &vault,
                 &args.blend_pools,
                 args.force_new,
@@ -889,7 +896,8 @@ fn deploy_stack<E: CommandExecutor>(
                 stellar,
                 manifest,
                 &wasm_hashes["custodial_adapter"],
-                &governance,
+                requested_adapter_admin
+                    .context("adapter deployment requires --adapter-admin <address|vault>")?,
                 &vault,
                 &asset_token,
                 &args.custodians,
@@ -1731,6 +1739,44 @@ fn verify_curator_proxy_version<E: CommandExecutor>(
     Ok(output.stdout)
 }
 
+fn require_adapter_admin(admin: Option<&AdapterAdminArg>) -> anyhow::Result<&AdapterAdminArg> {
+    admin.context(
+        "adapter deployment requires an explicit --adapter-admin <address|vault>; governance is not an implicit adapter admin",
+    )
+}
+
+fn verify_vault_companion_upgrade<E: CommandExecutor>(
+    cli: &Cli,
+    stellar: &Stellar<'_, E>,
+    vault: &str,
+) -> anyhow::Result<()> {
+    let output = stellar
+        .invoke_view(vault, "version", Vec::new())
+        .with_context(|| {
+            format!(
+                "cannot use vault {vault} as adapter admin: runtime capability detection via version() failed"
+            )
+        })?;
+    if cli.dry_run {
+        return Ok(());
+    }
+    let (version, feature_flags) = parse_runtime_version(&output.stdout).with_context(|| {
+        format!(
+            "cannot use vault {vault} as adapter admin: decode runtime version() capability response"
+        )
+    })?;
+    anyhow::ensure!(
+        feature_flags & RUNTIME_FEATURE_COMPANION_UPGRADE != 0,
+        "cannot use vault {vault} version {version} as adapter admin: companion-upgrade capability {RUNTIME_FEATURE_COMPANION_UPGRADE:#x} is not advertised (feature mask {feature_flags:#x})"
+    );
+    Ok(())
+}
+
+fn parse_runtime_version(raw: &str) -> anyhow::Result<(String, u64)> {
+    serde_json::from_str(raw.trim())
+        .context("expected runtime version response as [version, feature_flags]")
+}
+
 fn deploy_adapters<E: CommandExecutor>(
     cli: &Cli,
     stellar: &Stellar<'_, E>,
@@ -1741,6 +1787,7 @@ fn deploy_adapters<E: CommandExecutor>(
         !args.blend_pools.is_empty() || !args.custodians.is_empty(),
         "deploy adapters requires at least one --blend-pool or --custodian"
     );
+    let requested_adapter_admin = &args.adapter_admin;
 
     record_imported_contract_if_provided(cli, manifest, "vault", args.vault.as_ref())?;
     checkpoint_manifest(cli, manifest)?;
@@ -1774,7 +1821,7 @@ fn deploy_adapters<E: CommandExecutor>(
             stellar,
             manifest,
             &wasm_hash,
-            &governance,
+            requested_adapter_admin,
             &vault,
             &args.blend_pools,
             args.force_new,
@@ -1796,7 +1843,7 @@ fn deploy_adapters<E: CommandExecutor>(
             stellar,
             manifest,
             &wasm_hash,
-            &governance,
+            requested_adapter_admin,
             &vault,
             asset_token
                 .as_deref()
@@ -1850,6 +1897,18 @@ fn deploy_stack_plan(
 
     let include_blend = !args.blend_pools.is_empty();
     let include_custodial = !args.custodians.is_empty();
+    let adapter_admin = if include_blend || include_custodial {
+        let vault = (!args.force_new)
+            .then(|| contract_id(manifest, "vault"))
+            .flatten();
+        Some(plan_adapter_admin(
+            &mut plan,
+            require_adapter_admin(args.adapter_admin.as_ref())?,
+            vault,
+        ))
+    } else {
+        None
+    };
     for spec in ArtifactSpec::stack_artifacts(include_blend, include_custodial) {
         plan.wasm.push(wasm_plan(cli, manifest, spec, args.build)?);
     }
@@ -1905,12 +1964,23 @@ fn deploy_stack_plan(
             plan.manifest_mutations
                 .push(format!("record new Blend adapter for pool {pool}"));
             plan.stellar_commands.push(stellar_command_shape(
-                "contract deploy --wasm-hash <blend_adapter_hash> -- --admin <governance> --vault <vault> --pool <pool>",
+                &format!(
+                    "contract deploy --wasm-hash <blend_adapter_hash> -- --admin {} --vault <vault> --pool <pool>",
+                    adapter_admin
+                        .as_deref()
+                        .context("adapter deployment requires --adapter-admin <address|vault>")?
+                ),
                 true,
             ));
         }
     }
-    plan_custodial_adapters(&mut plan, manifest, &args.custodians, args.force_new);
+    plan_custodial_adapters(
+        &mut plan,
+        manifest,
+        &args.custodians,
+        adapter_admin.as_deref(),
+        args.force_new,
+    )?;
     plan.manifest_mutations
         .push("mark initialized contracts after successful initialize calls".to_string());
     Ok(plan)
@@ -1922,6 +1992,13 @@ fn deploy_adapters_plan(
     args: &crate::cli::DeployAdaptersArgs,
 ) -> anyhow::Result<PlanResponse> {
     let mut plan = PlanResponse::new("deploy adapters", &cli.network);
+    anyhow::ensure!(
+        !args.blend_pools.is_empty() || !args.custodians.is_empty(),
+        "deploy adapters requires at least one --blend-pool or --custodian"
+    );
+    let vault =
+        contract_id(manifest, "vault").or_else(|| args.vault.as_ref().map(AddressStr::as_str));
+    let adapter_admin = plan_adapter_admin(&mut plan, &args.adapter_admin, vault);
     plan.required_signers.push(default_source_label());
     if !args.blend_pools.is_empty() {
         plan.wasm.push(wasm_plan(
@@ -1982,21 +2059,48 @@ fn deploy_adapters_plan(
             plan.manifest_mutations
                 .push(format!("record new Blend adapter for pool {pool}"));
             plan.stellar_commands.push(stellar_command_shape(
-                "contract deploy --wasm-hash <blend_adapter_hash> -- --admin <governance> --vault <vault> --pool <pool>",
+                &format!(
+                    "contract deploy --wasm-hash <blend_adapter_hash> -- --admin {adapter_admin} --vault <vault> --pool <pool>"
+                ),
                 true,
             ));
         }
     }
-    plan_custodial_adapters(&mut plan, manifest, &args.custodians, args.force_new);
+    plan_custodial_adapters(
+        &mut plan,
+        manifest,
+        &args.custodians,
+        Some(&adapter_admin),
+        args.force_new,
+    )?;
     Ok(plan)
+}
+
+fn plan_adapter_admin(
+    plan: &mut PlanResponse,
+    admin: &AdapterAdminArg,
+    vault: Option<&str>,
+) -> String {
+    let resolved = admin.resolve(vault.unwrap_or("<vault>"));
+    if admin.targets_vault(vault.unwrap_or("<vault>")) {
+        plan.stellar_commands.push(stellar_command_shape(
+            &format!("contract invoke --id {resolved} --send no -- version"),
+            false,
+        ));
+        plan.warnings.push(format!(
+            "using the vault as adapter admin requires version() to advertise companion-upgrade capability {RUNTIME_FEATURE_COMPANION_UPGRADE:#x}"
+        ));
+    }
+    resolved.to_string()
 }
 
 fn plan_custodial_adapters(
     plan: &mut PlanResponse,
     manifest: &Manifest,
     custodians: &[AddressStr],
+    adapter_admin: Option<&str>,
     force_new: bool,
-) {
+) -> anyhow::Result<()> {
     let mut next_custodial_index = next_custodial_adapter_index(manifest);
     let mut planned_custodians = BTreeSet::new();
     for custodian in custodians {
@@ -2021,11 +2125,16 @@ fn plan_custodial_adapters(
                 "record new custodial adapter for custodian {custodian}"
             ));
             plan.stellar_commands.push(stellar_command_shape(
-                "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin <governance> --vault <vault> --custodian <custodian> --asset <asset_token>",
+                &format!(
+                    "contract deploy --wasm-hash <custodial_adapter_hash> -- --admin {} --vault <vault> --custodian <custodian> --asset <asset_token>",
+                    adapter_admin
+                        .context("adapter deployment requires --adapter-admin <address|vault>")?
+                ),
                 true,
             ));
         }
     }
+    Ok(())
 }
 
 fn push_contract_plan(plan: &mut PlanResponse, manifest: &Manifest, key: &str, force_new: bool) {
@@ -2194,7 +2303,7 @@ fn append_blend_adapters<E: CommandExecutor>(
     stellar: &Stellar<'_, E>,
     manifest: &mut Manifest,
     wasm_hash: &str,
-    governance: &str,
+    adapter_admin: &AdapterAdminArg,
     vault: &str,
     pools: &[AddressStr],
     force_new: bool,
@@ -2203,6 +2312,10 @@ fn append_blend_adapters<E: CommandExecutor>(
         if !force_new && blend_adapter_by_pool(manifest, pool).is_some() {
             continue;
         }
+        if adapter_admin.targets_vault(vault) {
+            verify_vault_companion_upgrade(cli, stellar, vault)?;
+        }
+        let adapter_admin = adapter_admin.resolve(vault);
         let key = next_blend_adapter_key(manifest);
         let adapter = deploy_contract_if_needed(
             cli,
@@ -2212,14 +2325,14 @@ fn append_blend_adapters<E: CommandExecutor>(
             wasm_hash,
             vec![
                 "--admin".to_string(),
-                governance.to_string(),
+                adapter_admin.to_string(),
                 "--vault".to_string(),
                 vault.to_string(),
                 "--pool".to_string(),
                 pool.to_string(),
             ],
             map_args([
-                ("admin", governance),
+                ("admin", adapter_admin),
                 ("vault", vault),
                 ("pool", pool.as_str()),
             ]),
@@ -2242,7 +2355,7 @@ fn append_custodial_adapters<E: CommandExecutor>(
     stellar: &Stellar<'_, E>,
     manifest: &mut Manifest,
     wasm_hash: &str,
-    governance: &str,
+    adapter_admin: &AdapterAdminArg,
     vault: &str,
     asset_token: &str,
     custodians: &[AddressStr],
@@ -2256,6 +2369,10 @@ fn append_custodial_adapters<E: CommandExecutor>(
         if !force_new && custodial_adapter_by_custodian(manifest, custodian).is_some() {
             continue;
         }
+        if adapter_admin.targets_vault(vault) {
+            verify_vault_companion_upgrade(cli, stellar, vault)?;
+        }
+        let adapter_admin = adapter_admin.resolve(vault);
         let key = next_custodial_adapter_key(manifest);
         let adapter = deploy_contract_if_needed(
             cli,
@@ -2265,7 +2382,7 @@ fn append_custodial_adapters<E: CommandExecutor>(
             wasm_hash,
             vec![
                 "--admin".to_string(),
-                governance.to_string(),
+                adapter_admin.to_string(),
                 "--vault".to_string(),
                 vault.to_string(),
                 "--custodian".to_string(),
@@ -2274,7 +2391,7 @@ fn append_custodial_adapters<E: CommandExecutor>(
                 asset_token.to_string(),
             ],
             map_args([
-                ("admin", governance),
+                ("admin", adapter_admin),
                 ("vault", vault),
                 ("custodian", custodian.as_str()),
                 ("asset", asset_token),
@@ -4884,12 +5001,18 @@ mod tests {
 
     struct RecordingExecutor {
         calls: Mutex<Vec<(String, Vec<String>)>>,
+        runtime_feature_flags: u64,
     }
 
     impl RecordingExecutor {
         fn new() -> Self {
+            Self::with_runtime_feature_flags(0x1f)
+        }
+
+        fn with_runtime_feature_flags(runtime_feature_flags: u64) -> Self {
             Self {
                 calls: Mutex::new(Vec::new()),
+                runtime_feature_flags,
             }
         }
 
@@ -4913,6 +5036,12 @@ mod tests {
             if args.iter().any(|arg| arg == "pending_ids") {
                 return Ok(CommandOutput {
                     stdout: "[1, 2]".to_string(),
+                    stderr: String::new(),
+                });
+            }
+            if args.iter().any(|arg| arg == "version") {
+                return Ok(CommandOutput {
+                    stdout: format!("[\"1.1.0\",{}]", self.runtime_feature_flags),
                     stderr: String::new(),
                 });
             }
@@ -5736,6 +5865,7 @@ mod tests {
                         ACCOUNT.parse().expect("new pool"),
                     ],
                     custodians: Vec::new(),
+                    adapter_admin: ACCOUNT.parse().expect("adapter admin"),
                     build: false,
                     force_new: false,
                 }),
@@ -5755,6 +5885,16 @@ mod tests {
                 .expect("appended adapter")
                 .constructor_args
                 .get("pool")
+                .map(String::as_str),
+            Some(ACCOUNT)
+        );
+        assert_eq!(
+            loaded
+                .contracts
+                .get("blend_adapter_1")
+                .expect("appended adapter")
+                .constructor_args
+                .get("admin")
                 .map(String::as_str),
             Some(ACCOUNT)
         );
@@ -5793,6 +5933,7 @@ mod tests {
                         ACCOUNT.parse().expect("custodian"),
                         ACCOUNT.parse().expect("duplicate custodian"),
                     ],
+                    adapter_admin: ACCOUNT.parse().expect("adapter admin"),
                     build: false,
                     force_new: false,
                 }),
@@ -5822,7 +5963,7 @@ mod tests {
         );
         assert_eq!(
             adapter.constructor_args.get("admin").map(String::as_str),
-            Some(CONTRACT)
+            Some(ACCOUNT)
         );
         assert_eq!(
             adapter.constructor_args.get("asset").map(String::as_str),
@@ -5856,6 +5997,7 @@ mod tests {
                     asset_token: None,
                     blend_pools: vec![CONTRACT.parse().expect("pool")],
                     custodians: Vec::new(),
+                    adapter_admin: ACCOUNT.parse().expect("adapter admin"),
                     build: false,
                     force_new: false,
                 }),
@@ -5869,6 +6011,164 @@ mod tests {
         assert!(executor.calls().is_empty());
         let after = fs::read_to_string(&state).expect("read manifest");
         assert_eq!(before, after);
+    }
+
+    #[test]
+    fn deploy_stack_requires_explicit_admin_when_adapters_are_requested() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("manifest.json");
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::Stack(Box::new(DeployStackArgs {
+                    admin: Some(ACCOUNT.parse().expect("admin")),
+                    asset_token: Some(CONTRACT.parse().expect("asset token")),
+                    governance_timelock_ns: Some(1_000),
+                    virtual_shares: 0,
+                    virtual_assets: 0,
+                    share_name: "Templar Vault Share".to_string(),
+                    share_symbol: "tvSHARE".to_string(),
+                    share_decimals: 7,
+                    blend_pools: vec![CONTRACT.parse().expect("pool")],
+                    custodians: Vec::new(),
+                    adapter_admin: None,
+                    build: false,
+                    force_new: false,
+                })),
+            }),
+            ..base_cli(state, Commands::Status)
+        };
+        let executor = RecordingExecutor::new();
+
+        let error = run(&cli, &executor).expect_err("adapter admin must be explicit");
+
+        assert!(error.to_string().contains("explicit --adapter-admin"));
+        assert!(executor.calls().is_empty());
+    }
+
+    #[test]
+    fn deploy_adapters_rejects_vault_admin_without_companion_upgrade_capability() {
+        for adapter_admin in ["vault", CONTRACT] {
+            let dir = tempfile::tempdir().expect("tempdir");
+            write_fake_blend_wasm(dir.path());
+            write_fake_custodial_wasm(dir.path());
+            let state = dir.path().join("manifest.json");
+            let mut manifest = Manifest::new("testnet", None);
+            for key in ["vault", "governance", "asset_token"] {
+                manifest
+                    .contracts
+                    .insert(key.to_string(), imported_record(CONTRACT));
+            }
+            manifest.save(&state).expect("save manifest");
+            let cli = Cli {
+                workspace_path: dir.path().into(),
+                command: Commands::Deploy(DeployArgs {
+                    command: DeployCommand::Adapters(crate::cli::DeployAdaptersArgs {
+                        vault: None,
+                        governance: None,
+                        asset_token: None,
+                        blend_pools: vec![CONTRACT.parse().expect("pool")],
+                        custodians: vec![ACCOUNT.parse().expect("custodian")],
+                        adapter_admin: adapter_admin.parse().expect("adapter admin"),
+                        build: false,
+                        force_new: false,
+                    }),
+                }),
+                ..base_cli(state, Commands::Status)
+            };
+            let executor = RecordingExecutor::new();
+
+            let error = run(&cli, &executor).expect_err("vault admin must be capability-gated");
+
+            assert!(error.to_string().contains("companion-upgrade capability"));
+            let calls = executor.calls();
+            assert!(calls.iter().any(|(_, args)| {
+                args.iter().any(|arg| arg == "version")
+                    && args.windows(2).any(|pair| pair == ["--send", "no"])
+            }));
+            assert!(!calls.iter().any(|(_, args)| {
+                args.iter()
+                    .any(|arg| arg == "--pool" || arg == "--custodian")
+            }));
+        }
+    }
+
+    #[test]
+    fn deploy_adapters_allows_vault_admin_after_companion_upgrade_detection() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_blend_wasm(dir.path());
+        write_fake_custodial_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        let mut manifest = Manifest::new("testnet", None);
+        for key in ["vault", "governance", "asset_token"] {
+            manifest
+                .contracts
+                .insert(key.to_string(), imported_record(CONTRACT));
+        }
+        manifest.save(&state).expect("save manifest");
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::Adapters(crate::cli::DeployAdaptersArgs {
+                    vault: None,
+                    governance: None,
+                    asset_token: None,
+                    blend_pools: vec![CONTRACT.parse().expect("pool")],
+                    custodians: vec![ACCOUNT.parse().expect("custodian")],
+                    adapter_admin: "vault".parse().expect("vault adapter admin"),
+                    build: false,
+                    force_new: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor =
+            RecordingExecutor::with_runtime_feature_flags(0x1f | RUNTIME_FEATURE_COMPANION_UPGRADE);
+
+        run(&cli, &executor).expect("deploy adapters with vault admin");
+
+        let loaded = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        for key in ["blend_adapter_0", "custodial_adapter_0"] {
+            assert_eq!(
+                loaded
+                    .contracts
+                    .get(key)
+                    .expect("adapter record")
+                    .constructor_args
+                    .get("admin")
+                    .map(String::as_str),
+                Some(CONTRACT)
+            );
+        }
+        let calls = executor.calls();
+        assert_eq!(
+            calls
+                .iter()
+                .filter(|(_, args)| args.iter().any(|arg| arg == "version"))
+                .count(),
+            2
+        );
+        let version_index = calls
+            .iter()
+            .position(|(_, args)| args.iter().any(|arg| arg == "version"))
+            .expect("runtime version query");
+        for constructor_flag in ["--pool", "--custodian"] {
+            let deploy_index = calls
+                .iter()
+                .position(|(_, args)| args.iter().any(|arg| arg == constructor_flag))
+                .expect("adapter deployment");
+            assert!(version_index < deploy_index);
+        }
+    }
+
+    #[test]
+    fn runtime_version_parser_requires_typed_version_and_feature_mask() {
+        assert_eq!(
+            parse_runtime_version("[\"1.2.3\",64]").expect("runtime version"),
+            ("1.2.3".to_string(), 64)
+        );
+        assert!(parse_runtime_version(CONTRACT).is_err());
+        assert!(parse_runtime_version("[\"1.2.3\"]").is_err());
     }
 
     #[test]
@@ -5893,6 +6193,7 @@ mod tests {
                         share_decimals: 7,
                         blend_pools: vec![CONTRACT.parse().expect("pool")],
                         custodians: Vec::new(),
+                        adapter_admin: Some(ACCOUNT.parse().expect("adapter admin")),
                         build: false,
                         force_new: false,
                     })),
@@ -5937,6 +6238,7 @@ mod tests {
                     ACCOUNT.parse().expect("duplicate custodian"),
                     CONTRACT.parse().expect("second custodian"),
                 ],
+                adapter_admin: ACCOUNT.parse().expect("adapter admin"),
                 build: false,
                 force_new: false,
             },
@@ -5957,6 +6259,48 @@ mod tests {
             custodial_keys,
             vec!["custodial_adapter_0", "custodial_adapter_1"]
         );
+    }
+
+    #[test]
+    fn deploy_plan_records_companion_upgrade_check_for_vault_admin() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let state = dir.path().join("manifest.json");
+        let mut manifest = Manifest::new("testnet", None);
+        for key in ["vault", "governance"] {
+            manifest
+                .contracts
+                .insert(key.to_string(), imported_record(CONTRACT));
+        }
+        let cli = base_cli(state, Commands::Status);
+
+        let plan = deploy_adapters_plan(
+            &cli,
+            &manifest,
+            &crate::cli::DeployAdaptersArgs {
+                vault: None,
+                governance: None,
+                asset_token: None,
+                blend_pools: vec![ACCOUNT.parse().expect("pool")],
+                custodians: Vec::new(),
+                adapter_admin: "vault".parse().expect("vault adapter admin"),
+                build: false,
+                force_new: false,
+            },
+        )
+        .expect("plan adapters");
+
+        assert!(plan
+            .stellar_commands
+            .iter()
+            .any(|command| command.contains("--send no -- version")));
+        assert!(plan
+            .stellar_commands
+            .iter()
+            .any(|command| command.contains(&format!("--admin {CONTRACT}"))));
+        assert!(plan
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("companion-upgrade capability 0x40")));
     }
 
     #[test]
@@ -6349,6 +6693,7 @@ mod tests {
                         ACCOUNT.parse().expect("second pool"),
                     ],
                     custodians: Vec::new(),
+                    adapter_admin: Some(ACCOUNT.parse().expect("adapter admin")),
                     build: false,
                     force_new: false,
                 })),
@@ -6391,6 +6736,7 @@ mod tests {
                     share_decimals: 7,
                     blend_pools: Vec::new(),
                     custodians: vec![ACCOUNT.parse().expect("custodian")],
+                    adapter_admin: Some(ACCOUNT.parse().expect("adapter admin")),
                     build: false,
                     force_new: false,
                 })),
@@ -6453,6 +6799,7 @@ mod tests {
                     share_decimals: 7,
                     blend_pools: Vec::new(),
                     custodians: Vec::new(),
+                    adapter_admin: None,
                     build: false,
                     force_new: false,
                 })),
@@ -7052,6 +7399,7 @@ mod tests {
                     share_decimals: 7,
                     blend_pools: Vec::new(),
                     custodians: Vec::new(),
+                    adapter_admin: None,
                     build: false,
                     force_new: false,
                 })),

--- a/tools/soroban-vault-cli/src/profile.rs
+++ b/tools/soroban-vault-cli/src/profile.rs
@@ -19,6 +19,7 @@ pub struct ProfileConfig {
     pub contract_source_repo: Option<String>,
     pub config_dir: Option<PathBuf>,
     pub admin: Option<String>,
+    pub adapter_admin: Option<String>,
     pub caller: Option<String>,
     pub operator: Option<String>,
 }
@@ -183,6 +184,15 @@ fn push_leaf_profile_args(
             profile.admin.as_deref(),
         );
     }
+    if needs_adapter_admin(raw_args) {
+        push_profile_arg(
+            expanded,
+            raw_args,
+            "--adapter-admin",
+            "SOROBAN_ADAPTER_ADMIN",
+            profile.adapter_admin.as_deref(),
+        );
+    }
     if needs_caller(raw_args) {
         push_profile_arg(
             expanded,
@@ -272,6 +282,13 @@ fn needs_caller(raw_args: &[String]) -> bool {
     .any(|command| raw_args.iter().any(|arg| arg == command))
 }
 
+fn needs_adapter_admin(raw_args: &[String]) -> bool {
+    primary_command(raw_args).as_deref() == Some("deploy")
+        && ["stack", "resume", "adapters"]
+            .into_iter()
+            .any(|command| raw_args.iter().any(|arg| arg == command))
+}
+
 fn needs_operator(raw_args: &[String]) -> bool {
     ["deposit", "mint", "withdraw", "execute-withdraw"]
         .into_iter()
@@ -356,6 +373,7 @@ workspace_path = "."
 # config_dir = "/home/operator/.config/stellar"
 # contract_source_repo = "github:Templar-Protocol/contracts"
 # admin = "G..."
+# adapter_admin = "G..." # or "vault" when capability 0x40 is advertised
 # caller = "G..."
 # operator = "G..."
 "#
@@ -414,6 +432,38 @@ admin = "GADMIN"
         assert!(expanded
             .windows(2)
             .any(|pair| pair == ["--admin", "GADMIN"]));
+    }
+
+    #[test]
+    fn profile_expansion_injects_explicit_adapter_admin_for_deploy_flows() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        fs::write(
+            dir.path().join("testnet.toml"),
+            r#"
+network = "testnet"
+adapter_admin = "vault"
+"#,
+        )
+        .expect("write profile");
+
+        let expanded = expand_args_with_dir(
+            &[
+                "tmplr-soroban-vault".to_string(),
+                "--profile".to_string(),
+                "testnet".to_string(),
+                "deploy".to_string(),
+                "plan".to_string(),
+                "adapters".to_string(),
+                "--blend-pool".to_string(),
+                "CDY3B7IXFN5L4OY4UFFS2FA4MAQWJZLJD76LW37S7HFVWRS3RPQ2SIXX".to_string(),
+            ],
+            dir.path(),
+        )
+        .expect("expand args");
+
+        assert!(expanded
+            .windows(2)
+            .any(|pair| pair == ["--adapter-admin", "vault"]));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/types.rs
+++ b/tools/soroban-vault-cli/src/types.rs
@@ -244,6 +244,50 @@ impl fmt::Display for AddressStr {
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AdapterAdminArg {
+    Vault,
+    Address(AddressStr),
+}
+
+impl AdapterAdminArg {
+    #[must_use]
+    pub fn resolve<'a>(&'a self, vault: &'a str) -> &'a str {
+        match self {
+            Self::Vault => vault,
+            Self::Address(address) => address.as_str(),
+        }
+    }
+
+    #[must_use]
+    pub fn targets_vault(&self, vault: &str) -> bool {
+        matches!(self, Self::Vault)
+            || matches!(self, Self::Address(address) if address.as_str() == vault)
+    }
+}
+
+impl FromStr for AdapterAdminArg {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value == "vault" {
+            return Ok(Self::Vault);
+        }
+        value.parse::<AddressStr>().map(Self::Address).map_err(|_| {
+            format!("expected `vault` or a valid Soroban account/contract address: {value}")
+        })
+    }
+}
+
+impl fmt::Display for AdapterAdminArg {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Vault => formatter.write_str("vault"),
+            Self::Address(address) => address.fmt(formatter),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
 pub struct WasmHash(String);
 
@@ -522,6 +566,22 @@ mod tests {
         assert!(ACCOUNT.parse::<AddressStr>().is_ok());
         assert!(CONTRACT.parse::<AddressStr>().is_ok());
         assert!("not-an-address".parse::<AddressStr>().is_err());
+    }
+
+    #[test]
+    fn adapter_admin_parses_explicit_address_or_vault_alias() {
+        let address = ACCOUNT
+            .parse::<AdapterAdminArg>()
+            .expect("explicit adapter admin");
+        let vault = "vault"
+            .parse::<AdapterAdminArg>()
+            .expect("vault adapter admin");
+
+        assert_eq!(address.resolve(CONTRACT), ACCOUNT);
+        assert!(!address.targets_vault(CONTRACT));
+        assert_eq!(vault.resolve(CONTRACT), CONTRACT);
+        assert!(vault.targets_vault(CONTRACT));
+        assert!("governance".parse::<AdapterAdminArg>().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Breaking change

New Blend and custodial adapter deployments must select the adapter administrator explicitly:

- CLI and profiles: `--adapter-admin <address|vault>` or `SOROBAN_ADAPTER_ADMIN`
- Soroban just recipes: `SOROBAN_ADAPTER_ADMIN=<address|vault>`

The deployment flow no longer silently assigns the governance contract as adapter admin.

## Why

The current governance contract dispatches typed actions only to its configured vault. It cannot call adapter upgrade or two-step admin-transfer methods. Using governance as the implicit adapter admin could therefore deploy an adapter whose administrative controls are operationally unreachable.

This change makes that authority boundary explicit and fails closed when the vault itself cannot prove that it supports companion-contract administration.

## Behavior

- `deploy stack` and `deploy resume` require `--adapter-admin` when Blend or custodial adapters are requested.
- `deploy adapters` always requires `--adapter-admin`.
- An explicit non-vault Soroban address is passed directly to every new adapter constructor.
- The `vault` alias, or the literal vault address, is accepted only after a fresh `version()` query returns a valid capability response containing companion-upgrade bit `0x40`.
- The current default runtime advertises `0x3f`, which does not include `0x40`, so selecting the vault fails closed.
- Deployment planning, profile expansion, CLI execution, documentation, and just recipes use the same rules.

## Scope and compatibility

- Existing deployed adapters and existing manifest records are unchanged.
- This PR does not implement companion-contract upgrades or recover previously deployed adapters with unreachable administrators.
- Explicit non-vault addresses remain an operator choice; the CLI does not claim that an arbitrary selected address has the required operational controls.
- No vault runtime migration or state migration is required.

## Validation

- `cargo test -p templar-soroban-vault-cli` — 101 passed
- `cargo fmt --all -- --check`
- `python3 -m py_compile contract/vault/soroban/scripts/require_runtime_feature.py`
- `git diff --check`
- Soroban size-budget check — 129,499 / 131,072 bytes

## Issue

[ENG-484](https://linear.app/templar-protocol/issue/ENG-484/add-reported-at-to-custodial-nav-adapter-reports)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/524)
<!-- Reviewable:end -->