### PR TITLE
feat(manager): on-chain preflight checks (ENG-541)

### DIFF
--- a/tools/manager/src/commands/spec.rs
+++ b/tools/manager/src/commands/spec.rs
@@ -1,16 +1,15 @@
-//! Local operations on a deployment spec. Nothing here touches the network —
-//! that is the property the offline checks exist to preserve.
+//! Local operations on a deployment spec. Arguments only — the preflight that
+//! fulfils `check` lives in [`crate::dispatch::preflight`], since it reads the
+//! chain.
 
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
 
-use crate::spec::{check, extends};
-
 #[derive(Subcommand, Debug)]
 #[command(rename_all = "kebab-case")]
 pub enum SpecNs {
-    /// Resolve a spec's `extends` chain and run every offline check.
+    /// Resolve a spec's `extends` chain and run its preflight checks.
     Check(Check),
     /// Emit the spec's JSON Schema, for editor completion and validation.
     PrintSchema,
@@ -19,37 +18,17 @@ pub enum SpecNs {
 #[derive(Args, Debug)]
 pub struct Check {
     /// Path to the market spec.
-    pub path: PathBuf,
-}
+    pub(crate) path: PathBuf,
 
-impl Check {
-    /// Load, check, and report. Fails when any check failed, so this is usable
-    /// as a gate in CI or a pre-deploy script.
-    pub fn run(&self) -> anyhow::Result<()> {
-        let spec = extends::load(&self.path)?;
-        let checks = check::run_offline(&spec);
+    /// Skip every check that reads the chain. The remaining checks need no
+    /// network, so this is the form to run in CI.
+    #[arg(long)]
+    pub(crate) offline: bool,
 
-        // The derived proxies are reported, not just the ids: their freshness
-        // bounds are defaulted here, so an operator should be able to see the
-        // resolved result before anything is deployed.
-        let price_maximum_age = spec.market.price_maximum_age;
-        crate::context::print_json(&serde_json::json!({
-            "market_id": spec.market_id()?,
-            "oracle_id": spec.oracle_id()?,
-            "governance_id": spec.governance_id()?,
-            "network": spec.network()?.to_string(),
-            "collateral_proxy": spec.collateral.clone().into_proxy(price_maximum_age),
-            "borrow_proxy": spec.borrow.clone().into_proxy(price_maximum_age),
-            "checks": checks,
-        }))?;
-
-        let failed = checks
-            .iter()
-            .filter(|check| check.status.is_failure())
-            .count();
-        anyhow::ensure!(failed == 0, "{failed} check(s) failed");
-        Ok(())
-    }
+    /// Accept a `decimals` override that disagrees with the token's metadata.
+    /// Only correct when the spec is right and the token is lying.
+    #[arg(long)]
+    pub(crate) accept_decimals_mismatch: bool,
 }
 
 /// Print the spec's JSON Schema.

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -6,6 +6,7 @@
 
 mod export;
 pub(crate) mod generic;
+mod preflight;
 mod proposals;
 mod teardown;
 
@@ -41,17 +42,16 @@ pub(crate) async fn dispatch(ctx: CliContext, command: Command) -> anyhow::Resul
         Command::Oracle { command } => oracle(ctx, command).await,
         Command::Pyth { command } => pyth(ctx, command).await,
         Command::Redstone { command } => redstone(ctx, command).await,
-        // Spec commands are purely local; the gateway context is unused.
-        Command::Spec { command } => spec(command),
+        Command::Spec { command } => spec(ctx, command).await,
         Command::RecoverNep141(args) => teardown::recover_nep141(ctx, args).await,
         Command::Read(call) => generic::read(ctx, call).await,
         Command::Write(call) => generic::write(ctx, call).await,
     }
 }
 
-fn spec(ns: SpecNs) -> anyhow::Result<()> {
+async fn spec(ctx: CliContext, ns: SpecNs) -> anyhow::Result<()> {
     match ns {
-        SpecNs::Check(a) => a.run(),
+        SpecNs::Check(a) => preflight::check(ctx, a).await,
         SpecNs::PrintSchema => crate::commands::spec::print_schema(),
     }
 }

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -1,0 +1,342 @@
+//! On-chain preflight for a deployment spec: read-only checks that run before
+//! any transaction.
+//!
+//! IO lives here rather than in `spec`, which stays offline so its checks and
+//! `market export` can be unit-tested without a network.
+
+use anyhow::Context as _;
+use near_account_id::AccountId;
+use templar_common::asset::{AssetClass, FungibleAsset};
+use templar_gateway_core::GatewayError;
+use templar_gateway_methods_spec::{account, contract, redstone, registry};
+use templar_gateway_types::common::{ContractArgs, Pagination};
+
+use crate::commands::spec::Check as CheckArgs;
+use crate::context::{print_json, CliContext};
+use crate::spec::{
+    check::{reconcile_decimals, Check, OnChainDecimals, Status},
+    oracle::{AssetSpec, SourceSpec},
+    MarketSpec,
+};
+
+/// `spec check` — load a spec, run its checks, and report. Fails when any check
+/// failed, so it is usable as a gate in CI or a pre-deploy script.
+pub(super) async fn check(ctx: CliContext, args: CheckArgs) -> anyhow::Result<()> {
+    let mut spec = crate::spec::extends::load(&args.path)?;
+    let mut checks = Vec::new();
+
+    if args.offline {
+        checks.push(Check::new(
+            "preflight.online",
+            Status::Skipped {
+                reason: "--offline".to_owned(),
+            },
+        ));
+    } else {
+        // Online first, writing resolved decimals back into the spec. Otherwise
+        // `config.validate` reports itself skipped for want of decimals this
+        // very run just read off the chain.
+        checks.extend(run(&ctx, &mut spec, args.accept_decimals_mismatch).await?);
+    }
+    // Offline checks run last so they see those decimals.
+    checks.extend(crate::spec::check::run_offline(&spec));
+
+    let price_maximum_age = spec.market.price_maximum_age;
+    print_json(&serde_json::json!({
+        "market_id": spec.market_id()?,
+        "oracle_id": spec.oracle_id()?,
+        "governance_id": spec.governance_id()?,
+        "network": spec.network()?.to_string(),
+        "collateral_proxy": spec.collateral.clone().into_proxy(price_maximum_age),
+        "borrow_proxy": spec.borrow.clone().into_proxy(price_maximum_age),
+        "checks": checks,
+    }))?;
+
+    let failed = checks
+        .iter()
+        .filter(|check| check.status.is_failure())
+        .count();
+    anyhow::ensure!(failed == 0, "{failed} check(s) failed");
+    Ok(())
+}
+
+/// Every check that needs the chain, in a stable order so two runs of the same
+/// spec produce comparable reports. Takes the spec mutably to write back the
+/// decimals it resolves.
+async fn run(
+    ctx: &CliContext,
+    spec: &mut MarketSpec,
+    accept_mismatch: bool,
+) -> anyhow::Result<Vec<Check>> {
+    let mut checks = Vec::new();
+    checks.extend(asset_checks(ctx, "collateral", &mut spec.collateral, accept_mismatch).await);
+    checks.extend(asset_checks(ctx, "borrow", &mut spec.borrow, accept_mismatch).await);
+    checks.extend(versions(ctx, spec).await?);
+    checks.extend(accounts(ctx, spec).await);
+    Ok(checks)
+}
+
+/// Existence, decimals, and source checks for one side of the pair.
+///
+/// Generic over the asset class rather than erasing it: the typed accessors on
+/// [`FungibleAsset`] identify the underlying token, and going through `Display`
+/// instead would tie this to that format staying fixed.
+async fn asset_checks<A: AssetClass>(
+    ctx: &CliContext,
+    side: &str,
+    spec: &mut AssetSpec<A>,
+    accept_mismatch: bool,
+) -> Vec<Check> {
+    let contract_id = spec.asset.contract_id().to_owned();
+    let mut checks = vec![Check::new(
+        format!("asset.exists.{side}"),
+        match exists(ctx, &contract_id).await {
+            Ok(true) => Status::passed(spec.asset.to_string()),
+            Ok(false) => Status::failed(format!("`{contract_id}` does not exist")),
+            Err(error) => Status::failed(format!("{error:#}")),
+        },
+    )];
+
+    let on_chain = match underlying_ft(&spec.asset) {
+        Some(account_id) => match ft_decimals(ctx, &account_id).await {
+            Ok(Some(decimals)) => OnChainDecimals::Known(decimals),
+            Ok(None) | Err(_) => OnChainDecimals::Unavailable,
+        },
+        None => OnChainDecimals::Unavailable,
+    };
+    let (status, resolved) = reconcile_decimals(side, spec.decimals, on_chain, accept_mismatch);
+    spec.decimals = resolved;
+    checks.push(Check::new(format!("asset.decimals.{side}"), status));
+
+    for (index, source) in spec.sources.iter().enumerate() {
+        checks.push(Check::new(
+            format!("oracle.source.{side}.{index}"),
+            source_status(ctx, source).await,
+        ));
+    }
+
+    checks
+}
+
+/// The adapter must exist. Whether it currently *holds* a price for the feed is
+/// reported, not required.
+///
+/// An adapter carries a feed once someone pushes one — Pyth Lazer will verify
+/// any feed it signs, and RedStone any feed written to it. A market being
+/// deployed for the first time may name a feed that has never appeared on this
+/// adapter on this chain, which says nothing about whether the adapter supports
+/// it. Failing on absence would block exactly the new-market case this pipeline
+/// exists for, so absence is reported as unverified instead.
+async fn source_status(ctx: &CliContext, source: &SourceSpec) -> Status {
+    let oracle_id = source.oracle_id();
+    match exists(ctx, oracle_id).await {
+        Ok(false) => return Status::failed(format!("adapter `{oracle_id}` does not exist")),
+        Err(error) => return Status::failed(format!("{error:#}")),
+        Ok(true) => {}
+    }
+
+    match holds_price(ctx, source).await {
+        Ok(true) => Status::passed(format!(
+            "{} on {oracle_id}, currently carrying a price",
+            describe(source)
+        )),
+        Ok(false) => Status::Skipped {
+            reason: format!(
+                "`{oracle_id}` holds no price for {} yet, which is expected for a feed \
+                 not previously used here and does not mean it is unsupported. The \
+                 aggregation dry-run cannot verify this feed until a price is pushed.",
+                describe(source)
+            ),
+        },
+        Err(error) => Status::failed(format!("{error:#}")),
+    }
+}
+
+/// Whether the adapter currently holds a price for this feed.
+async fn holds_price(ctx: &CliContext, source: &SourceSpec) -> anyhow::Result<bool> {
+    match source {
+        SourceSpec::Lazer {
+            oracle, feed_id, ..
+        } => {
+            // No typed gateway method covers the Lazer adapter, so this uses the
+            // documented generic escape hatch. `get_feed_data` answers `null`
+            // for a feed it is not currently carrying.
+            let result = ctx
+                .client
+                .read(contract::ViewFunction {
+                    contract_id: oracle.clone(),
+                    method_name: "get_feed_data".to_owned().into(),
+                    args: ContractArgs::Json(serde_json::json!({ "feed_id": feed_id })),
+                })
+                .await
+                .with_context(|| format!("read lazer feed {feed_id} from {oracle}"))?;
+            Ok(!result.value.is_null())
+        }
+        SourceSpec::RedStone {
+            oracle, price_id, ..
+        } => {
+            let result = ctx
+                .client
+                .read(redstone::ReadPriceData {
+                    oracle_id: oracle.clone(),
+                    feed_ids: vec![price_id.clone().into()],
+                })
+                .await
+                .with_context(|| format!("read redstone `{price_id}` from {oracle}"))?;
+            Ok(!result.entries.is_empty())
+        }
+    }
+}
+
+fn describe(source: &SourceSpec) -> String {
+    match source {
+        SourceSpec::Lazer { feed_id, .. } => format!("lazer feed {feed_id}"),
+        SourceSpec::RedStone { price_id, .. } => format!("redstone `{price_id}`"),
+    }
+}
+
+/// The NEP-141 account whose `ft_metadata` defines this asset's decimals.
+///
+/// A NEP-245 wrapper does not define them: `intents.near` holds many tokens, and
+/// the value that matters belongs to the *underlying* one its token id names.
+/// Where that id does not name a NEP-141 account, nothing on chain answers — and
+/// that is precisely the case the spec's `decimals` override exists for.
+fn underlying_ft<A: AssetClass>(asset: &FungibleAsset<A>) -> Option<AccountId> {
+    if let Some(contract_id) = asset.clone().into_nep141() {
+        return Some(contract_id);
+    }
+    asset
+        .nep245_token_id()?
+        .strip_prefix("nep141:")?
+        .parse()
+        .ok()
+}
+
+async fn ft_decimals(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result<Option<u8>> {
+    let result = ctx
+        .client
+        .read(contract::ViewFunction {
+            contract_id: account_id.clone(),
+            method_name: "ft_metadata".to_owned().into(),
+            args: ContractArgs::Json(serde_json::json!({})),
+        })
+        .await
+        .with_context(|| format!("read ft_metadata from {account_id}"))?;
+
+    Ok(result
+        .value
+        .get("decimals")
+        .and_then(serde_json::Value::as_u64)
+        .and_then(|decimals| u8::try_from(decimals).ok()))
+}
+
+/// Every version key must already be registered, or the deploy fails partway —
+/// which is how `deploy.sh` leaves an orphaned governance contract today.
+async fn versions(ctx: &CliContext, spec: &MarketSpec) -> anyhow::Result<Vec<Check>> {
+    let registered = ctx
+        .client
+        .read(registry::ListVersions {
+            registry_id: spec.registry.clone(),
+            args: Pagination::default(),
+        })
+        .await
+        .with_context(|| format!("list versions in {}", spec.registry))?;
+
+    Ok([
+        ("market", &spec.versions.market),
+        ("oracle", &spec.versions.proxy_oracle),
+        ("governance", &spec.versions.proxy_governance),
+    ]
+    .into_iter()
+    .map(|(label, key)| {
+        Check::new(
+            format!("registry.version.{label}"),
+            if registered.values.iter().any(|known| known == key) {
+                Status::passed(key.clone())
+            } else {
+                Status::failed(format!(
+                    "`{key}` is not registered in {}; the deploy would fail partway",
+                    spec.registry
+                ))
+            },
+        )
+    })
+    .collect())
+}
+
+/// Yield recipients must exist, or that share of yield is unclaimable.
+async fn accounts(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
+    let mut checks = vec![account_check(ctx, "protocol", &spec.market.protocol_account_id).await];
+    for account_id in spec.market.yield_weights.r#static.keys() {
+        checks.push(account_check(ctx, "yield_static", account_id).await);
+    }
+    checks
+}
+
+async fn account_check(ctx: &CliContext, label: &str, account_id: &AccountId) -> Check {
+    Check::new(
+        format!("account.exists.{label}"),
+        match exists(ctx, account_id).await {
+            Ok(true) => Status::passed(account_id.to_string()),
+            Ok(false) => Status::failed(format!("`{account_id}` does not exist")),
+            Err(error) => Status::failed(format!("{error:#}")),
+        },
+    )
+}
+
+/// Whether the account exists.
+///
+/// Only `AccountNotFound` means "no"; every other failure propagates. A timed-out
+/// RPC reported as "this account does not exist" would send an operator off to
+/// create an account that is already there.
+async fn exists(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result<bool> {
+    match ctx
+        .client
+        .read(account::Get {
+            account_id: account_id.clone(),
+        })
+        .await
+    {
+        Ok(_) => Ok(true),
+        Err(GatewayError::AccountNotFound(_)) => Ok(false),
+        Err(error) => {
+            Err(anyhow::Error::new(error).context(format!("look up account {account_id}")))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::underlying_ft;
+    use templar_common::asset::{CollateralAsset, FungibleAsset};
+
+    /// Which token defines an asset's decimals is not obvious, and getting it
+    /// wrong silently mis-scales every price the market sees.
+    #[test]
+    fn resolves_the_token_that_defines_decimals() {
+        let nep141: FungibleAsset<CollateralAsset> =
+            "nep141:usdc.near".parse().expect("valid asset");
+        assert_eq!(
+            underlying_ft(&nep141).map(|id| id.to_string()),
+            Some("usdc.near".to_owned())
+        );
+
+        // A NEP-245 wrapper does not define decimals; the token it names does.
+        let wrapped: FungibleAsset<CollateralAsset> =
+            "nep245:intents.near:nep141:eth-0xce6170.omft.near"
+                .parse()
+                .expect("valid asset");
+        assert_eq!(
+            underlying_ft(&wrapped).map(|id| id.to_string()),
+            Some("eth-0xce6170.omft.near".to_owned())
+        );
+
+        // A NEP-245 token id that names no NEP-141 account: nothing on chain
+        // answers, so the spec's `decimals` override is the only source.
+        let opaque: FungibleAsset<CollateralAsset> =
+            "nep245:intents.near:nep245:v2_1.omni.hot.tg:1100_abc"
+                .parse()
+                .expect("valid asset");
+        assert_eq!(underlying_ft(&opaque), None);
+    }
+}

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -97,14 +97,10 @@ async fn asset_checks<A: AssetClass>(
         },
     )];
 
-    let on_chain = match underlying_ft(&spec.asset) {
-        Some(account_id) => match ft_decimals(ctx, &account_id).await {
-            Ok(Some(decimals)) => OnChainDecimals::Known(decimals),
-            Ok(None) | Err(_) => OnChainDecimals::Unavailable,
-        },
-        None => OnChainDecimals::Unavailable,
+    let (status, resolved) = match underlying_decimals(ctx, side, &spec.asset).await {
+        Ok(on_chain) => reconcile_decimals(side, spec.decimals, on_chain, accept_mismatch),
+        Err(status) => (status, None),
     };
-    let (status, resolved) = reconcile_decimals(side, spec.decimals, on_chain, accept_mismatch);
     spec.decimals = resolved;
     checks.push(Check::new(format!("asset.decimals.{side}"), status));
 
@@ -210,6 +206,54 @@ fn underlying_ft<A: AssetClass>(asset: &FungibleAsset<A>) -> Option<AccountId> {
         .strip_prefix("nep141:")?
         .parse()
         .ok()
+}
+
+/// What the chain says about the decimals of the token that defines them, or a
+/// failed check.
+///
+/// `asset.exists` only covers `contract_id`, which for a NEP-245 asset is the
+/// *wrapper* — `intents.near` — not the token named inside its token id. So this
+/// is the only place the underlying account is ever touched, and swallowing its
+/// errors here means a mistyped bridge address produces an all-green report.
+/// That is the worst outcome the preflight can have, so:
+///
+/// - a token id naming an account that does not exist is a **failure**, not
+///   "unverified";
+/// - any other read failure is a **failure**, not "this token publishes no
+///   metadata";
+/// - only a real account with absent or unparseable metadata is `Unavailable`,
+///   which is the case the spec's `decimals` override exists for.
+async fn underlying_decimals<A: AssetClass>(
+    ctx: &CliContext,
+    side: &str,
+    asset: &FungibleAsset<A>,
+) -> Result<OnChainDecimals, Status> {
+    // An opaque NEP-245 token id names no NEP-141 account; nothing on chain can
+    // answer, and the override is the only source.
+    let Some(account_id) = underlying_ft(asset) else {
+        return Ok(OnChainDecimals::Unavailable);
+    };
+
+    match exists(ctx, &account_id).await {
+        Ok(true) => {}
+        Ok(false) => {
+            return Err(Status::failed(format!(
+                "the {side} token id names `{account_id}`, which does not exist. \
+                 Check the asset string — `asset.exists.{side}` only covers the \
+                 NEP-245 wrapper, not the token inside it."
+            )))
+        }
+        Err(error) => return Err(Status::failed(format!("{error:#}"))),
+    }
+
+    match ft_decimals(ctx, &account_id).await {
+        Ok(Some(decimals)) => Ok(OnChainDecimals::Known(decimals)),
+        Ok(None) => Ok(OnChainDecimals::Unavailable),
+        Err(error) => Err(Status::failed(format!(
+            "could not read decimals from `{account_id}`: {error:#}. This is \
+             inconclusive, not evidence the token publishes no metadata."
+        ))),
+    }
 }
 
 async fn ft_decimals(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result<Option<u8>> {

--- a/tools/manager/src/spec/check.rs
+++ b/tools/manager/src/spec/check.rs
@@ -49,7 +49,7 @@ pub struct Check {
 }
 
 impl Check {
-    fn new(id: impl Into<String>, status: Status) -> Self {
+    pub(crate) fn new(id: impl Into<String>, status: Status) -> Self {
         Self {
             id: id.into(),
             status,
@@ -70,6 +70,68 @@ pub fn run_offline(spec: &MarketSpec) -> Vec<Check> {
         sources(spec),
         validate_configuration(spec),
     ]
+}
+
+/// What the chain said about a token's decimals.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnChainDecimals {
+    /// `ft_metadata`/`mt_metadata` answered.
+    Known(u8),
+    /// The contract exists but its metadata is missing or unreadable. Real: at
+    /// least one bridged asset shipped without `ft_metadata` populated.
+    Unavailable,
+}
+
+/// Reconcile the spec's optional `decimals` override against the chain.
+///
+/// Pure, so the whole matrix is unit-testable without a network — the IO around
+/// it is a single view call.
+pub fn reconcile_decimals(
+    side: &str,
+    declared: Option<u8>,
+    on_chain: OnChainDecimals,
+    accept_mismatch: bool,
+) -> (Status, Option<u8>) {
+    match (declared, on_chain) {
+        (None, OnChainDecimals::Known(actual)) => (
+            Status::passed(format!("{actual} (from token metadata)")),
+            Some(actual),
+        ),
+        (None, OnChainDecimals::Unavailable) => (
+            Status::failed(format!(
+                "the {side} token publishes no readable decimals; set `{side}.decimals` \
+                 in the spec, verified against the asset's source chain"
+            )),
+            None,
+        ),
+        (Some(declared), OnChainDecimals::Known(actual)) if declared == actual => (
+            Status::passed(format!("{actual}, matching token metadata")),
+            Some(actual),
+        ),
+        (Some(declared), OnChainDecimals::Known(actual)) if accept_mismatch => (
+            Status::passed(format!(
+                "{declared} declared, overriding {actual} from token metadata \
+                 (--accept-decimals-mismatch)"
+            )),
+            Some(declared),
+        ),
+        (Some(declared), OnChainDecimals::Known(actual)) => (
+            Status::failed(format!(
+                "{side}.decimals says {declared} but token metadata says {actual}. \
+                 One of them is wrong; pass --accept-decimals-mismatch only if the \
+                 spec is right and the token is lying."
+            )),
+            None,
+        ),
+        (Some(declared), OnChainDecimals::Unavailable) => (
+            // Not a failure: this is exactly the case the override exists for.
+            // But it is unverified, and the report must not imply otherwise.
+            Status::passed(format!(
+                "{declared} declared; token publishes no metadata, so this is unverified"
+            )),
+            Some(declared),
+        ),
+    }
 }
 
 /// A market whose two sides are the same asset prices itself against itself.

--- a/tools/manager/src/tests/spec.rs
+++ b/tools/manager/src/tests/spec.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use templar_common::market::MarketConfiguration;
 
 use crate::spec::{
-    check::{self, Status},
+    check::{self, OnChainDecimals, Status},
     extends,
     oracle::SourceSpec,
     MarketSpec, BORROW_PRICE_ID, COLLATERAL_PRICE_ID,
@@ -236,6 +236,43 @@ fn config_validate_is_skipped_not_passed_without_decimals() {
         .expect("config.validate should always be reported");
 
     assert!(matches!(validate.status, Status::Skipped { .. }));
+}
+
+/// The whole decimals matrix, pure and offline. The override exists because a
+/// bridged asset shipped without `ft_metadata`, so "declared, nothing on chain"
+/// must pass — while still reading as unverified, not as confirmed.
+#[rstest::rstest]
+#[case::derived(None, OnChainDecimals::Known(6), false, Some(6), false)]
+#[case::agrees(Some(6), OnChainDecimals::Known(6), false, Some(6), false)]
+#[case::disagrees(Some(8), OnChainDecimals::Known(6), false, None, true)]
+#[case::disagrees_accepted(Some(8), OnChainDecimals::Known(6), true, Some(8), false)]
+#[case::override_unverified(Some(8), OnChainDecimals::Unavailable, false, Some(8), false)]
+#[case::nothing_to_go_on(None, OnChainDecimals::Unavailable, false, None, true)]
+fn decimals_reconciliation(
+    #[case] declared: Option<u8>,
+    #[case] on_chain: OnChainDecimals,
+    #[case] accept_mismatch: bool,
+    #[case] expected: Option<u8>,
+    #[case] should_fail: bool,
+) {
+    let (status, resolved) =
+        check::reconcile_decimals("collateral", declared, on_chain, accept_mismatch);
+
+    assert_eq!(resolved, expected);
+    assert_eq!(status.is_failure(), should_fail, "{status:?}");
+}
+
+/// An unverified override must not read as confirmed — the report is what an
+/// operator trusts before spending real NEAR.
+#[test]
+fn an_unverified_override_says_so() {
+    let (status, _) =
+        check::reconcile_decimals("borrow", Some(8), OnChainDecimals::Unavailable, false);
+
+    assert!(
+        matches!(&status, Status::Passed { detail } if detail.contains("unverified")),
+        "{status:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
Sub-PR 4 of 10 for ENG-537. Closes ENG-541. Targets the integration branch; master PR #540 is the gate.

## What

Read-only checks before any transaction: `asset.exists.*`, `asset.decimals.*`, `oracle.source.*`, `registry.version.*`, `account.exists.*`. `spec check` gains `--offline` (no network, CI-usable) and `--accept-decimals-mismatch`.

## Verified against mainnet

```
asset.decimals.collateral   passed   6, matching token metadata
asset.decimals.borrow       passed   7 declared; token publishes no metadata, so this is unverified
oracle.source.collateral.0  passed   lazer feed 14 on pyth-lazer.templar-alpha.near, currently carrying a price
registry.version.market     passed   v1.3.0
config.validate             passed   MarketConfiguration::validate
```

The borrow line is the bridged-asset case that motivated the `decimals` override: its NEP-245 token id names no NEP-141 account, so nothing on chain answers. Reported as **unverified**, not as confirmed.

## Three things worth reviewing

**Absence of a price is not evidence of an unsupported feed.** An adapter carries a feed once someone pushes one — Pyth Lazer verifies any feed it signs. A market deployed for the first time may name a feed that has never appeared on this adapter, which says nothing about support. So the adapter must exist (hard fail), but a missing price is reported as `Skipped` with the reason. Failing on it would block exactly the new-market case this pipeline exists for.

**Resolved decimals are written back into the spec before the offline checks run.** Otherwise `config.validate` reports itself skipped for want of decimals the same invocation just read off the chain — the two passes didn't compose.

**`exists` distinguishes `AccountNotFound` from other read failures.** `.is_ok()` would report a timed-out RPC as "this account does not exist", sending an operator to create an account that is already there. `GatewayError::AccountNotFound` already exists for this and is used the same way in `gateway/core/src/contract_kind.rs`.

## Verification

`cargo fmt` · `cargo clippy -p templar-manager --tests -- -D warnings` clean · `just test-fast -p templar-manager` 171/171 · mainnet smoke (read-only).

The decimals matrix is a pure function with 6 rstest cases, so the whole thing is testable without a network; the IO around it is one view call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/542)
<!-- Reviewable:end -->
