### PR TITLE
docs: fix rustdoc warnings and gate them in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,20 @@ jobs:
         run: |
           cargo clippy --all-features --workspace --tests -- -D warnings
 
+  documentation:
+    name: Documentation
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/rust
+      - name: Build rustdoc
+        env:
+          RUSTDOCFLAGS: -D warnings
+        run: cargo doc --workspace --no-deps
+
   binary-build:
     name: Binary Build
     runs-on: ubuntu-latest
@@ -572,6 +586,7 @@ jobs:
       - changes
       - code-formatting
       - code-linter
+      - documentation
       - binary-build
       - soroban
       - feature-matrix
@@ -589,6 +604,7 @@ jobs:
           CHANGES_RESULT: ${{ needs.changes.result }}
           FORMAT_RESULT: ${{ needs['code-formatting'].result }}
           LINTER_RESULT: ${{ needs['code-linter'].result }}
+          DOCUMENTATION_RESULT: ${{ needs.documentation.result }}
           BINARY_BUILD_RESULT: ${{ needs['binary-build'].result }}
           FAST_TEST_RESULT: ${{ needs['fast-tests'].result }}
           NEAR_TEST_RESULT: ${{ needs['near-integration-tests'].result }}
@@ -620,6 +636,7 @@ jobs:
           require_success "Change Detection" "$CHANGES_RESULT"
           require_success "Code Formatting" "$FORMAT_RESULT"
           require_success "Code Linter" "$LINTER_RESULT"
+          require_success "Documentation" "$DOCUMENTATION_RESULT"
           require_success "Binary Build" "$BINARY_BUILD_RESULT"
           require_success "Fast Tests" "$FAST_TEST_RESULT"
 

--- a/common/src/vault/mod.rs
+++ b/common/src/vault/mod.rs
@@ -230,7 +230,7 @@ impl From<Fees<U128>> for Fees<Wad> {
 pub struct VaultConfiguration {
     /// The account that owns this vault.
     pub owner: AccountId,
-    /// The account that can submit allocation plans. See [`AllocationMode`].
+    /// The account that can submit allocation plans. See [`AllocationPlan`].
     pub curator: AccountId,
     /// The emergency role that can cancel withdrawals and trigger deallocations.
     pub sentinel: AccountId,

--- a/contract/proxy-oracle/near/governance-contract/src/lib.rs
+++ b/contract/proxy-oracle/near/governance-contract/src/lib.rs
@@ -30,7 +30,7 @@ pub(crate) enum StorageKey {
     Proposals,
 }
 
-/// Wraps the versioned governance [`State`] (kernel ledger header, proposal bodies, governed oracle
+/// Wraps the versioned governance `State` (kernel ledger header, proposal bodies, governed oracle
 /// account). Role membership lives in `near-sdk-contract-tools` RBAC storage, separate from `state`.
 #[derive(Debug, Rbac, PanicOnDefault)]
 #[rbac(roles = "Role")]

--- a/contract/pyth-lazer/contract/src/lib.rs
+++ b/contract/pyth-lazer/contract/src/lib.rs
@@ -493,7 +493,7 @@ impl Contract {
 
     /// Atomically deploy new contract code and run its `migrate` in a single receipt: a failed
     /// migration reverts the code deployment too. `migrate_args` is the JSON-encoded
-    /// [`state::migration::Migration`] selecting the state transform to apply (none exist at v1, so
+    /// `state::migration::Migration` selecting the state transform to apply (none exist at v1, so
     /// this is the seam for future upgrades). The batched `migrate` is private — the runtime calls
     /// it as this account, so only the owner-gated path here can trigger it.
     #[payable]

--- a/contract/vault/curator-primitives/src/policy/cooldown/mod.rs
+++ b/contract/vault/curator-primitives/src/policy/cooldown/mod.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides a reusable [`Cooldown`] type for tracking time-based
 //! rate limits. It's used by both [`RefreshPlan`](super::refresh_plan::RefreshPlan)
-//! and [`MarketLock`](super::market_lock::MarketLock) for expiry semantics.
+//! and [`MarketLease`](super::market_lock::MarketLease) for expiry semantics.
 
 use core::num::NonZeroU64;
 

--- a/contract/vault/soroban/src/lib.rs
+++ b/contract/vault/soroban/src/lib.rs
@@ -14,7 +14,7 @@
 //! 1. Receives user actions (deposit, withdraw, etc.)
 //! 2. Validates authorization via [`AuthAdapter`]
 //! 3. Dispatches to kernel transitions
-//! 4. Interprets returned [`KernelEffect`]s via [`EffectInterpreter`]
+//! 4. Interprets returned [`KernelEffect`](templar_vault_kernel::effects::KernelEffect)s via [`EffectInterpreter`]
 //! 5. Persists state via [`Storage`]
 //!
 //! # Feature Flags

--- a/fuzz/src/account_id.rs
+++ b/fuzz/src/account_id.rs
@@ -55,7 +55,7 @@ pub enum ArbitraryAccountId {
     Named(NamedAccount),
 }
 
-/// A named account. The mandatory [`HeadSegment`] start is what guarantees the
+/// A named account. The mandatory `HeadSegment` start is what guarantees the
 /// rendered id meets NEAR's 2-char minimum without any runtime padding.
 #[derive(Arbitrary, Debug)]
 pub struct NamedAccount {

--- a/gateway/artifacts-spec/src/lib.rs
+++ b/gateway/artifacts-spec/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod artifact;
 
 /// Invoke `$callback!($spec)` once for every **read** method served by
-/// [`templar_gateway_artifacts_dispatch::Dispatch`].
+/// `templar_gateway_artifacts_dispatch::Dispatch`.
 ///
 /// Add or remove a line here whenever you add or remove a read method.
 #[macro_export]
@@ -13,7 +13,7 @@ macro_rules! for_each_artifact_read_method {
 }
 
 /// Invoke `$callback!($spec)` once for every **write** method served by
-/// [`templar_gateway_artifacts_dispatch::Dispatch`].
+/// `templar_gateway_artifacts_dispatch::Dispatch`.
 ///
 /// Add or remove a line here whenever you add or remove a write method.
 #[macro_export]

--- a/gateway/methods-spec/src/lib.rs
+++ b/gateway/methods-spec/src/lib.rs
@@ -22,7 +22,7 @@ pub mod universal_account;
 pub mod vault;
 
 /// Invoke `$callback!($spec)` once for every **read** method served by
-/// [`templar_gateway_methods_dispatch::Dispatch`].
+/// `templar_gateway_methods_dispatch::Dispatch`.
 ///
 /// **Whenever you add or remove a gateway read method, add or remove its line
 /// here.** Together with [`for_each_write_method`] this is the single canonical
@@ -133,7 +133,7 @@ macro_rules! for_each_read_method {
 }
 
 /// Invoke `$callback!($spec)` once for every **write** method served by
-/// [`templar_gateway_methods_dispatch::Dispatch`]. Add or remove a line here
+/// `templar_gateway_methods_dispatch::Dispatch`. Add or remove a line here
 /// whenever you add or remove a write method — see [`for_each_read_method`].
 #[macro_export]
 macro_rules! for_each_write_method {

--- a/gateway/oracle-updates-spec/src/lib.rs
+++ b/gateway/oracle-updates-spec/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod oracle;
 
 /// Invoke `$callback!($spec)` once for every gateway method served by
-/// [`templar_gateway_oracle_updates_dispatch::Dispatch`]. These are all writes.
+/// `templar_gateway_oracle_updates_dispatch::Dispatch`. These are all writes.
 /// The canonical list of oracle-update methods: add or remove a line here
 /// whenever you add or remove one — see
-/// [`templar_gateway_methods_spec::for_each_read_method`] for the rationale.
+/// `templar_gateway_methods_spec::for_each_read_method` for the rationale.
 #[macro_export]
 macro_rules! for_each_oracle_update_method {
     ($callback:ident) => {

--- a/gateway/store/src/memory.rs
+++ b/gateway/store/src/memory.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_MAX_COMPLETED_OPERATIONS: usize = 4096;
 ///
 /// Completed operations are retained up to a bounded window
 /// ([`MemoryStore::with_capacity`], default
-/// [`DEFAULT_MAX_COMPLETED_OPERATIONS`]) so a long-running consumer that streams
+/// `DEFAULT_MAX_COMPLETED_OPERATIONS`) so a long-running consumer that streams
 /// un-keyed operations does not grow without bound. Consumers needing durable
 /// idempotency/replay beyond this window use `PostgresStore`.
 pub struct MemoryStore {

--- a/gateway/store/src/postgres.rs
+++ b/gateway/store/src/postgres.rs
@@ -180,7 +180,7 @@ fn is_terminal(operation: &StoredOperation) -> bool {
 }
 
 impl PostgresStore {
-    /// Connect using [`DEFAULT_SCHEMA`].
+    /// Connect using `DEFAULT_SCHEMA` (`"gateway"`).
     pub fn new(database_url: &str) -> Result<Self, sqlx::Error> {
         Self::with_schema(database_url, DEFAULT_SCHEMA)
     }

--- a/gateway/testing/src/lib.rs
+++ b/gateway/testing/src/lib.rs
@@ -32,7 +32,7 @@ pub async fn harness() -> SandboxHarness {
         .expect("failed to start sandbox harness")
 }
 
-/// Like [`harness`], but always on a dedicated `neard`. Use only when the suite
+/// Like [`harness()`], but always on a dedicated `neard`. Use only when the suite
 /// genuinely cannot share a pooled node — see [`SandboxHarness::start_owned`]
 /// for the one situation that requires it. It costs a node boot per test.
 #[rstest::fixture]

--- a/gateway/testing/src/ops.rs
+++ b/gateway/testing/src/ops.rs
@@ -1810,7 +1810,8 @@ impl SandboxHarness {
 
     /// Total gas burnt across every transaction an operation produced (each
     /// transaction plus its receipts), summed over the operation's steps. Read
-    /// directly from each step's inline [`ExecutionOutcome`], whose
+    /// directly from each step's inline
+    /// [`ExecutionOutcome`](templar_gateway_types::operation::ExecutionOutcome), whose
     /// `total_gas_burnt` already covers the transaction and all its receipts — no
     /// follow-up `tx` query needed. Used by the gas-regression tests.
     pub fn operation_gas_burnt(&self, result: &WriteOperationResult) -> u64 {
@@ -2004,7 +2005,8 @@ impl SandboxHarness {
 
 /// Every receipt in the operation that failed.
 ///
-/// Top-level success is not receipt-level success (see [`ExecutionOutcome`] and
+/// Top-level success is not receipt-level success (see
+/// [`ExecutionOutcome`](templar_gateway_types::operation::ExecutionOutcome) and
 /// `OperationStatus`): a rejected inner receipt can be refunded by the token
 /// while the transaction still reports success. Tests asserting that a call was
 /// *rejected* should check this rather than the operation status, which would be

--- a/gateway/testing/src/sandbox.rs
+++ b/gateway/testing/src/sandbox.rs
@@ -224,10 +224,10 @@ impl SandboxHarness {
             .collect())
     }
 
-    /// Like [`create_account`](Self::create_account) but mints the account with a
+    /// Like `create_account` but mints the account with a
     /// real `create_account` transaction funded and signed by the per-process
     /// tenant root (not the genesis key). Kept for tests that assert on
-    /// account-creation behavior; the patch-based [`create_account`] is the
+    /// account-creation behavior; the patch-based `create_account` is the
     /// default and is far faster.
     pub async fn create_account_via_tx(
         &self,
@@ -1134,8 +1134,8 @@ fn block_delays_ms() -> (u64, u64) {
     (min, 2 * FAST_FORWARD_BLOCK_MS - min)
 }
 
-/// Sandbox launch config shared by owned mode ([`connect`]) and the out-of-band
-/// host (`bin/sandbox-host.rs`), so both nodes seed the [`FUNDER_ACCOUNT_ID`]
+/// Sandbox launch config shared by owned mode ([`SandboxHarness::start_owned`]) and the out-of-band
+/// host (`bin/sandbox-host.rs`), so both nodes seed the `FUNDER_ACCOUNT_ID`
 /// account identically and run the same block cadence.
 #[must_use]
 pub fn sandbox_config() -> SandboxConfig {

--- a/gateway/testing/src/sandbox_ext.rs
+++ b/gateway/testing/src/sandbox_ext.rs
@@ -52,7 +52,7 @@ fn client(network: &NetworkConfig) -> JsonRpcClient {
 
 /// Whether the sandbox node at `rpc_url` answers a `status` query within
 /// `timeout`. A short `timeout` lets the out-of-band host's supervisor notice a
-/// hung node promptly, unlike [`RPC_TIMEOUT`].
+/// hung node promptly, unlike `RPC_TIMEOUT`.
 pub async fn node_is_serving(rpc_url: &str, timeout: Duration) -> bool {
     build_client(rpc_url, timeout)
         .call(RpcStatusRequest)

--- a/service/accumulator/src/lib.rs
+++ b/service/accumulator/src/lib.rs
@@ -4,8 +4,8 @@
 //!
 //! All NEAR reads and writes go through the in-process gateway library
 //! ([`templar_gateway_client`]); this crate carries no bespoke RPC/transaction
-//! plumbing. Reads use [`SigningClient::read`]; writes use
-//! [`SigningClient::execute`], which signs and submits through the gateway's
+//! plumbing. Reads use [`SigningClient::read`](templar_gateway_client::Client::read);
+//! writes use [`SigningClient::execute`], which signs and submits through the gateway's
 //! operation driver (nonce sequencing, idempotency, and replay come for free).
 
 use std::collections::HashMap;

--- a/service/funding-bridge/src/bridge/client.rs
+++ b/service/funding-bridge/src/bridge/client.rs
@@ -1,7 +1,7 @@
 //! NEAR Intents Bridge API client
 //!
 //! HTTP client for interacting with NEAR Intents Bridge JSON-RPC API
-//! at https://bridge.chaindefuser.com/rpc
+//! at <https://bridge.chaindefuser.com/rpc>
 
 use reqwest::Client;
 use std::collections::HashMap;

--- a/service/funding-bridge/src/bridge/models.rs
+++ b/service/funding-bridge/src/bridge/models.rs
@@ -1,7 +1,7 @@
 //! NEAR Intents Bridge API models
 //!
 //! Type definitions for Bridge API requests and responses matching the real
-//! NEAR Intents Bridge at https://bridge.chaindefuser.com/rpc
+//! NEAR Intents Bridge at <https://bridge.chaindefuser.com/rpc>
 
 use serde::{Deserialize, Serialize};
 

--- a/service/relayer/src/client/database.rs
+++ b/service/relayer/src/client/database.rs
@@ -380,7 +380,7 @@ WHERE
     /// never reached the chain. Only clears the ledger row; the allowance was never
     /// debited at lock time, so nothing is refunded.
     ///
-    /// Idempotent, like [`Database::settle`].
+    /// Idempotent, like `Database::settle`.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
`cargo doc --workspace --no-deps` emitted **26 warnings**. This fixes all of them and adds a CI job so they can't come back.

## Fixing the links

Where a real referent exists, the link is corrected rather than deleted:

| Fix | Where |
|---|---|
| Wrong target repointed | `MarketLock`→`MarketLease`; `KernelEffect` and `ExecutionOutcome` to their defining modules; `SigningClient::read`→`Client::read` (it lives on `Client`, reached via `Deref`); `connect`→ the public `SandboxHarness::start_owned` |
| Stale target | `AllocationMode` was deleted in `40170176`; repointed at `AllocationPlan`, the surviving type the sentence is about |
| Ambiguity | `[harness]`→`[harness()]` — the rstest fixture macro also generates a struct named `harness` |
| Bare URLs | two `//!` lines in funding-bridge wrapped in `<>` so rustdoc renders them as links |

## Where a link wasn't the right answer

Two categories resisted a link, and forcing one would have made things worse:

**Deliberately internal referents** are rendered as code spans. Making them public purely to satisfy rustdoc would have broken real encapsulation:

- `SandboxHarness::create_account` / `create_accounts` — `create_user` is the public path external tests already use (`service/relayer/tests/common/mod.rs:39`, universal-account tests)
- `Database::settle` — `resolve_charge` validates the operation is terminal before settling; a public `settle` would let a caller debit an account with caller-supplied `tokens_burnt`/`succeeded` while the op is still pending
- `mod state` in pyth-lazer and proxy-oracle governance — contract storage internals; pyth-lazer is a real lib dependency of `gateway/testing`
- `RPC_TIMEOUT`, `FUNDER_ACCOUNT_ID`, `HeadSegment`, and the `gateway/store` default constants — all behind curated re-export lists or unusable externally

**Cross-crate references into a dependency cycle** are also code spans. Every `*-dispatch` crate depends on its `*-spec`, so the spec→dispatch direction can't resolve and no dep edge can be added. A relative `../crate/struct.X.html` URL would render but is unvalidated and depth-dependent, so the crate-qualified name is left as plain code.

## Enforcement

A `Documentation` job runs `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — the same command that builds the docs site — wired into `full-required-gate` as `require_success`.

This is intentionally the *only* point of enforcement. `script/build-docs.sh` stays lenient: if a warning ever does reach `dev` (most plausibly a new stable toolchain tightening a lint), CI goes red either way, and a strict deploy would additionally freeze the published site on its last good build. A fresh site plus a red check beats a stale site.

Note that `documentation.yml` has no `needs:` on `test.yml`, so on push to `dev` the deploy and the check run independently — that's the behavior this relies on.

## Verification

- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` — clean from a wiped `target/doc`
- plain `cargo doc --workspace --no-deps` — clean, no warnings emitted
- `cargo fmt --check`, `cargo check --workspace --all-targets`, `cargo clippy --all-features --workspace --tests -- -D warnings` — all pass

No visibility changes; docs and CI config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/532)
<!-- Reviewable:end -->
