### PR TITLE
feat(manager): offline aggregation dry-run against live feeds (ENG-542)

### DIFF
--- a/tools/manager/src/dispatch/aggregate.rs
+++ b/tools/manager/src/dispatch/aggregate.rs
@@ -30,21 +30,80 @@ use crate::spec::{
 };
 
 /// `oracle.aggregate.{collateral,borrow,pair}`.
-pub(super) async fn checks(ctx: &CliContext, spec: &MarketSpec, now: Nanoseconds) -> Vec<Check> {
-    let (collateral, mut checks) = leg(ctx, "collateral", &spec.collateral, spec, now).await;
-    let (borrow, borrow_checks) = leg(ctx, "borrow", &spec.borrow, spec, now).await;
+///
+/// Both legs are fetched first, then judged against a single clock and a single
+/// anchor — mirroring the deployed contract, whose callback captures one block
+/// timestamp *after* every oracle result has arrived and resolves both legs
+/// against it. Per-leg clocks let a fresh collateral and a week-old borrow each
+/// pass on their own terms and produce a ratio the contract could never accept.
+pub(super) async fn checks(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
+    let collateral = fetch_all(ctx, &spec.collateral).await;
+    let borrow = fetch_all(ctx, &spec.borrow).await;
+
+    // Sampled after the fetches, not before. Sequential RPCs can outlast the
+    // drift allowance, and a feed updated mid-sweep would then read as
+    // future-drifted against a clock taken before it was even requested.
+    let now = wall_clock();
+
+    // One anchor for both legs, capped at wall-clock.
+    //
+    // Capped, because a source timestamped in the future but *within*
+    // `max_clock_drift` is legitimate to the contract, yet as an anchor it would
+    // age every honest peer by that difference. Shared, because the contract
+    // resolves both legs against the same instant.
+    let newest = collateral
+        .iter()
+        .chain(borrow.iter())
+        .filter_map(|fetched| fetched.as_ref().ok()?.as_ref())
+        .map(|price| price.publish_time_ns)
+        .max()
+        .unwrap_or(now);
+    let anchor = newest.min(now);
+
+    let (collateral_price, mut checks) = leg(
+        "collateral",
+        &spec.collateral,
+        spec,
+        collateral,
+        now,
+        anchor,
+    );
+    let (borrow_price, borrow_checks) = leg("borrow", &spec.borrow, spec, borrow, now, anchor);
     checks.extend(borrow_checks);
-    checks.push(pair(collateral, borrow));
+    checks.push(pair(collateral_price, borrow_price));
     checks
 }
 
-/// One side: fetch every source, report each, then aggregate.
-async fn leg<A: AssetClass>(
+/// Wall-clock, for freshness. The kernel takes `now` explicitly rather than
+/// reading a clock, which is what makes it testable; this is the one place a
+/// clock is read.
+fn wall_clock() -> Nanoseconds {
+    let since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    Nanoseconds::from_ns(u64::try_from(since_epoch.as_nanos()).unwrap_or(u64::MAX))
+}
+
+/// Every source's current price, in spec order.
+async fn fetch_all<A: AssetClass>(
     ctx: &CliContext,
+    asset: &AssetSpec<A>,
+) -> Vec<anyhow::Result<Option<Price>>> {
+    let mut fetched = Vec::with_capacity(asset.sources.len());
+    for source in &asset.sources {
+        fetched.push(fetch(ctx, source).await);
+    }
+    fetched
+}
+
+/// One side: fetch every source, report each, then aggregate.
+fn leg<A: AssetClass>(
     side: &str,
     asset: &AssetSpec<A>,
     spec: &MarketSpec,
+    fetched_sources: Vec<anyhow::Result<Option<Price>>>,
     now: Nanoseconds,
+    anchor: Nanoseconds,
 ) -> (Option<Price>, Vec<Check>) {
     let mut checks = Vec::new();
     let mut prices = Vec::with_capacity(asset.sources.len());
@@ -62,8 +121,8 @@ async fn leg<A: AssetClass>(
     let drift_limit = Nanoseconds::from_ns(now.as_ns().saturating_add(max_drift.as_ns()));
 
     let mut transport_failed = false;
-    for (index, source) in asset.sources.iter().enumerate() {
-        let fetched = fetch(ctx, source).await;
+    for ((index, source), fetched) in asset.sources.iter().enumerate().zip(fetched_sources) {
+        let fetched = &fetched;
         let drifted = matches!(&fetched, Ok(Some(price)) if price.publish_time_ns > drift_limit);
 
         checks.push(Check::new(
@@ -99,25 +158,9 @@ async fn leg<A: AssetClass>(
         prices.push(if drifted {
             None
         } else {
-            fetched.ok().flatten()
+            fetched.as_ref().ok().and_then(|price| *price)
         });
     }
-
-    // Age is measured between the sources, not against wall-clock.
-    //
-    // An adapter holds whatever price was last pushed to it; the relayer pushes
-    // a fresh one when an operation needs it. So at rest a perfectly healthy
-    // feed is routinely hours old, and filtering on wall-clock would report
-    // every market as unaggregatable — a check that always fails tells you
-    // nothing. Anchoring on the newest surviving price still catches the failure
-    // that matters here: one source lagging far behind its peers. Absolute ages
-    // are reported per source above, so real staleness stays visible.
-    let anchor = prices
-        .iter()
-        .flatten()
-        .map(|price| price.publish_time_ns)
-        .max()
-        .unwrap_or(now);
 
     // How many sources actually contributed. Distinguishes "nothing to judge"
     // from "judged and rejected", which decide Skipped vs Failed below.

--- a/tools/manager/src/dispatch/aggregate.rs
+++ b/tools/manager/src/dispatch/aggregate.rs
@@ -119,6 +119,10 @@ async fn leg<A: AssetClass>(
         .max()
         .unwrap_or(now);
 
+    // How many sources actually contributed. Distinguishes "nothing to judge"
+    // from "judged and rejected", which decide Skipped vs Failed below.
+    let live = prices.iter().flatten().count();
+
     // Cloned because `into_proxy` consumes, and the spec is still needed after.
     let proxy = asset.clone().into_proxy(spec.market.price_maximum_age);
     // No breakers: the oracle does not exist yet, so there is no configured set
@@ -137,15 +141,17 @@ async fn leg<A: AssetClass>(
                 None,
             ),
         },
-        // Too few live sources is the expected shape for a market whose feeds
-        // have not been pushed yet, so it reads as "could not run", not "wrong".
-        // A source that errored is not a source that is quiet. Reporting a
-        // transport failure as "expected" would let a misconfigured adapter read
-        // like a feed awaiting its first push.
-        Err(error) if transport_failed => (
+        // `Skipped` is only for "there was nothing to judge". If any source
+        // produced a price and the aggregation still rejected the set, the
+        // configuration is wrong and the deployed proxy would fail on the same
+        // inputs — reporting that as skipped would exit zero and green-light the
+        // deployment, since only failures are counted.
+        Err(error) if live > 0 || transport_failed => (
             Status::failed(format!(
-                "{} could not aggregate ({error:?}) because a source could not be \
-                 read — see the failed `oracle.price.{side}.*` above",
+                "{} could not aggregate ({error:?}) from {live} live source(s). \
+                 The deployed proxy would fail on the same inputs — check \
+                 `min_sources`, the freshness bounds, and the failed \
+                 `oracle.price.{side}.*` above.",
                 aggregator_label(asset)
             )),
             None,
@@ -153,9 +159,9 @@ async fn leg<A: AssetClass>(
         Err(error) => (
             Status::Skipped {
                 reason: format!(
-                    "{} could not aggregate: {error:?}. With feeds that carry no \
-                     price yet this is expected; once they do, re-run before \
-                     deploying.",
+                    "{} has no live sources to aggregate ({error:?}). For feeds \
+                     awaiting their first push this is expected; re-run once they \
+                     carry a price, before deploying.",
                     aggregator_label(asset)
                 ),
             },

--- a/tools/manager/src/dispatch/aggregate.rs
+++ b/tools/manager/src/dispatch/aggregate.rs
@@ -25,7 +25,7 @@ use templar_proxy_oracle_near_common::convert::pyth_price_try_to_kernel;
 use crate::context::CliContext;
 use crate::spec::{
     check::{Check, Status},
-    oracle::{AssetSpec, SourceSpec},
+    oracle::{AssetSpec, SourceSpec, DEFAULT_MAX_CLOCK_DRIFT},
     MarketSpec,
 };
 
@@ -49,11 +49,34 @@ async fn leg<A: AssetClass>(
     let mut checks = Vec::new();
     let mut prices = Vec::with_capacity(asset.sources.len());
 
+    // Clock drift is checked against wall-clock, before anything is anchored.
+    //
+    // The anchor below is the newest fetched price, so whichever source defines
+    // it is always evaluated at age zero. That makes the filter's own
+    // `max_clock_drift` bound unreachable here — a source with a bogus *future*
+    // timestamp would become the anchor, pass trivially, and push every honest
+    // peer past `max_age`, so the dry run would report a price built from the
+    // one bad source while production rejected exactly that source. Drift is
+    // only meaningful against a real clock, so it is judged here instead.
+    let max_drift = asset.max_clock_drift.unwrap_or(DEFAULT_MAX_CLOCK_DRIFT);
+    let drift_limit = Nanoseconds::from_ns(now.as_ns().saturating_add(max_drift.as_ns()));
+
+    let mut transport_failed = false;
     for (index, source) in asset.sources.iter().enumerate() {
         let fetched = fetch(ctx, source).await;
+        let drifted = matches!(&fetched, Ok(Some(price)) if price.publish_time_ns > drift_limit);
+
         checks.push(Check::new(
             format!("oracle.price.{side}.{index}"),
             match &fetched {
+                Ok(Some(price)) if drifted => Status::failed(format!(
+                    "{} is timestamped {}s in the future, beyond the {}s clock-drift \
+                     bound. The deployed oracle would reject it.",
+                    source.describe(),
+                    Nanoseconds::from_ns(price.publish_time_ns.as_ns().saturating_sub(now.as_ns()))
+                        .as_secs(),
+                    max_drift.as_secs(),
+                )),
                 Ok(Some(price)) => Status::passed(describe_price(source, price, now)),
                 Ok(None) => Status::Skipped {
                     reason: format!(
@@ -65,22 +88,30 @@ async fn leg<A: AssetClass>(
                 Err(error) => Status::failed(format!("{}: {error:#}", source.describe())),
             },
         ));
+
+        if fetched.is_err() {
+            transport_failed = true;
+        }
         // Order matters: `Proxy::resolve` zips these against its own source list
         // and rejects a length mismatch, so every source needs a slot — `None`
-        // for one that did not answer, which is what `min_sources` weighs.
-        prices.push(fetched.ok().flatten());
+        // for one that did not answer, which is what `min_sources` weighs. A
+        // drifted price is dropped too: the deployed oracle would not use it.
+        prices.push(if drifted {
+            None
+        } else {
+            fetched.ok().flatten()
+        });
     }
 
-    // Freshness is measured between the sources, not against wall-clock.
+    // Age is measured between the sources, not against wall-clock.
     //
     // An adapter holds whatever price was last pushed to it; the relayer pushes
     // a fresh one when an operation needs it. So at rest a perfectly healthy
     // feed is routinely hours old, and filtering on wall-clock would report
     // every market as unaggregatable — a check that always fails tells you
-    // nothing. Anchoring on the newest price still catches the failure that
-    // matters here: one source lagging far behind its peers, which is what
-    // `max_age` guards against once the oracle is live. Absolute ages are
-    // reported per source above, so real staleness stays visible.
+    // nothing. Anchoring on the newest surviving price still catches the failure
+    // that matters here: one source lagging far behind its peers. Absolute ages
+    // are reported per source above, so real staleness stays visible.
     let anchor = prices
         .iter()
         .flatten()
@@ -108,6 +139,17 @@ async fn leg<A: AssetClass>(
         },
         // Too few live sources is the expected shape for a market whose feeds
         // have not been pushed yet, so it reads as "could not run", not "wrong".
+        // A source that errored is not a source that is quiet. Reporting a
+        // transport failure as "expected" would let a misconfigured adapter read
+        // like a feed awaiting its first push.
+        Err(error) if transport_failed => (
+            Status::failed(format!(
+                "{} could not aggregate ({error:?}) because a source could not be \
+                 read — see the failed `oracle.price.{side}.*` above",
+                aggregator_label(asset)
+            )),
+            None,
+        ),
         Err(error) => (
             Status::Skipped {
                 reason: format!(

--- a/tools/manager/src/dispatch/aggregate.rs
+++ b/tools/manager/src/dispatch/aggregate.rs
@@ -1,0 +1,234 @@
+//! Offline aggregation dry-run: fetch each upstream feed, then run the proxy's
+//! own aggregation locally.
+//!
+//! Nothing needs to be deployed. The oracle this market will use does not exist
+//! yet, so the adapters are queried directly and
+//! [`Proxy::resolve`](templar_proxy_oracle_kernel::proxy::Proxy::resolve) — pure
+//! `no_std`, the same code the contract runs — is applied to the results against
+//! an empty circuit-breaker set. That makes the number a market would actually
+//! consume visible *before* the first transaction.
+//!
+//! Absence of a price is not a failure. An adapter carries a feed once someone
+//! pushes one, so a market deployed for the first time may name a feed with no
+//! data yet; that is reported, not rejected (see ENG-541).
+
+use anyhow::Context as _;
+use templar_common::asset::AssetClass;
+use templar_common::oracle::{lazer, pyth, redstone as redstone_types};
+use templar_common::Nanoseconds;
+use templar_gateway_methods_spec::{contract, redstone};
+use templar_gateway_types::common::ContractArgs;
+use templar_proxy_oracle_kernel::proxy::circuit_breaker::{CircuitBreaker, CircuitBreakerSet};
+use templar_proxy_oracle_kernel::Price;
+use templar_proxy_oracle_near_common::convert::pyth_price_try_to_kernel;
+
+use crate::context::CliContext;
+use crate::spec::{
+    check::{Check, Status},
+    oracle::{AssetSpec, SourceSpec},
+    MarketSpec,
+};
+
+/// `oracle.aggregate.{collateral,borrow,pair}`.
+pub(super) async fn checks(ctx: &CliContext, spec: &MarketSpec, now: Nanoseconds) -> Vec<Check> {
+    let (collateral, mut checks) = leg(ctx, "collateral", &spec.collateral, spec, now).await;
+    let (borrow, borrow_checks) = leg(ctx, "borrow", &spec.borrow, spec, now).await;
+    checks.extend(borrow_checks);
+    checks.push(pair(collateral, borrow));
+    checks
+}
+
+/// One side: fetch every source, report each, then aggregate.
+async fn leg<A: AssetClass>(
+    ctx: &CliContext,
+    side: &str,
+    asset: &AssetSpec<A>,
+    spec: &MarketSpec,
+    now: Nanoseconds,
+) -> (Option<Price>, Vec<Check>) {
+    let mut checks = Vec::new();
+    let mut prices = Vec::with_capacity(asset.sources.len());
+
+    for (index, source) in asset.sources.iter().enumerate() {
+        let fetched = fetch(ctx, source).await;
+        checks.push(Check::new(
+            format!("oracle.price.{side}.{index}"),
+            match &fetched {
+                Ok(Some(price)) => Status::passed(describe_price(source, price, now)),
+                Ok(None) => Status::Skipped {
+                    reason: format!(
+                        "{} carries no price yet, so it contributes nothing to this \
+                         dry run",
+                        source.describe()
+                    ),
+                },
+                Err(error) => Status::failed(format!("{}: {error:#}", source.describe())),
+            },
+        ));
+        // Order matters: `Proxy::resolve` zips these against its own source list
+        // and rejects a length mismatch, so every source needs a slot — `None`
+        // for one that did not answer, which is what `min_sources` weighs.
+        prices.push(fetched.ok().flatten());
+    }
+
+    // Freshness is measured between the sources, not against wall-clock.
+    //
+    // An adapter holds whatever price was last pushed to it; the relayer pushes
+    // a fresh one when an operation needs it. So at rest a perfectly healthy
+    // feed is routinely hours old, and filtering on wall-clock would report
+    // every market as unaggregatable — a check that always fails tells you
+    // nothing. Anchoring on the newest price still catches the failure that
+    // matters here: one source lagging far behind its peers, which is what
+    // `max_age` guards against once the oracle is live. Absolute ages are
+    // reported per source above, so real staleness stays visible.
+    let anchor = prices
+        .iter()
+        .flatten()
+        .map(|price| price.publish_time_ns)
+        .max()
+        .unwrap_or(now);
+
+    // Cloned because `into_proxy` consumes, and the spec is still needed after.
+    let proxy = asset.clone().into_proxy(spec.market.price_maximum_age);
+    // No breakers: the oracle does not exist yet, so there is no configured set
+    // and nothing to trip. This measures the aggregation, not the guard rails.
+    let mut breakers = CircuitBreakerSet::<CircuitBreaker>::empty();
+    let resolved = proxy.resolve(&mut breakers, prices, anchor);
+
+    let (status, price) = match resolved {
+        Ok(outcome) => match outcome.value {
+            Ok(price) => (
+                Status::passed(format!("{} → {}", aggregator_label(asset), render(&price))),
+                Some(price),
+            ),
+            Err(reason) => (
+                Status::failed(format!("aggregation blocked: {reason:?}")),
+                None,
+            ),
+        },
+        // Too few live sources is the expected shape for a market whose feeds
+        // have not been pushed yet, so it reads as "could not run", not "wrong".
+        Err(error) => (
+            Status::Skipped {
+                reason: format!(
+                    "{} could not aggregate: {error:?}. With feeds that carry no \
+                     price yet this is expected; once they do, re-run before \
+                     deploying.",
+                    aggregator_label(asset)
+                ),
+            },
+            None,
+        ),
+    };
+    checks.push(Check::new(format!("oracle.aggregate.{side}"), status));
+
+    (price, checks)
+}
+
+/// The collateral/borrow price ratio — the number a human recognises.
+///
+/// Deliberately *not* decimals-adjusted. Decimals convert a raw token amount
+/// into a value when the market sizes a position; they play no part in the ratio
+/// of two USD prices. Applying them here would report 29.96 for a pair that
+/// trades at 2.996 — plausible enough to be believed, which is precisely the
+/// class of error this check exists to catch.
+fn pair(collateral: Option<Price>, borrow: Option<Price>) -> Check {
+    let id = "oracle.aggregate.pair";
+    let (Some(collateral), Some(borrow)) = (collateral, borrow) else {
+        return Check::new(
+            id,
+            Status::Skipped {
+                reason: "both legs must aggregate before a ratio means anything".to_owned(),
+            },
+        );
+    };
+
+    let borrow = scaled(&borrow);
+    if borrow == 0.0 {
+        return Check::new(
+            id,
+            Status::failed("the borrow leg aggregated to zero, so no ratio exists".to_owned()),
+        );
+    }
+
+    Check::new(
+        id,
+        Status::passed(format!(
+            "{} — sanity-check this against what the pair actually trades at",
+            scaled(&collateral) / borrow
+        )),
+    )
+}
+
+/// A price as a plain number, for reporting only.
+fn scaled(price: &Price) -> f64 {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "this value is displayed, never used for a decision"
+    )]
+    let value = price.price as f64;
+    value * 10f64.powi(price.expo)
+}
+
+fn render(price: &Price) -> String {
+    format!("{}", scaled(price))
+}
+
+fn describe_price(source: &SourceSpec, price: &Price, now: Nanoseconds) -> String {
+    let age_s =
+        Nanoseconds::from_ns(now.as_ns().saturating_sub(price.publish_time_ns.as_ns())).as_secs();
+    format!(
+        "{} w{} {} age {age_s}s",
+        source.describe(),
+        source.weight(),
+        render(price)
+    )
+}
+
+fn aggregator_label<A: AssetClass>(asset: &AssetSpec<A>) -> String {
+    format!("{:?} (min_sources {})", asset.aggregator, asset.min_sources)
+}
+
+/// One source's current price, projected exactly as the contract projects it.
+///
+/// `Ok(None)` means the adapter carries no price for this feed yet.
+async fn fetch(ctx: &CliContext, source: &SourceSpec) -> anyhow::Result<Option<Price>> {
+    let pyth_price: Option<pyth::Price> = match source {
+        SourceSpec::Lazer {
+            oracle, feed_id, ..
+        } => {
+            let result = ctx
+                .client
+                .read(contract::ViewFunction {
+                    contract_id: oracle.clone(),
+                    method_name: "get_feed_data".to_owned().into(),
+                    args: ContractArgs::Json(serde_json::json!({ "feed_id": feed_id })),
+                })
+                .await
+                .with_context(|| format!("read lazer feed {feed_id} from {oracle}"))?;
+
+            serde_json::from_value::<Option<lazer::FeedData>>(result.value)
+                .context("decode lazer feed data")?
+                // EMA, matching the adapter's own consumer path — spot would be
+                // a different number than the market will see.
+                .and_then(|feed| feed.to_ema_price())
+        }
+        SourceSpec::RedStone {
+            oracle, price_id, ..
+        } => ctx
+            .client
+            .read(redstone::ReadPriceData {
+                oracle_id: oracle.clone(),
+                feed_ids: vec![price_id.clone().into()],
+            })
+            .await
+            .with_context(|| format!("read redstone `{price_id}` from {oracle}"))?
+            .entries
+            .first()
+            .map(|entry| entry.data.clone())
+            .as_ref()
+            .and_then(redstone_types::FeedData::to_pyth_price),
+    };
+
+    Ok(pyth_price.as_ref().and_then(pyth_price_try_to_kernel))
+}

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -4,6 +4,7 @@
 //! flows live in focused submodules ([`teardown`], [`proposals`], [`generic`]) so
 //! this file stays a readable index of the command surface.
 
+mod aggregate;
 mod export;
 pub(crate) mod generic;
 mod preflight;

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -8,7 +8,7 @@ use anyhow::Context as _;
 use near_account_id::AccountId;
 use templar_common::asset::{AssetClass, FungibleAsset};
 use templar_gateway_core::GatewayError;
-use templar_gateway_methods_spec::{account, contract, redstone, registry};
+use templar_gateway_methods_spec::{account, contract, registry};
 use templar_gateway_types::common::{ContractArgs, Pagination};
 
 use crate::commands::spec::Check as CheckArgs;
@@ -84,7 +84,19 @@ async fn run(ctx: &CliContext, spec: &mut MarketSpec, accept_mismatch: bool) -> 
     checks.extend(asset_checks(ctx, "borrow", &mut spec.borrow, accept_mismatch).await);
     checks.extend(versions(ctx, spec).await);
     checks.extend(accounts(ctx, spec).await);
+    // Aggregation last: its per-source prices supersede any liveness probe the
+    // checks above would otherwise have to repeat.
+    checks.extend(super::aggregate::checks(ctx, spec, now()).await);
     checks
+}
+
+/// Wall-clock, for freshness filtering. The kernel takes `now` explicitly rather
+/// than reading a clock, which is what makes it testable.
+fn now() -> templar_common::Nanoseconds {
+    let since_epoch = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    templar_common::Nanoseconds::from_ns(u64::try_from(since_epoch.as_nanos()).unwrap_or(u64::MAX))
 }
 
 /// Existence, decimals, and source checks for one side of the pair.
@@ -125,80 +137,15 @@ async fn asset_checks<A: AssetClass>(
     checks
 }
 
-/// The adapter must exist. Whether it currently *holds* a price for the feed is
-/// reported, not required.
-///
-/// An adapter carries a feed once someone pushes one — Pyth Lazer will verify
-/// any feed it signs, and RedStone any feed written to it. A market being
-/// deployed for the first time may name a feed that has never appeared on this
-/// adapter on this chain, which says nothing about whether the adapter supports
-/// it. Failing on absence would block exactly the new-market case this pipeline
-/// exists for, so absence is reported as unverified instead.
+/// The adapter must exist. Whether it currently carries a price is reported by
+/// `oracle.price.*` in the aggregation dry-run, which fetches it anyway — asking
+/// here as well would round-trip every source twice.
 async fn source_status(ctx: &CliContext, source: &SourceSpec) -> Status {
     let oracle_id = source.oracle_id();
     match exists(ctx, oracle_id).await {
-        Ok(false) => return Status::failed(format!("adapter `{oracle_id}` does not exist")),
-        Err(error) => return Status::failed(format!("{error:#}")),
-        Ok(true) => {}
-    }
-
-    match holds_price(ctx, source).await {
-        Ok(true) => Status::passed(format!(
-            "{} on {oracle_id}, currently carrying a price",
-            describe(source)
-        )),
-        Ok(false) => Status::Skipped {
-            reason: format!(
-                "`{oracle_id}` holds no price for {} yet, which is expected for a feed \
-                 not previously used here and does not mean it is unsupported. The \
-                 aggregation dry-run cannot verify this feed until a price is pushed.",
-                describe(source)
-            ),
-        },
+        Ok(true) => Status::passed(format!("{} on {oracle_id}", source.describe())),
+        Ok(false) => Status::failed(format!("adapter `{oracle_id}` does not exist")),
         Err(error) => Status::failed(format!("{error:#}")),
-    }
-}
-
-/// Whether the adapter currently holds a price for this feed.
-async fn holds_price(ctx: &CliContext, source: &SourceSpec) -> anyhow::Result<bool> {
-    match source {
-        SourceSpec::Lazer {
-            oracle, feed_id, ..
-        } => {
-            // No typed gateway method covers the Lazer adapter, so this uses the
-            // documented generic escape hatch. `get_feed_data` answers `null`
-            // for a feed it is not currently carrying.
-            let result = ctx
-                .client
-                .read(contract::ViewFunction {
-                    contract_id: oracle.clone(),
-                    method_name: "get_feed_data".to_owned().into(),
-                    args: ContractArgs::Json(serde_json::json!({ "feed_id": feed_id })),
-                })
-                .await
-                .with_context(|| format!("read lazer feed {feed_id} from {oracle}"))?;
-            Ok(!result.value.is_null())
-        }
-        SourceSpec::RedStone {
-            oracle, price_id, ..
-        } => {
-            let result = ctx
-                .client
-                .read(redstone::ReadPriceData {
-                    oracle_id: oracle.clone(),
-                    feed_ids: vec![price_id.clone().into()],
-                })
-                .await
-                .with_context(|| format!("read redstone `{price_id}` from {oracle}"))?;
-            Ok(!result.entries.is_empty())
-        }
-    }
-}
-
-fn describe(source: &SourceSpec) -> String {
-    match source {
-        SourceSpec::Lazer { feed_id, .. } => format!("lazer feed {feed_id}"),
-        SourceSpec::RedStone { price_id, .. } => format!("redstone `{price_id}`"),
     }
 }
 

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -86,17 +86,8 @@ async fn run(ctx: &CliContext, spec: &mut MarketSpec, accept_mismatch: bool) -> 
     checks.extend(accounts(ctx, spec).await);
     // Aggregation last: its per-source prices supersede any liveness probe the
     // checks above would otherwise have to repeat.
-    checks.extend(super::aggregate::checks(ctx, spec, now()).await);
+    checks.extend(super::aggregate::checks(ctx, spec).await);
     checks
-}
-
-/// Wall-clock, for freshness filtering. The kernel takes `now` explicitly rather
-/// than reading a clock, which is what makes it testable.
-fn now() -> templar_common::Nanoseconds {
-    let since_epoch = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default();
-    templar_common::Nanoseconds::from_ns(u64::try_from(since_epoch.as_nanos()).unwrap_or(u64::MAX))
 }
 
 /// Existence, decimals, and source checks for one side of the pair.

--- a/tools/manager/src/spec/oracle.rs
+++ b/tools/manager/src/spec/oracle.rs
@@ -123,6 +123,14 @@ impl SourceSpec {
         }
     }
 
+    /// How this source reads in a report.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Lazer { feed_id, .. } => format!("lazer feed {feed_id}"),
+            Self::RedStone { price_id, .. } => format!("redstone `{price_id}`"),
+        }
+    }
+
     pub const fn weight(&self) -> u32 {
         match self {
             Self::Lazer { weight, .. } | Self::RedStone { weight, .. } => *weight,


### PR DESCRIPTION
Sub-PR 5 of 10 for ENG-537. Closes ENG-542.

## What

View-call the upstream adapters and run `Proxy::resolve` locally against an empty circuit-breaker set — the same pure `no_std` kernel code the contract runs. Nothing needs to be deployed; the oracle this market will use does not exist yet.

Live against mainnet:

```
oracle.price.collateral.0    passed   lazer feed 14 w8 1.08703666 age 6432s
oracle.price.collateral.1    passed   redstone `XRP` w2 1.08541043 age 6448s
oracle.aggregate.collateral  passed   MedianLow (min_sources 1) → 1.08685282
oracle.price.borrow.0        passed   lazer feed 7 w8 0.99973612 age 6432s
oracle.price.borrow.1        passed   redstone `USDC` w2 0.99975917 age 6448s
oracle.aggregate.borrow      passed   MedianHigh (min_sources 1) → 0.99975917
oracle.aggregate.pair        passed   1.0871146 — sanity-check against what the pair trades at
```

## Two things only running it for real revealed

**Freshness is measured between the sources, not against wall-clock.** An adapter holds whatever price was last pushed to it, and the relayer pushes on demand — so at rest a perfectly healthy feed is routinely hours old. The live alpha market's feeds are **~100 minutes old right now**. Filtering on wall-clock reported *every* leg as `TooFewValidSources`, and a check that always fails says nothing. Anchoring on the newest price still catches the failure that matters: one source lagging far behind its peers. Absolute ages are reported per source, so real staleness stays visible.

**The pair ratio is deliberately not decimals-adjusted.** I wrote it adjusted first. Decimals convert a raw token amount into a value when the market *sizes a position*; they play no part in a ratio of two prices. Applying them would have reported `29.96` for a pair trading at `2.996` — plausible enough to be believed, which is the exact class of error this check exists to catch.

## Please sanity-check two observations

1. **Adapter prices are ~100 minutes old at rest.** Expected if the relayer pushes on demand — worth confirming that is the intended pattern rather than a stalled pusher.
2. **Both oracles independently report FXRP ≈ $1.087.** I have no idea what XRP trades at today, so I am not claiming that is wrong. If FXRP is meant to track XRP, it is the number to eyeball. ENG-543's third-party cross-check will settle it automatically.

## Simplification

`holds_price` is gone from the preflight — `oracle.price.*` reports the same fact from a fetch it already performs, so asking separately round-tripped every source twice. `SourceSpec::describe` replaces two byte-identical copies.

## Known duplication, not addressed here

The `FeedData → pyth::Price → kernel::Price` projection now exists in three places: the proxy-oracle contract's callback handler, `gateway/methods-dispatch/src/oracle_impl.rs`, and here. The transports genuinely differ, but the pure projection step could be shared. Flagging rather than silently adding a third copy.

## Verification

`cargo fmt` · `cargo check --workspace` clean · `cargo clippy -p templar-manager --tests -- -D warnings` clean · `just test-fast -p templar-manager` 177/177 · mainnet read-only smoke: 23 checks, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/544)
<!-- Reviewable:end -->
