### PR TITLE
fix(soroban): allow account admins for Blend adapters

### DIFF
--- a/contract/vault/soroban/AGENTS.md
+++ b/contract/vault/soroban/AGENTS.md
@@ -47,6 +47,10 @@ measured, and re-verified:
   `execute_governance(env, caller, payload)`.
 - The share token only allows vault-authorized `mint()` and `burn()`. User transfers still require
   `from.require_auth()`.
+- A Blend adapter admin may be a Soroban account or contract. It must authenticate pause, admin
+  rotation, TTL extension, and upgrade calls; the vault and Blend pool remain contract-only.
+  Deployment tooling rejects the configured vault governance contract as adapter admin because the
+  shipped governance contract cannot dispatch companion administration calls.
 - Read-only preview and getter surfaces must stay non-authoritative.
 - Serialized `VaultState` remains a practical resource boundary because Soroban persists a single
   `StateBlob`. Pending withdrawals are the main long-lived growth vector.

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -356,7 +356,7 @@ Use recipes in [contract/vault/soroban/justfile](./justfile):
 **Breaking change:** adapter deployment no longer defaults the admin to governance. Set
 `SOROBAN_ADAPTER_ADMIN` to an explicit Soroban account or contract address. The literal value
 `vault` is accepted only when the deployed vault's `version()` response advertises
-companion-contract upgrade routing (`0x40`). The current default runtime mask is `0x1f`, so it
+companion-contract upgrade routing (`0x40`). The current default runtime mask is `0x3f`, so it
 rejects `SOROBAN_ADAPTER_ADMIN=vault`. The configured governance contract is also rejected because
 it cannot dispatch companion-contract administration calls; use a different explicit account or
 contract.

--- a/contract/vault/soroban/README.md
+++ b/contract/vault/soroban/README.md
@@ -350,15 +350,16 @@ Blend integration lives in the dedicated crate `contract/vault/soroban/blend-ada
 Use recipes in [contract/vault/soroban/justfile](./justfile):
 
 - `just build-blend-adapter`
-- `SOROBAN_ADAPTER_ADMIN=C... just deploy-blend-adapter <BLEND_POOL_ADDRESS>`
-- `SOROBAN_ADAPTER_ADMIN=C... just deploy-all-with-blend <BLEND_POOL_ADDRESS>`
+- `SOROBAN_ADAPTER_ADMIN=G... just deploy-blend-adapter <BLEND_POOL_ADDRESS>`
+- `SOROBAN_ADAPTER_ADMIN=G... just deploy-all-with-blend <BLEND_POOL_ADDRESS>`
 
 **Breaking change:** adapter deployment no longer defaults the admin to governance. Set
-`SOROBAN_ADAPTER_ADMIN` to an explicit Soroban contract address. The literal value `vault` is
-accepted only when the deployed vault's `version()` response advertises
+`SOROBAN_ADAPTER_ADMIN` to an explicit Soroban account or contract address. The literal value
+`vault` is accepted only when the deployed vault's `version()` response advertises
 companion-contract upgrade routing (`0x40`). The current default runtime mask is `0x1f`, so it
 rejects `SOROBAN_ADAPTER_ADMIN=vault`. The configured governance contract is also rejected because
-it cannot dispatch companion-contract administration calls; use a different explicit contract.
+it cannot dispatch companion-contract administration calls; use a different explicit account or
+contract.
 
 After deployment, register the adapter as a vault market before allocation.
 

--- a/contract/vault/soroban/STRIDE.md
+++ b/contract/vault/soroban/STRIDE.md
@@ -47,6 +47,10 @@ This document captures a Soroban-specific STRIDE threat model for `contract/vaul
    governance contract enforces timelocks and applies changes immediately once the handler confirms
    the caller is the configured governance contract.
 9. **Vault contract ↔ Share token contract** — Share token enforces vault auth for `mint()`/`burn()` and `from.require_auth()` for user `transfer()` (while allowing vault-driven internal transfers). The vault address is immutable in the share token after initialization.
+10. **Blend adapter administrator ↔ Blend adapter contract** — The explicit administrator may be
+    a Soroban account or contract. Every administrative call requires its authentication. It can
+    pause or unpause the adapter, rotate administration through a two-step handoff, extend instance
+    TTL, and upgrade adapter Wasm; vault-only asset movement remains separately authenticated.
 
 ### Privilege Hierarchy
 
@@ -59,6 +63,7 @@ This document captures a Soroban-specific STRIDE threat model for `contract/vaul
 | **Guardian** | Curator (via RBAC config) | Pause/unpause vault. **Note**: Same as allocator — no separate guardian wired in production. |
 | **User** | Any signed account | Deposit, request async withdrawal, or atomically withdraw/redeem idle assets. Subject to restrictions (whitelist/blacklist/pause). |
 | **Keeper/Allocator** | Curator-configured operational account | Execute queued withdrawals after cooldown once enough assets are idle; allocate/withdraw from markets to make liquidity available. |
+| **Blend adapter administrator** | Adapter constructor or two-step `set_admin` / `accept_admin` handoff | Pause or unpause the adapter, rotate administration, extend instance TTL, and upgrade adapter Wasm. May be an authenticated Soroban account or contract; it does not receive vault-only supply, withdrawal, or rescue authority. |
 
 ### High-Level Dataflow
 
@@ -135,6 +140,7 @@ This document captures a Soroban-specific STRIDE threat model for `contract/vaul
 | I23 | Governance contract → `submit()` / `approve()` / `consume()` | Yes | `require_auth(admin)` + timelock maturity | Governance contract internal state |
 | I24 | Governance contract → `abdicate(kind)` | Yes | `require_auth(admin)` | Governance contract storage (irreversible) |
 | I25 | Vault/User ↔ Share token (`transfer`/`mint`/`burn`) | Yes | `require_vault_invoker()` for `mint`/`burn`; `from.require_auth()` for user `transfer` | Vault/User ↔ Share token contract |
+| I26 | Blend adapter administrator → `set_paused` / `set_admin` / `accept_admin` / `extend_ttl` / `upgrade` | Yes | `require_auth(caller)` + configured-admin check; pending admin authenticates acceptance | Administrator ↔ Blend adapter contract |
 
 ---
 
@@ -194,6 +200,7 @@ Interaction: I24. |
 | | **Elevation.7** — If `has_role` for `Role::Sentinel` falls back to curator when no sentinel is set, the curator implicitly gains sentinel powers. This may be acceptable for bootstrapping but should be an explicit documented decision. Interaction: I20. |
 | | **Elevation.8** — Share token vault address is set at initialization and enforced for privileged operations (`mint`/`burn`). If the share token contract is upgradeable and the vault address is mutable post-init, an attacker who gains upgrade access could redirect privileged share operations to a different contract. Interaction: I25. |
 | | **Elevation.9** — Governance timelock kind/decision function mappings in `soroban/governance` must match the sensitivity of each action. A misconfigured mapping (e.g., `Skim` using an immediate timelock instead of a delayed one) reduces the governance friction intended for high-impact actions. Interaction: I23. |
+| | **Elevation.10** — Compromise or misconfiguration of a Blend adapter administrator, whether an account or contract, permits pause changes, admin rotation, and arbitrary adapter Wasm upgrades. The current implementation keeps asset movement vault-only, but upgraded code can change future adapter behavior. Interaction: I26. |
 
 ---
 
@@ -246,6 +253,7 @@ emit admin events via the existing `emit_admin_event()` pattern. |
 sentinel as soon as operational key infrastructure is ready. |
 | | **Elevation.8.R.1** — ✅ **Implemented**: Share token stores the vault address at initialization; `require_vault_invoker()` is enforced on `mint`/`burn`, while user transfers require `from.require_auth()`. **Elevation.8.R.2** — The share token contract has no admin endpoint to change the vault address post-initialization. Administrative pause, restriction, upgrade, TTL, and two-step rotation authority is assigned to a separate explicit admin; constructors and rotations reject the vault and share token itself as admin. **Elevation.8.R.3** — The CLI records the initial admin as constructor provenance and reconciles the immutable vault binding; admin rotation makes the current admin mutable state. Because the admin can upgrade the token implementation, it remains an ultimate trust boundary over token behavior. Future upgrades must preserve the intended vault-only mint/burn invariant. |
 | | **Elevation.9.R.1** — ✅ **Implemented**: `soroban/governance` maps each `GovernanceActionKind` to a `TimelockKind` with appropriate sensitivity levels. Decision functions from `curator-primitives` enforce directional timelocks (e.g., fee increases are timelocked, decreases are immediate). **Elevation.9.R.2** — Add integration tests that verify timelock kind mappings for all governance action kinds (partially done: 7 governance tests cover sentinel, cap, and core actions). |
+| | **Elevation.10.R.1** — ✅ **Implemented**: every Blend adapter administrative action authenticates the configured administrator, and rotation requires separate acceptance by the pending administrator. **Elevation.10.R.2** — Treat the administrator as an adapter upgrade trust boundary: use an independently controlled multisig/HSM account or reviewed contract and monitor pause, rotation, and upgrade events. **Elevation.10.R.3** — Deployment tooling rejects the configured vault governance contract as administrator and capability-gates use of the vault itself; future adapter upgrades must preserve vault-only asset movement. |
 
 ---
 

--- a/contract/vault/soroban/STRIDE.md
+++ b/contract/vault/soroban/STRIDE.md
@@ -63,7 +63,7 @@ This document captures a Soroban-specific STRIDE threat model for `contract/vaul
 | **Guardian** | Curator (via RBAC config) | Pause/unpause vault. **Note**: Same as allocator — no separate guardian wired in production. |
 | **User** | Any signed account | Deposit, request async withdrawal, or atomically withdraw/redeem idle assets. Subject to restrictions (whitelist/blacklist/pause). |
 | **Keeper/Allocator** | Curator-configured operational account | Execute queued withdrawals after cooldown once enough assets are idle; allocate/withdraw from markets to make liquidity available. |
-| **Blend adapter administrator** | Adapter constructor or two-step `set_admin` / `accept_admin` handoff | Pause or unpause the adapter, rotate administration, extend instance TTL, and upgrade adapter Wasm. May be an authenticated Soroban account or contract; it does not receive vault-only supply, withdrawal, or rescue authority. |
+| **Blend adapter administrator** | Adapter constructor or two-step `set_admin` / `accept_admin` handoff | Pause or unpause the adapter, rotate administration, extend instance TTL, and upgrade adapter Wasm. The administrator may be an authenticated Soroban account or contract; it does not receive vault-only supply, withdrawal, or rescue authority. |
 
 ### High-Level Dataflow
 

--- a/contract/vault/soroban/blend-adapter/src/lib.rs
+++ b/contract/vault/soroban/blend-adapter/src/lib.rs
@@ -65,7 +65,6 @@ impl BlendAdapterContract {
         pool: Address,
     ) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
-        require_contract_address(&admin, AdapterError::InvalidInput)?;
         require_contract_address(&vault, AdapterError::InvalidInput)?;
         require_contract_address(&pool, AdapterError::InvalidInput)?;
 
@@ -261,7 +260,6 @@ impl BlendAdapterContract {
     pub fn set_admin(env: Env, caller: Address, admin: Address) -> Result<(), AdapterError> {
         extend_instance_ttl(&env);
         require_admin(&env, &caller)?;
-        require_contract_address(&admin, AdapterError::InvalidInput)?;
         env.storage().instance().set(&DataKey::PendingAdmin, &admin);
         env.events()
             .publish((symbol_short!("admin_set"), caller), admin);
@@ -463,14 +461,16 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Error(Contract, #2)")]
-    fn constructor_rejects_non_contract_admin() {
+    fn constructor_accepts_account_admin() {
         let env = Env::default();
         let admin = account_address(&env);
         let vault = register_dummy_contract(&env);
         let pool = register_dummy_contract(&env);
 
-        env.register(BlendAdapterContract, (&admin, &vault, &pool));
+        let contract_id = env.register(BlendAdapterContract, (&admin, &vault, &pool));
+        env.as_contract(&contract_id, || {
+            assert_eq!(BlendAdapterContract::admin(env.clone()).unwrap(), admin);
+        });
     }
 
     #[test]
@@ -749,18 +749,27 @@ mod tests {
     }
 
     #[test]
-    fn set_admin_rejects_non_contract_admin() {
+    fn set_admin_accepts_account_admin() {
         let env = Env::default();
         env.mock_all_auths();
         let (contract_id, admin, _vault, _pool) = setup_adapter(&env);
         let account = account_address(&env);
         env.as_contract(&contract_id, || {
-            let result = BlendAdapterContract::set_admin(env.clone(), admin, account);
-            assert_eq!(result, Err(AdapterError::InvalidInput));
+            BlendAdapterContract::set_admin(env.clone(), admin, account.clone()).unwrap();
+        });
+        env.as_contract(&contract_id, || {
             assert_eq!(
-                BlendAdapterContract::pending_admin(env.clone()),
-                Err(AdapterError::MissingConfig)
+                BlendAdapterContract::pending_admin(env.clone()).unwrap(),
+                account
             );
+        });
+        env.as_contract(&contract_id, || {
+            BlendAdapterContract::accept_admin(env.clone(), account.clone()).unwrap();
+        });
+        env.as_contract(&contract_id, || {
+            BlendAdapterContract::set_paused(env.clone(), account.clone(), true).unwrap();
+            assert_eq!(BlendAdapterContract::admin(env.clone()).unwrap(), account);
+            assert!(BlendAdapterContract::paused(env.clone()));
         });
     }
 

--- a/contract/vault/soroban/justfile
+++ b/contract/vault/soroban/justfile
@@ -12,7 +12,7 @@ set dotenv-load := false
 #
 # WITH BLEND INTEGRATION (for yield):
 #   1. just setup
-#   2. SOROBAN_ADAPTER_ADMIN=C... just deploy-all-with-blend <BLEND_POOL_ADDRESS>
+#   2. SOROBAN_ADAPTER_ADMIN=G... just deploy-all-with-blend <BLEND_POOL_ADDRESS>
 #   3. just demo-deposit
 #
 # PREREQUISITES:
@@ -701,10 +701,6 @@ deploy-blend-adapter pool_address:
 	if ! admin=$(SOROBAN_ADAPTER_VAULT_ID="$vault_id" just -f "{{justfile_directory()}}/justfile" _resolve-adapter-admin); then \
 		exit 1; \
 	fi; \
-	case "$admin" in \
-		C*) ;; \
-		*) echo "Error: Blend adapter admin must be a contract address (C...)." >&2; exit 1 ;; \
-	esac; \
 	network="${SOROBAN_NETWORK:-{{default_network}}}"; \
 	source="${SOROBAN_IDENTITY:-{{default_identity}}}"; \
 	echo "Deploying Blend adapter..."; \
@@ -922,7 +918,7 @@ blend-adapter-status:
 		echo "Pool:       $(just blend-invoke pool 2>/dev/null || echo 'error')"; \
 	fi
 
-# Propose a new Blend adapter admin contract.
+# Propose a new Blend adapter admin address.
 blend-adapter-set-admin new_admin:
 	@admin="${SOROBAN_ADAPTER_ADMIN:-$(cat {{state_dir}}/governance_id 2>/dev/null)}"; \
 	if [ -z "$admin" ]; then admin="${SOROBAN_CONTRACT_ID:-$(cat {{state_dir}}/vault_id 2>/dev/null)}"; fi; \
@@ -1512,7 +1508,7 @@ help:
 	@echo "  just allocate-supply <mkt> <amt>  Supply to market via adapter"
 	@echo "  just allocate-withdraw <mkt> <amt>  Withdraw from market via adapter"
 	@echo "  just fund-adapter <amount>       Transfer tokens to adapter (manual)"
-	@echo "  just blend-adapter-set-admin <admin_contract>"
+	@echo "  just blend-adapter-set-admin <admin_address>"
 	@echo "  just demo-e2e-blend              Full Blend integration e2e"
 	@echo ""
 	@echo "CUSTODIAL ADAPTER:"

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -614,7 +614,9 @@ stellar contract invoke \
 - Zero governance timelocks require `--allow-zero-timelock`.
 - Existing manifests must record a nonempty network label matching `--network`. This label check does not authenticate custom network passphrases; do not reuse one network label with a different passphrase.
 - Adapter deployment requires an explicit `--adapter-admin`; selecting the vault fails closed unless runtime capability `0x40` is detected first.
-- Blend and custodial adapter admins may be accounts or contracts. Custodial adapter admins must differ from the bound asset token.
+- Blend and custodial adapter admins may be accounts or contracts, but must differ from the
+  configured governance contract. Custodial adapter admins must also differ from the bound asset
+  token.
 - Share-token deployment rejects `admin == vault`; the manifest retains the initial admin as constructor provenance and reconciliation verifies the immutable vault binding.
 - `--fresh-state deploy stack` atomically reserves an unused manifest path before network calls; planning and dry-run modes require the path to be absent without creating it.
 - `--dry-run` prints the `stellar` commands with source-account environment overrides redacted, returns planned contract ids in the response, and never writes the manifest.

--- a/tools/soroban-vault-cli/README.md
+++ b/tools/soroban-vault-cli/README.md
@@ -74,8 +74,8 @@ Every deployment that requests a Blend or custodial adapter must also pass
 `--adapter-admin <address|vault>` (or `SOROBAN_ADAPTER_ADMIN`). Governance is never selected
 implicitly. The `vault` alias, and an explicit address equal to the vault, are accepted only after
 the CLI calls `vault.version()` and detects companion-upgrade capability `0x40`. The current default
-runtime does not advertise that capability. Blend adapter admins must be contract addresses;
-custodial adapter admins may be independently controlled accounts or contracts.
+runtime does not advertise that capability. Blend and custodial adapter admins may be
+independently controlled accounts or contracts.
 
 For a new stack, `--admin` is passed explicitly to the governance contract, the initial vault
 curator configuration, and the share-token constructor. The share token keeps a separate immutable
@@ -96,7 +96,7 @@ tmplr-soroban-vault \
   --blend-pool CPOOL... \
   --blend-pool CPOOL2... \
   --custodian G... \
-  --adapter-admin CADAPTERADMIN...
+  --adapter-admin GADAPTERADMIN...
 ```
 
 To add adapters later without redeploying the stack, use `deploy adapters`. If the manifest already
@@ -111,7 +111,7 @@ tmplr-soroban-vault deploy adapters \
   --asset-token CASSET... \
   --blend-pool CPOOL... \
   --custodian G... \
-  --adapter-admin CADAPTERADMIN...
+  --adapter-admin GADAPTERADMIN...
 ```
 
 To deploy only a fresh curator proxy for an existing vault, use `deploy curator-proxy`. Vault and
@@ -154,14 +154,14 @@ tmplr-soroban-vault deploy plan stack \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
   --custodian G... \
-  --adapter-admin CADAPTERADMIN...
+  --adapter-admin GADAPTERADMIN...
 
 tmplr-soroban-vault deploy plan adapters \
   --vault CVAULT... \
   --governance CGOV... \
   --blend-pool CPOOL... \
   --custodian G... \
-  --adapter-admin CADAPTERADMIN...
+  --adapter-admin GADAPTERADMIN...
 ```
 
 Recover an interrupted deployment by reconciling first, then resuming if the repair plan reports
@@ -175,7 +175,7 @@ tmplr-soroban-vault deploy resume \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
   --custodian G... \
-  --adapter-admin CADAPTERADMIN...
+  --adapter-admin GADAPTERADMIN...
 ```
 
 The CLI validates Soroban account and contract addresses at parse time for operational commands.
@@ -537,7 +537,7 @@ tmplr-soroban-vault deploy stack \
   --governance-timelock-ns 86400000000000 \
   --blend-pool CPOOL... \
   --custodian GCUSTODIAN... \
-  --adapter-admin CADAPTERADMIN...
+  --adapter-admin GADAPTERADMIN...
 
 tmplr-soroban-vault governance submit-set-sentinel \
   --admin GCURATOR_OR_MULTISIG... \
@@ -614,7 +614,7 @@ stellar contract invoke \
 - Zero governance timelocks require `--allow-zero-timelock`.
 - Existing manifests must record a nonempty network label matching `--network`. This label check does not authenticate custom network passphrases; do not reuse one network label with a different passphrase.
 - Adapter deployment requires an explicit `--adapter-admin`; selecting the vault fails closed unless runtime capability `0x40` is detected first.
-- Blend adapter admins must be contract addresses. Custodial adapter admins must differ from the bound asset token.
+- Blend and custodial adapter admins may be accounts or contracts. Custodial adapter admins must differ from the bound asset token.
 - Share-token deployment rejects `admin == vault`; the manifest retains the initial admin as constructor provenance and reconciliation verifies the immutable vault binding.
 - `--fresh-state deploy stack` atomically reserves an unused manifest path before network calls; planning and dry-run modes require the path to be absent without creating it.
 - `--dry-run` prints the `stellar` commands with source-account environment overrides redacted, returns planned contract ids in the response, and never writes the manifest.

--- a/tools/soroban-vault-cli/src/commands/deploy/adapters.rs
+++ b/tools/soroban-vault-cli/src/commands/deploy/adapters.rs
@@ -57,13 +57,7 @@ pub(in crate::commands) fn validated_stack_adapter_admin<'a>(
             .map(AddressStr::as_str)
             .or_else(|| contract_id(manifest, "asset_token"))
     });
-    validate_adapter_admin(
-        admin,
-        include_blend,
-        vault,
-        governance,
-        custodial_asset.flatten(),
-    )?;
+    validate_adapter_admin(admin, vault, governance, custodial_asset.flatten())?;
     Ok(Some(admin))
 }
 
@@ -81,7 +75,6 @@ pub(in crate::commands) fn validate_adapter_deployment_request(
     });
     validate_adapter_admin(
         &args.adapter_admin,
-        !args.blend_pools.is_empty(),
         vault,
         governance,
         custodial_asset.flatten(),
@@ -90,19 +83,10 @@ pub(in crate::commands) fn validate_adapter_deployment_request(
 
 pub(in crate::commands) fn validate_adapter_admin(
     admin: &AdapterAdminArg,
-    include_blend: bool,
     vault: Option<&str>,
     governance: Option<&str>,
     custodial_asset: Option<&str>,
 ) -> anyhow::Result<()> {
-    if include_blend {
-        if let AdapterAdminArg::Address(address) = admin {
-            anyhow::ensure!(
-                address.as_str().starts_with('C'),
-                "Blend adapter admin must be a contract address or `vault`"
-            );
-        }
-    }
     let resolved = match admin {
         AdapterAdminArg::Vault => vault,
         AdapterAdminArg::Address(address) => Some(address.as_str()),
@@ -199,7 +183,6 @@ pub(in crate::commands) fn deploy_adapters<E: CommandExecutor>(
     };
     validate_adapter_admin(
         requested_adapter_admin,
-        !args.blend_pools.is_empty(),
         Some(&vault),
         Some(&governance),
         custodial_asset,

--- a/tools/soroban-vault-cli/src/commands/deploy/stack.rs
+++ b/tools/soroban-vault-cli/src/commands/deploy/stack.rs
@@ -448,7 +448,6 @@ pub(in crate::commands) fn deploy_stack<E: CommandExecutor>(
             .context("adapter deployment requires --adapter-admin <address|vault>")?;
         validate_adapter_admin(
             adapter_admin,
-            include_blend,
             Some(&vault),
             Some(&governance),
             include_custodial.then_some(asset_token.as_str()),

--- a/tools/soroban-vault-cli/src/commands/tests/deploy/adapters.rs
+++ b/tools/soroban-vault-cli/src/commands/tests/deploy/adapters.rs
@@ -80,11 +80,13 @@ fn deploy_adapters_appends_new_pool_to_existing_manifest() {
 }
 
 #[test]
-fn deploy_adapters_rejects_account_blend_admin_before_executor_calls() {
+fn deploy_adapters_accepts_account_blend_admin() {
     let dir = tempfile::tempdir().expect("tempdir");
+    write_fake_blend_wasm(dir.path());
     let state = dir.path().join("manifest.json");
     manifest_with_governance_and_vault(&state);
     let cli = Cli {
+        workspace_path: dir.path().into(),
         command: Commands::Deploy(DeployArgs {
             command: DeployCommand::Adapters(crate::cli::DeployAdaptersArgs {
                 vault: None,
@@ -97,16 +99,28 @@ fn deploy_adapters_rejects_account_blend_admin_before_executor_calls() {
                 force_new: false,
             }),
         }),
-        ..base_cli(state, Commands::Status)
+        ..base_cli(state.clone(), Commands::Status)
     };
     let executor = RecordingExecutor::new();
 
-    let error = run(&cli, &executor).expect_err("account admin must be rejected");
+    run(&cli, &executor).expect("account admin should be accepted");
 
-    assert!(error
-        .to_string()
-        .contains("Blend adapter admin must be a contract address"));
-    assert!(executor.calls().is_empty());
+    let loaded = Manifest::load_or_new(&state, "testnet", None).expect("load manifest");
+    assert_eq!(
+        loaded
+            .contracts
+            .get("blend_adapter_0")
+            .expect("deployed Blend adapter")
+            .constructor_args
+            .get("admin")
+            .map(String::as_str),
+        Some(ACCOUNT)
+    );
+    assert!(submitted_calls(&executor.calls())
+        .iter()
+        .any(|(_, args)| args
+            .windows(2)
+            .any(|window| window[0] == "--admin" && window[1] == ACCOUNT)));
 }
 
 #[test]
@@ -475,23 +489,17 @@ fn runtime_version_parser_requires_typed_version_and_feature_mask() {
 }
 
 #[test]
-fn adapter_constructor_guards_reject_invalid_admin_shapes() {
+fn adapter_admin_validation_accepts_accounts_and_rejects_collisions() {
     let account_admin = ACCOUNT.parse().expect("account admin");
     let asset_admin = CONTRACT.parse().expect("asset admin");
     let governance_admin = OTHER_CONTRACT.parse().expect("governance admin");
 
-    assert!(validate_adapter_admin(&account_admin, true, None, None, None).is_err());
-    assert!(validate_adapter_admin(
-        &asset_admin,
-        false,
-        Some(OTHER_CONTRACT),
-        None,
-        Some(CONTRACT),
-    )
-    .is_err());
+    assert!(validate_adapter_admin(&account_admin, None, None, None).is_ok());
+    assert!(
+        validate_adapter_admin(&asset_admin, Some(OTHER_CONTRACT), None, Some(CONTRACT),).is_err()
+    );
     assert!(validate_adapter_admin(
         &governance_admin,
-        false,
         Some(CONTRACT),
         Some(OTHER_CONTRACT),
         None,


### PR DESCRIPTION
## What changed

- Allow a Soroban account or contract to be the Blend adapter admin at construction.
- Allow two-step admin rotation to a Soroban account.
- Remove the matching account-admin rejection from the vault CLI and justfile deployment flow.
- Align deployment examples and safety documentation with the supported authority model.

## Why

The Blend adapter imposed an extra contract-address-only guard even though every privileged admin path already authenticates the configured `Address` with `require_auth()`. That rejected valid EOA and Stellar account multisig administrators and contradicted the documented single-curator deployment model.

## Security invariants preserved

- The vault and Blend pool must still be contract addresses.
- The configured vault governance contract is still rejected as adapter admin because it cannot dispatch companion administration calls.
- Selecting the vault as admin remains capability-gated on runtime feature `0x40`.
- Custodial adapter admin/asset collisions remain rejected.
- Admin rotation remains two-step: the proposed account must authenticate to accept.
- No storage layout, public method, or ABI shape changes.

## Validation

- `cargo fmt --all --check`
- `cargo test -p templar-soroban-blend-adapter -- --nocapture` — 30 passed
- `cargo test -p templar-soroban-vault-cli -- --nocapture` — 145 passed
- `just -f contract/vault/soroban/justfile build-blend-adapter`
  - optimized WASM: 12,121 bytes
  - 16 expected exports
- Post-commit Soroban runtime size gate: 129,499 bytes, passed
- Direct recipe check: account admin accepted; governance admin still rejected

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/535)
<!-- Reviewable:end -->
