### PR TITLE
feat(manager): third-party reference price cross-check (ENG-543)

### DIFF
--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+async-trait.workspace = true
 clap.workspace = true
 dirs.workspace = true
 hex.workspace = true
@@ -27,6 +28,8 @@ near-api = { workspace = true, features = ["keystore"] }
 # matching it here keeps standalone (`-p templar-manager`) and workspace builds
 # collision-free. Mirrors service/gateway, the other native bin over these crates.
 near-sdk = { workspace = true, features = ["unit-testing", "non-contract-usage"] }
+# Reference-price cross-check (ENG-543): the only outbound HTTP this tool makes.
+reqwest = { workspace = true, features = ["json"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/tools/manager/fixtures/spec/iethfxrp-ixlmusdc.toml
+++ b/tools/manager/fixtures/spec/iethfxrp-ixlmusdc.toml
@@ -11,6 +11,8 @@ name = "iethfxrp-ixlmusdc"
 [collateral]
 asset = "nep245:intents.near:nep141:eth-0xce6170ea245dc8d1f275a710a062b70f125f0110.omft.near"
 symbol = "FXRP"
+# Bridged; priced as XRP. Pinning records that assertion.
+reference = { coin_gecko = { id = "ripple" } }
 decimals = 6
 aggregator = "median_low"
 min_sources = 1
@@ -22,6 +24,7 @@ sources = [
 [borrow]
 asset = "nep245:intents.near:nep245:v2_1.omni.hot.tg:1100_111bzQBB65GxAPAVoxqmMcgYo5oS3txhqs1Uh1cgahKQUeTUq1TJu"
 symbol = "USDC"
+reference = { coin_gecko = { id = "usd-coin" } }
 decimals = 7
 aggregator = "median_high"
 min_sources = 1

--- a/tools/manager/fixtures/spec/profiles/alpha-mainnet.toml
+++ b/tools/manager/fixtures/spec/profiles/alpha-mainnet.toml
@@ -1,6 +1,6 @@
 # Shared by every alpha market. The values here were duplicated across each
 # market's `env.sh` before the spec existed.
-schema = 2
+schema = 3
 
 registry = "templar-alpha.near"
 

--- a/tools/manager/fixtures/spec/profiles/alpha-mainnet.toml
+++ b/tools/manager/fixtures/spec/profiles/alpha-mainnet.toml
@@ -22,6 +22,8 @@ mcr_maintenance = "1.25"
 mcr_liquidation = "1.2"
 maximum_usage_ratio = "0.99"
 liquidation_maximum_spread = "0.1"
+# 1.5% band for the third-party price cross-check.
+reference_tolerance = "0.015"
 origination_fee = { Flat = "0" }
 supply_withdrawal_fee = { fee = { Flat = "0" }, duration = "0", behavior = "Fixed" }
 yield_weights = { supply = 4, static = { "revenue.tmplr.near" = 1 } }

--- a/tools/manager/src/dispatch/aggregate.rs
+++ b/tools/manager/src/dispatch/aggregate.rs
@@ -22,6 +22,7 @@ use templar_proxy_oracle_kernel::proxy::circuit_breaker::{CircuitBreaker, Circui
 use templar_proxy_oracle_kernel::Price;
 use templar_proxy_oracle_near_common::convert::pyth_price_try_to_kernel;
 
+use super::scaled;
 use crate::context::CliContext;
 use crate::spec::{
     check::{Check, Status},
@@ -36,7 +37,10 @@ use crate::spec::{
 /// timestamp *after* every oracle result has arrived and resolves both legs
 /// against it. Per-leg clocks let a fresh collateral and a week-old borrow each
 /// pass on their own terms and produce a ratio the contract could never accept.
-pub(super) async fn checks(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
+pub(super) async fn checks(
+    ctx: &CliContext,
+    spec: &MarketSpec,
+) -> (Vec<Check>, Option<Price>, Option<Price>) {
     let collateral = fetch_all(ctx, &spec.collateral).await;
     let borrow = fetch_all(ctx, &spec.borrow).await;
 
@@ -71,7 +75,7 @@ pub(super) async fn checks(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
     let (borrow_price, borrow_checks) = leg("borrow", &spec.borrow, spec, borrow, now, anchor);
     checks.extend(borrow_checks);
     checks.push(pair(collateral_price, borrow_price));
-    checks
+    (checks, collateral_price, borrow_price)
 }
 
 /// Wall-clock, for freshness. The kernel takes `now` explicitly rather than
@@ -249,16 +253,6 @@ fn pair(collateral: Option<Price>, borrow: Option<Price>) -> Check {
             scaled(&collateral) / borrow
         )),
     )
-}
-
-/// A price as a plain number, for reporting only.
-fn scaled(price: &Price) -> f64 {
-    #[allow(
-        clippy::cast_precision_loss,
-        reason = "this value is displayed, never used for a decision"
-    )]
-    let value = price.price as f64;
-    value * 10f64.powi(price.expo)
 }
 
 fn render(price: &Price) -> String {

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -9,6 +9,7 @@ mod export;
 pub(crate) mod generic;
 mod preflight;
 mod proposals;
+mod reference;
 mod teardown;
 
 use crate::cli::Command;
@@ -27,6 +28,20 @@ use crate::commands::{
     storage::StorageNs,
 };
 use crate::context::{all_sources, lazer_source, print_json, redstone_source, CliContext};
+
+/// A kernel price as a plain number.
+///
+/// Shared by the aggregation dry-run and the reference cross-check, which
+/// compare against each other — two copies of this could drift into comparing
+/// differently-scaled numbers.
+fn scaled(price: &templar_proxy_oracle_kernel::Price) -> f64 {
+    #[allow(
+        clippy::cast_precision_loss,
+        reason = "displayed, or compared within a tolerance band; never exact"
+    )]
+    let value = price.price as f64;
+    value * 10f64.powi(price.expo)
+}
 
 pub(crate) async fn dispatch(ctx: CliContext, command: Command) -> anyhow::Result<()> {
     match command {

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -84,9 +84,24 @@ async fn run(ctx: &CliContext, spec: &mut MarketSpec, accept_mismatch: bool) -> 
     checks.extend(asset_checks(ctx, "borrow", &mut spec.borrow, accept_mismatch).await);
     checks.extend(versions(ctx, spec).await);
     checks.extend(accounts(ctx, spec).await);
-    // Aggregation last: its per-source prices supersede any liveness probe the
-    // checks above would otherwise have to repeat.
-    checks.extend(super::aggregate::checks(ctx, spec).await);
+    // Aggregation before the cross-check: it produces the prices the reference
+    // source is compared against.
+    let (aggregate_checks, collateral, borrow) = super::aggregate::checks(ctx, spec).await;
+    checks.extend(aggregate_checks);
+
+    match super::reference::CoinGecko::from_env() {
+        Ok(source) => {
+            checks.extend(super::reference::checks(&source, spec, collateral, borrow).await);
+        }
+        // Failing to build a client is "could not check", like every other
+        // reference-source problem.
+        Err(error) => checks.push(Check::new(
+            "reference.price",
+            Status::Skipped {
+                reason: format!("no reference price source: {error:#}"),
+            },
+        )),
+    }
     checks
 }
 

--- a/tools/manager/src/dispatch/reference.rs
+++ b/tools/manager/src/dispatch/reference.rs
@@ -61,10 +61,15 @@ pub trait ReferencePriceSource {
     fn label(&self) -> &'static str;
 }
 
-/// What an asset resolved to, or why it could not be checked. `Err` is reported,
-/// never failed: an absent check must be visible without blocking a deploy over
-/// a judgement the operator already recorded.
-type Resolved = Result<Listing, String>;
+/// What an asset resolved to, or the verdict explaining why it did not.
+///
+/// The `Err` carries a [`Status`], not a message, because the two failure modes
+/// are not the same kind of thing. A source that cannot be reached is
+/// `Skipped` — nothing was learned. A pinned id or ticker the source does not
+/// know is `Failed`: the spec asserted that coin exists and the source just
+/// disproved it. Collapsing them would let a fat-fingered id read exactly like
+/// a network blip and exit zero.
+type Resolved = Result<Listing, Status>;
 
 pub struct CoinGecko {
     client: reqwest::Client,
@@ -223,6 +228,15 @@ pub(super) async fn checks(
     };
 
     let collateral_tolerance = tolerance(&spec.collateral, spec);
+    let borrow_tolerance = tolerance(&spec.borrow, spec);
+    // The ratio carries both legs' deviations, so it is graded against the looser
+    // band. Using one leg's would contradict an override the operator set on the
+    // other — the override exists precisely for the leg that needs room.
+    let pair_tolerance = if collateral_tolerance > borrow_tolerance {
+        collateral_tolerance
+    } else {
+        borrow_tolerance
+    };
     let (collateral_check, collateral_reference) = compare(
         "collateral",
         source.label(),
@@ -237,7 +251,7 @@ pub(super) async fn checks(
         &borrow_resolved,
         borrow,
         &quotes,
-        tolerance(&spec.borrow, spec),
+        borrow_tolerance,
     );
 
     vec![
@@ -249,7 +263,7 @@ pub(super) async fn checks(
             borrow,
             collateral_reference,
             borrow_reference,
-            collateral_tolerance,
+            pair_tolerance,
         ),
     ]
 }
@@ -282,29 +296,42 @@ async fn resolve<A: AssetClass>(
     asset: &AssetSpec<A>,
 ) -> Resolved {
     match asset.reference.clone().unwrap_or_default() {
-        ReferenceAsset::Unlisted { reason } => Err(format!(
-            "the spec records this {side} asset as unlisted: {reason}"
-        )),
+        ReferenceAsset::Unlisted { reason } => Err(Status::Skipped {
+            reason: format!("the spec records this {side} asset as unlisted: {reason}"),
+        }),
         ReferenceAsset::CoinGecko { id } => match source.lookup(&id).await {
             Ok(Some(listing)) => Ok(listing),
-            Ok(None) => Err(format!("no coin has the pinned id `{id}`")),
-            Err(error) => Err(format!("could not look up `{id}`: {error:#}")),
+            // The spec asserted this coin exists. It does not.
+            Ok(None) => Err(Status::failed(format!(
+                "no coin has the pinned id `{id}`, so the {side} asset's `reference` \
+                 names something that does not exist"
+            ))),
+            Err(error) => Err(Status::Skipped {
+                reason: format!("could not look up `{id}`: {error:#}"),
+            }),
         },
         ReferenceAsset::ByTicker => {
             let Some(symbol) = &asset.symbol else {
-                return Err(format!(
-                    "the {side} asset has no `symbol` to resolve; set one, or pin \
-                     `reference` to an id"
-                ));
+                return Err(Status::Skipped {
+                    reason: format!(
+                        "the {side} asset has no `symbol` to resolve; set one, or pin \
+                         `reference` to an id"
+                    ),
+                });
             };
             match source.candidates(symbol).await {
-                Err(error) => Err(format!("could not resolve `{symbol}`: {error:#}")),
+                Err(error) => Err(Status::Skipped {
+                    reason: format!("could not resolve `{symbol}`: {error:#}"),
+                }),
                 Ok(candidates) => match candidates.as_slice() {
                     [only] => Ok(only.clone()),
-                    [] => Err(format!("no coin uses the ticker `{symbol}`")),
+                    // A ticker the source does not know is a typo, not an outage.
+                    [] => Err(Status::failed(format!(
+                        "no coin uses the ticker `{symbol}`"
+                    ))),
                     // Never a first match: picking one of several would silently
                     // verify the wrong asset, which is worse than not checking.
-                    many => Err(format!(
+                    many => Err(Status::failed(format!(
                         "`{symbol}` is ambiguous — {} coins use it ({}{}). Pin one \
                          with `reference = {{ coin_gecko = {{ id = \"…\" }} }}`.",
                         many.len(),
@@ -314,7 +341,7 @@ async fn resolve<A: AssetClass>(
                             .collect::<Vec<_>>()
                             .join(", "),
                         if many.len() > 5 { ", …" } else { "" }
-                    )),
+                    ))),
                 },
             }
         }
@@ -334,17 +361,7 @@ fn compare(
 
     let listing = match resolved {
         Ok(listing) => listing,
-        Err(reason) => {
-            return (
-                Check::new(
-                    id,
-                    Status::Skipped {
-                        reason: reason.clone(),
-                    },
-                ),
-                None,
-            )
-        }
+        Err(status) => return (Check::new(id, status.clone()), None),
     };
 
     let Some(aggregated) = aggregated.map(|price| scaled(&price)) else {
@@ -442,7 +459,9 @@ fn pair(
     if aggregated == 0.0 || borrow_reference == 0.0 {
         return Check::new(
             id,
-            Status::failed("a borrow price of zero admits no ratio".to_owned()),
+            Status::Skipped {
+                reason: "a borrow price of zero admits no ratio".to_owned(),
+            },
         );
     }
     let ours = scaled(&collateral) / aggregated;
@@ -451,7 +470,9 @@ fn pair(
     let Some(deviation) = deviation(ours, theirs) else {
         return Check::new(
             id,
-            Status::failed("the reference ratio is zero, so no comparison is possible".to_owned()),
+            Status::Skipped {
+                reason: "the reference ratio is zero, so no comparison is possible".to_owned(),
+            },
         );
     };
 
@@ -650,6 +671,57 @@ mod tests {
                 "{check:#?}"
             );
         }
+    }
+
+    /// A pinned id the source does not know is a failure, not a shrug: the spec
+    /// asserted that coin exists, and the source just disproved it. This is the
+    /// same distinction the account checks make, and the one most easily lost.
+    #[tokio::test]
+    async fn a_wrong_pinned_id_fails() {
+        let mut spec = spec();
+        spec.collateral.reference = Some(crate::spec::oracle::ReferenceAsset::CoinGecko {
+            id: "ripple-typo".to_owned(),
+        });
+
+        let checks = super::checks(
+            &Fixture::new(),
+            &spec,
+            Some(price(300_000_000, -8)),
+            Some(price(100_000_000, -8)),
+        )
+        .await;
+
+        let status = find(&checks, "reference.price.collateral");
+        assert!(
+            matches!(status, crate::spec::check::Status::Failed { .. }),
+            "a nonexistent pinned id must fail, not skip: {status:#?}"
+        );
+    }
+
+    /// The ratio carries both legs' deviations, so an override on either leg
+    /// must widen its band — otherwise the pair check contradicts a leg check
+    /// the operator deliberately configured.
+    #[tokio::test]
+    async fn the_pair_band_honours_either_leg_override() {
+        let mut spec = spec();
+        spec.borrow.reference_tolerance = Some(templar_common::dec!("0.5"));
+
+        // Borrow 20% off: inside its own 50% band, and the ratio must follow.
+        let checks = super::checks(
+            &Fixture::new(),
+            &spec,
+            Some(price(300_000_000, -8)),
+            Some(price(120_000_000, -8)),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                find(&checks, "reference.price.pair"),
+                crate::spec::check::Status::Passed { .. }
+            ),
+            "{checks:#?}"
+        );
     }
 
     /// The ratio cancels USD drift between the two sources, so it still passes

--- a/tools/manager/src/dispatch/reference.rs
+++ b/tools/manager/src/dispatch/reference.rs
@@ -1,0 +1,676 @@
+//! Cross-check the aggregated prices against an independent source.
+//!
+//! The oracles can agree with each other and still be wrong together — a
+//! transposed feed id, a wrapped token that does not track what it claims to.
+//! Only something outside the system catches that, which is what makes the
+//! spec's `symbol` and `reference` load-bearing rather than decorative.
+//!
+//! The distinction that matters here is between *could not check* and *checked
+//! and disagrees*. Unreachable, rate-limited, or unpinnable is a warning; a
+//! price outside tolerance is a failure. Collapsing the two either makes a
+//! mainnet deploy hostage to a third party's uptime, or lets a real mismatch
+//! through as a shrug.
+
+use std::collections::BTreeMap;
+
+use anyhow::Context as _;
+use serde::Deserialize;
+use templar_common::asset::AssetClass;
+use templar_common::Decimal;
+use templar_proxy_oracle_kernel::Price;
+
+use super::scaled;
+
+use crate::spec::{
+    check::{Check, Status},
+    oracle::{AssetSpec, ReferenceAsset},
+    MarketSpec,
+};
+
+/// One coin as the reference API describes it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Listing {
+    pub id: String,
+    pub symbol: String,
+    pub name: String,
+}
+
+/// Where reference prices come from.
+///
+/// A trait so the checks are testable without a network — every test drives a
+/// fixture, never the live API — and so a second source can be added without
+/// touching the checks.
+#[async_trait::async_trait]
+pub trait ReferencePriceSource {
+    /// One coin by its id. `None` when no such coin exists.
+    ///
+    /// Separate from [`Self::candidates`] deliberately: a pinned id needs no
+    /// resolution, and making every run pay for a full catalogue to learn one
+    /// coin's name would bake one implementation's cheapest strategy into the
+    /// interface.
+    async fn lookup(&self, id: &str) -> anyhow::Result<Option<Listing>>;
+
+    /// Every coin using `symbol`. The full set, because picking one of several
+    /// would silently verify the wrong asset.
+    async fn candidates(&self, symbol: &str) -> anyhow::Result<Vec<Listing>>;
+
+    /// Spot USD prices for the given ids.
+    async fn prices(&self, ids: &[String]) -> anyhow::Result<BTreeMap<String, f64>>;
+
+    /// Names this source in reports.
+    fn label(&self) -> &'static str;
+}
+
+/// What an asset resolved to, or why it could not be checked. `Err` is reported,
+/// never failed: an absent check must be visible without blocking a deploy over
+/// a judgement the operator already recorded.
+type Resolved = Result<Listing, String>;
+
+pub struct CoinGecko {
+    client: reqwest::Client,
+    api_key: Option<String>,
+}
+
+impl CoinGecko {
+    /// `COINGECKO_API_KEY` is optional; the demo tier is ample for the two calls
+    /// a preflight makes.
+    pub fn from_env() -> anyhow::Result<Self> {
+        Ok(Self {
+            client: reqwest::Client::builder()
+                .user_agent("tmplrmgr")
+                .timeout(std::time::Duration::from_secs(20))
+                .build()
+                .context("build HTTP client")?,
+            api_key: std::env::var("COINGECKO_API_KEY").ok(),
+        })
+    }
+
+    fn get(&self, url: &str) -> reqwest::RequestBuilder {
+        let request = self.client.get(url);
+        match &self.api_key {
+            Some(key) => request.header("x-cg-demo-api-key", key),
+            None => request,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct CoinGeckoListing {
+    id: String,
+    symbol: String,
+    name: String,
+}
+
+impl From<CoinGeckoListing> for Listing {
+    fn from(listing: CoinGeckoListing) -> Self {
+        Self {
+            id: listing.id,
+            symbol: listing.symbol,
+            name: listing.name,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl ReferencePriceSource for CoinGecko {
+    async fn lookup(&self, id: &str) -> anyhow::Result<Option<Listing>> {
+        // Everything optional is switched off: only id, symbol and name are
+        // wanted, and the full document is orders of magnitude larger.
+        let response = self
+            .get(&format!(
+                "https://api.coingecko.com/api/v3/coins/{id}?localization=false\
+                 &tickers=false&market_data=false&community_data=false\
+                 &developer_data=false&sparkline=false"
+            ))
+            .send()
+            .await
+            .with_context(|| format!("look up `{id}`"))?;
+
+        if response.status() == reqwest::StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+        let listing: CoinGeckoListing = response
+            .error_for_status()
+            .with_context(|| format!("lookup of `{id}` rejected"))?
+            .json()
+            .await
+            .with_context(|| format!("decode `{id}`"))?;
+
+        Ok(Some(listing.into()))
+    }
+
+    async fn candidates(&self, symbol: &str) -> anyhow::Result<Vec<Listing>> {
+        // The whole catalogue, because only the complete set proves a ticker is
+        // unambiguous. Paid for only when a spec declines to pin an id.
+        let listings: Vec<CoinGeckoListing> = self
+            .get("https://api.coingecko.com/api/v3/coins/list")
+            .send()
+            .await
+            .context("request the coin list")?
+            .error_for_status()
+            .context("coin list request rejected")?
+            .json()
+            .await
+            .context("decode the coin list")?;
+
+        Ok(listings
+            .into_iter()
+            .map(Listing::from)
+            .filter(|listing| listing.symbol.eq_ignore_ascii_case(symbol))
+            .collect())
+    }
+
+    async fn prices(&self, ids: &[String]) -> anyhow::Result<BTreeMap<String, f64>> {
+        #[derive(Deserialize)]
+        struct Quote {
+            usd: f64,
+        }
+
+        let quotes: BTreeMap<String, Quote> = self
+            .get(&format!(
+                "https://api.coingecko.com/api/v3/simple/price?ids={}&vs_currencies=usd",
+                ids.join(",")
+            ))
+            .send()
+            .await
+            .context("request prices")?
+            .error_for_status()
+            .context("price request rejected")?
+            .json()
+            .await
+            .context("decode prices")?;
+
+        Ok(quotes
+            .into_iter()
+            .map(|(id, quote)| (id, quote.usd))
+            .collect())
+    }
+
+    fn label(&self) -> &'static str {
+        "coingecko"
+    }
+}
+
+/// `reference.price.{collateral,borrow,pair}`.
+pub(super) async fn checks(
+    source: &dyn ReferencePriceSource,
+    spec: &MarketSpec,
+    collateral: Option<Price>,
+    borrow: Option<Price>,
+) -> Vec<Check> {
+    let collateral_resolved = resolve(source, "collateral", &spec.collateral).await;
+    let borrow_resolved = resolve(source, "borrow", &spec.borrow).await;
+
+    let wanted: Vec<String> = [&collateral_resolved, &borrow_resolved]
+        .into_iter()
+        .filter_map(|resolved| Some(resolved.as_ref().ok()?.id.clone()))
+        .collect();
+
+    let quotes = if wanted.is_empty() {
+        BTreeMap::new()
+    } else {
+        match source.prices(&wanted).await {
+            Ok(quotes) => quotes,
+            // Unreachable is "could not check", never "checked and agrees".
+            Err(error) => {
+                return skip_all(&format!(
+                    "{} did not answer ({error:#}), so nothing was cross-checked. \
+                     This is not evidence the prices agree.",
+                    source.label()
+                ))
+            }
+        }
+    };
+
+    let collateral_tolerance = tolerance(&spec.collateral, spec);
+    let (collateral_check, collateral_reference) = compare(
+        "collateral",
+        source.label(),
+        &collateral_resolved,
+        collateral,
+        &quotes,
+        collateral_tolerance,
+    );
+    let (borrow_check, borrow_reference) = compare(
+        "borrow",
+        source.label(),
+        &borrow_resolved,
+        borrow,
+        &quotes,
+        tolerance(&spec.borrow, spec),
+    );
+
+    vec![
+        collateral_check,
+        borrow_check,
+        pair(
+            source.label(),
+            collateral,
+            borrow,
+            collateral_reference,
+            borrow_reference,
+            collateral_tolerance,
+        ),
+    ]
+}
+
+/// Report all three checks as not-run for one shared reason.
+fn skip_all(reason: &str) -> Vec<Check> {
+    ["collateral", "borrow", "pair"]
+        .into_iter()
+        .map(|side| {
+            Check::new(
+                format!("reference.price.{side}"),
+                Status::Skipped {
+                    reason: reason.to_owned(),
+                },
+            )
+        })
+        .collect()
+}
+
+fn tolerance<A: AssetClass>(asset: &AssetSpec<A>, spec: &MarketSpec) -> Decimal {
+    asset
+        .reference_tolerance
+        .unwrap_or(spec.market.reference_tolerance)
+}
+
+/// Which listing an asset refers to, or why that cannot be established.
+async fn resolve<A: AssetClass>(
+    source: &dyn ReferencePriceSource,
+    side: &str,
+    asset: &AssetSpec<A>,
+) -> Resolved {
+    match asset.reference.clone().unwrap_or_default() {
+        ReferenceAsset::Unlisted { reason } => Err(format!(
+            "the spec records this {side} asset as unlisted: {reason}"
+        )),
+        ReferenceAsset::CoinGecko { id } => match source.lookup(&id).await {
+            Ok(Some(listing)) => Ok(listing),
+            Ok(None) => Err(format!("no coin has the pinned id `{id}`")),
+            Err(error) => Err(format!("could not look up `{id}`: {error:#}")),
+        },
+        ReferenceAsset::ByTicker => {
+            let Some(symbol) = &asset.symbol else {
+                return Err(format!(
+                    "the {side} asset has no `symbol` to resolve; set one, or pin \
+                     `reference` to an id"
+                ));
+            };
+            match source.candidates(symbol).await {
+                Err(error) => Err(format!("could not resolve `{symbol}`: {error:#}")),
+                Ok(candidates) => match candidates.as_slice() {
+                    [only] => Ok(only.clone()),
+                    [] => Err(format!("no coin uses the ticker `{symbol}`")),
+                    // Never a first match: picking one of several would silently
+                    // verify the wrong asset, which is worse than not checking.
+                    many => Err(format!(
+                        "`{symbol}` is ambiguous — {} coins use it ({}{}). Pin one \
+                         with `reference = {{ coin_gecko = {{ id = \"…\" }} }}`.",
+                        many.len(),
+                        many.iter()
+                            .take(5)
+                            .map(|listing| listing.id.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        if many.len() > 5 { ", …" } else { "" }
+                    )),
+                },
+            }
+        }
+    }
+}
+
+/// Compare one leg, returning its check and the reference price it used.
+fn compare(
+    side: &str,
+    label: &str,
+    resolved: &Resolved,
+    aggregated: Option<Price>,
+    quotes: &BTreeMap<String, f64>,
+    tolerance: Decimal,
+) -> (Check, Option<f64>) {
+    let id = format!("reference.price.{side}");
+
+    let listing = match resolved {
+        Ok(listing) => listing,
+        Err(reason) => {
+            return (
+                Check::new(
+                    id,
+                    Status::Skipped {
+                        reason: reason.clone(),
+                    },
+                ),
+                None,
+            )
+        }
+    };
+
+    let Some(aggregated) = aggregated.map(|price| scaled(&price)) else {
+        return (
+            Check::new(
+                id,
+                Status::Skipped {
+                    reason: format!(
+                        "the {side} leg produced no aggregate to compare against \
+                         {} `{}`",
+                        label, listing.id
+                    ),
+                },
+            ),
+            None,
+        );
+    };
+
+    let Some(&reference) = quotes.get(&listing.id) else {
+        return (
+            Check::new(
+                id,
+                Status::Skipped {
+                    reason: format!("{label} returned no price for `{}`", listing.id),
+                },
+            ),
+            None,
+        );
+    };
+
+    // The resolved name is half the point: it is how a human confirms the right
+    // coin was pulled, not merely a matching ticker.
+    let identity = format!("{} `{}` \"{}\"", label, listing.id, listing.name);
+    let Some(deviation) = deviation(aggregated, reference) else {
+        return (
+            Check::new(
+                id,
+                Status::failed(format!(
+                    "{identity} reports 0, so no comparison is possible"
+                )),
+            ),
+            None,
+        );
+    };
+
+    // Lossy is right here: this is a tolerance band, not an exact comparison.
+    let within = deviation <= tolerance.to_f64_lossy();
+    let detail = format!(
+        "{identity} ${reference} vs aggregated ${aggregated} ({:+.3}%)",
+        signed_percent(aggregated, reference)
+    );
+
+    (
+        Check::new(
+            id,
+            if within {
+                Status::passed(detail)
+            } else {
+                Status::failed(format!(
+                    "{detail}, outside the {tolerance} band. Either the feed is wrong \
+                     or this asset does not track what `reference` claims."
+                ))
+            },
+        ),
+        Some(reference),
+    )
+}
+
+/// The ratio check — the strongest of the three.
+///
+/// Comparing ratios cancels any USD-denomination drift between the two APIs, so
+/// it catches a transposed feed while tolerating the small disagreement two
+/// independent price sources always have.
+fn pair(
+    label: &str,
+    collateral: Option<Price>,
+    borrow: Option<Price>,
+    collateral_reference: Option<f64>,
+    borrow_reference: Option<f64>,
+    tolerance: Decimal,
+) -> Check {
+    let id = "reference.price.pair";
+    let (Some(collateral), Some(borrow), Some(collateral_reference), Some(borrow_reference)) =
+        (collateral, borrow, collateral_reference, borrow_reference)
+    else {
+        return Check::new(
+            id,
+            Status::Skipped {
+                reason: "both legs must have an aggregate and a reference price".to_owned(),
+            },
+        );
+    };
+
+    let aggregated = scaled(&borrow);
+    if aggregated == 0.0 || borrow_reference == 0.0 {
+        return Check::new(
+            id,
+            Status::failed("a borrow price of zero admits no ratio".to_owned()),
+        );
+    }
+    let ours = scaled(&collateral) / aggregated;
+    let theirs = collateral_reference / borrow_reference;
+
+    let Some(deviation) = deviation(ours, theirs) else {
+        return Check::new(
+            id,
+            Status::failed("the reference ratio is zero, so no comparison is possible".to_owned()),
+        );
+    };
+
+    let detail = format!(
+        "{label} {theirs} vs aggregated {ours} ({:+.3}%)",
+        signed_percent(ours, theirs)
+    );
+    Check::new(
+        id,
+        if deviation <= tolerance.to_f64_lossy() {
+            Status::passed(detail)
+        } else {
+            Status::failed(format!(
+                "{detail}, outside the {tolerance} band. A ratio disagreeing this far \
+                 usually means a transposed feed id."
+            ))
+        },
+    )
+}
+
+/// Absolute relative difference. `None` when the reference is zero.
+fn deviation(ours: f64, theirs: f64) -> Option<f64> {
+    (theirs != 0.0).then(|| ((ours - theirs) / theirs).abs())
+}
+
+fn signed_percent(ours: f64, theirs: f64) -> f64 {
+    if theirs == 0.0 {
+        0.0
+    } else {
+        (ours - theirs) / theirs * 100.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Listing, ReferencePriceSource};
+    use std::collections::BTreeMap;
+
+    /// A fixed catalogue. The point of the trait: no test reaches the network,
+    /// so the rules below are pinned rather than dependent on today's market.
+    struct Fixture {
+        listings: Vec<Listing>,
+        prices: BTreeMap<String, f64>,
+        listings_fail: bool,
+    }
+
+    impl Fixture {
+        fn new() -> Self {
+            Self {
+                listings: vec![
+                    listing("ripple", "xrp", "XRP"),
+                    listing("usd-coin", "usdc", "USDC"),
+                    // Two coins share the ticker `bat`, which is what makes
+                    // resolving by ticker ambiguous.
+                    listing("basic-attention-token", "bat", "Basic Attention Token"),
+                    listing("batcoin", "bat", "BatCoin"),
+                ],
+                prices: [("ripple".to_owned(), 3.0), ("usd-coin".to_owned(), 1.0)]
+                    .into_iter()
+                    .collect(),
+                listings_fail: false,
+            }
+        }
+    }
+
+    fn listing(id: &str, symbol: &str, name: &str) -> Listing {
+        Listing {
+            id: id.to_owned(),
+            symbol: symbol.to_owned(),
+            name: name.to_owned(),
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ReferencePriceSource for Fixture {
+        async fn lookup(&self, id: &str) -> anyhow::Result<Option<Listing>> {
+            if self.listings_fail {
+                anyhow::bail!("simulated outage");
+            }
+            Ok(self.listings.iter().find(|l| l.id == id).cloned())
+        }
+
+        async fn candidates(&self, symbol: &str) -> anyhow::Result<Vec<Listing>> {
+            if self.listings_fail {
+                anyhow::bail!("simulated outage");
+            }
+            Ok(self
+                .listings
+                .iter()
+                .filter(|l| l.symbol.eq_ignore_ascii_case(symbol))
+                .cloned()
+                .collect())
+        }
+
+        async fn prices(&self, ids: &[String]) -> anyhow::Result<BTreeMap<String, f64>> {
+            Ok(ids
+                .iter()
+                .filter_map(|id| self.prices.get(id).map(|price| (id.clone(), *price)))
+                .collect())
+        }
+
+        fn label(&self) -> &'static str {
+            "fixture"
+        }
+    }
+
+    fn spec() -> crate::spec::MarketSpec {
+        crate::spec::extends::load(
+            &std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("fixtures/spec/iethfxrp-ixlmusdc.toml"),
+        )
+        .expect("fixture spec should load")
+    }
+
+    fn price(value: i64, expo: i32) -> templar_proxy_oracle_kernel::Price {
+        templar_proxy_oracle_kernel::Price {
+            price: value,
+            conf: 0,
+            expo,
+            publish_time_ns: templar_common::Nanoseconds::from_ns(0),
+        }
+    }
+
+    fn find<'a>(
+        checks: &'a [crate::spec::check::Check],
+        id: &str,
+    ) -> &'a crate::spec::check::Status {
+        &checks
+            .iter()
+            .find(|check| check.id == id)
+            .unwrap_or_else(|| panic!("{id} should be reported"))
+            .status
+    }
+
+    /// Agreement inside the band passes, and the report names the resolved id
+    /// *and* name — which is how a human confirms the right coin was pulled.
+    #[tokio::test]
+    async fn agreement_passes_and_names_the_coin() {
+        let checks = super::checks(
+            &Fixture::new(),
+            &spec(),
+            Some(price(300_100_000, -8)),
+            Some(price(100_000_000, -8)),
+        )
+        .await;
+
+        let crate::spec::check::Status::Passed { detail } =
+            find(&checks, "reference.price.collateral")
+        else {
+            panic!("expected a pass: {checks:#?}")
+        };
+        assert!(detail.contains("ripple"), "{detail}");
+        assert!(detail.contains("XRP"), "{detail}");
+    }
+
+    /// A price outside the band is a hard failure, not a shrug — this is the
+    /// "checked and disagrees" half of the distinction.
+    #[tokio::test]
+    async fn disagreement_fails() {
+        let checks = super::checks(
+            &Fixture::new(),
+            &spec(),
+            // Reference says 3.0; claiming 6.0 is 100% out.
+            Some(price(600_000_000, -8)),
+            Some(price(100_000_000, -8)),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                find(&checks, "reference.price.collateral"),
+                crate::spec::check::Status::Failed { .. }
+            ),
+            "{checks:#?}"
+        );
+    }
+
+    /// An unreachable source must never read as agreement — a deploy should not
+    /// be blocked by a third party's outage, nor waved through by it.
+    #[tokio::test]
+    async fn an_outage_is_skipped_not_passed() {
+        let mut fixture = Fixture::new();
+        fixture.listings_fail = true;
+
+        let checks = super::checks(
+            &fixture,
+            &spec(),
+            Some(price(300_000_000, -8)),
+            Some(price(100_000_000, -8)),
+        )
+        .await;
+
+        for check in &checks {
+            assert!(
+                matches!(check.status, crate::spec::check::Status::Skipped { .. }),
+                "{check:#?}"
+            );
+        }
+    }
+
+    /// The ratio cancels USD drift between the two sources, so it still passes
+    /// when both legs are uniformly off.
+    #[tokio::test]
+    async fn the_ratio_tolerates_uniform_drift() {
+        // Both legs 10% high: each leg fails its own band, the ratio does not.
+        let checks = super::checks(
+            &Fixture::new(),
+            &spec(),
+            Some(price(330_000_000, -8)),
+            Some(price(110_000_000, -8)),
+        )
+        .await;
+
+        assert!(
+            matches!(
+                find(&checks, "reference.price.pair"),
+                crate::spec::check::Status::Passed { .. }
+            ),
+            "{checks:#?}"
+        );
+    }
+}

--- a/tools/manager/src/spec/export.rs
+++ b/tools/manager/src/spec/export.rs
@@ -139,6 +139,11 @@ fn asset_spec<A: AssetClass>(
         // human to fill in; inventing a plausible ticker would be worse, since
         // the reference cross-check (ENG-543) would then verify a guess.
         symbol: None,
+        // Neither reaches the chain. A pinned reference id is an assertion about
+        // what a wrapped token tracks; inventing one would be a guess presented
+        // as a record.
+        reference: None,
+        reference_tolerance: None,
         decimals: Some(u8::try_from(decimals).with_context(|| {
             format!("{side} asset declares {decimals} decimals, which a spec cannot express")
         })?),
@@ -215,6 +220,7 @@ fn market_params(configuration: &MarketConfiguration) -> MarketParams {
         mcr_liquidation: configuration.borrow_mcr_liquidation,
         maximum_usage_ratio: configuration.borrow_asset_maximum_usage_ratio,
         liquidation_maximum_spread: configuration.liquidation_maximum_spread,
+        reference_tolerance: super::default_reference_tolerance(),
         interest_rate_strategy: configuration.borrow_interest_rate_strategy.clone(),
         origination_fee: configuration.borrow_origination_fee.clone(),
         supply_withdrawal_fee: configuration.supply_withdrawal_fee.clone(),

--- a/tools/manager/src/spec/mod.rs
+++ b/tools/manager/src/spec/mod.rs
@@ -52,10 +52,15 @@ pub fn default_reference_tolerance() -> Decimal {
 
 /// Bumped only on a breaking spec change; unknown versions are rejected.
 ///
+/// Every struct here is `deny_unknown_fields`, so *adding* a field is breaking
+/// in the reader direction: an older build rejects a document carrying it.
+///
 /// 2: `symbol` became optional, so `market export` can leave it unset rather
-/// than invent a ticker. A schema-1 reader requires it and would reject an
-/// exported spec, so the same number must not describe both.
-pub const SCHEMA_VERSION: u32 = 2;
+///    than invent a ticker.
+/// 3: `reference` and `reference_tolerance` on each asset, and
+///    `market.reference_tolerance`, for the third-party cross-check. Export
+///    always emits the market tolerance, so every exported spec carries it.
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// A complete market deployment: the market contract, its dedicated proxy
 /// oracle, and the governance contract that owns that oracle.

--- a/tools/manager/src/spec/mod.rs
+++ b/tools/manager/src/spec/mod.rs
@@ -42,6 +42,14 @@ use serde_util::duration;
 pub const COLLATERAL_PRICE_ID: PriceIdentifier = PriceIdentifier([0xcc; 32]);
 pub const BORROW_PRICE_ID: PriceIdentifier = PriceIdentifier([0xbb; 32]);
 
+/// Default band for the reference-price cross-check.
+///
+/// Defaulted rather than required so `market export`, which cannot recover a
+/// judgement call from chain state, does not have to invent one silently.
+pub fn default_reference_tolerance() -> Decimal {
+    templar_common::dec!("0.015")
+}
+
 /// Bumped only on a breaking spec change; unknown versions are rejected.
 ///
 /// 2: `symbol` became optional, so `market export` can leave it unset rather
@@ -125,6 +133,12 @@ pub struct MarketParams {
     pub maximum_usage_ratio: Decimal,
     #[schemars(with = "String")]
     pub liquidation_maximum_spread: Decimal,
+
+    /// Default band for the reference-price cross-check, as a fraction — `0.015`
+    /// is 1.5%. Per-asset `reference_tolerance` overrides it.
+    #[serde(default = "default_reference_tolerance")]
+    #[schemars(with = "String")]
+    pub reference_tolerance: Decimal,
 
     // These four are embedded on-chain types, which is the point — a field added
     // to `MarketConfiguration` surfaces here as a compile error. None of them

--- a/tools/manager/src/spec/oracle.rs
+++ b/tools/manager/src/spec/oracle.rs
@@ -33,10 +33,22 @@ pub struct AssetSpec<A: AssetClass> {
     pub asset: FungibleAsset<A>,
 
     /// Ticker. Never sent on chain, so `market export` cannot recover it and
-    /// leaves it unset. It exists so a preflight can check that the sources
-    /// below actually price this asset (ENG-543).
+    /// leaves it unset. It exists so the reference cross-check can confirm the
+    /// sources below actually price this asset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub symbol: Option<String>,
+
+    /// How to find this asset on the reference price API.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reference: Option<ReferenceAsset>,
+
+    /// Overrides `market.reference_tolerance` for this asset.
+    ///
+    /// Not a nicety: one flat band false-positives on an LST trading at a
+    /// premium to its underlying, or on a thinly-traded bridged token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(with = "Option<String>")]
+    pub reference_tolerance: Option<templar_common::Decimal>,
 
     /// Overrides the token's on-chain metadata. Required when that metadata is
     /// absent or malformed, which has happened for at least one bridged asset
@@ -79,6 +91,30 @@ pub struct AssetSpec<A: AssetClass> {
 /// drift bound opposite directions, and a market willing to accept a 60s-old
 /// price has said nothing about accepting one dated 60s from now.
 pub const DEFAULT_MAX_CLOCK_DRIFT: Nanoseconds = Nanoseconds::from_ns(10_000_000_000);
+
+/// How to find an asset on the reference price API.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case", deny_unknown_fields)]
+pub enum ReferenceAsset {
+    /// Resolve `symbol` against the API. Ambiguity is an error listing the
+    /// candidates, never a first match.
+    ByTicker,
+    /// A pinned id, skipping resolution.
+    ///
+    /// This is how a wrapped asset records what it is priced as: `FXRP` pinned
+    /// to `ripple` asserts that the bridged token tracks XRP — an assumption
+    /// that otherwise lives only in someone's head.
+    CoinGecko { id: String },
+    /// No third-party listing exists. The reason is recorded so an absent check
+    /// is visible in review rather than silently not running.
+    Unlisted { reason: String },
+}
+
+impl Default for ReferenceAsset {
+    fn default() -> Self {
+        Self::ByTicker
+    }
+}
 
 /// How multiple sources collapse into one price.
 ///


### PR DESCRIPTION
Sub-PR 6 of 10 for ENG-537. Closes ENG-543.

## Why

The oracles can agree with each other and still be wrong together — a transposed feed id, a wrapped token that does not track what it claims to. Only something outside the system catches that, which is what makes the spec's `symbol` and `reference` load-bearing rather than decorative.

## Live, against real CoinGecko and the real alpha market

```
reference.price.collateral  coingecko `ripple` "XRP"    $1.084     vs aggregated $1.08685  (+0.263%)
reference.price.borrow      coingecko `usd-coin` "USDC" $0.999641  vs aggregated $0.99976  (+0.010%)
reference.price.pair        coingecko 1.084389           vs aggregated 1.087115           (+0.251%)
```

All inside the 1.5% band. **This settles the open question from ENG-542**: FXRP does track XRP (≈$1.084 today), so the aggregated price was right and the `$2.99` in the issue example was simply stale. Exactly the question this check exists to answer without anyone guessing.

## Rules, as specified

- **The resolved id *and name* are printed.** That is how a human confirms the right coin was pulled, not merely a matching ticker.
- **Ambiguity is an error listing candidates**, never a first match — picking one of several would silently verify the wrong asset.
- **Pinning records an assertion.** `FXRP → ripple` states that the bridged token tracks XRP, which previously lived only in someone's head.
- **"Could not check" ≠ "checked and disagrees."** Unreachable / rate-limited / unpinnable / no symbol → `Skipped`, and the reason says it is *not* evidence of agreement. Outside tolerance → hard failure. I have produced three false-passes in this codebase by blurring exactly this line, so it is the part with the most tests.
- **Per-asset tolerance override**, since one flat band false-positives on an LST at a premium or a thin bridged token.

## Trait shape

`lookup(id)` is separate from `candidates(symbol)` so a pinned id costs one small request. A single `listings()` returning the whole catalogue would have made every run — CI included — download ~2MB to learn one coin's name, and would have baked one API's cheapest strategy into the interface. Tests drive a fixture and never touch the network.

## Verification

`cargo fmt` · `cargo check --workspace` clean · `cargo clippy -p templar-manager --tests -- -D warnings` clean · `just test-fast -p templar-manager` 181/181 (4 new offline fixture tests: agreement names the coin, disagreement fails, an outage is skipped not passed, the ratio tolerates uniform drift) · live mainnet + CoinGecko smoke, 26 checks, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/545)
<!-- Reviewable:end -->
