### PR TITLE
ENG-484: expose vault version capabilities and replace curator proxy

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -275,8 +275,8 @@ jobs:
       - name: Enforce Soroban runtime size budget
         run: just -f contract/vault/soroban/justfile size-budget-check
 
-      - name: Verify custodial adapter release ABI
-        run: just -f contract/vault/soroban/justfile verify-custodial-adapter-release-abi
+      - name: Verify ENG-484 Soroban release ABIs
+        run: just -f contract/vault/soroban/justfile verify-release-wasm-abi
 
       - name: Enforce proxy-oracle Soroban size budgets
         run: just -f contract/proxy-oracle/soroban/justfile size-check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12935,7 +12935,7 @@ dependencies = [
 
 [[package]]
 name = "templar-curator-proxy-soroban"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "soroban-sdk",
  "templar-soroban-governance",
@@ -13832,7 +13832,7 @@ dependencies = [
 
 [[package]]
 name = "templar-soroban-runtime"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "blend-contract-sdk",
  "derive_more 1.0.0",
@@ -13860,7 +13860,7 @@ dependencies = [
 
 [[package]]
 name = "templar-soroban-shared-types"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "postcard",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1637,6 +1637,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
+ "zeroize",
 ]
 
 [[package]]
@@ -13872,10 +13873,13 @@ name = "templar-soroban-vault-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bip39",
  "clap",
  "clap_complete",
  "clap_mangen",
  "dirs 6.0.0",
+ "ed25519-dalek",
+ "ed25519-dalek-bip32",
  "hex",
  "indicatif",
  "secrecy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ arbitrary = { version = "1", features = ["derive"] }
 async-trait = "0.1.89"
 axum = "0.8.8"
 base64 = "0.22.1"
+bip39 = { version = "2.2.2", features = ["zeroize"] }
 borsh = { version = "1.5", features = ["unstable__schema"] }
 bs58 = "0.5.1"
 byteorder = "1"
@@ -68,6 +69,7 @@ clap = { version = "4.6.0", features = ["derive", "env"] }
 console = "0.16.3"
 dirs = "6"
 ed25519-dalek = "2.2.0"
+ed25519-dalek-bip32 = "0.3.0"
 futures = "0.3.31"
 derive_more = { version = "1", default-features = false, features = [
     "from",

--- a/contract/vault/kernel/src/lib.rs
+++ b/contract/vault/kernel/src/lib.rs
@@ -20,6 +20,19 @@ pub mod transitions;
 pub mod types;
 pub mod utils;
 
+/// Whether the `action-recovery` feature is enabled in this resolved kernel build.
+pub const ACTION_RECOVERY_ENABLED: bool = cfg!(feature = "action-recovery");
+/// Whether the `action-sync-external` feature is enabled in this resolved kernel build.
+pub const ACTION_SYNC_EXTERNAL_ENABLED: bool = cfg!(feature = "action-sync-external");
+/// Whether the `action-refresh-fees` feature is enabled in this resolved kernel build.
+pub const ACTION_REFRESH_FEES_ENABLED: bool = cfg!(feature = "action-refresh-fees");
+/// Whether the `action-allocation-lifecycle` feature is enabled in this resolved kernel build.
+pub const ACTION_ALLOCATION_LIFECYCLE_ENABLED: bool = cfg!(feature = "action-allocation-lifecycle");
+/// Whether the `action-refresh-lifecycle` feature is enabled in this resolved kernel build.
+pub const ACTION_REFRESH_LIFECYCLE_ENABLED: bool = cfg!(feature = "action-refresh-lifecycle");
+/// Whether the `action-pause` feature is enabled in this resolved kernel build.
+pub const ACTION_PAUSE_ENABLED: bool = cfg!(feature = "action-pause");
+
 pub use actions::{
     apply_action, convert_to_assets, convert_to_assets_bounded, convert_to_assets_ceil,
     convert_to_assets_ceil_bounded, convert_to_shares, convert_to_shares_bounded,

--- a/contract/vault/soroban/AGENTS.md
+++ b/contract/vault/soroban/AGENTS.md
@@ -258,6 +258,8 @@ Practical order of attack:
 
 - `initialize()` is highly sensitive because front-running it would seize governance/curator
   control. Keep deployment and initialization assumptions explicit.
+- Curator-proxy deployments pin a one-time initialization authority in `__constructor` and remove
+  it after successful initialization. Do not reintroduce an unauthenticated first-claim window.
 - Review auth on every privileged Soroban entrypoint. Do not rely on outer routing alone.
 - Soroban transactions are atomic, but adapter correctness, state ordering, and accepted external
   asset snapshots still matter for accounting safety.

--- a/contract/vault/soroban/AGENTS.md
+++ b/contract/vault/soroban/AGENTS.md
@@ -69,8 +69,8 @@ Important details:
 - `build` emits the optimized runtime WASM and uses that same artifact for deployment. It keeps
   contractspec metadata so standard Stellar CLI invocation and explorer source-attestation tooling
   can inspect the deployed WASM.
-- Recent local evidence records the unstripped deploy artifact at `128955` bytes (`125.9 KiB`),
-  leaving roughly `2.1 KiB` of headroom under the `131072` byte gate.
+- Current local evidence records the optimized deploy artifact at `129507` bytes (`126.47 KiB`),
+  leaving `1565` bytes of headroom under the `131072` byte gate.
 
 Common growth pitfalls:
 

--- a/contract/vault/soroban/AGENTS.md
+++ b/contract/vault/soroban/AGENTS.md
@@ -60,6 +60,7 @@ Use these commands:
 
 - `just -f contract/vault/soroban/justfile build`
 - `just -f contract/vault/soroban/justfile size-budget-check`
+- `just -f contract/vault/soroban/justfile verify-release-wasm-abi`
 - `just -f contract/vault/soroban/justfile wasm-analyze 250 120`
 - `just -f contract/vault/soroban/justfile wasm-analyze-print all 120`
 
@@ -304,6 +305,14 @@ Size verification:
 
 - `just -f contract/vault/soroban/justfile build`
 - `just -f contract/vault/soroban/justfile size-budget-check`
+
+Release ABI and capability-mask verification:
+
+- `just -f contract/vault/soroban/justfile verify-release-wasm-abi`
+
+This gate checks the isolated runtime feature matrix, exact optimized contract interfaces for
+`version`, `vault_version`, `initialize_legacy_v1`, and `reported_at`, plus the real-WASM proxy
+transition from pinned v1 semantics to the upgraded runtime response.
 
 When relevant, also run:
 

--- a/contract/vault/soroban/Cargo.toml
+++ b/contract/vault/soroban/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-soroban-runtime"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Soroban effect interpreter and runtime for Templar Protocol vaults"
@@ -10,13 +10,25 @@ crate-type = ["cdylib", "rlib"]
 path = "src/lib.rs"
 
 [features]
-default = []
+default = [
+    "action-recovery",
+    "action-sync-external",
+    "action-refresh-fees",
+    "action-allocation-lifecycle",
+    "action-refresh-lifecycle",
+]
 std = []
 testutils = ["soroban-sdk/testutils"]
+action-recovery = ["templar-vault-kernel/action-recovery"]
+action-sync-external = ["templar-vault-kernel/action-sync-external"]
+action-refresh-fees = ["templar-vault-kernel/action-refresh-fees"]
+action-allocation-lifecycle = ["templar-vault-kernel/action-allocation-lifecycle"]
+action-refresh-lifecycle = ["templar-vault-kernel/action-refresh-lifecycle"]
+action-pause = ["templar-vault-kernel/action-pause"]
 
 [dependencies]
 # Core dependency - vault kernel types
-templar-vault-kernel = { path = "../kernel", features = ["postcard", "soroban", "action-refresh-fees", "action-allocation-lifecycle", "action-refresh-lifecycle", "action-sync-external", "action-recovery"] }
+templar-vault-kernel = { path = "../kernel", default-features = false, features = ["postcard", "soroban"] }
 
 templar-curator-primitives = { path = "../curator-primitives", features = ["postcard"] }
 templar-soroban-shared-types = { path = "./shared-types" }
@@ -33,5 +45,5 @@ soroban-sdk = { version = "25.3.0", features = ["testutils", "alloc", "experimen
 rstest.workspace = true
 blend-contract-sdk = { version = "2.25.0", features = ["testutils"] }
 templar-soroban-blend-adapter = { path = "./blend-adapter" }
-templar-soroban-runtime = { path = ".", features = ["testutils"] }
+templar-soroban-runtime = { path = ".", default-features = false, features = ["testutils"] }
 templar-soroban-governance = { path = "./governance" }

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -289,14 +289,15 @@ New runtime artifacts expose `version() -> (String, u64)`. The string is the pac
 compiled by Cargo, and the bitmask reports the capabilities compiled into that exact WASM. Stable
 assignments are recovery `0x01`, external sync `0x02`, fee refresh `0x04`, allocation lifecycle
 `0x08`, refresh lifecycle `0x10`, pause `0x20`, and companion-contract upgrade routing `0x40`.
-The default production mask is `0x1f`; pause and companion upgrades remain disabled.
+The default production mask is `0x3f`: the governance pause path is public in every runtime build,
+while companion upgrades remain disabled.
 
 The curator proxy exposes the same information through `vault_version()`. Use its existing
 `initialize(vault, governance)` entrypoint for runtimes that expose `version`. For an approved,
 versionless v1 deployment, use
 `initialize_legacy_v1(vault, governance, legacy_v1_wasm_hash)`. Initialization requires the supplied
 hash to equal the vault's current Wasm executable. The proxy returns the approved v1 semantics
-`("1.0.0", 0x1f)` directly while that exact artifact remains installed; it does not invoke
+`("1.0.0", 0x3f)` directly while that exact artifact remains installed; it does not invoke
 `version`, inspect vault state, or infer v1 from a Soroban host error. After an upgrade changes the
 artifact hash, the proxy queries `version` and fails closed on any invocation or decoding error.
 
@@ -332,8 +333,9 @@ just -f contract/vault/soroban/justfile deploy-curator-proxy-legacy-v1 \
 
 Proxy deployment and initialization are separate transactions, but initialization is no longer
 claimable by an observer: only the source identity pinned by the constructor can complete or retry
-it. If that identity is unavailable, deploy a fresh proxy with a new authority instead of attempting
-to claim the recorded instance. The approved tTUSDC mainnet runtime hash is recorded in
+it. The CLI reuses a matching incomplete checkpoint by default; use `--force-new` only when the
+pinned identity is unavailable and the recorded instance must be replaced. The approved tTUSDC
+mainnet runtime hash is recorded in
 `contract/vault/deployments/tTUSDC/mainnet/manifest.json`; do not substitute a hash solely because
 its artifact lacks `version`.
 

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -279,9 +279,27 @@ Use recipes from [contract/vault/soroban/justfile](./justfile):
 
 From repo root: `just -f contract/vault/soroban/justfile <recipe>`.
 
-The build step compiles the runtime, governance, and share-token WASMs, runs the Stellar optimizer,
-and strips runtime contractspec metadata into a deploy artifact. The runtime deploy artifact is
-budgeted separately from the optimizer output because it is the artifact used for size gating.
+The build step compiles the runtime, governance, and share-token WASMs and runs the Stellar
+optimizer while retaining contractspec metadata. The optimized runtime output is both the deploy
+artifact and the artifact enforced by the size gate.
+
+## Runtime Version Discovery
+
+New runtime artifacts expose `version() -> (String, u64)`. The string is the package version
+compiled by Cargo, and the bitmask reports the kernel action handlers compiled into that exact
+WASM. Stable assignments are recovery `0x01`, external sync `0x02`, fee refresh `0x04`, allocation
+lifecycle `0x08`, refresh lifecycle `0x10`, and pause `0x20`. The default production mask is
+`0x1f`; pause remains disabled.
+
+The curator proxy exposes the same information through `vault_version()`. When the configured
+vault has no `version` export, the proxy returns the known v1 fallback `("1.0.0", 0x1f)`. It does
+not treat malformed responses or generic versionless contracts as legacy: because Soroban narrows
+recoverable host errors, the fallback also requires the configured contract to answer the typed v1
+`proxy_view`. This is a compatibility signal, not code-identity attestation; proxy configuration
+must remain restricted to approved vault artifacts. The runtime `version` entrypoint is additive
+and storage-free, so deployed v1 vaults do not need a runtime upgrade or state migration. Existing
+curator proxy deployments are non-upgradeable; consumers that need the query must use a replacement
+proxy pointed at the same vault and governance contracts.
 
 ## Blend Adapter
 
@@ -327,7 +345,10 @@ The custodial adapter's `extend_ttl()` entrypoint is permissionless because it o
 instance storage liveness and the transaction caller pays the Soroban resource cost.
 
 Existing adapter storage needs no migration: an absent timestamp key is returned as `None` until
-the next successful explicit report.
+the next successful explicit report. Rollout still requires upgrade authority over the adapter
+WASM. Adapters
+whose admin is the governance contract cannot currently be upgraded through the shipped governance
+actions; adding that authority or migrating those routes to replacement adapters is separate work.
 
 ### Custodial Runbook Checks
 

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -291,15 +291,48 @@ WASM. Stable assignments are recovery `0x01`, external sync `0x02`, fee refresh 
 lifecycle `0x08`, refresh lifecycle `0x10`, and pause `0x20`. The default production mask is
 `0x1f`; pause remains disabled.
 
-The curator proxy exposes the same information through `vault_version()`. When the configured
-vault has no `version` export, the proxy returns the known v1 fallback `("1.0.0", 0x1f)`. It does
-not treat malformed responses or generic versionless contracts as legacy: because Soroban narrows
-recoverable host errors, the fallback also requires the configured contract to answer the typed v1
-`proxy_view`. This is a compatibility signal, not code-identity attestation; proxy configuration
-must remain restricted to approved vault artifacts. The runtime `version` entrypoint is additive
-and storage-free, so deployed v1 vaults do not need a runtime upgrade or state migration. Existing
-curator proxy deployments are non-upgradeable; consumers that need the query must use a replacement
-proxy pointed at the same vault and governance contracts.
+The curator proxy exposes the same information through `vault_version()`. Use its existing
+`initialize(vault, governance)` entrypoint for runtimes that expose `version`. For an approved,
+versionless v1 deployment, use
+`initialize_legacy_v1(vault, governance, legacy_v1_wasm_hash)`. Initialization requires the supplied
+hash to equal the vault's current Wasm executable. The proxy returns the approved v1 semantics
+`("1.0.0", 0x1f)` directly while that exact artifact remains installed; it does not invoke
+`version`, inspect vault state, or infer v1 from a Soroban host error. After an upgrade changes the
+artifact hash, the proxy queries `version` and fails closed on any invocation or decoding error.
+
+The legacy initializer is an explicit operator assertion that the pinned artifact is a known v1
+runtime. Verify the hash against the approved deployment manifest or release record; the absence of
+a `version` export alone is insufficient because older pre-v1 artifacts can have different action
+capabilities. The runtime `version` entrypoint is additive and storage-free, so deployed v1 vaults
+do not need a runtime upgrade or state migration. Existing curator proxy deployments are
+non-upgradeable; consumers that need the query must use a replacement proxy pointed at the same
+vault and governance contracts.
+
+The targeted CLI flow verifies the vault's current on-chain Wasm hash before deploying a fresh
+proxy and invokes `initialize_legacy_v1`. It checkpoints the successful initialization and pinned
+hash before checking `vault_version`, then marks the proxy version-discovery-capable only after that
+query succeeds:
+
+```sh
+tmplr-soroban-vault deploy curator-proxy \
+  --vault <vault-address> \
+  --governance <governance-address> \
+  --legacy-v1-wasm-hash <approved-v1-wasm-hash>
+```
+
+The equivalent targeted just recipe builds the proxy, lets the contract validate the supplied
+32-byte hash, and checks `vault_version` before recording the new proxy ID:
+
+```sh
+just -f contract/vault/soroban/justfile deploy-curator-proxy-legacy-v1 \
+  <vault-address> <governance-address> <approved-v1-wasm-hash>
+```
+
+Proxy deployment and initialization are separate transactions under the existing deployment model,
+so operators must coordinate the first initialization and verify the emitted proxy address. The
+approved tTUSDC mainnet runtime hash is recorded in
+`contract/vault/deployments/tTUSDC/mainnet/manifest.json`; do not substitute a hash solely because
+its artifact lacks `version`.
 
 ## Blend Adapter
 

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -286,10 +286,10 @@ artifact and the artifact enforced by the size gate.
 ## Runtime Version Discovery
 
 New runtime artifacts expose `version() -> (String, u64)`. The string is the package version
-compiled by Cargo, and the bitmask reports the kernel action handlers compiled into that exact
-WASM. Stable assignments are recovery `0x01`, external sync `0x02`, fee refresh `0x04`, allocation
-lifecycle `0x08`, refresh lifecycle `0x10`, and pause `0x20`. The default production mask is
-`0x1f`; pause remains disabled.
+compiled by Cargo, and the bitmask reports the capabilities compiled into that exact WASM. Stable
+assignments are recovery `0x01`, external sync `0x02`, fee refresh `0x04`, allocation lifecycle
+`0x08`, refresh lifecycle `0x10`, pause `0x20`, and companion-contract upgrade routing `0x40`.
+The default production mask is `0x1f`; pause and companion upgrades remain disabled.
 
 The curator proxy exposes the same information through `vault_version()`. Use its existing
 `initialize(vault, governance)` entrypoint for runtimes that expose `version`. For an approved,

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -309,9 +309,11 @@ non-upgradeable; consumers that need the query must use a replacement proxy poin
 vault and governance contracts.
 
 The targeted CLI flow verifies the vault's current on-chain Wasm hash before deploying a fresh
-proxy and invokes `initialize_legacy_v1`. It checkpoints the successful initialization and pinned
-hash before checking `vault_version`, then marks the proxy version-discovery-capable only after that
-query succeeds:
+proxy. Its constructor atomically pins the resolved source-account address as the one-time
+initialization authority, and the CLI checkpoints that deployed-but-uninitialized proxy before
+invoking `initialize_legacy_v1`. It checkpoints the successful initialization and pinned hash before
+checking `vault_version`, then marks the proxy version-discovery-capable only after that query
+succeeds:
 
 ```sh
 tmplr-soroban-vault deploy curator-proxy \
@@ -320,17 +322,18 @@ tmplr-soroban-vault deploy curator-proxy \
   --legacy-v1-wasm-hash <approved-v1-wasm-hash>
 ```
 
-The equivalent targeted just recipe builds the proxy, lets the contract validate the supplied
-32-byte hash, and checks `vault_version` before recording the new proxy ID:
+The equivalent targeted just recipe builds the proxy, records the new proxy ID immediately after
+deployment, lets the contract validate the supplied 32-byte hash, and then checks `vault_version`:
 
 ```sh
 just -f contract/vault/soroban/justfile deploy-curator-proxy-legacy-v1 \
   <vault-address> <governance-address> <approved-v1-wasm-hash>
 ```
 
-Proxy deployment and initialization are separate transactions under the existing deployment model,
-so operators must coordinate the first initialization and verify the emitted proxy address. The
-approved tTUSDC mainnet runtime hash is recorded in
+Proxy deployment and initialization are separate transactions, but initialization is no longer
+claimable by an observer: only the source identity pinned by the constructor can complete or retry
+it. If that identity is unavailable, deploy a fresh proxy with a new authority instead of attempting
+to claim the recorded instance. The approved tTUSDC mainnet runtime hash is recorded in
 `contract/vault/deployments/tTUSDC/mainnet/manifest.json`; do not substitute a hash solely because
 its artifact lacks `version`.
 

--- a/contract/vault/soroban/curator-proxy/Cargo.toml
+++ b/contract/vault/soroban/curator-proxy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-curator-proxy-soroban"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Typed Soroban curator operations proxy for Templar Protocol"

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -7,10 +7,8 @@ use crate::governance_abi::{
     SupplyQueueProposalEntry, TimelockKind, Timelocks,
 };
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short,
-    xdr::{ScErrorCode, ScErrorType},
-    Address, Bytes, BytesN, Env, Error as SorobanError, IntoVal, InvokeError, String, Symbol,
-    TryFromVal, Val, Vec,
+    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, Executable,
+    IntoVal, InvokeError, String, Symbol, TryFromVal, Val, Vec,
 };
 use templar_soroban_shared_types::{
     EmptyReceipt, I128Receipt, ProxyPreviewFields, ProxyViewFields, ProxyViewResponse,
@@ -170,6 +168,7 @@ pub struct ProxyDataKey;
 impl ProxyDataKey {
     pub const VaultAddress: Symbol = symbol_short!("vault");
     pub const GovernanceAddress: Symbol = symbol_short!("gov");
+    pub const LegacyV1WasmHash: Symbol = symbol_short!("v1_hash");
     pub const Initialized: Symbol = symbol_short!("init");
 }
 
@@ -183,21 +182,25 @@ impl SorobanCuratorProxyContract {
         vault_address: Address,
         governance_address: Address,
     ) -> Result<(), ContractError> {
-        if is_initialized(&env) {
-            return Err(ContractError::AlreadyInitialized);
-        }
+        initialize_proxy(&env, vault_address, governance_address, None)
+    }
 
-        env.storage()
-            .instance()
-            .set(&ProxyDataKey::VaultAddress, &vault_address);
-        env.storage()
-            .instance()
-            .set(&ProxyDataKey::GovernanceAddress, &governance_address);
-        env.storage()
-            .instance()
-            .set(&ProxyDataKey::Initialized, &true);
-        extend_instance_ttl(&env);
-        Ok(())
+    /// Configure a proxy for a verified, versionless v1 runtime artifact.
+    ///
+    /// The supplied hash must match the vault's current Wasm executable. The
+    /// fallback remains valid only while that exact artifact stays installed.
+    pub fn initialize_legacy_v1(
+        env: Env,
+        vault_address: Address,
+        governance_address: Address,
+        legacy_v1_wasm_hash: BytesN<32>,
+    ) -> Result<(), ContractError> {
+        initialize_proxy(
+            &env,
+            vault_address,
+            governance_address,
+            Some(legacy_v1_wasm_hash),
+        )
     }
 
     pub fn vault(env: Env) -> Result<Address, ContractError> {
@@ -206,9 +209,8 @@ impl SorobanCuratorProxyContract {
 
     /// Return the configured vault runtime version and compiled action capabilities.
     ///
-    /// Vaults without the additive `version` entrypoint are treated as the known
-    /// v1 deployment after the typed v1 view is confirmed. Contract errors and
-    /// malformed return values remain errors.
+    /// The artifact pinned by `initialize_legacy_v1` returns the approved v1
+    /// semantics directly. Every other artifact must answer `version`.
     pub fn vault_version(env: Env) -> Result<(String, u64), ContractError> {
         call_vault_version(&env)
     }
@@ -711,6 +713,37 @@ pub(crate) fn is_initialized(env: &Env) -> bool {
         .unwrap_or(false)
 }
 
+fn initialize_proxy(
+    env: &Env,
+    vault_address: Address,
+    governance_address: Address,
+    legacy_v1_wasm_hash: Option<BytesN<32>>,
+) -> Result<(), ContractError> {
+    if is_initialized(env) {
+        return Err(ContractError::AlreadyInitialized);
+    }
+    if let Some(expected_hash) = legacy_v1_wasm_hash.as_ref() {
+        require_matching_wasm_hash(&vault_address, expected_hash)?;
+    }
+
+    env.storage()
+        .instance()
+        .set(&ProxyDataKey::VaultAddress, &vault_address);
+    env.storage()
+        .instance()
+        .set(&ProxyDataKey::GovernanceAddress, &governance_address);
+    if let Some(legacy_v1_wasm_hash) = legacy_v1_wasm_hash {
+        env.storage()
+            .instance()
+            .set(&ProxyDataKey::LegacyV1WasmHash, &legacy_v1_wasm_hash);
+    }
+    env.storage()
+        .instance()
+        .set(&ProxyDataKey::Initialized, &true);
+    extend_instance_ttl(env);
+    Ok(())
+}
+
 pub(crate) fn require_initialized(env: &Env) -> Result<(), ContractError> {
     if !is_initialized(env) {
         return Err(ContractError::NotInitialized);
@@ -739,6 +772,32 @@ pub(crate) fn read_governance_address(env: &Env) -> Result<Address, ContractErro
         .instance()
         .get(&ProxyDataKey::GovernanceAddress)
         .ok_or(ContractError::NotInitialized)
+}
+
+fn read_legacy_v1_wasm_hash(env: &Env) -> Result<Option<BytesN<32>>, ContractError> {
+    require_initialized(env)?;
+    Ok(env
+        .storage()
+        .instance()
+        .get(&ProxyDataKey::LegacyV1WasmHash))
+}
+
+fn require_matching_wasm_hash(
+    vault_address: &Address,
+    expected_hash: &BytesN<32>,
+) -> Result<(), ContractError> {
+    if has_matching_wasm_hash(vault_address, expected_hash) {
+        Ok(())
+    } else {
+        Err(ContractError::InvalidInput)
+    }
+}
+
+fn has_matching_wasm_hash(vault_address: &Address, expected_hash: &BytesN<32>) -> bool {
+    matches!(
+        vault_address.executable(),
+        Some(Executable::Wasm(actual_hash)) if actual_hash == *expected_hash
+    )
 }
 
 pub(crate) fn invoke_vault_execute(
@@ -787,7 +846,16 @@ fn call_proxy_view_full(
 
 fn call_vault_version(env: &Env) -> Result<RuntimeVersionResponse, ContractError> {
     let vault_address = read_vault_address(env)?;
-    let result = env.try_invoke_contract::<RuntimeVersionResponse, SorobanError>(
+    if read_legacy_v1_wasm_hash(env)?
+        .is_some_and(|expected_hash| has_matching_wasm_hash(&vault_address, &expected_hash))
+    {
+        return Ok((
+            String::from_str(env, RUNTIME_V1_VERSION),
+            RUNTIME_V1_FEATURE_FLAGS,
+        ));
+    }
+
+    let result = env.try_invoke_contract::<RuntimeVersionResponse, InvokeError>(
         &vault_address,
         &symbol_short!("version"),
         ().into_val(env),
@@ -795,23 +863,8 @@ fn call_vault_version(env: &Env) -> Result<RuntimeVersionResponse, ContractError
 
     match result {
         Ok(Ok(response)) => Ok(response),
-        Ok(Err(_)) => Err(ContractError::VaultError),
-        Err(Ok(error)) if is_legacy_version_candidate(error) => {
-            // Soroban narrows recoverable host errors from `try_call` to
-            // Context/InvalidAction. Require the established typed v1 view as
-            // a second signal before treating the missing export as legacy.
-            call_proxy_view_full(env, &env.current_contract_address(), 0, 0)?;
-            Ok((
-                String::from_str(env, RUNTIME_V1_VERSION),
-                RUNTIME_V1_FEATURE_FLAGS,
-            ))
-        }
-        Err(Ok(_)) | Err(Err(_)) => Err(ContractError::VaultError),
+        Ok(Err(_)) | Err(Ok(_)) | Err(Err(_)) => Err(ContractError::VaultError),
     }
-}
-
-pub(crate) fn is_legacy_version_candidate(error: SorobanError) -> bool {
-    error.is_type(ScErrorType::Context) && error.is_code(ScErrorCode::InvalidAction)
 }
 
 pub(crate) fn map_vault_invoke_error(error: InvokeError) -> ContractError {

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -169,6 +169,7 @@ impl ProxyDataKey {
     pub const VaultAddress: Symbol = symbol_short!("vault");
     pub const GovernanceAddress: Symbol = symbol_short!("gov");
     pub const LegacyV1WasmHash: Symbol = symbol_short!("v1_hash");
+    pub const InitializationAuthority: Symbol = symbol_short!("init_auth");
     pub const Initialized: Symbol = symbol_short!("init");
 }
 
@@ -177,6 +178,18 @@ pub struct SorobanCuratorProxyContract;
 
 #[contractimpl]
 impl SorobanCuratorProxyContract {
+    /// Pin the only address allowed to complete one-time proxy initialization.
+    ///
+    /// The constructor runs atomically with deployment, closing the first-claim
+    /// gap while preserving retryability for the intended deployer.
+    pub fn __constructor(env: Env, initialization_authority: Address) {
+        env.storage().instance().set(
+            &ProxyDataKey::InitializationAuthority,
+            &initialization_authority,
+        );
+        extend_instance_ttl(&env);
+    }
+
     pub fn initialize(
         env: Env,
         vault_address: Address,
@@ -722,6 +735,12 @@ fn initialize_proxy(
     if is_initialized(env) {
         return Err(ContractError::AlreadyInitialized);
     }
+    let initialization_authority: Address = env
+        .storage()
+        .instance()
+        .get(&ProxyDataKey::InitializationAuthority)
+        .ok_or(ContractError::NotInitialized)?;
+    initialization_authority.require_auth();
     if let Some(expected_hash) = legacy_v1_wasm_hash.as_ref() {
         require_matching_wasm_hash(&vault_address, expected_hash)?;
     }
@@ -732,6 +751,9 @@ fn initialize_proxy(
     env.storage()
         .instance()
         .set(&ProxyDataKey::GovernanceAddress, &governance_address);
+    env.storage()
+        .instance()
+        .remove(&ProxyDataKey::InitializationAuthority);
     if let Some(legacy_v1_wasm_hash) = legacy_v1_wasm_hash {
         env.storage()
             .instance()

--- a/contract/vault/soroban/curator-proxy/src/contract.rs
+++ b/contract/vault/soroban/curator-proxy/src/contract.rs
@@ -7,12 +7,15 @@ use crate::governance_abi::{
     SupplyQueueProposalEntry, TimelockKind, Timelocks,
 };
 use soroban_sdk::{
-    contract, contractimpl, contracttype, symbol_short, Address, Bytes, BytesN, Env, IntoVal,
-    InvokeError, String, Symbol, TryFromVal, Val, Vec,
+    contract, contractimpl, contracttype, symbol_short,
+    xdr::{ScErrorCode, ScErrorType},
+    Address, Bytes, BytesN, Env, Error as SorobanError, IntoVal, InvokeError, String, Symbol,
+    TryFromVal, Val, Vec,
 };
 use templar_soroban_shared_types::{
     EmptyReceipt, I128Receipt, ProxyPreviewFields, ProxyViewFields, ProxyViewResponse,
-    VaultCommand as WireVaultCommand,
+    RuntimeVersionResponse, VaultCommand as WireVaultCommand, RUNTIME_V1_FEATURE_FLAGS,
+    RUNTIME_V1_VERSION,
 };
 
 use crate::error::ContractError;
@@ -199,6 +202,15 @@ impl SorobanCuratorProxyContract {
 
     pub fn vault(env: Env) -> Result<Address, ContractError> {
         read_vault_address(&env)
+    }
+
+    /// Return the configured vault runtime version and compiled action capabilities.
+    ///
+    /// Vaults without the additive `version` entrypoint are treated as the known
+    /// v1 deployment after the typed v1 view is confirmed. Contract errors and
+    /// malformed return values remain errors.
+    pub fn vault_version(env: Env) -> Result<(String, u64), ContractError> {
+        call_vault_version(&env)
     }
 
     pub fn governance(env: Env) -> Result<Address, ContractError> {
@@ -771,6 +783,35 @@ fn call_proxy_view_full(
         Err(Ok(invoke_error)) => Err(map_vault_invoke_error(invoke_error)),
         Err(Err(invoke_error)) => Err(map_vault_invoke_error(invoke_error)),
     }
+}
+
+fn call_vault_version(env: &Env) -> Result<RuntimeVersionResponse, ContractError> {
+    let vault_address = read_vault_address(env)?;
+    let result = env.try_invoke_contract::<RuntimeVersionResponse, SorobanError>(
+        &vault_address,
+        &symbol_short!("version"),
+        ().into_val(env),
+    );
+
+    match result {
+        Ok(Ok(response)) => Ok(response),
+        Ok(Err(_)) => Err(ContractError::VaultError),
+        Err(Ok(error)) if is_legacy_version_candidate(error) => {
+            // Soroban narrows recoverable host errors from `try_call` to
+            // Context/InvalidAction. Require the established typed v1 view as
+            // a second signal before treating the missing export as legacy.
+            call_proxy_view_full(env, &env.current_contract_address(), 0, 0)?;
+            Ok((
+                String::from_str(env, RUNTIME_V1_VERSION),
+                RUNTIME_V1_FEATURE_FLAGS,
+            ))
+        }
+        Err(Ok(_)) | Err(Err(_)) => Err(ContractError::VaultError),
+    }
+}
+
+pub(crate) fn is_legacy_version_candidate(error: SorobanError) -> bool {
+    error.is_type(ScErrorType::Context) && error.is_code(ScErrorCode::InvalidAction)
 }
 
 pub(crate) fn map_vault_invoke_error(error: InvokeError) -> ContractError {

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -492,6 +492,7 @@ impl MockGovernanceContract {
 struct Fixture {
     env: Env,
     proxy: Address,
+    initialization_authority: Address,
     vault: Address,
     governance: Address,
 }
@@ -500,12 +501,14 @@ impl Fixture {
     fn new() -> Self {
         let env = Env::default();
         env.mock_all_auths();
-        let proxy = env.register(SorobanCuratorProxyContract, ());
+        let initialization_authority = Address::generate(&env);
+        let proxy = env.register(SorobanCuratorProxyContract, (&initialization_authority,));
         let vault = env.register(MockVaultContract, ());
         let governance = env.register(MockGovernanceContract, ());
         Self {
             env,
             proxy,
+            initialization_authority,
             vault,
             governance,
         }
@@ -569,6 +572,17 @@ fn address_wire(address: &Address) -> alloc::string::String {
 fn initialize_stores_target_contracts() {
     let fixture = Fixture::new();
 
+    fixture.env.as_contract(&fixture.proxy, || {
+        assert_eq!(
+            fixture
+                .env
+                .storage()
+                .instance()
+                .get(&ProxyDataKey::InitializationAuthority),
+            Some(fixture.initialization_authority.clone())
+        );
+    });
+
     fixture.initialize().expect("initialize succeeds");
 
     fixture.env.as_contract(&fixture.proxy, || {
@@ -583,6 +597,10 @@ fn initialize_stores_target_contracts() {
         );
         assert_eq!(
             storage.get::<_, BytesN<32>>(&ProxyDataKey::LegacyV1WasmHash),
+            None
+        );
+        assert_eq!(
+            storage.get::<_, Address>(&ProxyDataKey::InitializationAuthority),
             None
         );
         assert_eq!(storage.get(&ProxyDataKey::Initialized), Some(true));
@@ -742,7 +760,10 @@ fn vault_version_rejects_malformed_response_and_contract_failure() {
         Err(ContractError::VaultError)
     );
 
-    let failing_proxy = fixture.env.register(SorobanCuratorProxyContract, ());
+    let failing_proxy = fixture.env.register(
+        SorobanCuratorProxyContract,
+        (&fixture.initialization_authority,),
+    );
     let failing_vault = fixture.env.register(MockFailingVaultContract, ());
     fixture.env.as_contract(&failing_proxy, || {
         SorobanCuratorProxyContract::initialize(

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -1,8 +1,7 @@
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype,
-    xdr::{ScErrorCode, ScErrorType},
-    Address, Bytes, Env, Error as SorobanError, InvokeError, String, Vec,
+    contract, contracterror, contractimpl, contracttype, Address, Bytes, BytesN, Env, Executable,
+    InvokeError, String, Vec,
 };
 use templar_soroban_shared_types::{
     EmptyReceipt, I128Receipt, ProxyViewResponse, RuntimeVersionResponse,
@@ -11,8 +10,8 @@ use templar_soroban_shared_types::{
 
 use crate::{
     contract::{
-        is_legacy_version_candidate, map_vault_invoke_error, timelocks_from_kind_values,
-        AllocationDelta, ProxyDataKey, SorobanCuratorProxyContract,
+        map_vault_invoke_error, timelocks_from_kind_values, AllocationDelta, ProxyDataKey,
+        SorobanCuratorProxyContract,
     },
     error::ContractError,
     governance_abi::{
@@ -75,6 +74,16 @@ impl MockVaultContract {
 }
 
 #[contract]
+struct MockVersionlessVaultContract;
+
+#[contractimpl]
+impl MockVersionlessVaultContract {
+    pub fn ping() -> u32 {
+        1
+    }
+}
+
+#[contract]
 struct MockVersionedVaultContract;
 
 #[contractimpl]
@@ -91,6 +100,16 @@ struct MockMalformedVersionVaultContract;
 impl MockMalformedVersionVaultContract {
     pub fn version(_env: Env) -> u64 {
         7
+    }
+}
+
+#[contract]
+struct MockWrongArityVersionVaultContract;
+
+#[contractimpl]
+impl MockWrongArityVersionVaultContract {
+    pub fn version(env: Env, _nonce: u64) -> RuntimeVersionResponse {
+        (String::from_str(&env, "9.9.9"), u64::MAX)
     }
 }
 
@@ -502,6 +521,19 @@ impl Fixture {
         })
     }
 
+    fn initialize_legacy_v1_for(&self, vault: &Address) -> Result<BytesN<32>, ContractError> {
+        let wasm_hash = contract_wasm_hash(vault);
+        self.env.as_contract(&self.proxy, || {
+            SorobanCuratorProxyContract::initialize_legacy_v1(
+                self.env.clone(),
+                vault.clone(),
+                self.governance.clone(),
+                wasm_hash.clone(),
+            )
+        })?;
+        Ok(wasm_hash)
+    }
+
     fn recorded_payloads(&self) -> Vec<Bytes> {
         self.env.as_contract(&self.vault, || {
             MockVaultContract::recorded_payloads(self.env.clone())
@@ -512,6 +544,15 @@ impl Fixture {
         self.env.as_contract(&self.governance, || {
             MockGovernanceContract::set_pending(self.env.clone(), proposal)
         });
+    }
+}
+
+fn contract_wasm_hash(address: &Address) -> BytesN<32> {
+    match address.executable() {
+        Some(Executable::Wasm(wasm_hash)) => wasm_hash,
+        Some(Executable::StellarAsset) | Some(Executable::Account) | None => {
+            panic!("test contract must have a Wasm executable")
+        }
     }
 }
 
@@ -540,6 +581,10 @@ fn initialize_stores_target_contracts() {
             storage.get(&ProxyDataKey::GovernanceAddress),
             Some(fixture.governance.clone())
         );
+        assert_eq!(
+            storage.get::<_, BytesN<32>>(&ProxyDataKey::LegacyV1WasmHash),
+            None
+        );
         assert_eq!(storage.get(&ProxyDataKey::Initialized), Some(true));
     });
 }
@@ -547,7 +592,10 @@ fn initialize_stores_target_contracts() {
 #[test]
 fn vault_version_falls_back_for_legacy_vault() {
     let fixture = Fixture::new();
-    fixture.initialize().expect("initialize succeeds");
+    let legacy_vault = fixture.env.register(MockVersionlessVaultContract, ());
+    let wasm_hash = fixture
+        .initialize_legacy_v1_for(&legacy_vault)
+        .expect("legacy initialization succeeds");
 
     let result = fixture.env.as_contract(&fixture.proxy, || {
         SorobanCuratorProxyContract::vault_version(fixture.env.clone())
@@ -560,23 +608,49 @@ fn vault_version_falls_back_for_legacy_vault() {
             RUNTIME_V1_FEATURE_FLAGS,
         ))
     );
+    fixture.env.as_contract(&fixture.proxy, || {
+        assert_eq!(
+            fixture
+                .env
+                .storage()
+                .instance()
+                .get(&ProxyDataKey::LegacyV1WasmHash),
+            Some(wasm_hash)
+        );
+    });
 }
 
 #[test]
-fn vault_version_rejects_versionless_non_vault() {
+fn legacy_initialization_rejects_a_mismatched_wasm_hash() {
     let fixture = Fixture::new();
-    fixture.env.as_contract(&fixture.proxy, || {
-        SorobanCuratorProxyContract::initialize(
+    let wrong_hash = BytesN::from_array(&fixture.env, &[7; 32]);
+
+    let result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::initialize_legacy_v1(
             fixture.env.clone(),
+            fixture.vault.clone(),
             fixture.governance.clone(),
-            fixture.governance.clone(),
+            wrong_hash,
         )
-        .expect("initialize succeeds");
-        assert_eq!(
-            SorobanCuratorProxyContract::vault_version(fixture.env.clone()),
-            Err(ContractError::VaultError)
-        );
     });
+
+    assert_eq!(result, Err(ContractError::InvalidInput));
+    fixture.env.as_contract(&fixture.proxy, || {
+        assert!(!super::contract::is_initialized(&fixture.env));
+    });
+}
+
+#[test]
+fn vault_version_rejects_an_unpinned_versionless_vault() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+        }),
+        Err(ContractError::VaultError)
+    );
 }
 
 #[test]
@@ -597,6 +671,56 @@ fn vault_version_forwards_current_response() {
     });
 
     assert_eq!(result, Ok((String::from_str(&fixture.env, "2.4.6"), 0x2a)));
+}
+
+#[test]
+fn vault_version_uses_the_artifact_pin_before_calling_version() {
+    let fixture = Fixture::new();
+    let vault = fixture.env.register(MockVersionedVaultContract, ());
+    fixture
+        .initialize_legacy_v1_for(&vault)
+        .expect("legacy initialization succeeds");
+
+    // A query-first implementation would return the mock's 2.4.6/0x2a
+    // response. The explicit artifact assertion must take precedence.
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+        }),
+        Ok((
+            String::from_str(&fixture.env, RUNTIME_V1_VERSION),
+            RUNTIME_V1_FEATURE_FLAGS,
+        ))
+    );
+}
+
+#[test]
+fn vault_version_queries_version_when_the_current_hash_does_not_match_the_pin() {
+    let fixture = Fixture::new();
+    let vault = fixture.env.register(MockVersionlessVaultContract, ());
+    fixture
+        .initialize_legacy_v1_for(&vault)
+        .expect("legacy initialization succeeds");
+
+    let stale_hash = BytesN::from_array(&fixture.env, &[7; 32]);
+    assert_ne!(contract_wasm_hash(&vault), stale_hash);
+    fixture.env.as_contract(&fixture.proxy, || {
+        fixture
+            .env
+            .storage()
+            .instance()
+            .set(&ProxyDataKey::LegacyV1WasmHash, &stale_hash);
+    });
+    fixture
+        .env
+        .register_at(&vault, MockVersionedVaultContract, ());
+
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+        }),
+        Ok((String::from_str(&fixture.env, "2.4.6"), 0x2a))
+    );
 }
 
 #[test]
@@ -635,20 +759,24 @@ fn vault_version_rejects_malformed_response_and_contract_failure() {
 }
 
 #[test]
-fn legacy_version_candidate_classifier_is_narrow() {
-    assert!(is_legacy_version_candidate(
-        SorobanError::from_type_and_code(ScErrorType::Context, ScErrorCode::InvalidAction,)
-    ));
+fn vault_version_rejects_wrong_arity_without_an_explicit_legacy_pin() {
+    let fixture = Fixture::new();
+    let wrong_arity_vault = fixture.env.register(MockWrongArityVersionVaultContract, ());
+    fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::initialize(
+            fixture.env.clone(),
+            wrong_arity_vault,
+            fixture.governance.clone(),
+        )
+        .expect("initialize succeeds");
+    });
 
-    for error in [
-        SorobanError::from_type_and_code(ScErrorType::Context, ScErrorCode::MissingValue),
-        SorobanError::from_type_and_code(ScErrorType::WasmVm, ScErrorCode::InvalidAction),
-        SorobanError::from_type_and_code(ScErrorType::Storage, ScErrorCode::MissingValue),
-        SorobanError::from_type_and_code(ScErrorType::Context, ScErrorCode::UnexpectedType),
-        SorobanError::from_contract_error(1),
-    ] {
-        assert!(!is_legacy_version_candidate(error));
-    }
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+        }),
+        Err(ContractError::VaultError)
+    );
 }
 
 #[test]

--- a/contract/vault/soroban/curator-proxy/src/tests.rs
+++ b/contract/vault/soroban/curator-proxy/src/tests.rs
@@ -1,15 +1,18 @@
 use soroban_sdk::testutils::Address as _;
 use soroban_sdk::{
-    contract, contracterror, contractimpl, contracttype, Address, Bytes, Env, InvokeError, Vec,
+    contract, contracterror, contractimpl, contracttype,
+    xdr::{ScErrorCode, ScErrorType},
+    Address, Bytes, Env, Error as SorobanError, InvokeError, String, Vec,
 };
 use templar_soroban_shared_types::{
-    EmptyReceipt, I128Receipt, ProxyViewResponse, VaultCommand as WireVaultCommand,
+    EmptyReceipt, I128Receipt, ProxyViewResponse, RuntimeVersionResponse,
+    VaultCommand as WireVaultCommand, RUNTIME_V1_FEATURE_FLAGS, RUNTIME_V1_VERSION,
 };
 
 use crate::{
     contract::{
-        map_vault_invoke_error, timelocks_from_kind_values, AllocationDelta, ProxyDataKey,
-        SorobanCuratorProxyContract,
+        is_legacy_version_candidate, map_vault_invoke_error, timelocks_from_kind_values,
+        AllocationDelta, ProxyDataKey, SorobanCuratorProxyContract,
     },
     error::ContractError,
     governance_abi::{
@@ -56,6 +59,39 @@ impl MockVaultContract {
 
         Bytes::from_slice(&env, &receipt)
     }
+
+    pub fn proxy_view(env: Env, owner: Address, _assets: i128, _shares: i128) -> ProxyViewResponse {
+        (
+            (
+                (owner.clone(), owner.clone(), owner.clone(), owner),
+                (0, 0, false),
+                (0, 0, 0, 0),
+                (0, 0, 0, 0, 0),
+            ),
+            (Vec::new(&env), Vec::new(&env)),
+            (0, 0, 0, 0, 0, 0, 0, 0),
+        )
+    }
+}
+
+#[contract]
+struct MockVersionedVaultContract;
+
+#[contractimpl]
+impl MockVersionedVaultContract {
+    pub fn version(env: Env) -> RuntimeVersionResponse {
+        (String::from_str(&env, "2.4.6"), 0x2a)
+    }
+}
+
+#[contract]
+struct MockMalformedVersionVaultContract;
+
+#[contractimpl]
+impl MockMalformedVersionVaultContract {
+    pub fn version(_env: Env) -> u64 {
+        7
+    }
 }
 
 #[contracterror]
@@ -71,6 +107,10 @@ struct MockFailingVaultContract;
 
 #[contractimpl]
 impl MockFailingVaultContract {
+    pub fn version(_env: Env) -> Result<RuntimeVersionResponse, MockForeignVaultError> {
+        Err(MockForeignVaultError::CollidesWithNotImplemented)
+    }
+
     pub fn execute(_env: Env, _payload: Bytes) -> Result<Bytes, MockForeignVaultError> {
         Err(MockForeignVaultError::CollidesWithNotImplemented)
     }
@@ -502,6 +542,113 @@ fn initialize_stores_target_contracts() {
         );
         assert_eq!(storage.get(&ProxyDataKey::Initialized), Some(true));
     });
+}
+
+#[test]
+fn vault_version_falls_back_for_legacy_vault() {
+    let fixture = Fixture::new();
+    fixture.initialize().expect("initialize succeeds");
+
+    let result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+    });
+
+    assert_eq!(
+        result,
+        Ok((
+            String::from_str(&fixture.env, RUNTIME_V1_VERSION),
+            RUNTIME_V1_FEATURE_FLAGS,
+        ))
+    );
+}
+
+#[test]
+fn vault_version_rejects_versionless_non_vault() {
+    let fixture = Fixture::new();
+    fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::initialize(
+            fixture.env.clone(),
+            fixture.governance.clone(),
+            fixture.governance.clone(),
+        )
+        .expect("initialize succeeds");
+        assert_eq!(
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone()),
+            Err(ContractError::VaultError)
+        );
+    });
+}
+
+#[test]
+fn vault_version_forwards_current_response() {
+    let fixture = Fixture::new();
+    let vault = fixture.env.register(MockVersionedVaultContract, ());
+    fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::initialize(
+            fixture.env.clone(),
+            vault,
+            fixture.governance.clone(),
+        )
+        .expect("initialize succeeds");
+    });
+
+    let result = fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+    });
+
+    assert_eq!(result, Ok((String::from_str(&fixture.env, "2.4.6"), 0x2a)));
+}
+
+#[test]
+fn vault_version_rejects_malformed_response_and_contract_failure() {
+    let fixture = Fixture::new();
+    let malformed_vault = fixture.env.register(MockMalformedVersionVaultContract, ());
+    fixture.env.as_contract(&fixture.proxy, || {
+        SorobanCuratorProxyContract::initialize(
+            fixture.env.clone(),
+            malformed_vault,
+            fixture.governance.clone(),
+        )
+        .expect("initialize succeeds");
+    });
+    assert_eq!(
+        fixture.env.as_contract(&fixture.proxy, || {
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone())
+        }),
+        Err(ContractError::VaultError)
+    );
+
+    let failing_proxy = fixture.env.register(SorobanCuratorProxyContract, ());
+    let failing_vault = fixture.env.register(MockFailingVaultContract, ());
+    fixture.env.as_contract(&failing_proxy, || {
+        SorobanCuratorProxyContract::initialize(
+            fixture.env.clone(),
+            failing_vault,
+            fixture.governance.clone(),
+        )
+        .expect("initialize succeeds");
+        assert_eq!(
+            SorobanCuratorProxyContract::vault_version(fixture.env.clone()),
+            Err(ContractError::VaultError)
+        );
+    });
+}
+
+#[test]
+fn legacy_version_candidate_classifier_is_narrow() {
+    assert!(is_legacy_version_candidate(
+        SorobanError::from_type_and_code(ScErrorType::Context, ScErrorCode::InvalidAction,)
+    ));
+
+    for error in [
+        SorobanError::from_type_and_code(ScErrorType::Context, ScErrorCode::MissingValue),
+        SorobanError::from_type_and_code(ScErrorType::WasmVm, ScErrorCode::InvalidAction),
+        SorobanError::from_type_and_code(ScErrorType::Storage, ScErrorCode::MissingValue),
+        SorobanError::from_type_and_code(ScErrorType::Context, ScErrorCode::UnexpectedType),
+        SorobanError::from_contract_error(1),
+    ] {
+        assert!(!is_legacy_version_candidate(error));
+    }
 }
 
 #[test]

--- a/contract/vault/soroban/curator-proxy/tests/artifact_version.rs
+++ b/contract/vault/soroban/curator-proxy/tests/artifact_version.rs
@@ -29,8 +29,10 @@ fn wasm_hash(address: &Address) -> soroban_sdk::BytesN<32> {
 fn optimized_proxy_tracks_the_runtime_artifact_transition() {
     let env = Env::default();
     env.cost_estimate().budget().reset_unlimited();
-    let legacy_target = env.register(CURATOR_PROXY_WASM, ());
-    let proxy = env.register(CURATOR_PROXY_WASM, ());
+    env.mock_all_auths();
+    let initialization_authority = Address::generate(&env);
+    let legacy_target = env.register(CURATOR_PROXY_WASM, (&initialization_authority,));
+    let proxy = env.register(CURATOR_PROXY_WASM, (&initialization_authority,));
     let governance = Address::generate(&env);
     let legacy_hash = wasm_hash(&legacy_target);
 

--- a/contract/vault/soroban/curator-proxy/tests/artifact_version.rs
+++ b/contract/vault/soroban/curator-proxy/tests/artifact_version.rs
@@ -1,0 +1,76 @@
+#![allow(unexpected_cfgs)]
+#![cfg(artifact_wasm)]
+
+use soroban_sdk::{
+    testutils::Address as _, Address, Bytes, Env, Executable, IntoVal, String, Symbol,
+};
+use templar_soroban_shared_types::{
+    RuntimeVersionResponse, RUNTIME_DEFAULT_FEATURE_FLAGS, RUNTIME_V1_FEATURE_FLAGS,
+    RUNTIME_V1_VERSION,
+};
+
+const CURATOR_PROXY_WASM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../../target/wasm32-unknown-unknown/release-soroban/templar_curator_proxy_soroban.wasm"
+));
+const RUNTIME_WASM: &[u8] = include_bytes!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../../../target/wasm32-unknown-unknown/release-soroban/templar_soroban_runtime.wasm"
+));
+
+fn wasm_hash(address: &Address) -> soroban_sdk::BytesN<32> {
+    match address.executable() {
+        Some(Executable::Wasm(hash)) => hash,
+        executable => panic!("expected Wasm executable, got {executable:?}"),
+    }
+}
+
+#[test]
+fn optimized_proxy_tracks_the_runtime_artifact_transition() {
+    let env = Env::default();
+    env.cost_estimate().budget().reset_unlimited();
+    let legacy_target = env.register(CURATOR_PROXY_WASM, ());
+    let proxy = env.register(CURATOR_PROXY_WASM, ());
+    let governance = Address::generate(&env);
+    let legacy_hash = wasm_hash(&legacy_target);
+
+    env.invoke_contract::<()>(
+        &proxy,
+        &Symbol::new(&env, "initialize_legacy_v1"),
+        (&legacy_target, &governance, &legacy_hash).into_val(&env),
+    );
+
+    assert_eq!(
+        env.invoke_contract::<RuntimeVersionResponse>(
+            &proxy,
+            &Symbol::new(&env, "vault_version"),
+            soroban_sdk::vec![&env],
+        ),
+        (
+            String::from_str(&env, RUNTIME_V1_VERSION),
+            RUNTIME_V1_FEATURE_FLAGS,
+        )
+    );
+
+    let runtime_hash = env
+        .deployer()
+        .upload_contract_wasm(Bytes::from_slice(&env, RUNTIME_WASM));
+    assert_ne!(runtime_hash, legacy_hash);
+    env.as_contract(&legacy_target, || {
+        env.deployer()
+            .update_current_contract_wasm(runtime_hash.clone());
+    });
+    assert_eq!(wasm_hash(&legacy_target), runtime_hash);
+
+    assert_eq!(
+        env.invoke_contract::<RuntimeVersionResponse>(
+            &proxy,
+            &Symbol::new(&env, "vault_version"),
+            soroban_sdk::vec![&env],
+        ),
+        (
+            String::from_str(&env, templar_soroban_runtime::RUNTIME_VERSION),
+            RUNTIME_DEFAULT_FEATURE_FLAGS,
+        )
+    );
+}

--- a/contract/vault/soroban/curator-proxy/tests/integration_tests.rs
+++ b/contract/vault/soroban/curator-proxy/tests/integration_tests.rs
@@ -45,7 +45,19 @@ fn setup_harness_with_auth_mock(mock_auth: bool) -> Harness {
         (&governance, &governance, &asset, &share, &0i128, &0i128).into_val(&env),
     );
 
-    let proxy = env.register(SorobanCuratorProxyContract, ());
+    let proxy = env.register(SorobanCuratorProxyContract, (&admin,));
+    if !mock_auth {
+        let initialize_auth = MockAuthInvoke {
+            contract: &proxy,
+            fn_name: "initialize",
+            args: (&vault, &governance).into_val(&env),
+            sub_invokes: &[],
+        };
+        env.mock_auths(&[MockAuth {
+            address: &admin,
+            invoke: &initialize_auth,
+        }]);
+    }
     env.invoke_contract::<()>(
         &proxy,
         &Symbol::new(&env, "initialize"),
@@ -59,6 +71,70 @@ fn setup_harness_with_auth_mock(mock_auth: bool) -> Harness {
         governance,
         proxy,
     }
+}
+
+#[test]
+fn proxy_initialization_rejects_unauthorized_first_claim() {
+    let env = Env::default();
+    let initialization_authority = Address::generate(&env);
+    let attacker = Address::generate(&env);
+    let vault = Address::generate(&env);
+    let governance = Address::generate(&env);
+    let proxy = env.register(SorobanCuratorProxyContract, (&initialization_authority,));
+    let initialize_args: soroban_sdk::Vec<soroban_sdk::Val> = (&vault, &governance).into_val(&env);
+    let attacker_invoke = MockAuthInvoke {
+        contract: &proxy,
+        fn_name: "initialize",
+        args: initialize_args.clone(),
+        sub_invokes: &[],
+    };
+    env.mock_auths(&[MockAuth {
+        address: &attacker,
+        invoke: &attacker_invoke,
+    }]);
+
+    let unauthorized = env.try_invoke_contract::<(), ContractError>(
+        &proxy,
+        &Symbol::new(&env, "initialize"),
+        initialize_args.clone(),
+    );
+
+    assert!(unauthorized.is_err());
+    assert_eq!(
+        env.try_invoke_contract::<Address, ContractError>(
+            &proxy,
+            &Symbol::new(&env, "vault"),
+            soroban_sdk::vec![&env],
+        ),
+        Err(Ok(ContractError::NotInitialized))
+    );
+
+    let authority_invoke = MockAuthInvoke {
+        contract: &proxy,
+        fn_name: "initialize",
+        args: initialize_args.clone(),
+        sub_invokes: &[],
+    };
+    env.mock_auths(&[MockAuth {
+        address: &initialization_authority,
+        invoke: &authority_invoke,
+    }]);
+    assert_eq!(
+        env.try_invoke_contract::<(), ContractError>(
+            &proxy,
+            &Symbol::new(&env, "initialize"),
+            initialize_args,
+        ),
+        Ok(Ok(()))
+    );
+    assert_eq!(
+        env.invoke_contract::<Address>(
+            &proxy,
+            &Symbol::new(&env, "vault"),
+            soroban_sdk::vec![&env],
+        ),
+        vault
+    );
 }
 
 #[test]

--- a/contract/vault/soroban/curator-proxy/tests/integration_tests.rs
+++ b/contract/vault/soroban/curator-proxy/tests/integration_tests.rs
@@ -1,10 +1,11 @@
 use soroban_sdk::{
     testutils::{Address as _, MockAuth, MockAuthInvoke},
-    Address, Env, IntoVal, Symbol,
+    Address, Env, IntoVal, String as SdkString, Symbol,
 };
 use templar_curator_proxy_soroban::{ContractError, SorobanCuratorProxyContract};
 use templar_soroban_governance::SorobanVaultGovernanceContract;
 use templar_soroban_runtime::{SorobanVaultContract, VaultDataKey};
+use templar_soroban_shared_types::RuntimeVersionResponse;
 
 struct Harness {
     env: Env,
@@ -108,6 +109,26 @@ fn proxy_exposes_governance_views() {
 
     assert_eq!(governance, harness.governance);
     assert_eq!(admin, harness.admin);
+}
+
+#[test]
+fn proxy_forwards_real_runtime_version() {
+    let harness = setup_harness();
+
+    let (version, feature_flags) = harness.env.invoke_contract::<RuntimeVersionResponse>(
+        &harness.proxy,
+        &Symbol::new(&harness.env, "vault_version"),
+        soroban_sdk::vec![&harness.env],
+    );
+
+    assert_eq!(
+        version,
+        SdkString::from_str(&harness.env, templar_soroban_runtime::RUNTIME_VERSION)
+    );
+    assert_eq!(
+        feature_flags,
+        templar_soroban_runtime::RUNTIME_FEATURE_FLAGS
+    );
 }
 
 #[test]

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -52,10 +52,12 @@ soroban_rust_toolchain := env_var_or_default("SOROBAN_RUST_TOOLCHAIN", "1.89.0")
 default_wasm := optimized_wasm
 blend_adapter_wasm := wasm_dir + "/templar_soroban_blend_adapter.wasm"
 custodial_adapter_wasm := wasm_dir + "/templar_soroban_custodial_adapter.wasm"
+curator_proxy_wasm := wasm_dir + "/templar_curator_proxy_soroban.wasm"
 governance_wasm := wasm_dir + "/templar_soroban_governance.wasm"
 share_token_wasm := wasm_dir + "/templar_soroban_share_token.wasm"
 payload_script := justfile_directory() + "/scripts/vault_payload.py"
 custodial_adapter_abi_script := justfile_directory() + "/scripts/check_custodial_adapter_release_abi.py"
+release_abi_script := justfile_directory() + "/scripts/check_release_abi.py"
 default_friendbot := "https://friendbot.stellar.org"
 default_network := "testnet"
 default_rpc := "https://soroban-testnet.stellar.org"
@@ -162,6 +164,43 @@ verify-custodial-adapter-release-abi: build-custodial-adapter
 		-- --nocapture
 	@echo "✓ Custodial adapter release ABI and behavior verified"
 
+# Build and optimize the curator proxy WASM.
+build-curator-proxy:
+	@echo "Building curator proxy WASM..."
+	@just -f "{{justfile_directory()}}/justfile" _optimize-wasm templar-curator-proxy-soroban "{{curator_proxy_wasm}}"
+	@echo "✓ Built: {{curator_proxy_wasm}}"
+
+# Verify the runtime mask in isolated, selective, and deliberately unified builds.
+verify-runtime-feature-matrix:
+	@cargo test --manifest-path "{{root}}/Cargo.toml" \
+		-p templar-soroban-runtime \
+		test_version_is_available_before_initialization_and_matches_compiled_features
+	@cargo test --manifest-path "{{root}}/Cargo.toml" \
+		-p templar-soroban-runtime \
+		--no-default-features \
+		test_version_is_available_before_initialization_and_matches_compiled_features
+	@cargo test --manifest-path "{{root}}/Cargo.toml" \
+		-p templar-soroban-runtime \
+		--no-default-features \
+		--features action-pause \
+		test_version_is_available_before_initialization_and_matches_compiled_features
+	@cargo test --manifest-path "{{root}}/Cargo.toml" \
+		-p templar-soroban-runtime \
+		-p templar-common \
+		test_version_is_available_before_initialization_and_matches_compiled_features
+	@echo "✓ Runtime feature matrix verified"
+
+# Build release artifacts and verify exact version ABIs plus artifact behavior.
+verify-release-wasm-abi: verify-runtime-feature-matrix build build-curator-proxy verify-custodial-adapter-release-abi
+	@stellar contract info interface --wasm "{{deploy_wasm}}" --output json | python3 "{{release_abi_script}}" --contract runtime
+	@stellar contract info interface --wasm "{{curator_proxy_wasm}}" --output json | python3 "{{release_abi_script}}" --contract curator-proxy
+	@RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }--cfg artifact_wasm" cargo test \
+		--manifest-path "{{root}}/Cargo.toml" \
+		-p templar-curator-proxy-soroban \
+		--test artifact_version \
+		-- --nocapture
+	@echo "✓ Release WASM ABIs and behavior verified"
+
 # Check the Soroban ERC-4626 proxy crate.
 check-4626-proxy:
 	@echo "Checking Soroban ERC-4626 proxy crate..."
@@ -171,8 +210,8 @@ check-4626-proxy:
 		-p templar-4626-proxy-soroban
 	@echo "✓ Checked: templar-4626-proxy-soroban"
 
-# Build all WASMs (vault + governance + share token + adapters).
-build-all: build build-blend-adapter build-custodial-adapter
+# Build all WASMs (vault + governance + share token + adapters + curator proxy).
+build-all: build build-blend-adapter build-custodial-adapter build-curator-proxy
 	@echo "✓ All contracts built"
 
 # Build debug WASM, emit twiggy reports, and print them.
@@ -501,6 +540,55 @@ init:
 		exit 1; \
 	fi; \
 	echo "✓ Vault initialized"
+
+# Deploy a replacement curator proxy for an approved versionless-v1 vault artifact.
+# Deployment and initialization are separate transactions; coordinate this operation accordingly.
+deploy-curator-proxy-legacy-v1 vault_address governance_address legacy_v1_wasm_hash: build-curator-proxy
+	@if ! python3 -c 'import re, sys; sys.exit(0 if re.fullmatch(r"[0-9a-fA-F]{64}", sys.argv[1]) else 1)' "{{legacy_v1_wasm_hash}}"; then \
+		echo "Error: legacy_v1_wasm_hash must be exactly 64 hexadecimal characters."; \
+		exit 1; \
+	fi
+	@network="${SOROBAN_NETWORK:-{{default_network}}}"; \
+	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
+	echo "Deploying replacement curator proxy..."; \
+	echo "  Vault:       {{vault_address}}"; \
+	echo "  Governance:  {{governance_address}}"; \
+	echo "  Legacy hash: {{legacy_v1_wasm_hash}}"; \
+	proxy_id=$(stellar contract deploy \
+		--wasm "{{curator_proxy_wasm}}" \
+		--network "$network" \
+		--source-account "$source"); \
+	if [ -z "$proxy_id" ]; then \
+		echo "Error: curator proxy deploy failed — no contract ID returned"; \
+		exit 1; \
+	fi; \
+	if ! stellar contract invoke \
+		--id "$proxy_id" \
+		--network "$network" \
+		--source-account "$source" \
+		-- initialize_legacy_v1 \
+		--vault_address "{{vault_address}}" \
+		--governance_address "{{governance_address}}" \
+		--legacy_v1_wasm_hash "{{legacy_v1_wasm_hash}}"; then \
+		echo "Error: curator proxy legacy initialization failed for $proxy_id"; \
+		exit 1; \
+	fi; \
+	if ! version=$(stellar contract invoke \
+		--id "$proxy_id" \
+		--network "$network" \
+		--source-account "$source" \
+		-- vault_version); then \
+		echo "Error: curator proxy vault_version verification failed for $proxy_id"; \
+		exit 1; \
+	fi; \
+	if [ -z "$version" ]; then \
+		echo "Error: curator proxy vault_version returned an empty response for $proxy_id"; \
+		exit 1; \
+	fi; \
+	mkdir -p "{{state_dir}}"; \
+	echo "$proxy_id" > "{{state_dir}}/curator_proxy_id"; \
+	echo "✓ Curator proxy deployed and verified: $proxy_id"; \
+	echo "  Vault version: $version"
 
 # Extend contract TTL (prevent expiration).
 extend-ttl ledgers="100000":
@@ -1245,6 +1333,7 @@ status:
 	@echo "Blend Pool:    $(cat {{state_dir}}/blend_pool_id 2>/dev/null || echo 'not set')"
 	@echo "Custodial Adapter: $(cat {{state_dir}}/custodial_adapter_id 2>/dev/null || echo 'not deployed')"
 	@echo "Custodian:     $(cat {{state_dir}}/custodial_address 2>/dev/null || echo 'not set')"
+	@echo "Curator Proxy: $(cat {{state_dir}}/curator_proxy_id 2>/dev/null || echo 'not deployed')"
 	@echo ""
 	@if [ -f "{{state_dir}}/vault_id" ]; then \
 		echo "Vault state:"; \
@@ -1279,6 +1368,7 @@ export-env:
 	@echo "BLEND_POOL_ID=$(cat {{state_dir}}/blend_pool_id 2>/dev/null || echo '')"
 	@echo "CUSTODIAL_ADAPTER_ID=$(cat {{state_dir}}/custodial_adapter_id 2>/dev/null || echo '')"
 	@echo "CUSTODIAL_ADDRESS=$(cat {{state_dir}}/custodial_address 2>/dev/null || echo '')"
+	@echo "SOROBAN_CURATOR_PROXY=$(cat {{state_dir}}/curator_proxy_id 2>/dev/null || echo '')"
 
 # Internal: Ensure setup is complete.
 _ensure-setup:
@@ -1311,6 +1401,9 @@ help:
 	@echo "  just build-blend-adapter      Build Blend adapter WASM"
 	@echo "  just build-custodial-adapter  Build custodial adapter WASM"
 	@echo "  just verify-custodial-adapter-release-abi  Verify optimized custodial adapter ABI"
+	@echo "  just build-curator-proxy      Build curator proxy WASM"
+	@echo "  just verify-runtime-feature-matrix  Verify runtime capability masks"
+	@echo "  just verify-release-wasm-abi  Verify ENG-484 release ABIs and artifact behavior"
 	@echo "  just build-all                Build all WASMs"
 	@echo "  just wasm-analyze [rows]      Generate twiggy analysis reports"
 	@echo "  just wasm-analyze-print [report] [lines]  Print analysis reports"
@@ -1326,6 +1419,7 @@ help:
 	@echo "  just deploy                   Deploy vault contract"
 	@echo "  just deploy-share-token       Deploy standalone share token contract"
 	@echo "  just deploy-governance        Deploy governance contract"
+	@echo "  just deploy-curator-proxy-legacy-v1 <vault> <governance> <wasm-hash>"
 	@echo "  just init                     Initialize vault"
 	@echo "  just extend-ttl               Extend contract TTL"
 	@echo ""

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -172,22 +172,21 @@ build-curator-proxy:
 
 # Verify the runtime mask in isolated, selective, and deliberately unified builds.
 verify-runtime-feature-matrix:
-	@cargo test --manifest-path "{{root}}/Cargo.toml" \
-		-p templar-soroban-runtime \
-		test_version_is_available_before_initialization_and_matches_compiled_features
-	@cargo test --manifest-path "{{root}}/Cargo.toml" \
-		-p templar-soroban-runtime \
-		--no-default-features \
-		test_version_is_available_before_initialization_and_matches_compiled_features
-	@cargo test --manifest-path "{{root}}/Cargo.toml" \
-		-p templar-soroban-runtime \
-		--no-default-features \
-		--features action-pause \
-		test_version_is_available_before_initialization_and_matches_compiled_features
-	@cargo test --manifest-path "{{root}}/Cargo.toml" \
-		-p templar-soroban-runtime \
-		-p templar-common \
-		test_version_is_available_before_initialization_and_matches_compiled_features
+	@test_name="tests::contract_tests::test_version_is_available_before_initialization_and_matches_compiled_features"; \
+	run_capability_test() { \
+		output=$(cargo test --manifest-path "{{root}}/Cargo.toml" "$@" --lib "$test_name" -- --exact 2>&1); \
+		status=$?; \
+		printf '%s\n' "$output"; \
+		if [ "$status" -ne 0 ]; then return "$status"; fi; \
+		if ! printf '%s\n' "$output" | grep -Fq "$test_name ... ok"; then \
+			echo "Error: runtime capability test did not run exactly once"; \
+			return 1; \
+		fi; \
+	}; \
+	run_capability_test -p templar-soroban-runtime || exit $?; \
+	run_capability_test -p templar-soroban-runtime --no-default-features || exit $?; \
+	run_capability_test -p templar-soroban-runtime --no-default-features --features action-pause || exit $?; \
+	run_capability_test -p templar-soroban-runtime -p templar-common || exit $?
 	@echo "✓ Runtime feature matrix verified"
 
 # Build release artifacts and verify exact version ABIs plus artifact behavior.
@@ -542,7 +541,7 @@ init:
 	echo "✓ Vault initialized"
 
 # Deploy a replacement curator proxy for an approved versionless-v1 vault artifact.
-# Deployment and initialization are separate transactions; coordinate this operation accordingly.
+# Deployment atomically pins the source identity as the one-time initialization authority.
 deploy-curator-proxy-legacy-v1 vault_address governance_address legacy_v1_wasm_hash: build-curator-proxy
 	@if ! python3 -c 'import re, sys; sys.exit(0 if re.fullmatch(r"[0-9a-fA-F]{64}", sys.argv[1]) else 1)' "{{legacy_v1_wasm_hash}}"; then \
 		echo "Error: legacy_v1_wasm_hash must be exactly 64 hexadecimal characters."; \
@@ -550,18 +549,28 @@ deploy-curator-proxy-legacy-v1 vault_address governance_address legacy_v1_wasm_h
 	fi
 	@network="${SOROBAN_NETWORK:-{{default_network}}}"; \
 	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
+	if ! initialization_authority=$(stellar keys address "$source"); then \
+		echo "Error: unable to resolve initialization authority for identity $source"; \
+		exit 1; \
+	fi; \
 	echo "Deploying replacement curator proxy..."; \
 	echo "  Vault:       {{vault_address}}"; \
 	echo "  Governance:  {{governance_address}}"; \
+	echo "  Initializer: $initialization_authority"; \
 	echo "  Legacy hash: {{legacy_v1_wasm_hash}}"; \
 	proxy_id=$(stellar contract deploy \
 		--wasm "{{curator_proxy_wasm}}" \
 		--network "$network" \
-		--source-account "$source"); \
+		--source-account "$source" \
+		-- \
+		--initialization_authority "$initialization_authority"); \
 	if [ -z "$proxy_id" ]; then \
 		echo "Error: curator proxy deploy failed — no contract ID returned"; \
 		exit 1; \
 	fi; \
+	mkdir -p "{{state_dir}}"; \
+	echo "$proxy_id" > "{{state_dir}}/curator_proxy_id"; \
+	echo "  Deployed (awaiting authorized initialization): $proxy_id"; \
 	if ! stellar contract invoke \
 		--id "$proxy_id" \
 		--network "$network" \
@@ -585,8 +594,6 @@ deploy-curator-proxy-legacy-v1 vault_address governance_address legacy_v1_wasm_h
 		echo "Error: curator proxy vault_version returned an empty response for $proxy_id"; \
 		exit 1; \
 	fi; \
-	mkdir -p "{{state_dir}}"; \
-	echo "$proxy_id" > "{{state_dir}}/curator_proxy_id"; \
 	echo "✓ Curator proxy deployed and verified: $proxy_id"; \
 	echo "  Vault version: $version"
 
@@ -1233,6 +1240,19 @@ proxy-view owner assets="0" shares="0":
 vault-version:
 	@just invoke version
 
+# Get the vault version as reported by the curator proxy (including a pinned legacy-v1 response).
+curator-proxy-vault-version:
+	@proxy_id="${SOROBAN_CURATOR_PROXY:-$(cat {{state_dir}}/curator_proxy_id 2>/dev/null)}"; \
+	if [ -z "$proxy_id" ]; then \
+		echo "Error: No curator proxy. Run 'just deploy-curator-proxy-legacy-v1' first or set SOROBAN_CURATOR_PROXY"; \
+		exit 1; \
+	fi; \
+	stellar contract invoke \
+		--id "$proxy_id" \
+		--network "${SOROBAN_NETWORK:-{{default_network}}}" \
+		--source-account "${SOROBAN_IDENTITY:-{{default_identity}}}" \
+		-- vault_version
+
 # Get admin address.
 admin:
 	@echo "Curator/governance addresses are returned by proxy-view."
@@ -1466,6 +1486,7 @@ help:
 	@echo "VIEW:"
 	@echo "  just vault-state              Show vault summary"
 	@echo "  just vault-version            Show runtime version and feature mask"
+	@echo "  just curator-proxy-vault-version  Show proxy-reported vault version"
 	@echo "  just proxy-view <owner> [assets] [shares]"
 	@echo "  just supply-queue             Show configured supply queue"
 	@echo "  just my-balance               Show share balance"

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -1141,6 +1141,10 @@ vault-state:
 proxy-view owner assets="0" shares="0":
 	@just invoke proxy_view --owner "{{owner}}" --assets "{{assets}}" --shares "{{shares}}"
 
+# Get the installed runtime package version and compiled action-feature mask.
+vault-version:
+	@just invoke version
+
 # Get admin address.
 admin:
 	@echo "Curator/governance addresses are returned by proxy-view."
@@ -1367,6 +1371,7 @@ help:
 	@echo ""
 	@echo "VIEW:"
 	@echo "  just vault-state              Show vault summary"
+	@echo "  just vault-version            Show runtime version and feature mask"
 	@echo "  just proxy-view <owner> [assets] [shares]"
 	@echo "  just supply-queue             Show configured supply queue"
 	@echo "  just my-balance               Show share balance"

--- a/contract/vault/soroban/scripts/check_release_abi.py
+++ b/contract/vault/soroban/scripts/check_release_abi.py
@@ -25,6 +25,13 @@ EXPECTED: dict[str, dict[str, dict[str, Any]]] = {
         }
     },
     "curator-proxy": {
+        "__constructor": {
+            "name": "__constructor",
+            "inputs": [
+                {"name": "initialization_authority", "type_": "address"},
+            ],
+            "outputs": [],
+        },
         "initialize": {
             "name": "initialize",
             "inputs": [

--- a/contract/vault/soroban/scripts/check_release_abi.py
+++ b/contract/vault/soroban/scripts/check_release_abi.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Validate the exact runtime and curator-proxy version interfaces."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any
+
+
+CONTRACT_ERROR = {
+    "result": {
+        "ok_type": "void",
+        "error_type": {"udt": {"name": "ContractError"}},
+    }
+}
+
+EXPECTED: dict[str, dict[str, dict[str, Any]]] = {
+    "runtime": {
+        "version": {
+            "name": "version",
+            "inputs": [],
+            "outputs": [{"tuple": {"value_types": ["string", "u64"]}}],
+        }
+    },
+    "curator-proxy": {
+        "initialize": {
+            "name": "initialize",
+            "inputs": [
+                {"name": "vault_address", "type_": "address"},
+                {"name": "governance_address", "type_": "address"},
+            ],
+            "outputs": [CONTRACT_ERROR],
+        },
+        "initialize_legacy_v1": {
+            "name": "initialize_legacy_v1",
+            "inputs": [
+                {"name": "vault_address", "type_": "address"},
+                {"name": "governance_address", "type_": "address"},
+                {
+                    "name": "legacy_v1_wasm_hash",
+                    "type_": {"bytes_n": {"n": 32}},
+                },
+            ],
+            "outputs": [CONTRACT_ERROR],
+        },
+        "vault_version": {
+            "name": "vault_version",
+            "inputs": [],
+            "outputs": [
+                {
+                    "result": {
+                        "ok_type": {
+                            "tuple": {"value_types": ["string", "u64"]}
+                        },
+                        "error_type": {"udt": {"name": "ContractError"}},
+                    }
+                }
+            ],
+        },
+    },
+}
+
+
+def normalize(function: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": function.get("name"),
+        "inputs": [
+            {"name": item.get("name"), "type_": item.get("type_")}
+            for item in function.get("inputs", [])
+        ],
+        "outputs": function.get("outputs", []),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--contract", choices=EXPECTED, required=True)
+    args = parser.parse_args()
+
+    try:
+        entries = json.load(sys.stdin)
+    except (json.JSONDecodeError, OSError) as error:
+        print(f"invalid Stellar interface JSON: {error}", file=sys.stderr)
+        return 1
+    if not isinstance(entries, list):
+        print("Stellar interface JSON must be a list", file=sys.stderr)
+        return 1
+
+    functions: dict[str, dict[str, Any]] = {}
+    for entry in entries:
+        if not isinstance(entry, dict) or not isinstance(entry.get("function_v0"), dict):
+            continue
+        function = entry["function_v0"]
+        name = function.get("name")
+        if not isinstance(name, str):
+            continue
+        if name in functions:
+            print(f"duplicate function in contract interface: {name}", file=sys.stderr)
+            return 1
+        functions[name] = normalize(function)
+
+    valid = True
+    for name, expected in EXPECTED[args.contract].items():
+        actual = functions.get(name)
+        if actual != expected:
+            valid = False
+            print(f"{args.contract} ABI mismatch for {name}", file=sys.stderr)
+            print(f"expected: {json.dumps(expected, sort_keys=True)}", file=sys.stderr)
+            print(f"actual:   {json.dumps(actual, sort_keys=True)}", file=sys.stderr)
+
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contract/vault/soroban/shared-types/Cargo.toml
+++ b/contract/vault/soroban/shared-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-soroban-shared-types"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "GPL-3.0-only"
 description = "Shared Soroban ABI selector types for Templar vault contracts"

--- a/contract/vault/soroban/shared-types/src/lib.rs
+++ b/contract/vault/soroban/shared-types/src/lib.rs
@@ -42,7 +42,8 @@ pub const RUNTIME_V1_FEATURE_FLAGS: u64 = RUNTIME_FEATURE_ACTION_RECOVERY
     | RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL
     | RUNTIME_FEATURE_ACTION_REFRESH_FEES
     | RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE
-    | RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE;
+    | RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE
+    | RUNTIME_FEATURE_ACTION_PAUSE;
 
 /// Feature mask enabled by the current default runtime build.
 pub const RUNTIME_DEFAULT_FEATURE_FLAGS: u64 = RUNTIME_V1_FEATURE_FLAGS;
@@ -1136,7 +1137,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_feature_bits_are_stable_and_default_mask_excludes_optional_capabilities() {
+    fn runtime_feature_bits_are_stable_and_default_mask_matches_public_capabilities() {
         assert_eq!(RUNTIME_FEATURE_ACTION_RECOVERY, 0x01);
         assert_eq!(RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL, 0x02);
         assert_eq!(RUNTIME_FEATURE_ACTION_REFRESH_FEES, 0x04);
@@ -1145,11 +1146,11 @@ mod tests {
         assert_eq!(RUNTIME_FEATURE_ACTION_PAUSE, 0x20);
         assert_eq!(RUNTIME_FEATURE_COMPANION_UPGRADE, 0x40);
         assert_eq!(RUNTIME_V1_VERSION, "1.0.0");
-        assert_eq!(RUNTIME_V1_FEATURE_FLAGS, 0x1f);
-        assert_eq!(RUNTIME_DEFAULT_FEATURE_FLAGS, 0x1f);
+        assert_eq!(RUNTIME_V1_FEATURE_FLAGS, 0x3f);
+        assert_eq!(RUNTIME_DEFAULT_FEATURE_FLAGS, 0x3f);
         assert_eq!(
             RUNTIME_DEFAULT_FEATURE_FLAGS & RUNTIME_FEATURE_ACTION_PAUSE,
-            0
+            RUNTIME_FEATURE_ACTION_PAUSE
         );
         assert_eq!(
             RUNTIME_DEFAULT_FEATURE_FLAGS & RUNTIME_FEATURE_COMPANION_UPGRADE,

--- a/contract/vault/soroban/shared-types/src/lib.rs
+++ b/contract/vault/soroban/shared-types/src/lib.rs
@@ -31,6 +31,8 @@ pub const RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE: u64 = 1 << 3;
 pub const RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE: u64 = 1 << 4;
 /// Runtime includes pause action handlers.
 pub const RUNTIME_FEATURE_ACTION_PAUSE: u64 = 1 << 5;
+/// Runtime can authorize upgrades of vault companion contracts such as adapters.
+pub const RUNTIME_FEATURE_COMPANION_UPGRADE: u64 = 1 << 6;
 
 /// Package version returned for deployed runtimes without a version entrypoint.
 pub const RUNTIME_V1_VERSION: &str = "1.0.0";
@@ -1134,18 +1136,23 @@ mod tests {
     }
 
     #[test]
-    fn runtime_feature_bits_are_stable_and_default_mask_excludes_pause() {
+    fn runtime_feature_bits_are_stable_and_default_mask_excludes_optional_capabilities() {
         assert_eq!(RUNTIME_FEATURE_ACTION_RECOVERY, 0x01);
         assert_eq!(RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL, 0x02);
         assert_eq!(RUNTIME_FEATURE_ACTION_REFRESH_FEES, 0x04);
         assert_eq!(RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE, 0x08);
         assert_eq!(RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE, 0x10);
         assert_eq!(RUNTIME_FEATURE_ACTION_PAUSE, 0x20);
+        assert_eq!(RUNTIME_FEATURE_COMPANION_UPGRADE, 0x40);
         assert_eq!(RUNTIME_V1_VERSION, "1.0.0");
         assert_eq!(RUNTIME_V1_FEATURE_FLAGS, 0x1f);
         assert_eq!(RUNTIME_DEFAULT_FEATURE_FLAGS, 0x1f);
         assert_eq!(
             RUNTIME_DEFAULT_FEATURE_FLAGS & RUNTIME_FEATURE_ACTION_PAUSE,
+            0
+        );
+        assert_eq!(
+            RUNTIME_DEFAULT_FEATURE_FLAGS & RUNTIME_FEATURE_COMPANION_UPGRADE,
             0
         );
     }

--- a/contract/vault/soroban/shared-types/src/lib.rs
+++ b/contract/vault/soroban/shared-types/src/lib.rs
@@ -19,6 +19,35 @@ pub enum CodecError {
 pub const VAULT_ERR_INVALID_INPUT: u32 = 3;
 pub const VAULT_ERR_ALREADY_INITIALIZED: u32 = 8;
 
+/// Runtime includes recovery action handlers.
+pub const RUNTIME_FEATURE_ACTION_RECOVERY: u64 = 1 << 0;
+/// Runtime includes external-asset synchronization action handlers.
+pub const RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL: u64 = 1 << 1;
+/// Runtime includes fee-refresh action handlers.
+pub const RUNTIME_FEATURE_ACTION_REFRESH_FEES: u64 = 1 << 2;
+/// Runtime includes allocation lifecycle action handlers.
+pub const RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE: u64 = 1 << 3;
+/// Runtime includes refresh lifecycle action handlers.
+pub const RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE: u64 = 1 << 4;
+/// Runtime includes pause action handlers.
+pub const RUNTIME_FEATURE_ACTION_PAUSE: u64 = 1 << 5;
+
+/// Package version returned for deployed runtimes without a version entrypoint.
+pub const RUNTIME_V1_VERSION: &str = "1.0.0";
+
+/// Feature mask shipped by the original v1 runtime.
+pub const RUNTIME_V1_FEATURE_FLAGS: u64 = RUNTIME_FEATURE_ACTION_RECOVERY
+    | RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL
+    | RUNTIME_FEATURE_ACTION_REFRESH_FEES
+    | RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE
+    | RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE;
+
+/// Feature mask enabled by the current default runtime build.
+pub const RUNTIME_DEFAULT_FEATURE_FLAGS: u64 = RUNTIME_V1_FEATURE_FLAGS;
+
+/// Compact callable runtime version response.
+pub type RuntimeVersionResponse = (soroban_sdk::String, u64);
+
 pub mod strkey {
     use super::CodecError;
 
@@ -1102,6 +1131,23 @@ mod tests {
     fn receipt_address() -> ReceiptAddress {
         ReceiptAddress::from_str("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF")
             .expect("valid receipt address")
+    }
+
+    #[test]
+    fn runtime_feature_bits_are_stable_and_default_mask_excludes_pause() {
+        assert_eq!(RUNTIME_FEATURE_ACTION_RECOVERY, 0x01);
+        assert_eq!(RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL, 0x02);
+        assert_eq!(RUNTIME_FEATURE_ACTION_REFRESH_FEES, 0x04);
+        assert_eq!(RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE, 0x08);
+        assert_eq!(RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE, 0x10);
+        assert_eq!(RUNTIME_FEATURE_ACTION_PAUSE, 0x20);
+        assert_eq!(RUNTIME_V1_VERSION, "1.0.0");
+        assert_eq!(RUNTIME_V1_FEATURE_FLAGS, 0x1f);
+        assert_eq!(RUNTIME_DEFAULT_FEATURE_FLAGS, 0x1f);
+        assert_eq!(
+            RUNTIME_DEFAULT_FEATURE_FLAGS & RUNTIME_FEATURE_ACTION_PAUSE,
+            0
+        );
     }
 
     #[test]

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -1432,6 +1432,14 @@ fn initialize_impl(
 
 #[contractimpl]
 impl SorobanVaultContract {
+    /// Return the package version and action capabilities compiled into this runtime.
+    pub fn version(env: Env) -> (soroban_sdk::String, u64) {
+        (
+            soroban_sdk::String::from_str(&env, crate::RUNTIME_VERSION),
+            crate::RUNTIME_FEATURE_FLAGS,
+        )
+    }
+
     pub fn initialize(
         env: Env,
         curator: soroban_sdk::Address,

--- a/contract/vault/soroban/src/contract/entrypoints.rs
+++ b/contract/vault/soroban/src/contract/entrypoints.rs
@@ -1432,7 +1432,7 @@ fn initialize_impl(
 
 #[contractimpl]
 impl SorobanVaultContract {
-    /// Return the package version and action capabilities compiled into this runtime.
+    /// Return the package version and capabilities compiled into this runtime.
     pub fn version(env: Env) -> (soroban_sdk::String, u64) {
         (
             soroban_sdk::String::from_str(&env, crate::RUNTIME_VERSION),

--- a/contract/vault/soroban/src/lib.rs
+++ b/contract/vault/soroban/src/lib.rs
@@ -23,7 +23,8 @@
 //! recovery, external synchronization, fee refresh, allocation lifecycle, and
 //! refresh lifecycle. `action-pause` is available as an opt-in build feature.
 //! The callable `version()` entrypoint reports the package version and exact
-//! compiled action-feature mask.
+//! compiled runtime-capability mask. The reserved companion-upgrade capability
+//! remains unset until the runtime can authorize companion-contract upgrades.
 //!
 //! - `std` - Enable std library support (for testing)
 
@@ -50,7 +51,7 @@ const fn feature_flag(enabled: bool, flag: u64) -> u64 {
     }
 }
 
-/// Action-handler capabilities compiled into this runtime artifact.
+/// Runtime capabilities compiled into this artifact.
 pub const RUNTIME_FEATURE_FLAGS: u64 = feature_flag(
     templar_vault_kernel::ACTION_RECOVERY_ENABLED,
     RUNTIME_FEATURE_ACTION_RECOVERY,

--- a/contract/vault/soroban/src/lib.rs
+++ b/contract/vault/soroban/src/lib.rs
@@ -51,23 +51,25 @@ const fn feature_flag(enabled: bool, flag: u64) -> u64 {
 }
 
 /// Action-handler capabilities compiled into this runtime artifact.
-pub const RUNTIME_FEATURE_FLAGS: u64 =
-    feature_flag(
-        cfg!(feature = "action-recovery"),
-        RUNTIME_FEATURE_ACTION_RECOVERY,
-    ) | feature_flag(
-        cfg!(feature = "action-sync-external"),
-        RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
-    ) | feature_flag(
-        cfg!(feature = "action-refresh-fees"),
-        RUNTIME_FEATURE_ACTION_REFRESH_FEES,
-    ) | feature_flag(
-        cfg!(feature = "action-allocation-lifecycle"),
-        RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE,
-    ) | feature_flag(
-        cfg!(feature = "action-refresh-lifecycle"),
-        RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
-    ) | feature_flag(cfg!(feature = "action-pause"), RUNTIME_FEATURE_ACTION_PAUSE);
+pub const RUNTIME_FEATURE_FLAGS: u64 = feature_flag(
+    templar_vault_kernel::ACTION_RECOVERY_ENABLED,
+    RUNTIME_FEATURE_ACTION_RECOVERY,
+) | feature_flag(
+    templar_vault_kernel::ACTION_SYNC_EXTERNAL_ENABLED,
+    RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
+) | feature_flag(
+    templar_vault_kernel::ACTION_REFRESH_FEES_ENABLED,
+    RUNTIME_FEATURE_ACTION_REFRESH_FEES,
+) | feature_flag(
+    templar_vault_kernel::ACTION_ALLOCATION_LIFECYCLE_ENABLED,
+    RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE,
+) | feature_flag(
+    templar_vault_kernel::ACTION_REFRESH_LIFECYCLE_ENABLED,
+    RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
+) | feature_flag(
+    templar_vault_kernel::ACTION_PAUSE_ENABLED,
+    RUNTIME_FEATURE_ACTION_PAUSE,
+);
 
 pub mod auth;
 pub mod contract;

--- a/contract/vault/soroban/src/lib.rs
+++ b/contract/vault/soroban/src/lib.rs
@@ -21,7 +21,8 @@
 //!
 //! The default runtime forwards the five production kernel action gates:
 //! recovery, external synchronization, fee refresh, allocation lifecycle, and
-//! refresh lifecycle. `action-pause` is available as an opt-in build feature.
+//! refresh lifecycle. The public governance pause path is always available;
+//! `action-pause` separately controls the kernel action variant.
 //! The callable `version()` entrypoint reports the package version and exact
 //! compiled runtime-capability mask. The reserved companion-upgrade capability
 //! remains unset until the runtime can authorize companion-contract upgrades.
@@ -67,10 +68,7 @@ pub const RUNTIME_FEATURE_FLAGS: u64 = feature_flag(
 ) | feature_flag(
     templar_vault_kernel::ACTION_REFRESH_LIFECYCLE_ENABLED,
     RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
-) | feature_flag(
-    templar_vault_kernel::ACTION_PAUSE_ENABLED,
-    RUNTIME_FEATURE_ACTION_PAUSE,
-);
+) | RUNTIME_FEATURE_ACTION_PAUSE;
 
 pub mod auth;
 pub mod contract;

--- a/contract/vault/soroban/src/lib.rs
+++ b/contract/vault/soroban/src/lib.rs
@@ -19,6 +19,12 @@
 //!
 //! # Feature Flags
 //!
+//! The default runtime forwards the five production kernel action gates:
+//! recovery, external synchronization, fee refresh, allocation lifecycle, and
+//! refresh lifecycle. `action-pause` is available as an opt-in build feature.
+//! The callable `version()` entrypoint reports the package version and exact
+//! compiled action-feature mask.
+//!
 //! - `std` - Enable std library support (for testing)
 
 #![no_std]
@@ -26,6 +32,42 @@
 extern crate alloc;
 #[cfg(test)]
 extern crate std;
+
+use templar_soroban_shared_types::{
+    RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE, RUNTIME_FEATURE_ACTION_PAUSE,
+    RUNTIME_FEATURE_ACTION_RECOVERY, RUNTIME_FEATURE_ACTION_REFRESH_FEES,
+    RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE, RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
+};
+
+/// Package version compiled into this runtime artifact.
+pub const RUNTIME_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+const fn feature_flag(enabled: bool, flag: u64) -> u64 {
+    if enabled {
+        flag
+    } else {
+        0
+    }
+}
+
+/// Action-handler capabilities compiled into this runtime artifact.
+pub const RUNTIME_FEATURE_FLAGS: u64 =
+    feature_flag(
+        cfg!(feature = "action-recovery"),
+        RUNTIME_FEATURE_ACTION_RECOVERY,
+    ) | feature_flag(
+        cfg!(feature = "action-sync-external"),
+        RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
+    ) | feature_flag(
+        cfg!(feature = "action-refresh-fees"),
+        RUNTIME_FEATURE_ACTION_REFRESH_FEES,
+    ) | feature_flag(
+        cfg!(feature = "action-allocation-lifecycle"),
+        RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE,
+    ) | feature_flag(
+        cfg!(feature = "action-refresh-lifecycle"),
+        RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
+    ) | feature_flag(cfg!(feature = "action-pause"), RUNTIME_FEATURE_ACTION_PAUSE);
 
 pub mod auth;
 pub mod contract;

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -595,13 +595,10 @@ mod contract_tests {
                 RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
                 templar_vault_kernel::ACTION_REFRESH_LIFECYCLE_ENABLED,
             ),
-            (
-                RUNTIME_FEATURE_ACTION_PAUSE,
-                templar_vault_kernel::ACTION_PAUSE_ENABLED,
-            ),
         ] {
             assert_eq!(feature_flags & flag != 0, enabled);
         }
+        assert_ne!(feature_flags & RUNTIME_FEATURE_ACTION_PAUSE, 0);
         assert_eq!(feature_flags & RUNTIME_FEATURE_COMPANION_UPGRADE, 0);
 
         if templar_vault_kernel::ACTION_RECOVERY_ENABLED
@@ -609,7 +606,6 @@ mod contract_tests {
             && templar_vault_kernel::ACTION_REFRESH_FEES_ENABLED
             && templar_vault_kernel::ACTION_ALLOCATION_LIFECYCLE_ENABLED
             && templar_vault_kernel::ACTION_REFRESH_LIFECYCLE_ENABLED
-            && !templar_vault_kernel::ACTION_PAUSE_ENABLED
         {
             assert_eq!(
                 feature_flags,

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -368,6 +368,7 @@ mod contract_tests {
         RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE, RUNTIME_FEATURE_ACTION_PAUSE,
         RUNTIME_FEATURE_ACTION_RECOVERY, RUNTIME_FEATURE_ACTION_REFRESH_FEES,
         RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE, RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
+        RUNTIME_FEATURE_COMPANION_UPGRADE,
     };
     use templar_vault_kernel::effects::KernelEffect;
     use templar_vault_kernel::fee::FeeSlot;
@@ -601,6 +602,7 @@ mod contract_tests {
         ] {
             assert_eq!(feature_flags & flag != 0, enabled);
         }
+        assert_eq!(feature_flags & RUNTIME_FEATURE_COMPANION_UPGRADE, 0);
 
         if templar_vault_kernel::ACTION_RECOVERY_ENABLED
             && templar_vault_kernel::ACTION_SYNC_EXTERNAL_ENABLED

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -356,15 +356,18 @@ mod contract_tests {
     use alloc::vec::Vec;
     use proptest::prelude::*;
     use soroban_sdk::testutils::Address as _;
-    use soroban_sdk::{Address as SdkAddress, Bytes, Env};
+    use soroban_sdk::{Address as SdkAddress, Bytes, Env, String as SdkString, Symbol};
     use templar_curator_primitives::policy::state::MarketConfig;
     use templar_curator_primitives::PolicyState;
     use templar_soroban_governance::SorobanVaultGovernanceContract;
     use templar_soroban_shared_types::{
         DepositReceipt, EmptyReceipt, ExecuteWithdrawReceipt, ExecuteWithdrawStatus,
-        GovernanceCommand, I128Receipt, ReceiptAddress, RequestWithdrawReceipt, VaultCommand,
-        GOVERNANCE_CONFIG_KIND_IDLE_RESYNC_COOLDOWN, GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS,
-        GOVERNANCE_CONFIG_KIND_WITHDRAWAL_COOLDOWN,
+        GovernanceCommand, I128Receipt, ReceiptAddress, RequestWithdrawReceipt,
+        RuntimeVersionResponse, VaultCommand, GOVERNANCE_CONFIG_KIND_IDLE_RESYNC_COOLDOWN,
+        GOVERNANCE_CONFIG_KIND_VIRTUAL_OFFSETS, GOVERNANCE_CONFIG_KIND_WITHDRAWAL_COOLDOWN,
+        RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE, RUNTIME_FEATURE_ACTION_PAUSE,
+        RUNTIME_FEATURE_ACTION_RECOVERY, RUNTIME_FEATURE_ACTION_REFRESH_FEES,
+        RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE, RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
     };
     use templar_vault_kernel::effects::KernelEffect;
     use templar_vault_kernel::fee::FeeSlot;
@@ -555,6 +558,59 @@ mod contract_tests {
         );
         vault.load_state().unwrap();
         vault
+    }
+
+    #[test]
+    fn test_version_is_available_before_initialization_and_matches_compiled_features() {
+        let env = Env::default();
+        let contract_id = env.register(SorobanVaultContract, ());
+
+        let (version, feature_flags) = env.invoke_contract::<RuntimeVersionResponse>(
+            &contract_id,
+            &Symbol::new(&env, "version"),
+            soroban_sdk::vec![&env],
+        );
+
+        assert_eq!(version, SdkString::from_str(&env, crate::RUNTIME_VERSION));
+        assert_eq!(feature_flags, crate::RUNTIME_FEATURE_FLAGS);
+        for (flag, enabled) in [
+            (
+                RUNTIME_FEATURE_ACTION_RECOVERY,
+                cfg!(feature = "action-recovery"),
+            ),
+            (
+                RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
+                cfg!(feature = "action-sync-external"),
+            ),
+            (
+                RUNTIME_FEATURE_ACTION_REFRESH_FEES,
+                cfg!(feature = "action-refresh-fees"),
+            ),
+            (
+                RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE,
+                cfg!(feature = "action-allocation-lifecycle"),
+            ),
+            (
+                RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
+                cfg!(feature = "action-refresh-lifecycle"),
+            ),
+            (RUNTIME_FEATURE_ACTION_PAUSE, cfg!(feature = "action-pause")),
+        ] {
+            assert_eq!(feature_flags & flag != 0, enabled);
+        }
+
+        #[cfg(all(
+            feature = "action-recovery",
+            feature = "action-sync-external",
+            feature = "action-refresh-fees",
+            feature = "action-allocation-lifecycle",
+            feature = "action-refresh-lifecycle",
+            not(feature = "action-pause")
+        ))]
+        assert_eq!(
+            feature_flags,
+            templar_soroban_shared_types::RUNTIME_DEFAULT_FEATURE_FLAGS
+        );
     }
 
     #[test]

--- a/contract/vault/soroban/src/tests.rs
+++ b/contract/vault/soroban/src/tests.rs
@@ -576,41 +576,44 @@ mod contract_tests {
         for (flag, enabled) in [
             (
                 RUNTIME_FEATURE_ACTION_RECOVERY,
-                cfg!(feature = "action-recovery"),
+                templar_vault_kernel::ACTION_RECOVERY_ENABLED,
             ),
             (
                 RUNTIME_FEATURE_ACTION_SYNC_EXTERNAL,
-                cfg!(feature = "action-sync-external"),
+                templar_vault_kernel::ACTION_SYNC_EXTERNAL_ENABLED,
             ),
             (
                 RUNTIME_FEATURE_ACTION_REFRESH_FEES,
-                cfg!(feature = "action-refresh-fees"),
+                templar_vault_kernel::ACTION_REFRESH_FEES_ENABLED,
             ),
             (
                 RUNTIME_FEATURE_ACTION_ALLOCATION_LIFECYCLE,
-                cfg!(feature = "action-allocation-lifecycle"),
+                templar_vault_kernel::ACTION_ALLOCATION_LIFECYCLE_ENABLED,
             ),
             (
                 RUNTIME_FEATURE_ACTION_REFRESH_LIFECYCLE,
-                cfg!(feature = "action-refresh-lifecycle"),
+                templar_vault_kernel::ACTION_REFRESH_LIFECYCLE_ENABLED,
             ),
-            (RUNTIME_FEATURE_ACTION_PAUSE, cfg!(feature = "action-pause")),
+            (
+                RUNTIME_FEATURE_ACTION_PAUSE,
+                templar_vault_kernel::ACTION_PAUSE_ENABLED,
+            ),
         ] {
             assert_eq!(feature_flags & flag != 0, enabled);
         }
 
-        #[cfg(all(
-            feature = "action-recovery",
-            feature = "action-sync-external",
-            feature = "action-refresh-fees",
-            feature = "action-allocation-lifecycle",
-            feature = "action-refresh-lifecycle",
-            not(feature = "action-pause")
-        ))]
-        assert_eq!(
-            feature_flags,
-            templar_soroban_shared_types::RUNTIME_DEFAULT_FEATURE_FLAGS
-        );
+        if templar_vault_kernel::ACTION_RECOVERY_ENABLED
+            && templar_vault_kernel::ACTION_SYNC_EXTERNAL_ENABLED
+            && templar_vault_kernel::ACTION_REFRESH_FEES_ENABLED
+            && templar_vault_kernel::ACTION_ALLOCATION_LIFECYCLE_ENABLED
+            && templar_vault_kernel::ACTION_REFRESH_LIFECYCLE_ENABLED
+            && !templar_vault_kernel::ACTION_PAUSE_ENABLED
+        {
+            assert_eq!(
+                feature_flags,
+                templar_soroban_shared_types::RUNTIME_DEFAULT_FEATURE_FLAGS
+            );
+        }
     }
 
     #[test]

--- a/tools/soroban-vault-cli/Cargo.toml
+++ b/tools/soroban-vault-cli/Cargo.toml
@@ -11,10 +11,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+bip39.workspace = true
 clap.workspace = true
 clap_complete = "4.5"
 clap_mangen = "0.2"
 dirs.workspace = true
+ed25519-dalek.workspace = true
+ed25519-dalek-bip32.workspace = true
 hex.workspace = true
 indicatif = "0.18.4"
 secrecy.workspace = true

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -99,7 +99,7 @@ reuses the current curator-proxy WASM and deploys a new proxy instance whose con
 pins the resolved source-account address as its one-time initialization authority. Deployment and
 initialization remain separate transactions, but the deployed contract ID and authority are
 checkpointed before `initialize` runs. Only that same source account can complete or retry
-initialization. Rerunning the command reuses a matching incomplete checkpoint for initialization or
+initialization. Rerunning the command reuses a matching checkpoint for initialization or
 `vault_version` verification; pass `--force-new` only to abandon it and deploy a replacement. The
 command checkpoints successful initialization provenance before querying `vault_version` and marks
 the replacement version-discovery-capable only after that query succeeds.

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -93,6 +93,33 @@ tmplr-soroban-vault deploy adapters \
   --custodian G...
 ```
 
+To deploy only a fresh curator proxy for an existing vault, use `deploy curator-proxy`. Vault and
+governance addresses are read from the manifest unless supplied explicitly. The command uploads or
+reuses the current curator-proxy WASM, deploys a new proxy instance, and checkpoints its successful
+initialization provenance before querying `vault_version`. It marks the replacement
+version-discovery-capable only after that query succeeds.
+
+```sh
+tmplr-soroban-vault deploy curator-proxy \
+  --vault CVAULT... \
+  --governance CGOV...
+```
+
+For an approved versionless v1 vault, pass its verified current on-chain WASM hash. The CLI checks
+the supplied hash against the vault before deploying the proxy, then invokes
+`initialize_legacy_v1` instead of `initialize`.
+
+```sh
+tmplr-soroban-vault deploy curator-proxy \
+  --vault CVAULT... \
+  --governance CGOV... \
+  --legacy-v1-wasm-hash cd8ad034fd37e246ca578b1cfd1dc3d95fb532a6591ecf491ee01d2db03f5244
+```
+
+Reconciliation calls `vault_version` for curator proxies recorded by this flow. Older manifests and
+older curator proxies remain backward compatible: without the capability marker, reconciliation
+continues to verify only their existing vault and governance wiring.
+
 Use `deploy plan` to inspect reuse, upload, deploy, and manifest decisions without network writes or
 manifest changes:
 

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -99,9 +99,10 @@ reuses the current curator-proxy WASM and deploys a new proxy instance whose con
 pins the resolved source-account address as its one-time initialization authority. Deployment and
 initialization remain separate transactions, but the deployed contract ID and authority are
 checkpointed before `initialize` runs. Only that same source account can complete or retry
-initialization; a different operator must deploy a fresh proxy. The command checkpoints successful
-initialization provenance before querying `vault_version` and marks the replacement
-version-discovery-capable only after that query succeeds.
+initialization. Rerunning the command reuses a matching incomplete checkpoint for initialization or
+`vault_version` verification; pass `--force-new` only to abandon it and deploy a replacement. The
+command checkpoints successful initialization provenance before querying `vault_version` and marks
+the replacement version-discovery-capable only after that query succeeds.
 
 ```sh
 tmplr-soroban-vault deploy curator-proxy \

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -95,8 +95,12 @@ tmplr-soroban-vault deploy adapters \
 
 To deploy only a fresh curator proxy for an existing vault, use `deploy curator-proxy`. Vault and
 governance addresses are read from the manifest unless supplied explicitly. The command uploads or
-reuses the current curator-proxy WASM, deploys a new proxy instance, and checkpoints its successful
-initialization provenance before querying `vault_version`. It marks the replacement
+reuses the current curator-proxy WASM and deploys a new proxy instance whose constructor atomically
+pins the resolved source-account address as its one-time initialization authority. Deployment and
+initialization remain separate transactions, but the deployed contract ID and authority are
+checkpointed before `initialize` runs. Only that same source account can complete or retry
+initialization; a different operator must deploy a fresh proxy. The command checkpoints successful
+initialization provenance before querying `vault_version` and marks the replacement
 version-discovery-capable only after that query succeeds.
 
 ```sh

--- a/tools/soroban-vault-cli/src/cli.rs
+++ b/tools/soroban-vault-cli/src/cli.rs
@@ -334,6 +334,10 @@ pub struct DeployCuratorProxyArgs {
     /// Rebuild the curator-proxy artifact before upload/deploy.
     #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
     pub build: bool,
+
+    /// Abandon a matching checkpointed proxy and deploy a fresh instance.
+    #[arg(long)]
+    pub force_new: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1311,6 +1315,7 @@ mod tests {
             &legacy_hash,
             "--build",
             "false",
+            "--force-new",
         ])
         .expect("parse targeted curator proxy deploy");
 
@@ -1333,6 +1338,7 @@ mod tests {
                         Some(legacy_hash.as_str())
                     );
                     assert!(!args.build);
+                    assert!(args.force_new);
                 }
                 DeployCommand::Plan(_)
                 | DeployCommand::Stack(_)

--- a/tools/soroban-vault-cli/src/cli.rs
+++ b/tools/soroban-vault-cli/src/cli.rs
@@ -205,6 +205,8 @@ pub enum DeployCommand {
     Repair(ReconcileArgs),
     /// Add Blend or custodial adapters to an existing or imported vault deployment
     Adapters(DeployAdaptersArgs),
+    /// Deploy a fresh curator proxy for an existing or imported vault deployment
+    CuratorProxy(DeployCuratorProxyArgs),
     /// Upload or verify a single WASM artifact
     Wasm(DeployWasmArgs),
 }
@@ -313,6 +315,25 @@ pub struct DeployAdaptersArgs {
     /// Deploy a fresh adapter even if an adapter for the same pool already exists
     #[arg(long)]
     pub force_new: bool,
+}
+
+#[derive(Args, Debug)]
+pub struct DeployCuratorProxyArgs {
+    /// Existing vault contract address. Required when the manifest does not already contain `vault`.
+    #[arg(long, env = "SOROBAN_VAULT")]
+    pub vault: Option<AddressStr>,
+
+    /// Existing governance contract address. Required when the manifest does not already contain `governance`.
+    #[arg(long, env = "SOROBAN_GOVERNANCE")]
+    pub governance: Option<AddressStr>,
+
+    /// Verified current vault WASM hash for an approved versionless v1 runtime.
+    #[arg(long, env = "SOROBAN_LEGACY_V1_WASM_HASH")]
+    pub legacy_v1_wasm_hash: Option<WasmHash>,
+
+    /// Rebuild the curator-proxy artifact before upload/deploy.
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    pub build: bool,
 }
 
 #[derive(Args, Debug)]
@@ -1141,6 +1162,7 @@ mod tests {
                 | DeployCommand::Resume(_)
                 | DeployCommand::Repair(_)
                 | DeployCommand::Adapters(_)
+                | DeployCommand::CuratorProxy(_)
                 | DeployCommand::Wasm(_) => panic!("expected deploy stack"),
             },
             _ => panic!("expected deploy command"),
@@ -1174,6 +1196,7 @@ mod tests {
                 | DeployCommand::Resume(_)
                 | DeployCommand::Repair(_)
                 | DeployCommand::Adapters(_)
+                | DeployCommand::CuratorProxy(_)
                 | DeployCommand::Wasm(_) => panic!("expected deploy stack"),
             },
             _ => panic!("expected deploy command"),
@@ -1213,6 +1236,7 @@ mod tests {
                 | DeployCommand::Stack(_)
                 | DeployCommand::Resume(_)
                 | DeployCommand::Repair(_)
+                | DeployCommand::CuratorProxy(_)
                 | DeployCommand::Wasm(_) => panic!("expected deploy adapters"),
             },
             _ => panic!("expected deploy command"),
@@ -1248,6 +1272,7 @@ mod tests {
                 | DeployCommand::Resume(_)
                 | DeployCommand::Repair(_)
                 | DeployCommand::Adapters(_)
+                | DeployCommand::CuratorProxy(_)
                 | DeployCommand::Wasm(_) => panic!("expected deploy plan"),
             },
             _ => panic!("expected deploy command"),
@@ -1269,6 +1294,55 @@ mod tests {
             legacy.command,
             Commands::ExtendTtl(ExtendTtlArgs { caller: Some(_) })
         ));
+    }
+
+    #[test]
+    fn parses_targeted_legacy_curator_proxy_deploy() {
+        let legacy_hash = "11".repeat(32);
+        let cli = Cli::try_parse_from([
+            "tmplr-soroban-vault",
+            "deploy",
+            "curator-proxy",
+            "--vault",
+            POOL,
+            "--governance",
+            POOL,
+            "--legacy-v1-wasm-hash",
+            &legacy_hash,
+            "--build",
+            "false",
+        ])
+        .expect("parse targeted curator proxy deploy");
+
+        match cli.command {
+            Commands::Deploy(args) => match args.command {
+                DeployCommand::CuratorProxy(args) => {
+                    assert_eq!(
+                        args.vault.as_ref().map(ToString::to_string).as_deref(),
+                        Some(POOL)
+                    );
+                    assert_eq!(
+                        args.governance.as_ref().map(ToString::to_string).as_deref(),
+                        Some(POOL)
+                    );
+                    assert_eq!(
+                        args.legacy_v1_wasm_hash
+                            .as_ref()
+                            .map(ToString::to_string)
+                            .as_deref(),
+                        Some(legacy_hash.as_str())
+                    );
+                    assert!(!args.build);
+                }
+                DeployCommand::Plan(_)
+                | DeployCommand::Stack(_)
+                | DeployCommand::Resume(_)
+                | DeployCommand::Repair(_)
+                | DeployCommand::Adapters(_)
+                | DeployCommand::Wasm(_) => panic!("expected deploy curator-proxy"),
+            },
+            _ => panic!("expected deploy command"),
+        }
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -19,8 +19,9 @@ use crate::{
     artifacts::{ensure_uploaded, sha256_file, ArtifactSpec},
     cli::{
         AdapterArgs, AdapterCommand, Cli, Commands, CuratorCommand, DeployCommand,
-        DeployPlanCommand, ExtendTtlArgs, GovernanceCommand, GovernanceSubmitAndWaitCommand,
-        ProfileCommand, ReconcileArgs, ShareTokenCommand, UserCommand,
+        DeployCuratorProxyArgs, DeployPlanCommand, ExtendTtlArgs, GovernanceCommand,
+        GovernanceSubmitAndWaitCommand, ProfileCommand, ReconcileArgs, ShareTokenCommand,
+        UserCommand,
     },
     manifest::{ContractRecord, Manifest, TransactionRecord},
     profile,
@@ -32,6 +33,11 @@ use crate::{
 };
 
 const CONTRACT_TTL_EXTEND_LEDGERS: u32 = 3_110_400;
+const CURATOR_PROXY_INITIALIZER_ARG: &str = "initializer";
+const CURATOR_PROXY_VERSION_DISCOVERY_ARG: &str = "version_discovery";
+const CURATOR_PROXY_VAULT_ARG: &str = "vault_address";
+const CURATOR_PROXY_GOVERNANCE_ARG: &str = "governance_address";
+const CURATOR_PROXY_LEGACY_V1_HASH_ARG: &str = "legacy_v1_wasm_hash";
 
 pub fn run<E: CommandExecutor>(cli: &Cli, executor: &E) -> anyhow::Result<()> {
     guard_write(cli)?;
@@ -71,6 +77,9 @@ pub fn run<E: CommandExecutor>(cli: &Cli, executor: &E) -> anyhow::Result<()> {
             DeployCommand::Repair(repair) => Ok(run_reconcile(&stellar, &manifest, repair)),
             DeployCommand::Adapters(adapters) => {
                 deploy_adapters(cli, &stellar, &mut manifest, adapters)
+            }
+            DeployCommand::CuratorProxy(args) => {
+                deploy_curator_proxy(cli, &stellar, &mut manifest, args)
             }
             DeployCommand::Wasm(wasm) => {
                 let spec = ArtifactSpec::from_name(wasm.artifact);
@@ -820,6 +829,20 @@ fn deploy_stack<E: CommandExecutor>(
                 governance.clone(),
             ],
         )?;
+        let needs_version_verification =
+            manifest
+                .contracts
+                .get("curator_proxy")
+                .is_some_and(|record| {
+                    curator_proxy_needs_version_verification(record, &wasm_hashes["curator_proxy"])
+                });
+        if needs_version_verification {
+            record_standard_curator_proxy_initialization_if_missing(manifest, &vault, &governance)?;
+            checkpoint_manifest(cli, manifest)?;
+            verify_curator_proxy_version(cli, stellar, &curator_proxy)?;
+            mark_curator_proxy_version_discovery(manifest)?;
+            checkpoint_manifest(cli, manifest)?;
+        }
         checkpoint_manifest(cli, manifest)
     })?;
 
@@ -1201,6 +1224,9 @@ fn verify_component_wiring<E: CommandExecutor>(
                 "governance",
                 contract_id(manifest, "governance"),
             )?);
+            if curator_proxy_supports_version_discovery(record) {
+                checks.push(curator_proxy_version_check(stellar, &record.contract_id)?);
+            }
         }
         key if key.starts_with("blend_adapter") => {
             checks.push(view_equals_check(
@@ -1261,6 +1287,38 @@ fn verify_component_wiring<E: CommandExecutor>(
     Ok(checks)
 }
 
+fn curator_proxy_supports_version_discovery(record: &ContractRecord) -> bool {
+    record
+        .constructor_args
+        .get(CURATOR_PROXY_VERSION_DISCOVERY_ARG)
+        .is_some_and(|value| value == "true")
+}
+
+fn curator_proxy_needs_version_verification(
+    record: &ContractRecord,
+    current_wasm_hash: &str,
+) -> bool {
+    record.wasm_hash == current_wasm_hash && !curator_proxy_supports_version_discovery(record)
+}
+
+fn curator_proxy_version_check<E: CommandExecutor>(
+    stellar: &Stellar<'_, E>,
+    contract_id: &str,
+) -> anyhow::Result<WiringCheck> {
+    let output = stellar.invoke_view(contract_id, "vault_version", Vec::new())?;
+    let matched = !output.stdout.trim().is_empty();
+    Ok(WiringCheck {
+        field: "vault_version".to_string(),
+        expected: Some("successful non-empty response".to_string()),
+        observed: Some(output.stdout),
+        status: if matched {
+            WiringStatus::Match
+        } else {
+            WiringStatus::Mismatch
+        },
+    })
+}
+
 fn view_equals_check<E: CommandExecutor>(
     stellar: &Stellar<'_, E>,
     contract_id: &str,
@@ -1304,6 +1362,189 @@ fn push_contains_check(
             None => WiringStatus::Unknown,
         },
     });
+}
+
+fn deploy_curator_proxy<E: CommandExecutor>(
+    cli: &Cli,
+    stellar: &Stellar<'_, E>,
+    manifest: &mut Manifest,
+    args: &DeployCuratorProxyArgs,
+) -> anyhow::Result<Response> {
+    record_imported_contract_if_provided(cli, manifest, "vault", args.vault.as_ref())?;
+    checkpoint_manifest(cli, manifest)?;
+    record_imported_contract_if_provided(cli, manifest, "governance", args.governance.as_ref())?;
+    checkpoint_manifest(cli, manifest)?;
+
+    let vault = required_contract(manifest, "vault")?.to_string();
+    let governance = required_contract(manifest, "governance")?.to_string();
+    if let Some(expected_hash) = args.legacy_v1_wasm_hash.as_ref() {
+        verify_current_contract_wasm_hash(cli, stellar, &vault, expected_hash.as_str())?;
+    }
+
+    let wasm_hash = ensure_uploaded(
+        stellar,
+        manifest,
+        &cli.workspace_path,
+        ArtifactSpec::from_name(crate::cli::ArtifactName::CuratorProxy),
+        args.build,
+    )?;
+    checkpoint_manifest(cli, manifest)?;
+
+    let curator_proxy = deploy_contract_if_needed(
+        cli,
+        stellar,
+        manifest,
+        "curator_proxy",
+        &wasm_hash,
+        Vec::new(),
+        BTreeMap::new(),
+        true,
+    )?;
+
+    let (initializer, initializer_args, legacy_hash) =
+        if let Some(legacy_hash) = args.legacy_v1_wasm_hash.as_ref() {
+            (
+                "initialize_legacy_v1",
+                vec![
+                    "--vault_address".to_string(),
+                    vault.clone(),
+                    "--governance_address".to_string(),
+                    governance.clone(),
+                    "--legacy_v1_wasm_hash".to_string(),
+                    legacy_hash.to_string(),
+                ],
+                Some(legacy_hash.as_str()),
+            )
+        } else {
+            (
+                "initialize",
+                vec![
+                    "--vault_address".to_string(),
+                    vault.clone(),
+                    "--governance_address".to_string(),
+                    governance.clone(),
+                ],
+                None,
+            )
+        };
+
+    stellar.invoke(&curator_proxy, initializer, initializer_args)?;
+    if let Some(record) = manifest.contracts.get_mut("curator_proxy") {
+        record.initialized = true;
+    }
+    record_curator_proxy_initialization(manifest, &vault, &governance, initializer, legacy_hash)?;
+    checkpoint_manifest(cli, manifest)?;
+    let version = verify_curator_proxy_version(cli, stellar, &curator_proxy)?;
+    mark_curator_proxy_version_discovery(manifest)?;
+    checkpoint_manifest(cli, manifest)?;
+    Ok(Response::message(format!(
+        "curator proxy {curator_proxy} vault version: {version}"
+    )))
+}
+
+fn verify_current_contract_wasm_hash<E: CommandExecutor>(
+    cli: &Cli,
+    stellar: &Stellar<'_, E>,
+    contract_id: &str,
+    expected_hash: &str,
+) -> anyhow::Result<()> {
+    if cli.dry_run {
+        return Ok(());
+    }
+    let actual_hash = stellar.fetch_contract_wasm_hash(contract_id)?;
+    anyhow::ensure!(
+        actual_hash == expected_hash,
+        "legacy v1 WASM hash mismatch for vault {contract_id}: expected {expected_hash}, found {actual_hash}"
+    );
+    Ok(())
+}
+
+fn record_curator_proxy_initialization(
+    manifest: &mut Manifest,
+    vault: &str,
+    governance: &str,
+    initializer: &str,
+    legacy_v1_wasm_hash: Option<&str>,
+) -> anyhow::Result<()> {
+    let record = manifest
+        .contracts
+        .get_mut("curator_proxy")
+        .context("curator proxy deployment was not recorded in manifest")?;
+    record.constructor_args.insert(
+        CURATOR_PROXY_INITIALIZER_ARG.to_string(),
+        initializer.to_string(),
+    );
+    record
+        .constructor_args
+        .remove(CURATOR_PROXY_VERSION_DISCOVERY_ARG);
+    record
+        .constructor_args
+        .insert(CURATOR_PROXY_VAULT_ARG.to_string(), vault.to_string());
+    record.constructor_args.insert(
+        CURATOR_PROXY_GOVERNANCE_ARG.to_string(),
+        governance.to_string(),
+    );
+    match legacy_v1_wasm_hash {
+        Some(hash) => {
+            record.constructor_args.insert(
+                CURATOR_PROXY_LEGACY_V1_HASH_ARG.to_string(),
+                hash.to_string(),
+            );
+        }
+        None => {
+            record
+                .constructor_args
+                .remove(CURATOR_PROXY_LEGACY_V1_HASH_ARG);
+        }
+    }
+    Ok(())
+}
+
+fn record_standard_curator_proxy_initialization_if_missing(
+    manifest: &mut Manifest,
+    vault: &str,
+    governance: &str,
+) -> anyhow::Result<()> {
+    let has_initializer = manifest
+        .contracts
+        .get("curator_proxy")
+        .is_some_and(|record| {
+            record
+                .constructor_args
+                .contains_key(CURATOR_PROXY_INITIALIZER_ARG)
+        });
+    if has_initializer {
+        return Ok(());
+    }
+    record_curator_proxy_initialization(manifest, vault, governance, "initialize", None)
+}
+
+fn mark_curator_proxy_version_discovery(manifest: &mut Manifest) -> anyhow::Result<()> {
+    let record = manifest
+        .contracts
+        .get_mut("curator_proxy")
+        .context("curator proxy deployment was not recorded in manifest")?;
+    record.constructor_args.insert(
+        CURATOR_PROXY_VERSION_DISCOVERY_ARG.to_string(),
+        "true".to_string(),
+    );
+    Ok(())
+}
+
+fn verify_curator_proxy_version<E: CommandExecutor>(
+    cli: &Cli,
+    stellar: &Stellar<'_, E>,
+    curator_proxy: &str,
+) -> anyhow::Result<String> {
+    let output = stellar.invoke_view(curator_proxy, "vault_version", Vec::new())?;
+    if cli.dry_run {
+        return Ok("<dry-run>".to_string());
+    }
+    anyhow::ensure!(
+        !output.stdout.trim().is_empty(),
+        "curator proxy vault_version returned an empty response"
+    );
+    Ok(output.stdout)
 }
 
 fn deploy_adapters<E: CommandExecutor>(
@@ -3170,6 +3411,10 @@ fn command_artifact_hash(command: &Commands, manifest: &Manifest) -> Option<Stri
             .artifacts
             .get(ArtifactSpec::from_name(wasm.artifact).key)
             .and_then(|record| record.remote_wasm_hash.clone()),
+        DeployCommand::CuratorProxy(_) => manifest
+            .artifacts
+            .get("curator_proxy")
+            .and_then(|record| record.remote_wasm_hash.clone()),
         DeployCommand::Stack(_)
         | DeployCommand::Resume(_)
         | DeployCommand::Adapters(_)
@@ -4409,8 +4654,8 @@ mod tests {
         artifacts::ArtifactSpec,
         cli::{
             ArtifactName, Cli, Commands, CuratorArgs, CuratorCommand, DeployArgs, DeployCommand,
-            DeployStackArgs, ExtendTtlArgs, GovernanceArgs, ShareTokenArgs, UserArgs,
-            DEFAULT_CONTRACT_SOURCE_REPO,
+            DeployCuratorProxyArgs, DeployStackArgs, ExtendTtlArgs, GovernanceArgs, ShareTokenArgs,
+            UserArgs, DEFAULT_CONTRACT_SOURCE_REPO,
         },
         stellar::{CommandExecutor, CommandOutput},
     };
@@ -4507,7 +4752,9 @@ mod tests {
             redacted_args: &[usize],
             env: &[crate::stellar::CommandEnv],
         ) -> anyhow::Result<CommandOutput> {
-            if matches!(args, [contract, fetch, ..] if contract == "contract" && fetch == "fetch") {
+            if matches!(args, [contract, fetch, ..] if contract == "contract" && fetch == "fetch")
+                && args.iter().any(|arg| arg == "--id")
+            {
                 let contract_id = args
                     .windows(2)
                     .find_map(|pair| (pair[0] == "--id").then_some(pair[1].as_str()))
@@ -4522,6 +4769,43 @@ mod tests {
                     contract_id.as_bytes()
                 };
                 fs::write(output_path, wasm).expect("write fetched contract WASM");
+            }
+            self.inner.run(program, args, redacted_args, env)
+        }
+    }
+
+    struct FailingVaultVersionExecutor {
+        inner: TtlRecordingExecutor,
+    }
+
+    impl FailingVaultVersionExecutor {
+        fn new() -> Self {
+            Self {
+                inner: TtlRecordingExecutor::new(),
+            }
+        }
+
+        fn calls(&self) -> Vec<(String, Vec<String>)> {
+            self.inner.calls()
+        }
+    }
+
+    impl CommandExecutor for FailingVaultVersionExecutor {
+        fn run(
+            &self,
+            program: &str,
+            args: &[String],
+            redacted_args: &[usize],
+            env: &[crate::stellar::CommandEnv],
+        ) -> anyhow::Result<CommandOutput> {
+            if args.iter().any(|arg| arg == "vault_version") {
+                self.inner
+                    .inner
+                    .calls
+                    .lock()
+                    .expect("lock calls")
+                    .push((program.to_string(), args.to_vec()));
+                anyhow::bail!("forced vault_version failure");
             }
             self.inner.run(program, args, redacted_args, env)
         }
@@ -4828,6 +5112,181 @@ mod tests {
         assert_eq!(vault.status, ReconcileStatus::Mismatched);
         assert!(!response.safe_to_resume);
         assert!(response.drift_detected);
+    }
+
+    #[test]
+    fn reconcile_verifies_vault_version_for_capable_curator_proxy() {
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("vault".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("governance".to_string(), imported_record(CONTRACT));
+        let mut proxy = imported_record(CONTRACT);
+        proxy.constructor_args.insert(
+            CURATOR_PROXY_VERSION_DISCOVERY_ARG.to_string(),
+            "true".to_string(),
+        );
+        manifest
+            .contracts
+            .insert("curator_proxy".to_string(), proxy);
+        let cli = base_cli("manifest.json".into(), Commands::Status);
+        let executor = TtlRecordingExecutor::new();
+        let stellar = Stellar::new(&cli, &executor);
+
+        let response = reconcile_manifest(&stellar, &manifest, true);
+
+        let proxy = response
+            .components
+            .iter()
+            .find(|component| component.key == "curator_proxy")
+            .expect("curator proxy component");
+        assert_eq!(proxy.status, ReconcileStatus::Initialized);
+        assert!(proxy.wiring.iter().any(|check| {
+            check.field == "vault_version" && check.status == WiringStatus::Match
+        }));
+        assert!(executor
+            .calls()
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "vault_version")));
+    }
+
+    #[test]
+    fn reconcile_does_not_require_vault_version_for_legacy_proxy_manifest() {
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("vault".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("governance".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("curator_proxy".to_string(), imported_record(CONTRACT));
+        let cli = base_cli("manifest.json".into(), Commands::Status);
+        let executor = TtlRecordingExecutor::new();
+        let stellar = Stellar::new(&cli, &executor);
+
+        let response = reconcile_manifest(&stellar, &manifest, true);
+
+        let proxy = response
+            .components
+            .iter()
+            .find(|component| component.key == "curator_proxy")
+            .expect("curator proxy component");
+        assert_eq!(proxy.status, ReconcileStatus::Initialized);
+        assert!(!proxy
+            .wiring
+            .iter()
+            .any(|check| check.field == "vault_version"));
+        assert!(!executor
+            .calls()
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "vault_version")));
+    }
+
+    #[test]
+    fn current_initialized_proxy_without_marker_still_needs_version_verification() {
+        let mut proxy = imported_record(CONTRACT);
+        proxy.wasm_hash = "current-proxy-hash".to_string();
+        proxy.initialized = true;
+
+        assert!(curator_proxy_needs_version_verification(
+            &proxy,
+            "current-proxy-hash"
+        ));
+
+        proxy.constructor_args.insert(
+            CURATOR_PROXY_VERSION_DISCOVERY_ARG.to_string(),
+            "true".to_string(),
+        );
+        assert!(!curator_proxy_needs_version_verification(
+            &proxy,
+            "current-proxy-hash"
+        ));
+    }
+
+    #[test]
+    fn stack_reverification_preserves_legacy_initializer_provenance() {
+        let legacy_hash = "11".repeat(32);
+        let mut proxy = imported_record(CONTRACT);
+        proxy.wasm_hash = "current-proxy-hash".to_string();
+        proxy.constructor_args.insert(
+            CURATOR_PROXY_INITIALIZER_ARG.to_string(),
+            "initialize_legacy_v1".to_string(),
+        );
+        proxy.constructor_args.insert(
+            CURATOR_PROXY_LEGACY_V1_HASH_ARG.to_string(),
+            legacy_hash.clone(),
+        );
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("curator_proxy".to_string(), proxy);
+
+        record_standard_curator_proxy_initialization_if_missing(
+            &mut manifest,
+            "different-vault",
+            "different-governance",
+        )
+        .expect("preserve existing initialization provenance");
+
+        let proxy = manifest
+            .contracts
+            .get("curator_proxy")
+            .expect("curator proxy record");
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
+            Some(&"initialize_legacy_v1".to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_LEGACY_V1_HASH_ARG),
+            Some(&legacy_hash)
+        );
+        assert!(!proxy
+            .constructor_args
+            .contains_key(CURATOR_PROXY_VERSION_DISCOVERY_ARG));
+    }
+
+    #[test]
+    fn reconcile_blocks_capable_curator_proxy_when_vault_version_fails() {
+        let mut manifest = Manifest::new("testnet", None);
+        manifest
+            .contracts
+            .insert("vault".to_string(), imported_record(CONTRACT));
+        manifest
+            .contracts
+            .insert("governance".to_string(), imported_record(CONTRACT));
+        let mut proxy = imported_record(CONTRACT);
+        proxy.constructor_args.insert(
+            CURATOR_PROXY_VERSION_DISCOVERY_ARG.to_string(),
+            "true".to_string(),
+        );
+        manifest
+            .contracts
+            .insert("curator_proxy".to_string(), proxy);
+        let cli = base_cli("manifest.json".into(), Commands::Status);
+        let executor = FailingVaultVersionExecutor::new();
+        let stellar = Stellar::new(&cli, &executor);
+
+        let response = reconcile_manifest(&stellar, &manifest, true);
+
+        let proxy = response
+            .components
+            .iter()
+            .find(|component| component.key == "curator_proxy")
+            .expect("curator proxy component");
+        assert_eq!(proxy.status, ReconcileStatus::Unknown);
+        assert!(!response.safe_to_resume);
+        assert!(proxy
+            .warnings
+            .iter()
+            .any(|warning| warning.contains("vault_version")));
+        assert!(executor
+            .calls()
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "vault_version")));
     }
 
     #[test]
@@ -5915,6 +6374,226 @@ mod tests {
     }
 
     #[test]
+    fn targeted_curator_proxy_deploy_uses_standard_initializer_and_verifies_version() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: None,
+                    build: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = RecordingExecutor::new();
+
+        run(&cli, &executor).expect("deploy curator proxy");
+
+        let calls = executor.calls();
+        assert!(calls.iter().any(|(_, args)| {
+            args.iter().any(|arg| arg == "initialize")
+                && args
+                    .windows(2)
+                    .any(|pair| pair == ["--vault_address", CONTRACT])
+                && args
+                    .windows(2)
+                    .any(|pair| pair == ["--governance_address", CONTRACT])
+        }));
+        assert!(calls.iter().any(|(_, args)| {
+            args.iter().any(|arg| arg == "vault_version")
+                && args.windows(2).any(|pair| pair == ["--send", "no"])
+        }));
+
+        let manifest = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        let proxy = manifest
+            .contracts
+            .get("curator_proxy")
+            .expect("curator proxy record");
+        assert!(proxy.initialized);
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
+            Some(&"initialize".to_string())
+        );
+        assert_eq!(
+            proxy
+                .constructor_args
+                .get(CURATOR_PROXY_VERSION_DISCOVERY_ARG),
+            Some(&"true".to_string())
+        );
+        assert!(!proxy
+            .constructor_args
+            .contains_key(CURATOR_PROXY_LEGACY_V1_HASH_ARG));
+    }
+
+    #[test]
+    fn targeted_curator_proxy_deploy_imports_targets_and_uses_legacy_initializer() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        let legacy_hash = format!("{:x}", Sha256::digest(CONTRACT.as_bytes()));
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: Some(CONTRACT.parse().expect("vault")),
+                    governance: Some(CONTRACT.parse().expect("governance")),
+                    legacy_v1_wasm_hash: Some(legacy_hash.parse().expect("legacy hash")),
+                    build: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = TtlRecordingExecutor::new();
+
+        run(&cli, &executor).expect("deploy legacy curator proxy");
+
+        let calls = executor.calls();
+        assert!(calls.iter().any(|(_, args)| {
+            args.iter().any(|arg| arg == "initialize_legacy_v1")
+                && args
+                    .windows(2)
+                    .any(|pair| pair == ["--legacy_v1_wasm_hash", legacy_hash.as_str()])
+        }));
+        assert!(calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "vault_version")));
+
+        let manifest = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        assert!(manifest.contracts.contains_key("vault"));
+        assert!(manifest.contracts.contains_key("governance"));
+        let proxy = manifest
+            .contracts
+            .get("curator_proxy")
+            .expect("curator proxy record");
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
+            Some(&"initialize_legacy_v1".to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_LEGACY_V1_HASH_ARG),
+            Some(&legacy_hash)
+        );
+    }
+
+    #[test]
+    fn targeted_legacy_curator_proxy_rejects_wrong_current_vault_hash_before_deploy() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: Some("11".repeat(32).parse().expect("legacy hash")),
+                    build: false,
+                }),
+            }),
+            ..base_cli(state, Commands::Status)
+        };
+        let executor = TtlRecordingExecutor::new();
+
+        let error = run(&cli, &executor).expect_err("legacy hash mismatch must fail");
+
+        assert!(error.to_string().contains("legacy v1 WASM hash mismatch"));
+        assert!(!executor.calls().iter().any(|(_, args)| {
+            matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
+        }));
+    }
+
+    #[test]
+    fn targeted_curator_proxy_preserves_initialization_provenance_when_version_check_fails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: None,
+                    build: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = FailingVaultVersionExecutor::new();
+
+        let error = run(&cli, &executor).expect_err("vault version check must fail");
+
+        assert!(error.to_string().contains("forced vault_version failure"));
+        let manifest = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        let proxy = manifest
+            .contracts
+            .get("curator_proxy")
+            .expect("curator proxy record");
+        assert!(proxy.initialized);
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
+            Some(&"initialize".to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_VAULT_ARG),
+            Some(&CONTRACT.to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_GOVERNANCE_ARG),
+            Some(&CONTRACT.to_string())
+        );
+        assert!(!curator_proxy_supports_version_discovery(proxy));
+    }
+
+    #[test]
+    fn targeted_legacy_proxy_preserves_pinned_hash_when_version_check_fails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let legacy_hash = format!("{:x}", Sha256::digest(CONTRACT.as_bytes()));
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: Some(legacy_hash.parse().expect("legacy v1 Wasm hash")),
+                    build: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = FailingVaultVersionExecutor::new();
+
+        run(&cli, &executor).expect_err("vault version check must fail");
+
+        let manifest = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        let proxy = manifest
+            .contracts
+            .get("curator_proxy")
+            .expect("curator proxy record");
+        assert!(proxy.initialized);
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
+            Some(&"initialize_legacy_v1".to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_LEGACY_V1_HASH_ARG),
+            Some(&legacy_hash)
+        );
+        assert!(!curator_proxy_supports_version_discovery(proxy));
+    }
+
+    #[test]
     fn deploy_stack_without_blend_pools_skips_blend_adapter() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_fake_stack_wasms(dir.path());
@@ -6074,5 +6753,11 @@ mod tests {
         let path = ArtifactSpec::from_name(ArtifactName::CustodialAdapter).wasm_path(root);
         fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
         fs::write(path, "custodial").expect("write wasm");
+    }
+
+    fn write_fake_curator_proxy_wasm(root: &std::path::Path) {
+        let path = ArtifactSpec::from_name(ArtifactName::CuratorProxy).wasm_path(root);
+        fs::create_dir_all(path.parent().expect("parent")).expect("create parent");
+        fs::write(path, "curator proxy").expect("write wasm");
     }
 }

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -1410,26 +1410,8 @@ fn deploy_curator_proxy<E: CommandExecutor>(
 
     let (initializer, initializer_args, legacy_hash) =
         curator_proxy_initializer(args, &vault, &governance);
-    let reuse_checkpoint = !args.force_new
-        && manifest
-            .contracts
-            .get("curator_proxy")
-            .is_some_and(|record| curator_proxy_needs_version_verification(record, &wasm_hash));
-    let (constructor_args, constructor_summary) = if reuse_checkpoint {
-        (Vec::new(), BTreeMap::new())
-    } else {
-        let initialization_authority = stellar.keys_address_source_account()?;
-        (
-            vec![
-                "--initialization_authority".to_string(),
-                initialization_authority.clone(),
-            ],
-            map_args([(
-                CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG,
-                initialization_authority.as_str(),
-            )]),
-        )
-    };
+    let (reuse_checkpoint, constructor_args, constructor_summary) =
+        curator_proxy_deployment_args(args, stellar, manifest, &wasm_hash)?;
     let curator_proxy = deploy_contract_if_needed_with_initialized_state(
         cli,
         stellar,
@@ -1447,13 +1429,35 @@ fn deploy_curator_proxy<E: CommandExecutor>(
         .get("curator_proxy")
         .is_some_and(|record| record.initialized);
     if already_initialized {
-        ensure_curator_proxy_initialization_matches(
-            manifest,
-            &vault,
-            &governance,
-            initializer,
-            legacy_hash,
-        )?;
+        let has_provenance = manifest
+            .contracts
+            .get("curator_proxy")
+            .is_some_and(|record| {
+                record
+                    .constructor_args
+                    .contains_key(CURATOR_PROXY_INITIALIZER_ARG)
+            });
+        if has_provenance {
+            ensure_curator_proxy_initialization_matches(
+                manifest,
+                &vault,
+                &governance,
+                initializer,
+                legacy_hash,
+            )?;
+        } else {
+            if !cli.dry_run {
+                verify_curator_proxy_targets(stellar, &curator_proxy, &vault, &governance)?;
+            }
+            record_curator_proxy_initialization(
+                manifest,
+                &vault,
+                &governance,
+                initializer,
+                legacy_hash,
+            )?;
+            checkpoint_manifest(cli, manifest)?;
+        }
     } else {
         stellar.invoke(&curator_proxy, initializer, initializer_args)?;
         if let Some(record) = manifest.contracts.get_mut("curator_proxy") {
@@ -1506,6 +1510,35 @@ fn curator_proxy_initializer<'a>(
             None,
         )
     }
+}
+
+fn curator_proxy_deployment_args<E: CommandExecutor>(
+    args: &DeployCuratorProxyArgs,
+    stellar: &Stellar<'_, E>,
+    manifest: &Manifest,
+    wasm_hash: &str,
+) -> anyhow::Result<(bool, Vec<String>, BTreeMap<String, String>)> {
+    let reuse_checkpoint = !args.force_new
+        && manifest
+            .contracts
+            .get("curator_proxy")
+            .is_some_and(|record| curator_proxy_needs_version_verification(record, wasm_hash));
+    if reuse_checkpoint {
+        return Ok((true, Vec::new(), BTreeMap::new()));
+    }
+
+    let initialization_authority = stellar.keys_address_source_account()?;
+    Ok((
+        false,
+        vec![
+            "--initialization_authority".to_string(),
+            initialization_authority.clone(),
+        ],
+        map_args([(
+            CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG,
+            initialization_authority.as_str(),
+        )]),
+    ))
 }
 
 fn verify_current_contract_wasm_hash<E: CommandExecutor>(
@@ -1609,6 +1642,23 @@ fn ensure_curator_proxy_initialization_matches(
             == legacy_v1_wasm_hash,
         "checkpointed curator proxy used a different legacy-v1 hash; pass --force-new to replace it"
     );
+    Ok(())
+}
+
+fn verify_curator_proxy_targets<E: CommandExecutor>(
+    stellar: &Stellar<'_, E>,
+    curator_proxy: &str,
+    vault: &str,
+    governance: &str,
+) -> anyhow::Result<()> {
+    for (function, expected) in [("vault", vault), ("governance", governance)] {
+        let output = stellar.invoke_view(curator_proxy, function, Vec::new())?;
+        anyhow::ensure!(
+            output.stdout.contains(expected),
+            "checkpointed curator proxy {function} mismatch: expected {expected}, observed {}",
+            output.stdout
+        );
+    }
     Ok(())
 }
 
@@ -6587,6 +6637,70 @@ mod tests {
         assert!(!proxy
             .constructor_args
             .contains_key(CURATOR_PROXY_LEGACY_V1_HASH_ARG));
+    }
+
+    #[test]
+    fn targeted_curator_proxy_backfills_verified_imported_provenance() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: None,
+                    build: false,
+                    force_new: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        run(&cli, &RecordingExecutor::new()).expect("seed initialized curator proxy");
+
+        let mut imported = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        let proxy = imported
+            .contracts
+            .get_mut("curator_proxy")
+            .expect("curator proxy record");
+        proxy.constructor_args.clear();
+        imported.save(&state).expect("save imported manifest");
+
+        let retry_executor = RecordingExecutor::new();
+        run(&cli, &retry_executor).expect("backfill imported curator proxy");
+
+        let retry_calls = retry_executor.calls();
+        assert!(!retry_calls.iter().any(|(_, args)| {
+            matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
+        }));
+        assert!(!retry_calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "initialize")));
+        for function in ["vault", "governance", "vault_version"] {
+            assert!(retry_calls
+                .iter()
+                .any(|(_, args)| args.iter().any(|arg| arg == function)));
+        }
+        let backfilled = Manifest::load_or_new(&state, "testnet", None).expect("load backfill");
+        let proxy = backfilled
+            .contracts
+            .get("curator_proxy")
+            .expect("backfilled curator proxy");
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
+            Some(&"initialize".to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_VAULT_ARG),
+            Some(&CONTRACT.to_string())
+        );
+        assert_eq!(
+            proxy.constructor_args.get(CURATOR_PROXY_GOVERNANCE_ARG),
+            Some(&CONTRACT.to_string())
+        );
+        assert!(curator_proxy_supports_version_discovery(proxy));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -1408,64 +1408,104 @@ fn deploy_curator_proxy<E: CommandExecutor>(
     )?;
     checkpoint_manifest(cli, manifest)?;
 
-    let initialization_authority = stellar.keys_address_source_account()?;
+    let (initializer, initializer_args, legacy_hash) =
+        curator_proxy_initializer(args, &vault, &governance);
+    let reuse_checkpoint = !args.force_new
+        && manifest
+            .contracts
+            .get("curator_proxy")
+            .is_some_and(|record| curator_proxy_needs_version_verification(record, &wasm_hash));
+    let (constructor_args, constructor_summary) = if reuse_checkpoint {
+        (Vec::new(), BTreeMap::new())
+    } else {
+        let initialization_authority = stellar.keys_address_source_account()?;
+        (
+            vec![
+                "--initialization_authority".to_string(),
+                initialization_authority.clone(),
+            ],
+            map_args([(
+                CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG,
+                initialization_authority.as_str(),
+            )]),
+        )
+    };
     let curator_proxy = deploy_contract_if_needed_with_initialized_state(
         cli,
         stellar,
         manifest,
         "curator_proxy",
         &wasm_hash,
-        vec![
-            "--initialization_authority".to_string(),
-            initialization_authority.clone(),
-        ],
-        map_args([(
-            CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG,
-            initialization_authority.as_str(),
-        )]),
-        true,
+        constructor_args,
+        constructor_summary,
+        !reuse_checkpoint,
         false,
     )?;
 
-    let (initializer, initializer_args, legacy_hash) =
-        if let Some(legacy_hash) = args.legacy_v1_wasm_hash.as_ref() {
-            (
-                "initialize_legacy_v1",
-                vec![
-                    "--vault_address".to_string(),
-                    vault.clone(),
-                    "--governance_address".to_string(),
-                    governance.clone(),
-                    "--legacy_v1_wasm_hash".to_string(),
-                    legacy_hash.to_string(),
-                ],
-                Some(legacy_hash.as_str()),
-            )
-        } else {
-            (
-                "initialize",
-                vec![
-                    "--vault_address".to_string(),
-                    vault.clone(),
-                    "--governance_address".to_string(),
-                    governance.clone(),
-                ],
-                None,
-            )
-        };
-
-    stellar.invoke(&curator_proxy, initializer, initializer_args)?;
-    if let Some(record) = manifest.contracts.get_mut("curator_proxy") {
-        record.initialized = true;
+    let already_initialized = manifest
+        .contracts
+        .get("curator_proxy")
+        .is_some_and(|record| record.initialized);
+    if already_initialized {
+        ensure_curator_proxy_initialization_matches(
+            manifest,
+            &vault,
+            &governance,
+            initializer,
+            legacy_hash,
+        )?;
+    } else {
+        stellar.invoke(&curator_proxy, initializer, initializer_args)?;
+        if let Some(record) = manifest.contracts.get_mut("curator_proxy") {
+            record.initialized = true;
+        }
+        record_curator_proxy_initialization(
+            manifest,
+            &vault,
+            &governance,
+            initializer,
+            legacy_hash,
+        )?;
+        checkpoint_manifest(cli, manifest)?;
     }
-    record_curator_proxy_initialization(manifest, &vault, &governance, initializer, legacy_hash)?;
-    checkpoint_manifest(cli, manifest)?;
     let version = verify_curator_proxy_version(cli, stellar, &curator_proxy)?;
     mark_curator_proxy_version_discovery(manifest)?;
     checkpoint_manifest(cli, manifest)?;
     Ok(Response::message(format!(
         "curator proxy {curator_proxy} vault version: {version}"
     )))
+}
+
+fn curator_proxy_initializer<'a>(
+    args: &'a DeployCuratorProxyArgs,
+    vault: &str,
+    governance: &str,
+) -> (&'static str, Vec<String>, Option<&'a str>) {
+    if let Some(legacy_hash) = args.legacy_v1_wasm_hash.as_ref() {
+        (
+            "initialize_legacy_v1",
+            vec![
+                "--vault_address".to_string(),
+                vault.to_string(),
+                "--governance_address".to_string(),
+                governance.to_string(),
+                "--legacy_v1_wasm_hash".to_string(),
+                legacy_hash.to_string(),
+            ],
+            Some(legacy_hash.as_str()),
+        )
+    } else {
+        (
+            "initialize",
+            vec![
+                "--vault_address".to_string(),
+                vault.to_string(),
+                "--governance_address".to_string(),
+                governance.to_string(),
+            ],
+            None,
+        )
+    }
 }
 
 fn verify_current_contract_wasm_hash<E: CommandExecutor>(
@@ -1523,6 +1563,52 @@ fn record_curator_proxy_initialization(
                 .remove(CURATOR_PROXY_LEGACY_V1_HASH_ARG);
         }
     }
+    Ok(())
+}
+
+fn ensure_curator_proxy_initialization_matches(
+    manifest: &Manifest,
+    vault: &str,
+    governance: &str,
+    initializer: &str,
+    legacy_v1_wasm_hash: Option<&str>,
+) -> anyhow::Result<()> {
+    let record = manifest
+        .contracts
+        .get("curator_proxy")
+        .context("curator proxy deployment was not recorded in manifest")?;
+    anyhow::ensure!(
+        record
+            .constructor_args
+            .get(CURATOR_PROXY_INITIALIZER_ARG)
+            .map(String::as_str)
+            == Some(initializer),
+        "checkpointed curator proxy used a different initializer; pass --force-new to replace it"
+    );
+    anyhow::ensure!(
+        record
+            .constructor_args
+            .get(CURATOR_PROXY_VAULT_ARG)
+            .map(String::as_str)
+            == Some(vault),
+        "checkpointed curator proxy targets a different vault; pass --force-new to replace it"
+    );
+    anyhow::ensure!(
+        record
+            .constructor_args
+            .get(CURATOR_PROXY_GOVERNANCE_ARG)
+            .map(String::as_str)
+            == Some(governance),
+        "checkpointed curator proxy targets different governance; pass --force-new to replace it"
+    );
+    anyhow::ensure!(
+        record
+            .constructor_args
+            .get(CURATOR_PROXY_LEGACY_V1_HASH_ARG)
+            .map(String::as_str)
+            == legacy_v1_wasm_hash,
+        "checkpointed curator proxy used a different legacy-v1 hash; pass --force-new to replace it"
+    );
     Ok(())
 }
 
@@ -6446,6 +6532,7 @@ mod tests {
                     governance: None,
                     legacy_v1_wasm_hash: None,
                     build: false,
+                    force_new: false,
                 }),
             }),
             ..base_cli(state.clone(), Commands::Status)
@@ -6516,6 +6603,7 @@ mod tests {
                     governance: Some(CONTRACT.parse().expect("governance")),
                     legacy_v1_wasm_hash: Some(legacy_hash.parse().expect("legacy hash")),
                     build: false,
+                    force_new: false,
                 }),
             }),
             ..base_cli(state.clone(), Commands::Status)
@@ -6572,6 +6660,7 @@ mod tests {
                     governance: None,
                     legacy_v1_wasm_hash: Some("11".repeat(32).parse().expect("legacy hash")),
                     build: false,
+                    force_new: false,
                 }),
             }),
             ..base_cli(state, Commands::Status)
@@ -6600,6 +6689,7 @@ mod tests {
                     governance: None,
                     legacy_v1_wasm_hash: None,
                     build: false,
+                    force_new: false,
                 }),
             }),
             ..base_cli(state.clone(), Commands::Status)
@@ -6627,6 +6717,24 @@ mod tests {
         assert!(!proxy
             .constructor_args
             .contains_key(CURATOR_PROXY_INITIALIZER_ARG));
+
+        let retry_executor = RecordingExecutor::new();
+        run(&cli, &retry_executor).expect("retry checkpointed curator proxy");
+        let retry_calls = retry_executor.calls();
+        assert!(!retry_calls.iter().any(|(_, args)| {
+            matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
+        }));
+        assert!(retry_calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "initialize")));
+        let retried =
+            Manifest::load_or_new(&state, "testnet", None).expect("load retried manifest");
+        let proxy = retried
+            .contracts
+            .get("curator_proxy")
+            .expect("retried curator proxy");
+        assert!(proxy.initialized);
+        assert!(curator_proxy_supports_version_discovery(proxy));
     }
 
     #[test]
@@ -6643,6 +6751,7 @@ mod tests {
                     governance: None,
                     legacy_v1_wasm_hash: None,
                     build: false,
+                    force_new: false,
                 }),
             }),
             ..base_cli(state.clone(), Commands::Status)
@@ -6671,6 +6780,27 @@ mod tests {
             Some(&CONTRACT.to_string())
         );
         assert!(!curator_proxy_supports_version_discovery(proxy));
+
+        let retry_executor = RecordingExecutor::new();
+        run(&cli, &retry_executor).expect("retry curator proxy version verification");
+        let retry_calls = retry_executor.calls();
+        assert!(!retry_calls.iter().any(|(_, args)| {
+            matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
+        }));
+        assert!(!retry_calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "initialize")));
+        assert!(retry_calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "vault_version")));
+        let retried =
+            Manifest::load_or_new(&state, "testnet", None).expect("load retried manifest");
+        assert!(curator_proxy_supports_version_discovery(
+            retried
+                .contracts
+                .get("curator_proxy")
+                .expect("retried curator proxy")
+        ));
     }
 
     #[test]
@@ -6688,6 +6818,7 @@ mod tests {
                     governance: None,
                     legacy_v1_wasm_hash: Some(legacy_hash.parse().expect("legacy v1 Wasm hash")),
                     build: false,
+                    force_new: false,
                 }),
             }),
             ..base_cli(state.clone(), Commands::Status)

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -1449,13 +1449,7 @@ fn deploy_curator_proxy<E: CommandExecutor>(
             if !cli.dry_run {
                 verify_curator_proxy_targets(stellar, &curator_proxy, &vault, &governance)?;
             }
-            record_curator_proxy_initialization(
-                manifest,
-                &vault,
-                &governance,
-                initializer,
-                legacy_hash,
-            )?;
+            record_verified_curator_proxy_targets(manifest, &vault, &governance)?;
             checkpoint_manifest(cli, manifest)?;
         }
     } else {
@@ -1522,7 +1516,7 @@ fn curator_proxy_deployment_args<E: CommandExecutor>(
         && manifest
             .contracts
             .get("curator_proxy")
-            .is_some_and(|record| curator_proxy_needs_version_verification(record, wasm_hash));
+            .is_some_and(|record| record.wasm_hash == wasm_hash);
     if reuse_checkpoint {
         return Ok((true, Vec::new(), BTreeMap::new()));
     }
@@ -1596,6 +1590,31 @@ fn record_curator_proxy_initialization(
                 .remove(CURATOR_PROXY_LEGACY_V1_HASH_ARG);
         }
     }
+    Ok(())
+}
+
+fn record_verified_curator_proxy_targets(
+    manifest: &mut Manifest,
+    vault: &str,
+    governance: &str,
+) -> anyhow::Result<()> {
+    let record = manifest
+        .contracts
+        .get_mut("curator_proxy")
+        .context("curator proxy deployment was not recorded in manifest")?;
+    record
+        .constructor_args
+        .remove(CURATOR_PROXY_INITIALIZER_ARG);
+    record
+        .constructor_args
+        .remove(CURATOR_PROXY_LEGACY_V1_HASH_ARG);
+    record
+        .constructor_args
+        .insert(CURATOR_PROXY_VAULT_ARG.to_string(), vault.to_string());
+    record.constructor_args.insert(
+        CURATOR_PROXY_GOVERNANCE_ARG.to_string(),
+        governance.to_string(),
+    );
     Ok(())
 }
 
@@ -6640,7 +6659,43 @@ mod tests {
     }
 
     #[test]
-    fn targeted_curator_proxy_backfills_verified_imported_provenance() {
+    fn targeted_curator_proxy_reuses_fully_verified_manifest() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: None,
+                    build: false,
+                    force_new: false,
+                }),
+            }),
+            ..base_cli(state, Commands::Status)
+        };
+        run(&cli, &RecordingExecutor::new()).expect("deploy curator proxy");
+
+        let retry_executor = RecordingExecutor::new();
+        run(&cli, &retry_executor).expect("reuse verified curator proxy");
+
+        let retry_calls = retry_executor.calls();
+        assert!(!retry_calls.iter().any(|(_, args)| {
+            matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
+        }));
+        assert!(!retry_calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "initialize")));
+        assert!(retry_calls
+            .iter()
+            .any(|(_, args)| args.iter().any(|arg| arg == "vault_version")));
+    }
+
+    #[test]
+    fn targeted_curator_proxy_records_verified_imported_targets_without_provenance() {
         let dir = tempfile::tempdir().expect("tempdir");
         write_fake_curator_proxy_wasm(dir.path());
         let state = dir.path().join("manifest.json");
@@ -6658,7 +6713,7 @@ mod tests {
             }),
             ..base_cli(state.clone(), Commands::Status)
         };
-        run(&cli, &RecordingExecutor::new()).expect("seed initialized curator proxy");
+        run(&cli, &TtlRecordingExecutor::new()).expect("seed initialized curator proxy");
 
         let mut imported = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
         let proxy = imported
@@ -6668,8 +6723,22 @@ mod tests {
         proxy.constructor_args.clear();
         imported.save(&state).expect("save imported manifest");
 
-        let retry_executor = RecordingExecutor::new();
-        run(&cli, &retry_executor).expect("backfill imported curator proxy");
+        let legacy_hash = format!("{:x}", Sha256::digest(CONTRACT.as_bytes()));
+        let retry_cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: Some(legacy_hash.parse().expect("legacy v1 Wasm hash")),
+                    build: false,
+                    force_new: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let retry_executor = TtlRecordingExecutor::new();
+        run(&retry_cli, &retry_executor).expect("record imported curator proxy targets");
 
         let retry_calls = retry_executor.calls();
         assert!(!retry_calls.iter().any(|(_, args)| {
@@ -6688,10 +6757,12 @@ mod tests {
             .contracts
             .get("curator_proxy")
             .expect("backfilled curator proxy");
-        assert_eq!(
-            proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
-            Some(&"initialize".to_string())
-        );
+        assert!(!proxy
+            .constructor_args
+            .contains_key(CURATOR_PROXY_INITIALIZER_ARG));
+        assert!(!proxy
+            .constructor_args
+            .contains_key(CURATOR_PROXY_LEGACY_V1_HASH_ARG));
         assert_eq!(
             proxy.constructor_args.get(CURATOR_PROXY_VAULT_ARG),
             Some(&CONTRACT.to_string())

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -33,6 +33,7 @@ use crate::{
 };
 
 const CONTRACT_TTL_EXTEND_LEDGERS: u32 = 3_110_400;
+const CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG: &str = "initialization_authority";
 const CURATOR_PROXY_INITIALIZER_ARG: &str = "initializer";
 const CURATOR_PROXY_VERSION_DISCOVERY_ARG: &str = "version_discovery";
 const CURATOR_PROXY_VAULT_ARG: &str = "vault_address";
@@ -802,15 +803,32 @@ fn deploy_stack<E: CommandExecutor>(
     })?;
 
     let curator_proxy = progress.step("curator proxy deploy/reuse", || {
-        let curator_proxy = deploy_contract_if_needed(
+        let (constructor_args, constructor_summary) =
+            if !args.force_new && manifest.contracts.contains_key("curator_proxy") {
+                (Vec::new(), BTreeMap::new())
+            } else {
+                let initialization_authority = stellar.keys_address_source_account()?;
+                (
+                    vec![
+                        "--initialization_authority".to_string(),
+                        initialization_authority.clone(),
+                    ],
+                    map_args([(
+                        CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG,
+                        initialization_authority.as_str(),
+                    )]),
+                )
+            };
+        let curator_proxy = deploy_contract_if_needed_with_initialized_state(
             cli,
             stellar,
             manifest,
             "curator_proxy",
             &wasm_hashes["curator_proxy"],
-            Vec::new(),
-            BTreeMap::new(),
+            constructor_args,
+            constructor_summary,
             args.force_new,
+            false,
         )?;
         checkpoint_manifest(cli, manifest)?;
         Ok(curator_proxy)
@@ -1390,15 +1408,23 @@ fn deploy_curator_proxy<E: CommandExecutor>(
     )?;
     checkpoint_manifest(cli, manifest)?;
 
-    let curator_proxy = deploy_contract_if_needed(
+    let initialization_authority = stellar.keys_address_source_account()?;
+    let curator_proxy = deploy_contract_if_needed_with_initialized_state(
         cli,
         stellar,
         manifest,
         "curator_proxy",
         &wasm_hash,
-        Vec::new(),
-        BTreeMap::new(),
+        vec![
+            "--initialization_authority".to_string(),
+            initialization_authority.clone(),
+        ],
+        map_args([(
+            CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG,
+            initialization_authority.as_str(),
+        )]),
         true,
+        false,
     )?;
 
     let (initializer, initializer_args, legacy_hash) =
@@ -1866,10 +1892,15 @@ fn push_contract_plan(plan: &mut PlanResponse, manifest: &Manifest, key: &str, f
     });
     plan.manifest_mutations
         .push(format!("record deployed {key} contract id"));
-    plan.stellar_commands.push(stellar_command_shape(
-        &format!("contract deploy --wasm-hash <{key}_hash>"),
-        true,
-    ));
+    let command = if key == "curator_proxy" {
+        format!(
+            "contract deploy --wasm-hash <{key}_hash> -- --initialization_authority <source-account-address>"
+        )
+    } else {
+        format!("contract deploy --wasm-hash <{key}_hash>")
+    };
+    plan.stellar_commands
+        .push(stellar_command_shape(&command, true));
 }
 
 fn wasm_plan(
@@ -1932,6 +1963,35 @@ fn deploy_contract_if_needed<E: CommandExecutor>(
     constructor_summary: BTreeMap<String, String>,
     force_new: bool,
 ) -> anyhow::Result<String> {
+    let initialized = !constructor_args.is_empty();
+    deploy_contract_if_needed_with_initialized_state(
+        cli,
+        stellar,
+        manifest,
+        key,
+        wasm_hash,
+        constructor_args,
+        constructor_summary,
+        force_new,
+        initialized,
+    )
+}
+
+#[allow(
+    clippy::too_many_arguments,
+    reason = "partial-constructor deployments must record their initialization state explicitly"
+)]
+fn deploy_contract_if_needed_with_initialized_state<E: CommandExecutor>(
+    cli: &Cli,
+    stellar: &Stellar<'_, E>,
+    manifest: &mut Manifest,
+    key: &str,
+    wasm_hash: &str,
+    constructor_args: Vec<String>,
+    constructor_summary: BTreeMap<String, String>,
+    force_new: bool,
+    initialized: bool,
+) -> anyhow::Result<String> {
     if !force_new {
         if let Some(record) = manifest.contracts.get(key) {
             info!(
@@ -1946,7 +2006,6 @@ fn deploy_contract_if_needed<E: CommandExecutor>(
         contract_key = key,
         wasm_hash, force_new, "deploying contract"
     );
-    let has_constructor_args = !constructor_args.is_empty();
     let contract_id = stellar.deploy(wasm_hash, constructor_args)?;
     manifest.contracts.insert(
         key.to_string(),
@@ -1956,7 +2015,7 @@ fn deploy_contract_if_needed<E: CommandExecutor>(
             salt: None,
             constructor_args: constructor_summary,
             deploy_tx: None,
-            initialized: has_constructor_args,
+            initialized,
         },
     );
     checkpoint_manifest(cli, manifest)?;
@@ -3413,7 +3472,7 @@ fn command_artifact_hash(command: &Commands, manifest: &Manifest) -> Option<Stri
             .and_then(|record| record.remote_wasm_hash.clone()),
         DeployCommand::CuratorProxy(_) => manifest
             .artifacts
-            .get("curator_proxy")
+            .get(ArtifactSpec::from_name(crate::cli::ArtifactName::CuratorProxy).key)
             .and_then(|record| record.remote_wasm_hash.clone()),
         DeployCommand::Stack(_)
         | DeployCommand::Resume(_)
@@ -6397,6 +6456,12 @@ mod tests {
 
         let calls = executor.calls();
         assert!(calls.iter().any(|(_, args)| {
+            matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
+                && args.windows(2).any(|pair| {
+                    pair == ["--initialization_authority", CONTRACT]
+                })
+        }));
+        assert!(calls.iter().any(|(_, args)| {
             args.iter().any(|arg| arg == "initialize")
                 && args
                     .windows(2)
@@ -6416,6 +6481,12 @@ mod tests {
             .get("curator_proxy")
             .expect("curator proxy record");
         assert!(proxy.initialized);
+        assert_eq!(
+            proxy
+                .constructor_args
+                .get(CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG),
+            Some(&CONTRACT.to_string())
+        );
         assert_eq!(
             proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
             Some(&"initialize".to_string())
@@ -6472,6 +6543,12 @@ mod tests {
             .get("curator_proxy")
             .expect("curator proxy record");
         assert_eq!(
+            proxy
+                .constructor_args
+                .get(CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG),
+            Some(&CONTRACT.to_string())
+        );
+        assert_eq!(
             proxy.constructor_args.get(CURATOR_PROXY_INITIALIZER_ARG),
             Some(&"initialize_legacy_v1".to_string())
         );
@@ -6507,6 +6584,49 @@ mod tests {
         assert!(!executor.calls().iter().any(|(_, args)| {
             matches!(args.as_slice(), [contract, deploy, ..] if contract == "contract" && deploy == "deploy")
         }));
+    }
+
+    #[test]
+    fn targeted_curator_proxy_checkpoint_stays_uninitialized_when_initialize_fails() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        write_fake_curator_proxy_wasm(dir.path());
+        let state = dir.path().join("manifest.json");
+        manifest_with_governance_and_vault(&state);
+        let cli = Cli {
+            workspace_path: dir.path().into(),
+            command: Commands::Deploy(DeployArgs {
+                command: DeployCommand::CuratorProxy(DeployCuratorProxyArgs {
+                    vault: None,
+                    governance: None,
+                    legacy_v1_wasm_hash: None,
+                    build: false,
+                }),
+            }),
+            ..base_cli(state.clone(), Commands::Status)
+        };
+        let executor = FailingInitializeExecutor::new();
+
+        let error = run(&cli, &executor).expect_err("initialize must fail");
+
+        assert!(
+            error.to_string().contains("forced initialize failure")
+                || error.to_string().contains("preflight simulation failed")
+        );
+        let manifest = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+        let proxy = manifest
+            .contracts
+            .get("curator_proxy")
+            .expect("deployed proxy must be checkpointed");
+        assert!(!proxy.initialized);
+        assert_eq!(
+            proxy
+                .constructor_args
+                .get(CURATOR_PROXY_INITIALIZATION_AUTHORITY_ARG),
+            Some(&CONTRACT.to_string())
+        );
+        assert!(!proxy
+            .constructor_args
+            .contains_key(CURATOR_PROXY_INITIALIZER_ARG));
     }
 
     #[test]

--- a/tools/soroban-vault-cli/src/commands.rs
+++ b/tools/soroban-vault-cli/src/commands.rs
@@ -1395,9 +1395,6 @@ fn deploy_curator_proxy<E: CommandExecutor>(
 
     let vault = required_contract(manifest, "vault")?.to_string();
     let governance = required_contract(manifest, "governance")?.to_string();
-    if let Some(expected_hash) = args.legacy_v1_wasm_hash.as_ref() {
-        verify_current_contract_wasm_hash(cli, stellar, &vault, expected_hash.as_str())?;
-    }
 
     let wasm_hash = ensure_uploaded(
         stellar,
@@ -1412,6 +1409,16 @@ fn deploy_curator_proxy<E: CommandExecutor>(
         curator_proxy_initializer(args, &vault, &governance);
     let (reuse_checkpoint, constructor_args, constructor_summary) =
         curator_proxy_deployment_args(args, stellar, manifest, &wasm_hash)?;
+    let already_initialized = reuse_checkpoint
+        && manifest
+            .contracts
+            .get("curator_proxy")
+            .is_some_and(|record| record.initialized);
+    if !already_initialized {
+        if let Some(expected_hash) = args.legacy_v1_wasm_hash.as_ref() {
+            verify_current_contract_wasm_hash(cli, stellar, &vault, expected_hash.as_str())?;
+        }
+    }
     let curator_proxy = deploy_contract_if_needed_with_initialized_state(
         cli,
         stellar,
@@ -1424,10 +1431,6 @@ fn deploy_curator_proxy<E: CommandExecutor>(
         false,
     )?;
 
-    let already_initialized = manifest
-        .contracts
-        .get("curator_proxy")
-        .is_some_and(|record| record.initialized);
     if already_initialized {
         let has_provenance = manifest
             .contracts
@@ -6723,7 +6726,7 @@ mod tests {
         proxy.constructor_args.clear();
         imported.save(&state).expect("save imported manifest");
 
-        let legacy_hash = format!("{:x}", Sha256::digest(CONTRACT.as_bytes()));
+        let legacy_hash = "11".repeat(32);
         let retry_cli = Cli {
             workspace_path: dir.path().into(),
             command: Commands::Deploy(DeployArgs {

--- a/tools/soroban-vault-cli/src/stellar.rs
+++ b/tools/soroban-vault-cli/src/stellar.rs
@@ -9,8 +9,11 @@ use std::{
 };
 
 use anyhow::Context;
+use ed25519_dalek::SigningKey;
+use ed25519_dalek_bip32::{ChildIndex, ExtendedSigningKey};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use stellar_strkey::Strkey;
 use tracing::{debug, info, warn};
 use zeroize::Zeroize;
 use zeroize::Zeroizing;
@@ -166,10 +169,29 @@ impl<'a, E: CommandExecutor> Stellar<'a, E> {
     }
 
     pub fn keys_address_source_account(&self) -> anyhow::Result<String> {
-        let (args, redacted_args) = keys_address_source_account_args(
-            self.cli.source_account.as_ref(),
-            std::env::var_os("STELLAR_ACCOUNT").is_some(),
-        )?;
+        let stellar_account = if self.cli.source_account.is_none() {
+            match std::env::var("STELLAR_ACCOUNT") {
+                Ok(value) => Some(Zeroizing::new(value)),
+                Err(std::env::VarError::NotPresent) => None,
+                Err(std::env::VarError::NotUnicode(_)) => {
+                    anyhow::bail!("STELLAR_ACCOUNT must be valid UTF-8")
+                }
+            }
+        } else {
+            None
+        };
+        if let Some(account) = stellar_account.as_ref() {
+            if let Some(address) = public_address_from_stellar_account(account.as_str())? {
+                return Ok(address);
+            }
+        }
+        let source = self
+            .cli
+            .source_account
+            .as_ref()
+            .map(SourceAccount::as_secret_str)
+            .or_else(|| stellar_account.as_ref().map(|account| account.as_str()));
+        let (args, redacted_args) = keys_address_source_account_args(source);
         let out = self.run(args, &redacted_args, Vec::new())?;
         if self.cli.dry_run {
             return Ok("GDRYRUNSOURCEACCOUNT".to_string());
@@ -789,21 +811,70 @@ fn shell_escape(value: &str) -> String {
     }
 }
 
-fn keys_address_source_account_args(
-    source_account: Option<&SourceAccount>,
-    stellar_account_env_is_set: bool,
-) -> anyhow::Result<(Vec<String>, Vec<usize>)> {
+fn keys_address_source_account_args(source_account: Option<&str>) -> (Vec<String>, Vec<usize>) {
     let mut args = vec!["keys".to_string(), "address".to_string()];
     let mut redacted_args = Vec::new();
     if let Some(source) = source_account {
         redacted_args.push(args.len());
-        args.push(source.clone_secret());
-    } else if stellar_account_env_is_set {
-        anyhow::bail!(
-            "cannot derive a public address from STELLAR_ACCOUNT without exposing it to child argv; pass --admin/--caller explicitly or use a Stellar keystore/default identity"
-        );
+        args.push(source.to_string());
     }
-    Ok((args, redacted_args))
+    (args, redacted_args)
+}
+
+fn public_address_from_stellar_account(value: &str) -> anyhow::Result<Option<String>> {
+    match Strkey::from_string(value) {
+        Ok(Strkey::PrivateKeyEd25519(mut private_key)) => {
+            let signing_key = SigningKey::from_bytes(&private_key.0);
+            private_key.0.zeroize();
+            Ok(Some(stellar_public_key(
+                signing_key.verifying_key().to_bytes(),
+            )))
+        }
+        Ok(Strkey::PublicKeyEd25519(public_key)) => Ok(Some(public_key.to_string().to_string())),
+        Ok(Strkey::MuxedAccountEd25519(muxed_account)) => {
+            Ok(Some(stellar_public_key(muxed_account.ed25519)))
+        }
+        Ok(_) => anyhow::bail!("STELLAR_ACCOUNT is not a supported account source"),
+        Err(_) if value.split_whitespace().count() > 1 => {
+            let mnemonic = bip39::Mnemonic::parse(value)
+                .context("STELLAR_ACCOUNT contains an invalid seed phrase")?;
+            let seed = Zeroizing::new(mnemonic.to_seed(""));
+            let mut root = ExtendedSigningKey::from_seed(seed.as_ref())
+                .context("derive STELLAR_ACCOUNT seed phrase root key")?;
+            let path = [
+                ChildIndex::Hardened(44),
+                ChildIndex::Hardened(148),
+                ChildIndex::Hardened(0),
+            ];
+            let mut derived = root
+                .derive(&path)
+                .context("derive STELLAR_ACCOUNT default Stellar account")?;
+            root.chain_code.zeroize();
+            drop(root);
+            let public_key = derived.verifying_key().to_bytes();
+            derived.chain_code.zeroize();
+            drop(derived);
+            Ok(Some(stellar_public_key(public_key)))
+        }
+        Err(_) => {
+            anyhow::ensure!(
+                !value.is_empty()
+                    && value.len() < 56
+                    && value
+                        .chars()
+                        .all(|character| character.is_ascii_alphanumeric()
+                            || "-_.".contains(character)),
+                "STELLAR_ACCOUNT is neither a valid account key nor a safe Stellar identity name"
+            );
+            Ok(None)
+        }
+    }
+}
+
+fn stellar_public_key(bytes: [u8; 32]) -> String {
+    stellar_strkey::ed25519::PublicKey(bytes)
+        .to_string()
+        .to_string()
 }
 
 #[cfg(test)]
@@ -867,13 +938,56 @@ mod tests {
     }
 
     #[test]
-    fn refuses_env_secret_for_source_address_derivation() {
-        let err = keys_address_source_account_args(None, true)
-            .expect_err("STELLAR_ACCOUNT should not be converted into argv");
+    fn derives_env_secret_for_source_address_without_argv() {
+        let address = public_address_from_stellar_account(
+            "SBU2RRGLXH3E5CQHTD3ODLDF2BWDCYUSSBLLZ5GNW7JXHDIYKXZWHOKR",
+        )
+        .expect("derive secret key")
+        .expect("public address");
 
-        assert!(err
-            .to_string()
-            .contains("without exposing it to child argv"));
+        assert_eq!(
+            address,
+            "GA3D5KRYM6CB7OWQ6TWYRR3Z4T7GNZLKERYNZGGA5SOAOPIFY6YQHES5"
+        );
+    }
+
+    #[test]
+    fn derives_env_seed_phrase_for_source_address_without_argv() {
+        let address = public_address_from_stellar_account(
+            "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+        )
+        .expect("derive seed phrase")
+        .expect("public address");
+
+        assert_eq!(
+            address,
+            "GB3JDWCQJCWMJ3IILWIGDTQJJC5567PGVEVXSCVPEQOTDN64VJBDQBYX"
+        );
+    }
+
+    #[test]
+    fn derives_underlying_account_from_env_muxed_address() {
+        let address = public_address_from_stellar_account(
+            "MA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJUAAAAAAAAAAAACJUQ",
+        )
+        .expect("derive muxed account")
+        .expect("public address");
+
+        assert_eq!(
+            address,
+            "GA7QYNF7SOWQ3GLR2BGMZEHXAVIRZA4KVWLTJJFC7MGXUA74P7UJVSGZ"
+        );
+    }
+
+    #[test]
+    fn accepts_env_keystore_identity_for_redacted_lookup() {
+        assert_eq!(
+            public_address_from_stellar_account("operator").expect("accept identity name"),
+            None
+        );
+        let (args, redacted_args) = keys_address_source_account_args(Some("operator"));
+        assert_eq!(args, vec!["keys", "address", "operator"]);
+        assert_eq!(redacted_args, vec![2]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add the storage-free runtime query `version() -> (String, u64)`.
- Report stable capability bits from the kernel's resolved Cargo features so workspace feature
  unification cannot make the runtime advertise an incorrect mask.
- Keep companion-contract upgrade capability `0x40` reserved and disabled; the current runtime
  truthfully reports the always-available governance pause path in mask `0x3f`.
- Add curator-proxy `vault_version()` for versioned runtimes.
- Add `initialize_legacy_v1(vault, governance, approved_hash)` for explicitly approved,
  versionless v1 artifacts.
- Fail closed after the vault Wasm hash changes unless the installed runtime returns a valid
  `version()` response.
- Add `deploy curator-proxy` CLI support with hash validation, constructor-pinned initialization
  authority, post-deployment version verification, manifest reconciliation, and interrupted-
  deployment recovery.

## Why

Curator consumers need a callable way to identify the installed vault runtime and its compiled
capabilities. Gami's deployed runtime predates the query, so method absence alone cannot safely be
treated as v1: different versionless artifacts may expose different behavior.

The legacy path therefore requires an operator-approved exact Wasm hash. A matching hash returns
the approved v1 semantics; a changed hash must answer the real version query or discovery fails
closed.

## Compatibility and rollout

- No Gami vault runtime upgrade or state migration is required.
- Normal `initialize(vault, governance)` is used for versioned vault runtimes.
- Gami uses `initialize_legacy_v1` with approved vault hash
  `e4860606e47717e144df89a886e54241cc7fb479b81d20dddd2172e461dd0e73`.
- Existing curator proxies are non-upgradeable and must be replaced rather than mutated.
- Proxy deployment and initialization remain separate transactions, but deployment atomically
  pins the source account as the one-time initialization authority. The CLI reuses a matching
  incomplete checkpoint for initialization or version verification; `--force-new` explicitly
  abandons it.

## Stack

This is PR 2 of 3.

1. [PR #529](https://github.com/Templar-Protocol/contracts/pull/529): custodial NAV report timestamps.
2. **This PR:** runtime version discovery and curator-proxy replacement.
3. [PR #524](https://github.com/Templar-Protocol/contracts/pull/524): explicit adapter-admin guardrails and the Gami rollout checklist.

GitHub base: `dev` (PR #529 is merged).

## Validation

- `cargo test -q -p templar-soroban-shared-types -p templar-soroban-runtime
  -p templar-curator-proxy-soroban -p templar-soroban-vault-cli` — passed.
- Runtime feature matrix: default, no-default, pause-only, and workspace-unified builds passed.
- `just -f contract/vault/soroban/justfile verify-release-wasm-abi`
  - composes PR #529's optimized adapter gate;
  - verifies exact runtime and curator-proxy interfaces;
  - executes the optimized proxy across a real Wasm hash transition.
- `just -f contract/vault/soroban/justfile size-budget-check` — passed at
  `129499 / 131072` bytes.
- `cargo fmt --all -- --check`
- `git diff --check`

The repository's `pull_request` workflow now runs against the rebased `dev` target. The commands
above were rerun locally against the rebased head before marking this PR ready.

Optimized artifacts:

- runtime: `129499 / 131072` bytes, hash
  `4d24790f3ea2a02e521b84d583dab00bfa246cdfd06ee858f1f656a831cccc83`;
- curator proxy: `50250` bytes, hash
  `a2932a58e22d206bd63732d7023321bbc9bb1c629865b4767e1ae589228f7868`.

## Issue

[ENG-484](https://linear.app/templar-protocol/issue/ENG-484/add-reported-at-to-custodial-nav-adapter-reports)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/530)
<!-- Reviewable:end -->
