### PR TITLE
feat(manager): select the signing backend with --sign-with (ENG-538)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,6 +2903,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "dbus"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab69f03cc8c4340c9c8e315114e1658e6775a9b16a04357973aa21cec22b32e"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "openssl",
+ "zeroize",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4578,6 +4600,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
+name = "hidapi"
+version = "2.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c78dadfc12f865bc3fcac3897e64533b930737ceb9ef245c8277de98d0b010e9"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "pkg-config",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "hidapi-rusb"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5465,6 +5500,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "openssl",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5510,10 +5561,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "ledger-apdu"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c21ffd28d97c9252671ab2ebe7078c9fa860ff3c5a125039e174d25ec6872169"
+dependencies = [
+ "arrayref",
+ "no-std-compat",
+ "snafu",
+]
+
+[[package]]
+name = "ledger-transport"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2f18de77d956a030dbc5869ced47d404bbd641216ef2f9dce7ca90833ca64ff"
+dependencies = [
+ "async-trait",
+ "ledger-apdu",
+]
+
+[[package]]
+name = "ledger-transport-hid"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e34341e2708fbf805a9ada44ef6182170c6464c4fc068ab801abb7562fd5e8"
+dependencies = [
+ "byteorder",
+ "cfg-if 1.0.4",
+ "hex",
+ "hidapi",
+ "ledger-transport",
+ "libc",
+ "log",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "libflate"
@@ -5962,7 +6060,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5992,23 +6090,25 @@ dependencies = [
 
 [[package]]
 name = "near-api"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e581e637caa8ca9f3dc86936606f3a87ab55211fbf76dcf98725c4f4854211"
+checksum = "7d40379fdb1c7b3fec53512150c0dc97ee2fbcb1ecf2710158edb1e157bafb36"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bip39",
  "borsh 1.6.1",
  "futures",
+ "keyring",
  "near-api-types",
+ "near-ledger",
  "near-openapi-client",
+ "near-slip10",
  "openssl",
  "reqwest 0.12.28",
  "serde",
  "serde_dbgfmt",
  "serde_json",
- "slipped10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6018,9 +6118,9 @@ dependencies = [
 
 [[package]]
 name = "near-api-types"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "676c29c763f46fa05bdbc113e1f83ed22f328038f74a5730989aa163de6fb83c"
+checksum = "48aac696975885828c0abfa00d017a3da3681b79f214bd8c5c0092d1f97d55e4"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.1",
@@ -6029,6 +6129,7 @@ dependencies = [
  "near-abi",
  "near-account-id",
  "near-gas",
+ "near-ledger",
  "near-openapi-types",
  "near-token",
  "primitive-types 0.10.1",
@@ -6167,6 +6268,22 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "near-ledger"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89447ef8a0c6b622e3c4ae123ce53af2c5b9d073a76f21ec9fb3517ea2288a14"
+dependencies = [
+ "borsh 1.6.1",
+ "ed25519-dalek",
+ "hex",
+ "ledger-apdu",
+ "ledger-transport",
+ "ledger-transport-hid",
+ "log",
+ "near-slip10",
 ]
 
 [[package]]
@@ -6409,6 +6526,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-slip10"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "462a1564a47c9d1c629caffe31655260f65b6da25df7c8ef49991770105270c8"
+dependencies = [
+ "ed25519-dalek",
+ "hmac 0.9.0",
+ "sha2 0.9.9",
+]
+
+[[package]]
 name = "near-stdx"
 version = "0.34.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6505,6 +6633,12 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
 
 [[package]]
 name = "nom"
@@ -8387,7 +8521,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -8688,6 +8822,19 @@ dependencies = [
  "serde",
  "serde_json",
  "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
 ]
 
 [[package]]
@@ -9126,18 +9273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
-name = "slipped10"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0467009f63d9ec6920100ddb026ccdb8b661ba37aaa86664c5e9ac3a4e3e316b"
-dependencies = [
- "ed25519-dalek",
- "hmac 0.9.0",
- "rand 0.10.1",
- "sha2 0.9.9",
-]
-
-[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9162,6 +9297,27 @@ name = "smawk"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "socket2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,8 +88,10 @@ k256 = "0.13.4"
 libfuzzer-sys = "0.4"
 moka = { version = "0.12.10", features = ["future", "sync"] }
 near-account-id = "2.6"
-near-api = "0.8.5"
-near-api-types = "0.8.5"
+# 0.8.6 is the floor for the `ledger` feature: 0.8.5 passes `slipped10::BIP32Path`
+# to near-ledger, which expects `near_slip10::BIP32Path`, so it does not compile.
+near-api = "0.8.6"
+near-api-types = "0.8.6"
 near-chain-configs = "0.34.7"
 near-contract-standards = "5.25"
 near-crypto = "0.34.7"

--- a/docs/src/deployments.md
+++ b/docs/src/deployments.md
@@ -21,6 +21,33 @@ A selection of available markets is shown below:
 | [`stnear-usdc-1.v1.tmplr.near`](https://nearblocks.io/address/stnear-usdc-1.v1.tmplr.near) | stNEAR on NEAR | USDC on NEAR |
 | [`ixlm-ixlmusdc.v1.tmplr.near`](https://nearblocks.io/address/ixlm-ixlmusdc.v1.tmplr.near) | Native XLM (via NEAR Intents) | USDC on XLM (via NEAR Intents) |
 
+## Signing
+
+Most `tmplrmgr` writes take `--signer-id` plus one credential, and `--sign-with`
+selects where that signing key lives:
+
+| Backend | Credential | Notes |
+|---|---|---|
+| `secret-key` (default) | `--secret-key`, or `$SECRET_KEY` | Puts a plaintext key in the environment. Fine for testnet and CI; avoid for mainnet. |
+| `keychain` | the OS keychain | Looked up by account id. The account's on-chain keys are listed to find a match. |
+| `ledger` | a Ledger device | Uses near-api's default HD path. The device must be unlocked with the NEAR app open. |
+
+For mainnet, prefer to sign nothing directly. `--print sputnik` emits a
+SputnikDAO proposal instead of executing, so a deployment can be reviewed and
+approved by the multisig with no operator key involved at all:
+
+```bash
+tmplrmgr market create --signer-id dao.near --print sputnik --public-key ed25519:… …
+```
+
+`keychain` and `ledger` hold their key outside this process, so writes that
+embed the signer's public key on a new account (any `registry deploy`) need it
+passed explicitly with `--public-key`.
+
+`registry clear-deployments` is the exception: it signs many *discovered*
+accounts with one authorized key, so it has no `--signer-id` and takes only
+`--secret-key`.
+
 ### Contract Verification
 
 All smart contracts use reproducible builds. To verify deployed code:

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -15,7 +15,9 @@ clap.workspace = true
 dirs.workspace = true
 hex.workspace = true
 near-account-id.workspace = true
-near-api.workspace = true
+# `keystore`/`ledger` back the `--sign-with` backends, so an operator never has
+# to put a plaintext key in the environment.
+near-api = { workspace = true, features = ["keystore", "ledger"] }
 # Native binary linking the proxy-oracle contract crates (`Operation`/`Proxy`/
 # `Source`): on non-wasm, `near_sdk::env::abort` references the `panic` host
 # import, which only near-sdk's `unit-testing` mock defines. `unit-testing` is

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -2,12 +2,18 @@
 //! plan-only output format on every write; reads reject signer arguments.
 //! Dispatch rejects print mode only for orchestrated writes that cannot produce
 //! one transaction without performing execution steps.
+//!
+//! Credentials resolve to an [`Arc<Signer>`] rather than a [`SecretKey`], so a
+//! backend that never surrenders its key (Ledger) is expressible. `--sign-with`
+//! selects the backend; `--print sputnik` remains the key-less path and never
+//! reaches credential resolution at all.
 
-use std::{ffi::OsStr, fmt};
+use std::{ffi::OsStr, fmt, sync::Arc};
 
+use anyhow::Context as _;
 use clap::{builder::TypedValueParser, error::ErrorKind, Args, ValueEnum};
 use near_account_id::AccountId;
-use near_api::{PublicKey as CliPublicKey, SecretKey};
+use near_api::{NetworkConfig, PublicKey as CliPublicKey, SecretKey, Signer};
 use templar_gateway_types::{primitive::PublicKey, ManagedAccountId};
 
 /// Placeholder for the secret key in `Debug` output, so `{:?}` on a command that
@@ -20,6 +26,19 @@ pub(crate) enum PrintFormat {
     Sputnik,
 }
 
+/// Where the signing key lives. Only [`SigningBackend::SecretKey`] puts one in
+/// the process; the others keep it in the OS keychain or on the device.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
+pub(crate) enum SigningBackend {
+    /// `--secret-key`, or `$SECRET_KEY`.
+    #[default]
+    SecretKey,
+    /// The OS keychain, looked up by account id.
+    Keychain,
+    /// A Ledger device, at near-api's default HD path.
+    Ledger,
+}
+
 /// The account authorizing a write and either its execution credential or its
 /// plan-only output format. Clap enforces the credential-mode split.
 ///
@@ -29,13 +48,23 @@ pub struct SignerArgs {
     /// Account that signs the transaction, or the DAO account that will execute a plan.
     #[arg(long, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
     signer_id: AccountId,
+    /// Where the signing key lives.
+    ///
+    /// A defaulted value is not "explicitly present" to clap, so `--secret-key`
+    /// stays required until this is named.
+    #[arg(long, value_enum, value_name = "BACKEND", default_value_t = SigningBackend::SecretKey)]
+    sign_with: SigningBackend,
     /// Private key for `--signer-id`, in `ed25519:…` form.
+    ///
+    /// Required only for the default `secret-key` backend: naming any
+    /// `--sign-with` backend lifts the requirement, and `--print` needs no
+    /// credential at all.
     #[arg(
         long,
         env = "SECRET_KEY",
         hide_env_values = true,
         value_name = "SECRET_KEY",
-        required_unless_present = "print",
+        required_unless_present_any = ["print", "sign_with"],
         conflicts_with = "print",
         value_parser = SecretKeyParser
     )]
@@ -43,13 +72,9 @@ pub struct SignerArgs {
     /// Plan the write without executing it, then print the selected representation.
     #[arg(long, value_enum, value_name = "FORMAT")]
     print: Option<PrintFormat>,
-    /// Public key embedded by deploy/create writes in plan-only mode.
-    #[arg(
-        long,
-        value_name = "PUBLIC_KEY",
-        requires = "print",
-        conflicts_with = "secret_key"
-    )]
+    /// Public key embedded by deploy/create writes. Required in plan-only mode,
+    /// and for backends that hold their key outside this process.
+    #[arg(long, value_name = "PUBLIC_KEY", conflicts_with = "secret_key")]
     public_key: Option<CliPublicKey>,
 }
 
@@ -58,6 +83,7 @@ impl fmt::Debug for SignerArgs {
         f.debug_struct("SignerArgs")
             .field("secret_key", &self.secret_key.as_ref().map(|_| REDACTED))
             .field("signer_id", &self.signer_id)
+            .field("sign_with", &self.sign_with)
             .field("print", &self.print)
             .field("public_key", &self.public_key)
             .finish()
@@ -77,6 +103,10 @@ impl SignerArgs {
 
     /// The signer's public key, used by from-registry deploys that grant it a
     /// full access key on the new account.
+    ///
+    /// Only the `secret-key` backend can derive this locally. Plan mode has no
+    /// credential, and the keychain and Ledger backends hold their key outside
+    /// this process, so both require `--public-key`.
     pub fn public_key(&self) -> anyhow::Result<PublicKey> {
         if let Some(public_key) = &self.public_key {
             return Ok(PublicKey::from(*public_key));
@@ -86,18 +116,47 @@ impl SignerArgs {
                 "--public-key is required with --print for writes that embed the signer's key"
             );
         }
+        if self.sign_with != SigningBackend::SecretKey {
+            anyhow::bail!(
+                "--public-key is required with --sign-with keychain/ledger for writes that embed the signer's key"
+            );
+        }
         Ok(PublicKey::from(self.secret()?.public_key()))
     }
 
-    /// The signing account together with its secret key.
-    pub fn resolve(&self) -> anyhow::Result<(ManagedAccountId, SecretKey)> {
-        Ok((self.account_id(), self.secret()?.clone()))
-    }
-
-    fn secret(&self) -> anyhow::Result<&SecretKey> {
+    /// The signing account together with a signer for it.
+    ///
+    /// Async because the keychain backend discovers the account's keys on chain
+    /// before matching them against the OS keystore.
+    pub async fn resolve(
+        &self,
+        network: &NetworkConfig,
+    ) -> anyhow::Result<(ManagedAccountId, Arc<Signer>)> {
         if self.print.is_some() {
             anyhow::bail!("--print is not supported for this orchestrated write");
         }
+
+        let signer = match self.sign_with {
+            SigningBackend::SecretKey => Signer::from_secret_key(self.secret()?.clone())
+                .context("build a signer from --secret-key")?,
+            SigningBackend::Keychain => {
+                Signer::from_keystore_with_search_for_keys(self.signer_id.clone(), network)
+                    .await
+                    .context("find a usable key for this account in the OS keychain")?
+            }
+            // near-api pins its default HD path here. Exposing `--ledger-hd-path`
+            // would mean naming `near_slip10::BIP32Path`, which near-api does not
+            // re-export — it would cost a direct dependency on near-slip10.
+            SigningBackend::Ledger => Signer::from_ledger()
+                .context("connect to Ledger — is it unlocked with the NEAR app open?")?,
+        };
+
+        Ok((self.account_id(), signer))
+    }
+
+    /// Both callers reject print mode before reaching here, so this only has to
+    /// account for a credential that clap left absent.
+    fn secret(&self) -> anyhow::Result<&SecretKey> {
         self.secret_key
             .as_deref()
             .ok_or_else(|| anyhow::anyhow!("missing --secret-key"))
@@ -166,6 +225,7 @@ impl TypedValueParser for SecretKeyParser {
 mod tests {
     use super::*;
     use clap::Parser;
+    use templar_gateway_client::{Network, NetworkConfigBuilder};
 
     const SECRET: &str = "ed25519:2vVTQWpoZvYZBS4HYFZtzU2rxpoQSrhyFWdaHLqSdyaEfgjefbSKiFpuVatuRqax3HFvVq2tkkqWH2h7tso2nK8q";
 
@@ -173,6 +233,12 @@ mod tests {
     struct Harness {
         #[command(flatten)]
         signer: SignerArgs,
+    }
+
+    /// The `secret-key` backend never dials out, so resolution stays offline;
+    /// this only satisfies the signature.
+    fn offline_network() -> NetworkConfig {
+        NetworkConfigBuilder::new(Network::Testnet).build()
     }
 
     #[test]
@@ -201,10 +267,11 @@ mod tests {
         );
     }
 
-    #[test]
-    fn plan_mode_rejects_credential_resolution() {
+    #[tokio::test]
+    async fn plan_mode_rejects_credential_resolution() {
         let signer = SignerArgs {
             signer_id: "dao.near".parse().expect("valid account"),
+            sign_with: SigningBackend::SecretKey,
             secret_key: None,
             print: Some(PrintFormat::Sputnik),
             public_key: None,
@@ -212,7 +279,10 @@ mod tests {
 
         assert_eq!(
             signer
-                .resolve()
+                .resolve(&offline_network())
+                .await
+                // `Signer` is not `Debug`, so discard the Ok value before asserting.
+                .map(|_| ())
                 .expect_err("plan mode has no execution credentials")
                 .to_string(),
             "--print is not supported for this orchestrated write"
@@ -223,6 +293,7 @@ mod tests {
     fn plan_write_that_embeds_a_key_requires_public_key() {
         let signer = SignerArgs {
             signer_id: "dao.near".parse().expect("valid account"),
+            sign_with: SigningBackend::SecretKey,
             secret_key: None,
             print: Some(PrintFormat::Json),
             public_key: None,
@@ -241,11 +312,52 @@ mod tests {
         let expected = PublicKey::from(secret_key.public_key());
         let signer = SignerArgs {
             signer_id: "signer.testnet".parse().expect("valid account"),
+            sign_with: SigningBackend::SecretKey,
             secret_key: Some(Box::new(secret_key)),
             print: None,
             public_key: None,
         };
 
         assert_eq!(signer.public_key().expect("derived public key"), expected);
+    }
+
+    /// The point of the flag: an operator can sign without a key in the
+    /// environment, so naming a backend must lift the `--secret-key` demand.
+    #[rstest::rstest]
+    #[case(SigningBackend::Keychain, "keychain")]
+    #[case(SigningBackend::Ledger, "ledger")]
+    fn external_backend_parses_without_a_secret_key(
+        #[case] expected: SigningBackend,
+        #[case] flag: &str,
+    ) {
+        let harness = Harness::try_parse_from([
+            "tmplrmgr",
+            "--signer-id",
+            "signer.testnet",
+            "--sign-with",
+            flag,
+        ])
+        .expect("external backend should parse with no credential");
+
+        assert_eq!(harness.signer.sign_with, expected);
+    }
+
+    /// A key held in the keychain or on a device cannot be derived in-process,
+    /// so writes that embed the signer's key must be told what it is.
+    #[test]
+    fn external_backend_requires_an_explicit_public_key() {
+        let signer = SignerArgs {
+            signer_id: "signer.testnet".parse().expect("valid account"),
+            sign_with: SigningBackend::Ledger,
+            secret_key: None,
+            print: None,
+            public_key: None,
+        };
+
+        assert!(signer
+            .public_key()
+            .expect_err("a device key cannot be derived locally")
+            .to_string()
+            .contains("--public-key"));
     }
 }

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -36,10 +36,12 @@ pub(crate) struct CliContext {
 }
 
 impl CliContext {
-    /// Build a single-signer client for `account_id` from `secret_key`. Each
-    /// executed write signs with credentials carried by its own command, and
-    /// teardown flows (e.g. `registry clear-deployments`) sign many discovered
-    /// accounts with one authorized key.
+    /// Build a single-signer client for `account_id` from a bare `secret_key`.
+    ///
+    /// For the teardown flows that sign many *discovered* accounts with one
+    /// authorized key (`registry clear-deployments`), where there is no single
+    /// `SignerArgs` to resolve. Writes that carry their own credentials use
+    /// [`Self::signing_client_for`] instead.
     pub(crate) fn signing_client(
         &self,
         account_id: impl Into<ManagedAccountId>,
@@ -49,6 +51,23 @@ impl CliContext {
             .secret_key(account_id, secret_key)?
             .build()
             .context("build signing client")
+    }
+
+    /// Resolve a write command's credentials through its selected backend and
+    /// build a single-signer client from them.
+    ///
+    /// The signer stays behind `Arc<Signer>` rather than being unwrapped to a
+    /// secret key, so backends that never surrender one (Ledger) work here.
+    pub(crate) async fn signing_client_for(
+        &self,
+        signer: &SignerArgs,
+    ) -> anyhow::Result<(ManagedAccountId, Client)> {
+        let (account_id, signing) = signer.resolve(&self.network).await?;
+        let client = Client::builder(self.network.clone())
+            .with_signer(account_id.clone(), signing)
+            .build()
+            .context("build signing client")?;
+        Ok((account_id, client))
     }
 
     /// Dispatch a read and print its JSON result.
@@ -80,8 +99,7 @@ impl CliContext {
             return print_plan(format, plan);
         }
 
-        let (account_id, secret_key) = signer.resolve()?;
-        let client = self.signing_client(account_id.clone(), secret_key)?;
+        let (account_id, client) = self.signing_client_for(&signer).await?;
         let output = client.execute_as(account_id, body).await?;
         self.finish_write(&output)
     }
@@ -113,9 +131,9 @@ impl CliContext {
             return print_plan(format, plan);
         }
 
-        let (account_id, secret_key) = signer.resolve()?;
+        let (account_id, signing) = signer.resolve(&self.network).await?;
         let (base_context, driver, signer_account_ids) = Client::builder(self.network.clone())
-            .secret_key(account_id.clone(), secret_key)?
+            .with_signer(account_id.clone(), signing)
             .build_parts()
             .context("build oracle-updates client")?;
         let client: Client<OracleUpdatesDispatch, Ctx> =

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -90,8 +90,7 @@ async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
         MarketNs::Remove(a) => {
             // `market remove` is self-signed: the signer is the market account
             // being torn down.
-            let (market, secret_key) = a.signer.resolve()?;
-            let client = ctx.signing_client(market.clone(), secret_key)?;
+            let (market, client) = ctx.signing_client_for(&a.signer).await?;
             teardown::remove_market(&ctx, &client, market, a.beneficiary_id(), a.force()).await?;
             print_json(&serde_json::json!({ "removed": true }))
         }

--- a/tools/manager/src/dispatch/proposals.rs
+++ b/tools/manager/src/dispatch/proposals.rs
@@ -51,8 +51,7 @@ pub(super) async fn create(ctx: CliContext, mut args: CreateProposal) -> anyhow:
         return ctx.write(signer_args, create_spec).await;
     }
 
-    let (signer, secret_key) = signer_args.resolve()?;
-    let client = ctx.signing_client(signer.clone(), secret_key)?;
+    let (signer, client) = ctx.signing_client_for(&signer_args).await?;
     let create = client.execute_as(signer.clone(), create_spec).await?;
     // Fail fast if the create reverted, before waiting on / executing a proposal
     // that was never created.

--- a/tools/manager/src/dispatch/teardown.rs
+++ b/tools/manager/src/dispatch/teardown.rs
@@ -16,8 +16,7 @@ use crate::context::{check_operation_status, print_json, CliContext};
 pub(super) async fn recover_nep141(ctx: CliContext, args: RecoverNep141) -> anyhow::Result<()> {
     use templar_gateway_methods_spec::{storage, token};
 
-    let (signer, secret_key) = args.signer.resolve()?;
-    let client = ctx.signing_client(signer.clone(), secret_key)?;
+    let (signer, client) = ctx.signing_client_for(&args.signer).await?;
     let account_id = signer.0.clone();
     let token = token::TokenReference::Ft {
         contract_id: args.token_id.clone(),
@@ -66,8 +65,7 @@ pub(super) async fn remove_version(
         return ctx.write(args.signer.clone(), spec).await;
     }
 
-    let (signer, secret_key) = args.signer.resolve()?;
-    let client = ctx.signing_client(signer.clone(), secret_key)?;
+    let (signer, client) = ctx.signing_client_for(&args.signer).await?;
     let removed = remove_all_versions(&ctx, &client, &signer, args.registry_id()).await?;
     print_json(&json!({ "removed": removed }))
 }
@@ -111,8 +109,7 @@ async fn remove_all_versions(
 pub(super) async fn registry_remove(ctx: CliContext, args: registry::Remove) -> anyhow::Result<()> {
     use templar_gateway_methods_spec::account;
 
-    let (signer, secret_key) = args.signer.resolve()?;
-    let client = ctx.signing_client(signer.clone(), secret_key)?;
+    let (signer, client) = ctx.signing_client_for(&args.signer).await?;
     let registry_id = signer.0.clone();
     remove_all_versions(&ctx, &client, &signer, &registry_id).await?;
 

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -180,7 +180,9 @@ fn parses_write_fallback_with_json() {
         super::cli::Command::Write(call) => {
             assert_eq!(call.call.method, "registry.removeVersion");
             assert!(call.call.json.is_some());
-            call.signer.resolve().expect("credentials should resolve");
+            call.signer
+                .public_key()
+                .expect("credentials should resolve");
         }
         _ => panic!("expected Write variant"),
     }
@@ -218,6 +220,19 @@ fn write_requires_secret_key_or_print() {
         error.kind(),
         clap::error::ErrorKind::MissingRequiredArgument
     );
+}
+
+/// The whole point of `--sign-with`: naming a backend that holds the key
+/// elsewhere must satisfy the credential requirement with nothing in the
+/// environment. Credentials are cleared so an ambient `SECRET_KEY` cannot make
+/// this pass for the wrong reason.
+#[test]
+fn write_with_an_external_backend_needs_no_secret_key() {
+    let result = with_cleared_credential_env(|| {
+        try_parse_write(["--signer-id", "dao.near", "--sign-with", "ledger"])
+    });
+
+    result.expect("--sign-with ledger should satisfy the credential requirement");
 }
 
 #[test]
@@ -260,7 +275,7 @@ fn print_conflicts_with_secret_key_from_environment() {
 }
 
 #[test]
-fn public_key_requires_print_mode() {
+fn public_key_is_not_a_credential() {
     let error = with_cleared_credential_env(|| {
         try_parse_write([
             "--signer-id",
@@ -269,13 +284,16 @@ fn public_key_requires_print_mode() {
             "ed25519:5TMKtTtD5uuMF28ovo7vVge7oAu58eXjySJWTrwcEB5w",
         ])
     })
-    .expect_err("--public-key is plan-only");
+    .expect_err("--public-key names a key, it does not authorize a write");
 
     assert_eq!(
         error.kind(),
         clap::error::ErrorKind::MissingRequiredArgument
     );
-    assert!(error.to_string().contains("--print <FORMAT>"));
+    assert!(
+        error.to_string().contains("--secret-key"),
+        "the error should name the missing credential: {error}"
+    );
 }
 
 #[test]
@@ -320,7 +338,7 @@ fn signer_env_satisfies_write_credentials() {
         let cli = try_parse_write([]).map_err(|error| anyhow::anyhow!(error.to_string()))?;
 
         match cli.command {
-            super::cli::Command::Write(call) => call.signer.resolve().map(|_| ()),
+            super::cli::Command::Write(call) => call.signer.public_key().map(|_| ()),
             _ => anyhow::bail!("expected Write variant"),
         }
     })();


### PR DESCRIPTION
Sub-PR 1 of 10 for ENG-537. Targets the integration branch, so CI does not run here (`test.yml` / `kani.yml` trigger only on PRs into `main`/`dev`). The master PR into `dev` is the full gate.

Closes ENG-538.

## What

`--sign-with keychain|ledger|secret-key` on every write, defaulting to `secret-key` so existing invocations are unchanged.

`SignerArgs::resolve` returned a materialized `SecretKey` — which a Ledger never surrenders. It now returns `Arc<Signer>` and is async, since the keychain backend discovers the account's keys on chain.

**The gateway needed no change.** `ClientBuilder::with_signer` already took a built signer; `secret_key()` was only ever a wrapper over it.

## Notable

- Six `resolve()` + `signing_client()` pairs collapse into one `CliContext::signing_client_for`, removing the secret key from every call site. Net simplification.
- The bare-key `signing_client` stays for `registry clear-deployments`, which signs many *discovered* accounts with one key and has no `--signer-id` to resolve. Extending backends to that path is deliberately out of scope.
- `--public-key` no longer requires `--print`: keychain and Ledger hold their key outside this process, so writes that embed the signer's key on a new account need it in execution mode too. It is still not a credential on its own (`public_key_is_not_a_credential`).
- Ledger is pinned to near-api's default HD path. A `--ledger-hd-path` flag would mean naming `near_slip10::BIP32Path`, which near-api does not re-export.

## Dependency bump — please note

**near-api 0.8.5 → 0.8.6, workspace-wide.** Not optional: 0.8.5's `ledger` feature does not compile, passing `slipped10::BIP32Path` to near-ledger which expects `near_slip10::BIP32Path`. 0.8.6 switched crates. `cargo check --workspace` is clean on 0.8.6.

**CI risk to watch on the master PR:** enabling `keystore`/`ledger` pulls `keyring` → `dbus-secret-service` → `libdbus-sys` (pkg-config variant, links system libdbus) and `near-ledger` → `hidapi`. Because Cargo unifies features across a workspace build, every crate's build links the feature-enabled near-api. Builds fine locally; if the CI image lacks `libdbus-1-dev` this will need an install step.

## Verification

`cargo fmt` · `cargo check --workspace` clean · `cargo clippy -p templar-manager --tests -- -D warnings` clean · `just test-fast -p templar-manager` 146/146.

A `/simplify` pass ran before this landed: dropped an `Option<SigningBackend>` + accessor in favour of clap `default_value_t`, removed a now-unreachable print guard in `secret()`, and corrected two stale comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/538)
<!-- Reviewable:end -->
