### PR TITLE
ENG-484: add custodial NAV report timestamps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,6 +275,9 @@ jobs:
       - name: Enforce Soroban runtime size budget
         run: just -f contract/vault/soroban/justfile size-budget-check
 
+      - name: Verify custodial adapter release ABI
+        run: just -f contract/vault/soroban/justfile verify-custodial-adapter-release-abi
+
       - name: Enforce proxy-oracle Soroban size budgets
         run: just -f contract/proxy-oracle/soroban/justfile size-check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13812,7 +13812,7 @@ dependencies = [
 
 [[package]]
 name = "templar-soroban-custodial-adapter"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "proptest",
  "soroban-sdk",

--- a/contract/vault/soroban/AGENTS.md
+++ b/contract/vault/soroban/AGENTS.md
@@ -11,6 +11,7 @@ Soroban-side companion contracts:
 - `templar-soroban-governance` in `contract/vault/soroban/governance`
 - `templar-soroban-share-token` in `contract/vault/soroban/share-token`
 - `templar-soroban-blend-adapter` in `contract/vault/soroban/blend-adapter`
+- `templar-soroban-custodial-adapter` in `contract/vault/soroban/custodial-adapter`
 - shared ABI/types in `contract/vault/soroban/shared-types`
 
 Read these first before making non-trivial changes:
@@ -290,6 +291,14 @@ Minimum runtime verification:
 - `cargo test -p templar-soroban-runtime -- --nocapture`
 - `cargo test -p templar-soroban-runtime --test integration_tests -- --nocapture`
 - `cargo test -p templar-soroban-runtime --test property_tests -- --nocapture`
+
+Custodial adapter ABI changes:
+
+- `cargo test -p templar-soroban-custodial-adapter -- --nocapture`
+- `just -f contract/vault/soroban/justfile verify-custodial-adapter-release-abi`
+
+The release-ABI gate builds the optimized adapter, checks the exact contract interface, and invokes
+the real Wasm artifact to ensure the exported method decodes and executes as expected.
 
 Size verification:
 

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -306,6 +306,9 @@ returned to the adapter on Stellar. It does not initiate or prove a market exit.
 `total_assets(asset)` value is explicit reported accounting, updated by vault allocation flow or by
 `set_reported_assets(caller, asset, expected_current, amount, report_nonce)` from the configured
 admin, vault, or custodian.
+The additive `reported_at(asset)` query returns the ledger timestamp of the latest successful
+explicit report, or `None` for adapters/assets that have never received one. Allocation and
+withdrawal lifecycle updates intentionally do not refresh that timestamp.
 Returned idle balances are not auto-counted as NAV because the adapter cannot prove their offchain
 source. When the adapter is paused, vault and custodian reports are blocked, but the adapter admin
 can still submit reported-NAV corrections for incident recovery. The `report_nonce` is an exact
@@ -317,10 +320,14 @@ Use recipes in [contract/vault/soroban/justfile](./justfile):
 - `just deploy-custodial-adapter <CUSTODIAN_OR_MULTISIG_ADDRESS>`
 - `just deploy-all-with-custodial <CUSTODIAN_OR_MULTISIG_ADDRESS>`
 - `just custodial-adapter-status`
+- `just custodial-adapter-reported-at <ASSET_ADDRESS>`
 - `just custodial-adapter-set-reported-assets <CALLER_ADDRESS> <ASSET_ADDRESS> <EXPECTED_CURRENT> <RAW_AMOUNT> <REPORT_NONCE>`
 
 The custodial adapter's `extend_ttl()` entrypoint is permissionless because it only refreshes
 instance storage liveness and the transaction caller pays the Soroban resource cost.
+
+Existing adapter storage needs no migration: an absent timestamp key is returned as `None` until
+the next successful explicit report.
 
 ### Custodial Runbook Checks
 

--- a/contract/vault/soroban/custodial-adapter/Cargo.toml
+++ b/contract/vault/soroban/custodial-adapter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-soroban-custodial-adapter"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Soroban custodial market adapter for offchain-managed vault allocations"

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -1336,6 +1336,7 @@ mod tests {
 
         env.ledger().set_timestamp(100);
         set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 10);
+        let accepted_nonce = report_nonce(&env, &contract_id, &asset);
 
         env.ledger().set_timestamp(200);
         env.as_contract(&contract_id, || {
@@ -1344,9 +1345,9 @@ mod tests {
                     env.clone(),
                     vault,
                     asset.clone(),
-                    9,
+                    10,
                     11,
-                    2,
+                    accepted_nonce,
                 ),
                 Err(AdapterError::InvalidInput)
             );

--- a/contract/vault/soroban/custodial-adapter/src/lib.rs
+++ b/contract/vault/soroban/custodial-adapter/src/lib.rs
@@ -25,6 +25,7 @@ enum DataKey {
     Paused,
     ReportedAssets(Address),
     ReportNonce(Address),
+    ReportedAt(Address),
 }
 
 #[contracterror]
@@ -218,6 +219,16 @@ impl CustodialAdapterContract {
         load_reported_assets(&env, &asset)
     }
 
+    /// Return the ledger timestamp of the latest explicit reported-NAV update.
+    ///
+    /// `None` means `set_reported_assets` has never succeeded for this asset.
+    /// Allocation and withdrawal lifecycle mutations do not change this value.
+    pub fn reported_at(env: Env, asset: Address) -> Result<Option<u64>, AdapterError> {
+        extend_instance_ttl(&env);
+        require_asset(&env, &asset)?;
+        Ok(load_reported_at(&env, &asset))
+    }
+
     /// Explicitly set reported route NAV for `asset`.
     ///
     /// The configured custodian is allowed to report NAV because custody of the
@@ -254,6 +265,7 @@ impl CustodialAdapterContract {
         }
         store_reported_assets(&env, &asset, amount);
         store_report_nonce(&env, &asset, report_nonce);
+        store_reported_at(&env, &asset, env.ledger().timestamp());
         env.events()
             .publish((symbol_short!("report"), caller, asset), amount);
         Ok(())
@@ -473,6 +485,12 @@ fn load_report_nonce(env: &Env, asset: &Address) -> u64 {
         .unwrap_or(0)
 }
 
+fn load_reported_at(env: &Env, asset: &Address) -> Option<u64> {
+    env.storage()
+        .instance()
+        .get(&DataKey::ReportedAt(asset.clone()))
+}
+
 fn next_report_nonce(env: &Env, asset: &Address) -> Result<u64, AdapterError> {
     load_report_nonce(env, asset)
         .checked_add(1)
@@ -492,6 +510,12 @@ fn store_report_nonce(env: &Env, asset: &Address, nonce: u64) {
     env.storage()
         .instance()
         .set(&DataKey::ReportNonce(asset.clone()), &nonce);
+}
+
+fn store_reported_at(env: &Env, asset: &Address, timestamp: u64) {
+    env.storage()
+        .instance()
+        .set(&DataKey::ReportedAt(asset.clone()), &timestamp);
 }
 
 fn require_admin(env: &Env, caller: &Address) -> Result<(), AdapterError> {
@@ -610,7 +634,9 @@ mod kani_proofs {
 mod tests {
     use super::*;
     use proptest::prelude::*;
-    use soroban_sdk::testutils::{Address as _, Events as _, MockAuth, MockAuthInvoke};
+    use soroban_sdk::testutils::{
+        Address as _, Events as _, Ledger as _, MockAuth, MockAuthInvoke,
+    };
     use soroban_sdk::{contract, contractimpl, IntoVal, Symbol};
 
     const ADAPTER_SOURCE: &str = include_str!("lib.rs");
@@ -702,6 +728,12 @@ mod tests {
     fn report_nonce(env: &Env, contract_id: &Address, asset: &Address) -> u64 {
         env.as_contract(contract_id, || {
             CustodialAdapterContract::report_nonce(env.clone(), asset.clone()).unwrap()
+        })
+    }
+
+    fn reported_at(env: &Env, contract_id: &Address, asset: &Address) -> Option<u64> {
+        env.as_contract(contract_id, || {
+            CustodialAdapterContract::reported_at(env.clone(), asset.clone()).unwrap()
         })
     }
 
@@ -1228,6 +1260,99 @@ mod tests {
                 5
             );
         });
+    }
+
+    #[test]
+    fn reported_at_is_none_for_legacy_state_and_tracks_explicit_reports() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+
+        env.as_contract(&contract_id, || {
+            store_reported_assets(&env, &asset, 50);
+            store_report_nonce(&env, &asset, 7);
+        });
+        assert_eq!(reported_assets(&env, &contract_id, &asset), 50);
+        assert_eq!(report_nonce(&env, &contract_id, &asset), 7);
+        assert_eq!(reported_at(&env, &contract_id, &asset), None);
+
+        env.ledger().set_timestamp(123);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 7);
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(123));
+
+        env.ledger().set_timestamp(456);
+        set_reported_assets_for(&env, &contract_id, vault, asset.clone(), 0);
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(456));
+        assert!(!has_reported_assets_key(&env, &contract_id, &asset));
+    }
+
+    #[test]
+    fn lifecycle_nav_mutations_do_not_change_reported_at() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+        let asset_admin = soroban_sdk::token::StellarAssetClient::new(&env, &asset);
+
+        env.ledger().set_timestamp(100);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 100);
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(100));
+
+        env.ledger().set_timestamp(200);
+        asset_admin.mint(&contract_id, &10);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::supply(env.clone(), vault.clone(), asset.clone(), 10)
+                .unwrap();
+        });
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(100));
+
+        env.ledger().set_timestamp(300);
+        asset_admin.mint(&contract_id, &30);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::progress_withdrawal(
+                    env.clone(),
+                    vault.clone(),
+                    asset.clone(),
+                    20,
+                )
+                .unwrap(),
+                20
+            );
+        });
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(100));
+
+        env.ledger().set_timestamp(400);
+        env.as_contract(&contract_id, || {
+            CustodialAdapterContract::withdraw(env.clone(), vault, asset.clone(), 10).unwrap();
+        });
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(100));
+    }
+
+    #[test]
+    fn failed_explicit_report_does_not_change_reported_at() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let (contract_id, _admin, vault, _custodian, asset) = setup_adapter(&env);
+
+        env.ledger().set_timestamp(100);
+        set_reported_assets_for(&env, &contract_id, vault.clone(), asset.clone(), 10);
+
+        env.ledger().set_timestamp(200);
+        env.as_contract(&contract_id, || {
+            assert_eq!(
+                CustodialAdapterContract::set_reported_assets(
+                    env.clone(),
+                    vault,
+                    asset.clone(),
+                    9,
+                    11,
+                    2,
+                ),
+                Err(AdapterError::InvalidInput)
+            );
+        });
+
+        assert_eq!(reported_at(&env, &contract_id, &asset), Some(100));
     }
 
     #[test]

--- a/contract/vault/soroban/custodial-adapter/tests/artifact_reported_at.rs
+++ b/contract/vault/soroban/custodial-adapter/tests/artifact_reported_at.rs
@@ -1,0 +1,35 @@
+#![allow(unexpected_cfgs)]
+#![cfg(artifact_wasm)]
+
+use soroban_sdk::{contract, testutils::Address as _, Address, Env, IntoVal, Symbol};
+
+const CUSTODIAL_ADAPTER_WASM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../../target/wasm32-unknown-unknown/release-soroban/templar_soroban_custodial_adapter.wasm"
+));
+
+#[contract]
+struct DummyVault;
+
+#[test]
+fn optimized_custodial_adapter_exports_reported_at() {
+    let env = Env::default();
+    env.cost_estimate().budget().reset_unlimited();
+    let admin = Address::generate(&env);
+    let vault = env.register(DummyVault, ());
+    let custodian = Address::generate(&env);
+    let asset_admin = Address::generate(&env);
+    let asset = env
+        .register_stellar_asset_contract_v2(asset_admin)
+        .address();
+    let adapter = env.register(CUSTODIAL_ADAPTER_WASM, (&admin, &vault, &custodian, &asset));
+
+    assert_eq!(
+        env.invoke_contract::<Option<u64>>(
+            &adapter,
+            &Symbol::new(&env, "reported_at"),
+            (&asset,).into_val(&env),
+        ),
+        None
+    );
+}

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -55,6 +55,7 @@ custodial_adapter_wasm := wasm_dir + "/templar_soroban_custodial_adapter.wasm"
 governance_wasm := wasm_dir + "/templar_soroban_governance.wasm"
 share_token_wasm := wasm_dir + "/templar_soroban_share_token.wasm"
 payload_script := justfile_directory() + "/scripts/vault_payload.py"
+custodial_adapter_abi_script := justfile_directory() + "/scripts/check_custodial_adapter_release_abi.py"
 default_friendbot := "https://friendbot.stellar.org"
 default_network := "testnet"
 default_rpc := "https://soroban-testnet.stellar.org"
@@ -150,6 +151,16 @@ build-custodial-adapter:
 	@echo "Building custodial adapter WASM..."
 	@just -f "{{justfile_directory()}}/justfile" _optimize-wasm templar-soroban-custodial-adapter "{{wasm_dir}}/templar_soroban_custodial_adapter.wasm"
 	@echo "✓ Built: {{custodial_adapter_wasm}}"
+
+# Verify the optimized custodial adapter exports and executes reported_at.
+verify-custodial-adapter-release-abi: build-custodial-adapter
+	@stellar contract info interface --wasm "{{custodial_adapter_wasm}}" --output json | python3 "{{custodial_adapter_abi_script}}"
+	@RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }--cfg artifact_wasm" cargo test \
+		--manifest-path "{{root}}/Cargo.toml" \
+		-p templar-soroban-custodial-adapter \
+		--test artifact_reported_at \
+		-- --nocapture
+	@echo "✓ Custodial adapter release ABI and behavior verified"
 
 # Check the Soroban ERC-4626 proxy crate.
 check-4626-proxy:
@@ -639,6 +650,10 @@ custodial-adapter-custodian:
 custodial-adapter-total-assets asset_address:
 	@just custodial-invoke total_assets --asset "{{asset_address}}"
 
+# Get the timestamp of the latest explicit NAV report for an asset.
+custodial-adapter-reported-at asset_address:
+	@just custodial-invoke reported_at --asset "{{asset_address}}"
+
 # Set reported assets for an offchain-managed position.
 # caller must be the configured admin, vault, or custodian and must authorize the call.
 custodial-adapter-set-reported-assets caller asset_address expected_current amount report_nonce:
@@ -661,6 +676,7 @@ custodial-adapter-status:
 		asset="${SOROBAN_ASSET_TOKEN:-$(cat {{state_dir}}/asset_token_id 2>/dev/null)}"; \
 		if [ -n "$asset" ]; then \
 			echo "Reported:  $(just custodial-invoke total_assets --asset "$asset" 2>/dev/null || echo 'error')"; \
+			echo "Reported at: $(just custodial-invoke reported_at --asset "$asset" 2>/dev/null || echo 'error')"; \
 		fi; \
 	fi
 
@@ -1290,6 +1306,7 @@ help:
 	@echo "  just build                    Build vault WASM"
 	@echo "  just build-blend-adapter      Build Blend adapter WASM"
 	@echo "  just build-custodial-adapter  Build custodial adapter WASM"
+	@echo "  just verify-custodial-adapter-release-abi  Verify optimized custodial adapter ABI"
 	@echo "  just build-all                Build all WASMs"
 	@echo "  just wasm-analyze [rows]      Generate twiggy analysis reports"
 	@echo "  just wasm-analyze-print [report] [lines]  Print analysis reports"
@@ -1322,6 +1339,7 @@ help:
 	@echo "  just deploy-custodial-adapter <custodian>  Deploy adapter for offchain custody route"
 	@echo "  just custodial-adapter-status              Show adapter status"
 	@echo "  just custodial-adapter-total-assets <asset>  Query reported position"
+	@echo "  just custodial-adapter-reported-at <asset>   Query latest explicit report timestamp"
 	@echo "  just custodial-adapter-set-reported-assets <caller> <asset> <expected_current> <amount> <report_nonce>"
 	@echo ""
 	@echo "DEPOSITS:"

--- a/contract/vault/soroban/scripts/check_custodial_adapter_release_abi.py
+++ b/contract/vault/soroban/scripts/check_custodial_adapter_release_abi.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Validate the exact custodial-adapter reported_at release ABI."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+
+EXPECTED = {
+    "name": "reported_at",
+    "inputs": [{"name": "asset", "type_": "address"}],
+    "outputs": [
+        {
+            "result": {
+                "ok_type": {"option": {"value_type": "u64"}},
+                "error_type": {"udt": {"name": "AdapterError"}},
+            }
+        }
+    ],
+}
+
+
+def normalize(function: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": function.get("name"),
+        "inputs": [
+            {"name": item.get("name"), "type_": item.get("type_")}
+            for item in function.get("inputs", [])
+        ],
+        "outputs": function.get("outputs", []),
+    }
+
+
+def main() -> int:
+    try:
+        entries = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError) as error:
+        print(f"invalid Stellar interface JSON: {error}", file=sys.stderr)
+        return 1
+    if not isinstance(entries, list):
+        print("Stellar interface JSON must be a list", file=sys.stderr)
+        return 1
+
+    matches = []
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("function_v0"), dict):
+            continue
+        function = entry["function_v0"]
+        if function.get("name") == "reported_at":
+            matches.append(normalize(function))
+
+    if matches != [EXPECTED]:
+        print("custodial-adapter ABI mismatch for reported_at", file=sys.stderr)
+        print(f"expected: {json.dumps([EXPECTED], sort_keys=True)}", file=sys.stderr)
+        print(f"actual:   {json.dumps(matches, sort_keys=True)}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add `reported_at(asset) -> Result<Option<u64>, AdapterError>` to the custodial adapter.
- Stamp the current ledger timestamp only after a successful explicit `set_reported_assets` call.
- Keep allocation, supply, return, and withdrawal lifecycle mutations from refreshing the report timestamp.
- Preserve existing nonce and absolute-report replay protections.
- Bump `templar-soroban-custodial-adapter` to `1.1.0` and update its lockfile entry.
- Add operator docs/recipes plus a self-contained optimized-Wasm ABI and execution gate.

## Why

Custodial NAV reports exposed their value and nonce but not when the last explicit off-chain report
was accepted. Curators and monitors therefore could not measure report freshness independently of
normal custody lifecycle activity.

## Compatibility

- Existing deployed adapter state requires no migration.
- A missing timestamp key returns `None` until the next successful explicit report.
- Failed or replayed reports do not update the timestamp.
- This PR does not change adapter administration or deploy a replacement adapter.

## Stack

This is PR 1 of 3 and targets `dev`.

1. **This PR:** custodial NAV report timestamps.
2. [PR #530](https://github.com/Templar-Protocol/contracts/pull/530): runtime version/capability discovery and curator-proxy replacement.
3. [PR #524](https://github.com/Templar-Protocol/contracts/pull/524): explicit adapter-admin guardrails and the Gami rollout checklist.

## Validation

- `cargo test -q -p templar-soroban-custodial-adapter` — 42 passed.
- `just -f contract/vault/soroban/justfile verify-custodial-adapter-release-abi`
  - built the optimized adapter;
  - checked the exact `reported_at(address) -> Result<Option<u64>, AdapterError>` interface;
  - invoked the real Wasm artifact and verified its initial result is `None`.
- `cargo fmt --all -- --check`
- `git diff --check`
- Optimized adapter: `11981` bytes, hash
  `03c1c749613d67d5ed460bc4fbb12eedb1a043068665a295fbefb774588a796b`.

## Issue

[ENG-484](https://linear.app/templar-protocol/issue/ENG-484/add-reported-at-to-custodial-nav-adapter-reports)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/529)
<!-- Reviewable:end -->
