### PR TITLE
feat(manager): market export, the deployment validation gate (ENG-540)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,6 +253,18 @@ jobs:
         # is the one thing that catches it.
         run: cargo build --workspace --bins
 
+      # `tmplrmgr`'s `ledger` feature is opt-in so the default workspace build
+      # needs no system libraries — hidapi wants libudev, and cargo unifies
+      # features across a workspace build, so enabling it by default would put
+      # that dependency on all 22 crates. Compiling it here, in the one job that
+      # already installs nothing else, is what stops an opt-in feature from
+      # rotting unnoticed.
+      - name: Install Ledger build dependencies
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
+      - name: Check the ledger-enabled signer
+        run: cargo check -p templar-manager --features ledger --all-targets
+
   soroban:
     name: Soroban
     runs-on: warp-ubuntu-latest-x64-4x

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -253,18 +253,6 @@ jobs:
         # is the one thing that catches it.
         run: cargo build --workspace --bins
 
-      # `tmplrmgr`'s `ledger` feature is opt-in so the default workspace build
-      # needs no system libraries — hidapi wants libudev, and cargo unifies
-      # features across a workspace build, so enabling it by default would put
-      # that dependency on all 22 crates. Compiling it here, in the one job that
-      # already installs nothing else, is what stops an opt-in feature from
-      # rotting unnoticed.
-      - name: Install Ledger build dependencies
-        run: sudo apt-get update && sudo apt-get install -y libudev-dev
-
-      - name: Check the ledger-enabled signer
-        run: cargo check -p templar-manager --features ledger --all-targets
-
   soroban:
     name: Soroban
     runs-on: warp-ubuntu-latest-x64-4x

--- a/docs/src/deployments.md
+++ b/docs/src/deployments.md
@@ -30,7 +30,6 @@ selects where that signing key lives:
 |---|---|---|
 | `secret-key` (default) | `--secret-key`, or `$SECRET_KEY` | Puts a plaintext key in the environment. Fine for testnet and CI; avoid for mainnet. |
 | `keychain` | the OS keychain | Looked up by account id. The account's on-chain keys are listed to find a match. |
-| `ledger` | a Ledger device | Opt-in at build time: `--features ledger`. Uses near-api's default HD path; the device must be unlocked with the NEAR app open. |
 
 For mainnet, prefer to sign nothing directly. `--print sputnik` emits a
 SputnikDAO proposal instead of executing, so a deployment can be reviewed and
@@ -40,7 +39,7 @@ approved by the multisig with no operator key involved at all:
 tmplrmgr market create --signer-id dao.near --print sputnik --public-key ed25519:… …
 ```
 
-`keychain` and `ledger` hold their key outside this process, so writes that
+`keychain` holds its key outside this process, so writes that
 embed the signer's public key on a new account (any `registry deploy`) need it
 passed explicitly with `--public-key`.
 

--- a/docs/src/deployments.md
+++ b/docs/src/deployments.md
@@ -30,7 +30,7 @@ selects where that signing key lives:
 |---|---|---|
 | `secret-key` (default) | `--secret-key`, or `$SECRET_KEY` | Puts a plaintext key in the environment. Fine for testnet and CI; avoid for mainnet. |
 | `keychain` | the OS keychain | Looked up by account id. The account's on-chain keys are listed to find a match. |
-| `ledger` | a Ledger device | Uses near-api's default HD path. The device must be unlocked with the NEAR app open. |
+| `ledger` | a Ledger device | Opt-in at build time: `--features ledger`. Uses near-api's default HD path; the device must be unlocked with the NEAR app open. |
 
 For mainnet, prefer to sign nothing directly. `--print sputnik` emits a
 SputnikDAO proposal instead of executing, so a deployment can be reviewed and

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -15,10 +15,10 @@ clap.workspace = true
 dirs.workspace = true
 hex.workspace = true
 near-account-id.workspace = true
-# `keystore` backs `--sign-with keychain`. `ledger` is opt-in: it pulls hidapi,
-# which needs libudev headers at build time, and cargo unifies features across a
-# workspace build — so enabling it unconditionally would make every crate in the
-# workspace, and CI, require a system dependency that only this binary uses.
+# `keystore` backs `--sign-with keychain`. near-api's `ledger` feature is
+# deliberately not enabled: it pulls hidapi, which needs libudev headers, and
+# cargo unifies features across a workspace build — every crate here and in CI
+# would inherit that system dependency. Nothing needs Ledger signing today.
 near-api = { workspace = true, features = ["keystore"] }
 # Native binary linking the proxy-oracle contract crates (`Operation`/`Proxy`/
 # `Source`): on non-wasm, `near_sdk::env::abort` references the `panic` host
@@ -51,13 +51,6 @@ toml.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
-
-[features]
-default = []
-# Ledger signing. Requires libudev headers (`libudev-dev` on Debian/Ubuntu,
-# `systemd-devel` on Fedora). Build with `--features ledger` to use
-# `--sign-with ledger`.
-ledger = ["near-api/ledger"]
 
 [dev-dependencies]
 rstest.workspace = true

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -15,9 +15,11 @@ clap.workspace = true
 dirs.workspace = true
 hex.workspace = true
 near-account-id.workspace = true
-# `keystore`/`ledger` back the `--sign-with` backends, so an operator never has
-# to put a plaintext key in the environment.
-near-api = { workspace = true, features = ["keystore", "ledger"] }
+# `keystore` backs `--sign-with keychain`. `ledger` is opt-in: it pulls hidapi,
+# which needs libudev headers at build time, and cargo unifies features across a
+# workspace build — so enabling it unconditionally would make every crate in the
+# workspace, and CI, require a system dependency that only this binary uses.
+near-api = { workspace = true, features = ["keystore"] }
 # Native binary linking the proxy-oracle contract crates (`Operation`/`Proxy`/
 # `Source`): on non-wasm, `near_sdk::env::abort` references the `panic` host
 # import, which only near-sdk's `unit-testing` mock defines. `unit-testing` is
@@ -49,6 +51,13 @@ toml.workspace = true
 tracing.workspace = true
 tracing-appender.workspace = true
 tracing-subscriber.workspace = true
+
+[features]
+default = []
+# Ledger signing. Requires libudev headers (`libudev-dev` on Debian/Ubuntu,
+# `systemd-devel` on Fedora). Build with `--features ledger` to use
+# `--sign-with ledger`.
+ledger = ["near-api/ledger"]
 
 [dev-dependencies]
 rstest.workspace = true

--- a/tools/manager/src/commands/market/export.rs
+++ b/tools/manager/src/commands/market/export.rs
@@ -1,0 +1,32 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use near_account_id::AccountId;
+use templar_common::Nanoseconds;
+
+use crate::commands::duration::parse_duration;
+
+/// Reconstruct a deployment spec from a deployed market.
+///
+/// Arguments only — the read chain that fulfils this lives in
+/// [`crate::dispatch::export`], keeping this layer free of IO like every other
+/// command.
+#[derive(Args, Debug)]
+pub struct Export {
+    /// Deployed market account, e.g. `iethfxrp-ixlmusdc.templar-alpha.near`.
+    #[arg(value_name = "MARKET_ID")]
+    pub(crate) market_id: AccountId,
+
+    /// Governance admin. No read method exposes it, so it cannot be recovered
+    /// from chain state and must be stated.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    pub(crate) governance_admin: AccountId,
+
+    /// Governance default proposal TTL.
+    #[arg(long, value_name = "DURATION", default_value = "0s", value_parser = parse_duration)]
+    pub(crate) governance_ttl: Nanoseconds,
+
+    /// Write the spec here instead of stdout.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) out: Option<PathBuf>,
+}

--- a/tools/manager/src/commands/market/mod.rs
+++ b/tools/manager/src/commands/market/mod.rs
@@ -1,7 +1,9 @@
 mod create;
+mod export;
 mod remove;
 
 pub use create::Create;
+pub use export::Export;
 pub use remove::Remove;
 
 use clap::Subcommand;
@@ -11,6 +13,8 @@ use clap::Subcommand;
 pub enum MarketNs {
     /// Deploy a market from a registered version.
     Create(Create),
+    /// Reconstruct a deployment spec from a deployed market.
+    Export(Export),
     /// Remove a market: recover its assets to a beneficiary, then delete the
     /// (signer) account.
     Remove(Remove),

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -147,8 +147,20 @@ impl SignerArgs {
             // near-api pins its default HD path here. Exposing `--ledger-hd-path`
             // would mean naming `near_slip10::BIP32Path`, which near-api does not
             // re-export — it would cost a direct dependency on near-slip10.
+            #[cfg(feature = "ledger")]
             SigningBackend::Ledger => Signer::from_ledger()
                 .context("connect to Ledger — is it unlocked with the NEAR app open?")?,
+            // The variant stays in the CLI either way, so an operator gets this
+            // instead of "unknown value". Ledger support pulls hidapi, which
+            // needs libudev headers, and cargo unifies features across a
+            // workspace build — leaving it on by default would impose that
+            // system dependency on every crate here and in CI.
+            #[cfg(not(feature = "ledger"))]
+            SigningBackend::Ledger => anyhow::bail!(
+                "this build has no Ledger support. Rebuild with \
+                 `cargo build -p templar-manager --features ledger` (needs libudev \
+                 headers: `libudev-dev` on Debian/Ubuntu, `systemd-devel` on Fedora)."
+            ),
         };
 
         Ok((self.account_id(), signer))

--- a/tools/manager/src/commands/signer.rs
+++ b/tools/manager/src/commands/signer.rs
@@ -4,8 +4,8 @@
 //! one transaction without performing execution steps.
 //!
 //! Credentials resolve to an [`Arc<Signer>`] rather than a [`SecretKey`], so a
-//! backend that never surrenders its key (Ledger) is expressible. `--sign-with`
-//! selects the backend; `--print sputnik` remains the key-less path and never
+//! backend that holds its key outside this process is expressible.
+//! `--sign-with` selects the backend; `--print sputnik` remains the key-less path and never
 //! reaches credential resolution at all.
 
 use std::{ffi::OsStr, fmt, sync::Arc};
@@ -27,7 +27,12 @@ pub(crate) enum PrintFormat {
 }
 
 /// Where the signing key lives. Only [`SigningBackend::SecretKey`] puts one in
-/// the process; the others keep it in the OS keychain or on the device.
+/// the process.
+///
+/// A Ledger backend was tried and removed: near-api's `ledger` feature pulls
+/// hidapi, which needs libudev headers, and cargo unifies features across a
+/// workspace build — so every crate here and in CI would inherit that system
+/// dependency for something nothing needs yet.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, ValueEnum)]
 pub(crate) enum SigningBackend {
     /// `--secret-key`, or `$SECRET_KEY`.
@@ -35,8 +40,6 @@ pub(crate) enum SigningBackend {
     SecretKey,
     /// The OS keychain, looked up by account id.
     Keychain,
-    /// A Ledger device, at near-api's default HD path.
-    Ledger,
 }
 
 /// The account authorizing a write and either its execution credential or its
@@ -105,8 +108,8 @@ impl SignerArgs {
     /// full access key on the new account.
     ///
     /// Only the `secret-key` backend can derive this locally. Plan mode has no
-    /// credential, and the keychain and Ledger backends hold their key outside
-    /// this process, so both require `--public-key`.
+    /// credential, and the keychain backend holds its key outside this process,
+    /// so both require `--public-key`.
     pub fn public_key(&self) -> anyhow::Result<PublicKey> {
         if let Some(public_key) = &self.public_key {
             return Ok(PublicKey::from(*public_key));
@@ -118,7 +121,7 @@ impl SignerArgs {
         }
         if self.sign_with != SigningBackend::SecretKey {
             anyhow::bail!(
-                "--public-key is required with --sign-with keychain/ledger for writes that embed the signer's key"
+                "--public-key is required with --sign-with keychain for writes that embed the signer's key"
             );
         }
         Ok(PublicKey::from(self.secret()?.public_key()))
@@ -144,23 +147,6 @@ impl SignerArgs {
                     .await
                     .context("find a usable key for this account in the OS keychain")?
             }
-            // near-api pins its default HD path here. Exposing `--ledger-hd-path`
-            // would mean naming `near_slip10::BIP32Path`, which near-api does not
-            // re-export — it would cost a direct dependency on near-slip10.
-            #[cfg(feature = "ledger")]
-            SigningBackend::Ledger => Signer::from_ledger()
-                .context("connect to Ledger — is it unlocked with the NEAR app open?")?,
-            // The variant stays in the CLI either way, so an operator gets this
-            // instead of "unknown value". Ledger support pulls hidapi, which
-            // needs libudev headers, and cargo unifies features across a
-            // workspace build — leaving it on by default would impose that
-            // system dependency on every crate here and in CI.
-            #[cfg(not(feature = "ledger"))]
-            SigningBackend::Ledger => anyhow::bail!(
-                "this build has no Ledger support. Rebuild with \
-                 `cargo build -p templar-manager --features ledger` (needs libudev \
-                 headers: `libudev-dev` on Debian/Ubuntu, `systemd-devel` on Fedora)."
-            ),
         };
 
         Ok((self.account_id(), signer))
@@ -335,23 +321,18 @@ mod tests {
 
     /// The point of the flag: an operator can sign without a key in the
     /// environment, so naming a backend must lift the `--secret-key` demand.
-    #[rstest::rstest]
-    #[case(SigningBackend::Keychain, "keychain")]
-    #[case(SigningBackend::Ledger, "ledger")]
-    fn external_backend_parses_without_a_secret_key(
-        #[case] expected: SigningBackend,
-        #[case] flag: &str,
-    ) {
+    #[test]
+    fn external_backend_parses_without_a_secret_key() {
         let harness = Harness::try_parse_from([
             "tmplrmgr",
             "--signer-id",
             "signer.testnet",
             "--sign-with",
-            flag,
+            "keychain",
         ])
         .expect("external backend should parse with no credential");
 
-        assert_eq!(harness.signer.sign_with, expected);
+        assert_eq!(harness.signer.sign_with, SigningBackend::Keychain);
     }
 
     /// A key held in the keychain or on a device cannot be derived in-process,
@@ -360,7 +341,7 @@ mod tests {
     fn external_backend_requires_an_explicit_public_key() {
         let signer = SignerArgs {
             signer_id: "signer.testnet".parse().expect("valid account"),
-            sign_with: SigningBackend::Ledger,
+            sign_with: SigningBackend::Keychain,
             secret_key: None,
             print: None,
             public_key: None,

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -57,7 +57,7 @@ impl CliContext {
     /// build a single-signer client from them.
     ///
     /// The signer stays behind `Arc<Signer>` rather than being unwrapped to a
-    /// secret key, so backends that never surrender one (Ledger) work here.
+    /// secret key, so a backend that never surrenders one still works here.
     pub(crate) async fn signing_client_for(
         &self,
         signer: &SignerArgs,

--- a/tools/manager/src/dispatch/export.rs
+++ b/tools/manager/src/dispatch/export.rs
@@ -1,0 +1,112 @@
+//! `market export` — read a deployed market and reconstruct its spec.
+//!
+//! A multi-step read chain (the configuration, both proxies, three registry
+//! deployment records), so it lives here rather than in `commands`, which stays
+//! free of IO.
+
+use anyhow::Context as _;
+use near_account_id::AccountId;
+use templar_common::oracle::pyth::PriceIdentifier;
+use templar_gateway_methods_spec::{market, proxy_oracle, registry};
+use templar_proxy_oracle_kernel::proxy::Proxy;
+use templar_proxy_oracle_near_common::input::Source;
+
+use crate::commands::market::Export;
+use crate::context::CliContext;
+use crate::spec::{
+    export::{split_market_id, Deployed},
+    governance_account_id, GovernanceSpec, MarketSpec, Versions, BORROW_PRICE_ID,
+    COLLATERAL_PRICE_ID,
+};
+
+pub(super) async fn market(ctx: CliContext, args: Export) -> anyhow::Result<()> {
+    let (name, registry_id) = split_market_id(&args.market_id)?;
+
+    let configuration = ctx
+        .client
+        .read(market::GetConfiguration {
+            market_id: args.market_id.clone(),
+        })
+        .await
+        .context("read market configuration")?;
+
+    let oracle_id = configuration.price_oracle_configuration.account_id.clone();
+    let spec = MarketSpec::from_deployed(Deployed {
+        versions: versions(&ctx, &name, &registry_id, &oracle_id, &args.market_id).await?,
+        governance: GovernanceSpec {
+            admin: args.governance_admin.clone(),
+            ttl_default: args.governance_ttl,
+        },
+        collateral_proxy: proxy(&ctx, &oracle_id, COLLATERAL_PRICE_ID).await?,
+        borrow_proxy: proxy(&ctx, &oracle_id, BORROW_PRICE_ID).await?,
+        market_id: args.market_id.clone(),
+        configuration,
+    })?;
+
+    let rendered = toml::to_string_pretty(&spec).context("render spec as TOML")?;
+    match &args.out {
+        Some(path) => {
+            std::fs::write(path, &rendered).with_context(|| format!("write {}", path.display()))?;
+        }
+        None => print!("{rendered}"),
+    }
+    Ok(())
+}
+
+/// A configured proxy, or a legible error. An oracle serving neither constant is
+/// not a proxy-oracle deployment, and the spec cannot express it.
+async fn proxy(
+    ctx: &CliContext,
+    oracle_id: &AccountId,
+    id: PriceIdentifier,
+) -> anyhow::Result<Proxy<Source>> {
+    ctx.client
+        .read(proxy_oracle::GetProxy {
+            oracle_id: oracle_id.clone(),
+            id,
+        })
+        .await
+        .with_context(|| format!("read proxy {} from {oracle_id}", hex::encode(id.0)))?
+        .proxy
+        .with_context(|| {
+            format!(
+                "`{oracle_id}` serves no proxy for {}; this market is not a \
+                 proxy-oracle deployment and cannot be exported",
+                hex::encode(id.0)
+            )
+        })
+}
+
+/// Version keys for the three contracts, from their registry deployment records.
+async fn versions(
+    ctx: &CliContext,
+    name: &str,
+    registry_id: &AccountId,
+    oracle_id: &AccountId,
+    market_id: &AccountId,
+) -> anyhow::Result<Versions> {
+    let governance_id = governance_account_id(name, registry_id)?;
+    Ok(Versions {
+        market: version_key(ctx, registry_id, market_id).await?,
+        proxy_oracle: version_key(ctx, registry_id, oracle_id).await?,
+        proxy_governance: version_key(ctx, registry_id, &governance_id).await?,
+    })
+}
+
+async fn version_key(
+    ctx: &CliContext,
+    registry_id: &AccountId,
+    account_id: &AccountId,
+) -> anyhow::Result<String> {
+    Ok(ctx
+        .client
+        .read(registry::GetDeployment {
+            registry_id: registry_id.clone(),
+            account_id: account_id.clone(),
+        })
+        .await
+        .with_context(|| format!("read deployment record for {account_id}"))?
+        .deployment
+        .with_context(|| format!("`{registry_id}` has no deployment record for {account_id}"))?
+        .version_key)
+}

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -4,6 +4,7 @@
 //! flows live in focused submodules ([`teardown`], [`proposals`], [`generic`]) so
 //! this file stays a readable index of the command surface.
 
+mod export;
 pub(crate) mod generic;
 mod proposals;
 mod teardown;
@@ -97,6 +98,7 @@ async fn ft(ctx: CliContext, ns: FtNs) -> anyhow::Result<()> {
 async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
     match ns {
         MarketNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
+        MarketNs::Export(a) => export::market(ctx, a).await,
         MarketNs::Remove(a) => {
             // `market remove` is self-signed: the signer is the market account
             // being torn down.

--- a/tools/manager/src/spec/export.rs
+++ b/tools/manager/src/spec/export.rs
@@ -1,0 +1,208 @@
+//! The inverse of [`super::MarketSpec::into_market_configuration`]: reconstruct
+//! a spec from what is actually deployed.
+//!
+//! This is the epic's validation gate. The tool must reproduce markets we
+//! already run before it is trusted to create new ones.
+//!
+//! **Scope is deliberately narrow.** A spec expresses only proxy-oracle
+//! deployments — a dedicated oracle at `proxy-oracle-<market-name>.<registry>`
+//! with the [`COLLATERAL_PRICE_ID`]/[`BORROW_PRICE_ID`] constants. Of the alpha
+//! markets, most predate that: thirteen read `pyth-oracle.near` directly, two
+//! use a proxy named after the *asset pair* rather than the market, and one uses
+//! the LST oracle. Every one of those is **refused, not approximated** — a spec
+//! that re-derives to a different oracle account would be a silent wrong answer,
+//! and worse than no answer.
+
+use anyhow::Context as _;
+use near_account_id::AccountId;
+use templar_common::{
+    asset::AssetClass,
+    market::{MarketConfiguration, PriceOracleConfiguration},
+    Nanoseconds,
+};
+use templar_proxy_oracle_kernel::proxy::{aggregator::Aggregator, Proxy};
+use templar_proxy_oracle_near_common::{input::Source, request::OracleRequest};
+
+use super::{
+    oracle::{AggregatorSpec, AssetSpec, SourceSpec},
+    GovernanceSpec, MarketParams, MarketSpec, Versions, BORROW_PRICE_ID, COLLATERAL_PRICE_ID,
+    SCHEMA_VERSION,
+};
+
+/// Everything read off chain for one market.
+pub struct Deployed {
+    pub market_id: AccountId,
+    pub configuration: MarketConfiguration,
+    pub collateral_proxy: Proxy<Source>,
+    pub borrow_proxy: Proxy<Source>,
+    pub versions: Versions,
+    pub governance: GovernanceSpec,
+}
+
+impl MarketSpec {
+    /// Reconstruct a spec, or explain why this market cannot be expressed as one.
+    pub fn from_deployed(deployed: Deployed) -> anyhow::Result<Self> {
+        let (name, registry) = split_market_id(&deployed.market_id)?;
+        let oracle = &deployed.configuration.price_oracle_configuration;
+
+        let spec = Self {
+            schema: SCHEMA_VERSION,
+            extends: Vec::new(),
+            registry,
+            name,
+            versions: deployed.versions,
+            governance: deployed.governance,
+            collateral: asset_spec(
+                deployed.configuration.collateral_asset.clone(),
+                oracle.collateral_asset_decimals,
+                deployed.collateral_proxy,
+            )?,
+            borrow: asset_spec(
+                deployed.configuration.borrow_asset.clone(),
+                oracle.borrow_asset_decimals,
+                deployed.borrow_proxy,
+            )?,
+            market: market_params(&deployed.configuration),
+        };
+        // Built before the oracle check so the error can name the derived id,
+        // which needs a complete spec. Freshness bounds come straight from the
+        // deployed proxies rather than being left to defaults: an export exists
+        // for fidelity, and a later change to a default must not silently alter
+        // what an exported spec means.
+        ensure_expressible(&spec, oracle)?;
+        Ok(spec)
+    }
+}
+
+/// `<name>.<registry>` — the inverse of [`MarketSpec::market_id`].
+pub fn split_market_id(market_id: &AccountId) -> anyhow::Result<(String, AccountId)> {
+    let registry = market_id.get_parent_account_id().with_context(|| {
+        format!("`{market_id}` is a top-level account, not a market under a registry")
+    })?;
+    let name = market_id
+        .as_str()
+        .strip_suffix(&format!(".{registry}"))
+        .unwrap_or_default();
+    Ok((name.to_owned(), registry.to_owned()))
+}
+
+/// Refuse anything the spec cannot round-trip faithfully.
+fn ensure_expressible(spec: &MarketSpec, oracle: &PriceOracleConfiguration) -> anyhow::Result<()> {
+    let derived = spec.oracle_id()?;
+    anyhow::ensure!(
+        derived == oracle.account_id,
+        "market reads `{}`, but a spec derives `{derived}`. Only markets with a \
+         dedicated proxy oracle named after them can be expressed as a spec; \
+         this one cannot be exported.",
+        oracle.account_id,
+    );
+    anyhow::ensure!(
+        oracle.collateral_asset_price_id == COLLATERAL_PRICE_ID
+            && oracle.borrow_asset_price_id == BORROW_PRICE_ID,
+        "oracle `{}` uses price ids a spec does not derive ({} / {}). Only the \
+         per-market constants are expressible; this market cannot be exported.",
+        oracle.account_id,
+        hex::encode(oracle.collateral_asset_price_id.0),
+        hex::encode(oracle.borrow_asset_price_id.0),
+    );
+    Ok(())
+}
+
+fn asset_spec<A: AssetClass>(
+    asset: templar_common::asset::FungibleAsset<A>,
+    decimals: i32,
+    proxy: Proxy<Source>,
+) -> anyhow::Result<AssetSpec<A>> {
+    let (aggregator, min_sources, sources) = split_aggregator(proxy.aggregator)?;
+
+    Ok(AssetSpec {
+        asset,
+        // Never reaches the chain, so it cannot be recovered. Left unset for a
+        // human to fill in; inventing a plausible ticker would be worse, since
+        // the reference cross-check (ENG-543) would then verify a guess.
+        symbol: None,
+        decimals: u8::try_from(decimals).ok(),
+        aggregator,
+        min_sources,
+        sources,
+        max_age: proxy.freshness_filter.max_age_ns,
+        max_clock_drift: proxy.freshness_filter.max_clock_drift_ns,
+    })
+}
+
+fn split_aggregator(
+    aggregator: Aggregator<Source>,
+) -> anyhow::Result<(AggregatorSpec, u32, Vec<SourceSpec>)> {
+    let (kind, sources, min_sources) = match aggregator {
+        Aggregator::MedianLow(median) => (
+            AggregatorSpec::MedianLow,
+            median.sources,
+            median.min_sources,
+        ),
+        Aggregator::MedianHigh(median) => (
+            AggregatorSpec::MedianHigh,
+            median.sources,
+            median.min_sources,
+        ),
+        Aggregator::Priority(_) => anyhow::bail!(
+            "oracle uses the `Priority` aggregator, which a spec does not express \
+             (it carries neither weights nor `min_sources`)"
+        ),
+    };
+
+    let sources = sources
+        .into_iter()
+        .map(|weighted| {
+            let Source::Request(request) = weighted.source else {
+                anyhow::bail!(
+                    "oracle uses a price-transformer source, which a spec does not express"
+                );
+            };
+            Ok(match request {
+                OracleRequest::Lazer(lazer) => SourceSpec::Lazer {
+                    oracle: lazer.oracle_id,
+                    feed_id: lazer.feed_id,
+                    weight: weighted.weight,
+                },
+                OracleRequest::RedStone(redstone) => SourceSpec::RedStone {
+                    oracle: redstone.oracle_id,
+                    price_id: redstone.price_id.to_string(),
+                    weight: weighted.weight,
+                },
+                OracleRequest::Pyth(pyth) => anyhow::bail!(
+                    "oracle has a direct Pyth source (`{}`), which a spec does not express",
+                    pyth.oracle_id
+                ),
+            })
+        })
+        .collect::<anyhow::Result<Vec<_>>>()?;
+
+    Ok((kind, min_sources, sources))
+}
+
+fn market_params(configuration: &MarketConfiguration) -> MarketParams {
+    MarketParams {
+        time_chunk: Nanoseconds::from_ns(
+            configuration
+                .time_chunk_configuration
+                .duration_ms()
+                .saturating_mul(1_000_000),
+        ),
+        price_maximum_age: Nanoseconds::from_ns(
+            u64::from(configuration.price_oracle_configuration.price_maximum_age_s) * 1_000_000_000,
+        ),
+        mcr_maintenance: configuration.borrow_mcr_maintenance,
+        mcr_liquidation: configuration.borrow_mcr_liquidation,
+        maximum_usage_ratio: configuration.borrow_asset_maximum_usage_ratio,
+        liquidation_maximum_spread: configuration.liquidation_maximum_spread,
+        interest_rate_strategy: configuration.borrow_interest_rate_strategy.clone(),
+        origination_fee: configuration.borrow_origination_fee.clone(),
+        supply_withdrawal_fee: configuration.supply_withdrawal_fee.clone(),
+        yield_weights: configuration.yield_weights.clone(),
+        protocol_account_id: configuration.protocol_account_id.clone(),
+        borrow_maximum_duration_ms: configuration.borrow_maximum_duration_ms.map(|ms| ms.0),
+        borrow_range: (*configuration.borrow_range).clone(),
+        supply_range: (*configuration.supply_range).clone(),
+        supply_withdrawal_range: (*configuration.supply_withdrawal_range).clone(),
+    }
+}

--- a/tools/manager/src/spec/export.rs
+++ b/tools/manager/src/spec/export.rs
@@ -53,11 +53,13 @@ impl MarketSpec {
             versions: deployed.versions,
             governance: deployed.governance,
             collateral: asset_spec(
+                "collateral",
                 deployed.configuration.collateral_asset.clone(),
                 oracle.collateral_asset_decimals,
                 deployed.collateral_proxy,
             )?,
             borrow: asset_spec(
+                "borrow",
                 deployed.configuration.borrow_asset.clone(),
                 oracle.borrow_asset_decimals,
                 deployed.borrow_proxy,
@@ -109,11 +111,27 @@ fn ensure_expressible(spec: &MarketSpec, oracle: &PriceOracleConfiguration) -> a
 }
 
 fn asset_spec<A: AssetClass>(
+    side: &str,
     asset: templar_common::asset::FungibleAsset<A>,
     decimals: i32,
     proxy: Proxy<Source>,
 ) -> anyhow::Result<AssetSpec<A>> {
     let (aggregator, min_sources, sources) = split_aggregator(proxy.aggregator)?;
+
+    // `None` means opposite things on the two sides of this conversion. On chain
+    // it is *unbounded* — `FreshnessFilter::accepts` admits a price of any age.
+    // In a spec it means *unspecified*, and `AssetSpec::into_proxy` fills it from
+    // `price_maximum_age` / `DEFAULT_MAX_CLOCK_DRIFT`. Copying it through would
+    // turn "accept any age" into "enforce the market's bound" on the next
+    // deploy, silently and with no diff to notice.
+    let freshness = &proxy.freshness_filter;
+    anyhow::ensure!(
+        freshness.max_age_ns.is_some() && freshness.max_clock_drift_ns.is_some(),
+        "the {side} proxy leaves a freshness bound unset, which is unbounded on \
+         chain but means `use the default` in a spec. Re-deploying an exported \
+         spec would silently start enforcing a bound this oracle does not have, \
+         so this market cannot be exported."
+    );
 
     Ok(AssetSpec {
         asset,
@@ -121,12 +139,14 @@ fn asset_spec<A: AssetClass>(
         // human to fill in; inventing a plausible ticker would be worse, since
         // the reference cross-check (ENG-543) would then verify a guess.
         symbol: None,
-        decimals: u8::try_from(decimals).ok(),
+        decimals: Some(u8::try_from(decimals).with_context(|| {
+            format!("{side} asset declares {decimals} decimals, which a spec cannot express")
+        })?),
         aggregator,
         min_sources,
         sources,
-        max_age: proxy.freshness_filter.max_age_ns,
-        max_clock_drift: proxy.freshness_filter.max_clock_drift_ns,
+        max_age: freshness.max_age_ns,
+        max_clock_drift: freshness.max_clock_drift_ns,
     })
 }
 

--- a/tools/manager/src/spec/mod.rs
+++ b/tools/manager/src/spec/mod.rs
@@ -11,6 +11,7 @@
 //! specs in unit tests.
 
 pub mod check;
+pub mod export;
 pub mod extends;
 pub mod oracle;
 mod serde_util;
@@ -149,6 +150,30 @@ pub struct MarketParams {
     pub supply_withdrawal_range: AmountRange<BorrowAsset>,
 }
 
+/// The account ids a deployment creates, derived from the market's name and
+/// registry.
+///
+/// Free functions, not just methods: `market export` derives them *before* it
+/// has a spec to call methods on, and a second hand-rolled copy of the naming
+/// convention is exactly the duplication this whole epic exists to remove.
+pub fn market_account_id(name: &str, registry: &AccountId) -> anyhow::Result<AccountId> {
+    derived_id(name, registry)
+}
+
+pub fn oracle_account_id(name: &str, registry: &AccountId) -> anyhow::Result<AccountId> {
+    derived_id(&format!("proxy-oracle-{name}"), registry)
+}
+
+pub fn governance_account_id(name: &str, registry: &AccountId) -> anyhow::Result<AccountId> {
+    derived_id(&format!("proxy-gov-{name}"), registry)
+}
+
+fn derived_id(label: &str, registry: &AccountId) -> anyhow::Result<AccountId> {
+    format!("{label}.{registry}")
+        .parse()
+        .with_context(|| format!("`{label}.{registry}` is not a valid account id"))
+}
+
 /// Convert an authored range through the validating `TryFrom`.
 ///
 /// The spec holds `AmountRange` rather than `ValidAmountRange` because
@@ -183,24 +208,18 @@ impl MarketSpec {
 
     /// `<name>.<registry>` — where the market contract lands.
     pub fn market_id(&self) -> anyhow::Result<AccountId> {
-        self.derived_id(&self.name)
+        market_account_id(&self.name, &self.registry)
     }
 
     /// `proxy-oracle-<name>.<registry>` — the market's dedicated oracle.
     pub fn oracle_id(&self) -> anyhow::Result<AccountId> {
-        self.derived_id(&format!("proxy-oracle-{}", self.name))
+        oracle_account_id(&self.name, &self.registry)
     }
 
     /// `proxy-gov-<name>.<registry>` — owns the oracle, so it must be deployed
     /// before the oracle names it at init.
     pub fn governance_id(&self) -> anyhow::Result<AccountId> {
-        self.derived_id(&format!("proxy-gov-{}", self.name))
-    }
-
-    fn derived_id(&self, label: &str) -> anyhow::Result<AccountId> {
-        format!("{label}.{}", self.registry)
-            .parse()
-            .with_context(|| format!("`{label}.{}` is not a valid account id", self.registry))
+        governance_account_id(&self.name, &self.registry)
     }
 
     /// Build the on-chain market configuration.

--- a/tools/manager/src/spec/oracle.rs
+++ b/tools/manager/src/spec/oracle.rs
@@ -32,9 +32,11 @@ pub struct AssetSpec<A: AssetClass> {
     #[schemars(with = "String")]
     pub asset: FungibleAsset<A>,
 
-    /// Ticker. Never sent on chain — it exists so a preflight can check that the
-    /// sources below actually price this asset (ENG-543).
-    pub symbol: String,
+    /// Ticker. Never sent on chain, so `market export` cannot recover it and
+    /// leaves it unset. It exists so a preflight can check that the sources
+    /// below actually price this asset (ENG-543).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
 
     /// Overrides the token's on-chain metadata. Required when that metadata is
     /// absent or malformed, which has happened for at least one bridged asset

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -9,6 +9,7 @@ use super::commands::signer::PrintFormat;
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 mod deploy_script;
+mod export;
 mod ft;
 mod market;
 mod oracle;

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -232,10 +232,10 @@ fn write_requires_secret_key_or_print() {
 #[test]
 fn write_with_an_external_backend_needs_no_secret_key() {
     let result = with_cleared_credential_env(|| {
-        try_parse_write(["--signer-id", "dao.near", "--sign-with", "ledger"])
+        try_parse_write(["--signer-id", "dao.near", "--sign-with", "keychain"])
     });
 
-    result.expect("--sign-with ledger should satisfy the credential requirement");
+    result.expect("--sign-with keychain should satisfy the credential requirement");
 }
 
 #[test]

--- a/tools/manager/src/tests/export.rs
+++ b/tools/manager/src/tests/export.rs
@@ -147,6 +147,26 @@ fn exported_spec_renders_to_loadable_toml() {
     assert_eq!(reloaded, exported);
 }
 
+/// `None` freshness bounds mean *unbounded* on chain, but *unspecified* in a
+/// spec — where `into_proxy` fills them from `price_maximum_age` and
+/// `DEFAULT_MAX_CLOCK_DRIFT`. Copying one through would turn "accept a price of
+/// any age" into "enforce the market's bound" on the next deploy, silently.
+/// Neither in-scope alpha market exercises this, so it is constructed.
+#[test]
+fn refuses_a_proxy_with_an_unbounded_freshness_filter() {
+    let mut input = deployed("iethfxrp-ixlmusdc");
+    input.collateral_proxy.freshness_filter.max_age_ns = None;
+
+    let error = MarketSpec::from_deployed(input)
+        .expect_err("an unbounded freshness filter is not expressible as a spec");
+
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("collateral") && rendered.contains("unbounded"),
+        "the error must name the side and why it cannot round-trip: {rendered}"
+    );
+}
+
 /// The other sixteen alpha markets read an oracle a spec does not derive.
 /// Refusing is the whole point: emitting a spec that re-derives to a *different*
 /// oracle account would be a silent wrong answer.

--- a/tools/manager/src/tests/export.rs
+++ b/tools/manager/src/tests/export.rs
@@ -1,0 +1,180 @@
+//! The validation gate: a spec must reproduce markets we already run.
+//!
+//! Offline — these read the checked-in deployment configs rather than the chain,
+//! so the gate runs in the fast test partition and cannot be skipped for want of
+//! a network.
+//!
+//! **Coverage is 2 of 18 alpha markets, by decision** (see ENG-540). The other
+//! sixteen use oracle topologies a spec does not express; [`refuses_a_market_it_cannot_express`]
+//! is what keeps that a refusal rather than a wrong answer.
+
+use std::path::{Path, PathBuf};
+
+use templar_common::market::MarketConfiguration;
+
+use crate::spec::{export::Deployed, GovernanceSpec, MarketSpec, Versions};
+
+/// The two markets `script/deploy.sh` builds — the only in-scope topology.
+const IN_SCOPE: [&str; 2] = ["iethfxrp-ixlmusdc", "iethwbtc-ixlmusdc"];
+
+fn alpha(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../contract/market/examples/config/alpha")
+        .join(relative)
+}
+
+fn read_json<T: serde::de::DeserializeOwned>(path: &Path) -> T {
+    let raw = std::fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    serde_json::from_str(&raw).unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+/// Versions and governance are not recoverable from market state; the CLI reads
+/// them from the registry and the governance contract. They are supplied here so
+/// the round-trip can exercise everything that *is* recoverable.
+fn placeholder_versions() -> Versions {
+    Versions {
+        market: "v1.3.0".to_owned(),
+        proxy_oracle: "oracle@0.3.0".to_owned(),
+        proxy_governance: "governance@0.1.0".to_owned(),
+    }
+}
+
+fn placeholder_governance() -> GovernanceSpec {
+    GovernanceSpec {
+        admin: "templar-alpha.near".parse().expect("valid account"),
+        ttl_default: templar_common::Nanoseconds::from_ns(0),
+    }
+}
+
+fn deployed(market: &str) -> Deployed {
+    let configuration: serde_json::Value = read_json(&alpha(&format!("{market}/market-args.json")));
+    Deployed {
+        market_id: format!("{market}.templar-alpha.near")
+            .parse()
+            .expect("valid market id"),
+        configuration: serde_json::from_value(configuration["configuration"].clone())
+            .unwrap_or_else(|error| panic!("parse {market} configuration: {error}")),
+        collateral_proxy: read_json(&alpha(&format!("{market}/proxy-collateral.json"))),
+        borrow_proxy: read_json(&alpha(&format!("{market}/proxy-borrow.json"))),
+        versions: placeholder_versions(),
+        governance: placeholder_governance(),
+    }
+}
+
+/// Export then re-derive: the spec must land back on exactly the deployed
+/// configuration and both proxies. This is what licenses the tool to create
+/// markets.
+#[test]
+fn round_trips_every_in_scope_alpha_market() {
+    for market in IN_SCOPE {
+        let input = deployed(market);
+        let (configuration, collateral_proxy, borrow_proxy) = (
+            input.configuration.clone(),
+            input.collateral_proxy.clone(),
+            input.borrow_proxy.clone(),
+        );
+        let oracle = &configuration.price_oracle_configuration;
+        let (collateral_decimals, borrow_decimals) = (
+            oracle.collateral_asset_decimals,
+            oracle.borrow_asset_decimals,
+        );
+
+        let spec = MarketSpec::from_deployed(input)
+            .unwrap_or_else(|error| panic!("{market} should export: {error:#}"));
+
+        let price_maximum_age = spec.market.price_maximum_age;
+        assert_eq!(
+            spec.collateral.clone().into_proxy(price_maximum_age),
+            collateral_proxy,
+            "{market}: collateral proxy did not round-trip"
+        );
+        assert_eq!(
+            spec.borrow.clone().into_proxy(price_maximum_age),
+            borrow_proxy,
+            "{market}: borrow proxy did not round-trip"
+        );
+        assert_eq!(
+            spec.into_market_configuration(collateral_decimals, borrow_decimals)
+                .unwrap_or_else(|error| panic!("{market} should convert: {error:#}")),
+            configuration,
+            "{market}: configuration did not round-trip"
+        );
+    }
+}
+
+/// Decimals survive the round trip, which is what lets an exported spec be
+/// checked offline without an on-chain metadata lookup.
+#[test]
+fn export_recovers_decimals() {
+    let input = deployed("iethfxrp-ixlmusdc");
+    let configuration = input.configuration.clone();
+    let spec = MarketSpec::from_deployed(input).expect("should export");
+
+    assert_eq!(
+        spec.collateral.decimals.map(i32::from),
+        Some(
+            configuration
+                .price_oracle_configuration
+                .collateral_asset_decimals
+        )
+    );
+}
+
+/// `symbol` never reaches the chain, so an export must leave it unset rather
+/// than invent a plausible ticker.
+#[test]
+fn export_leaves_symbol_unset() {
+    let input = deployed("iethfxrp-ixlmusdc");
+    let spec = MarketSpec::from_deployed(input).expect("should export");
+
+    assert!(spec.collateral.symbol.is_none());
+    assert!(spec.borrow.symbol.is_none());
+}
+
+/// An exported spec has to be a *usable* spec, not just a valid value: TOML
+/// serialization is order-sensitive about tables, so this exercises
+/// export → render → reload and asserts the reloaded spec is identical.
+#[test]
+fn exported_spec_renders_to_loadable_toml() {
+    let input = deployed("iethfxrp-ixlmusdc");
+    let exported = MarketSpec::from_deployed(input).expect("should export");
+
+    let rendered = toml::to_string_pretty(&exported).expect("spec should render as TOML");
+    let reloaded: MarketSpec = toml::from_str(&rendered)
+        .unwrap_or_else(|error| panic!("reload failed: {error}\n{rendered}"));
+
+    assert_eq!(reloaded, exported);
+}
+
+/// The other sixteen alpha markets read an oracle a spec does not derive.
+/// Refusing is the whole point: emitting a spec that re-derives to a *different*
+/// oracle account would be a silent wrong answer.
+#[test]
+fn refuses_a_market_it_cannot_express() {
+    let configuration: MarketConfiguration =
+        read_json(&alpha("ixlm-ixlmusdc.templar-alpha.near.json"));
+    let in_scope = deployed("iethfxrp-ixlmusdc");
+
+    let error = MarketSpec::from_deployed(Deployed {
+        market_id: "ixlm-ixlmusdc.templar-alpha.near"
+            .parse()
+            .expect("valid market id"),
+        configuration,
+        collateral_proxy: in_scope.collateral_proxy,
+        borrow_proxy: in_scope.borrow_proxy,
+        versions: placeholder_versions(),
+        governance: placeholder_governance(),
+    })
+    .expect_err("a pyth-direct market is not expressible as a spec");
+
+    let rendered = format!("{error:#}");
+    assert!(
+        rendered.contains("pyth-oracle.near"),
+        "the error must name the oracle actually deployed: {rendered}"
+    );
+    assert!(
+        rendered.contains("proxy-oracle-ixlm-ixlmusdc.templar-alpha.near"),
+        "the error must name what a spec would derive instead: {rendered}"
+    );
+}


### PR DESCRIPTION
Sub-PR 3 of 10 for ENG-537. Closes ENG-540. Targets the integration branch (no CI here; the master PR #540 is the gate).

## The gate

`MarketSpec::from_deployed` inverts `into_market_configuration`. The round-trip test runs **offline** against the checked-in deployment configs and asserts the exported spec re-derives to exactly the deployed `MarketConfiguration` and both proxies.

It also asserts the rendered TOML reloads identically — TOML serialization is order-sensitive about tables, so "it serializes" was an assumption worth testing rather than trusting.

## Coverage is 2 of 18, deliberately

Per your call: a spec expresses only proxy-oracle deployments. Thirteen alpha markets read `pyth-oracle.near` directly, two use a proxy named after the asset pair rather than the market (`proxy-oracle-cetes-usdc` for market `ixlmcetes-ixlmusdc`), one uses the LST oracle.

Those are **refused, not approximated** — a spec that re-derives to a different oracle account is a silent wrong answer. `refuses_a_market_it_cannot_express` asserts the error names both the deployed oracle and what a spec would derive instead.

Stated in the module docs, the test docs, and here, because a gate that quietly covers 11% reads like one that covers everything.

## Notable

- `symbol` is left unset by export rather than invented. A plausible-looking ticker would give ENG-543's reference check a guess to verify.
- Account-id derivation moved to free functions in `spec` (`oracle_account_id`, `governance_account_id`). Export needs them before it has a spec to call methods on, and a second copy of the naming convention is the duplication this epic exists to remove.
- Governance admin is a required flag: no read method exposes it, so it cannot be recovered from chain state. Version keys *are* recovered, from the registry deployment records.

## Verification

`cargo fmt` · `cargo check --workspace` clean · `cargo clippy -p templar-manager --tests -- -D warnings` clean · `just test-fast -p templar-manager` 163/163.

`/simplify` ran before this landed and produced five findings, all applied — notably that the read chain sat in `commands/`, breaking the layering `dispatch/mod.rs` documents (commands stay pure; multi-step IO lives in `dispatch/`). It now lives in `dispatch/export.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/541)
<!-- Reviewable:end -->
