### PR TITLE
feat(manager): market plan/apply — a hand-editable deployment artifact (ENG-544)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13484,6 +13484,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "sputnikdao2",
  "templar-common",
  "templar-contract-artifacts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13485,6 +13485,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serde_json_canonicalizer",
  "sputnikdao2",
  "templar-common",
  "templar-contract-artifacts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13473,6 +13473,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "clap",
  "dirs 6.0.0",
  "hex",
@@ -13484,7 +13485,6 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "sputnikdao2",
  "templar-common",
  "templar-contract-artifacts",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13472,12 +13472,14 @@ name = "templar-manager"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "clap",
  "dirs 6.0.0",
  "hex",
  "near-account-id",
  "near-api",
  "near-sdk",
+ "reqwest 0.12.28",
  "rstest",
  "schemars 0.8.22",
  "serde",

--- a/justfile
+++ b/justfile
@@ -2,7 +2,11 @@
 
 set positional-arguments
 
-network_filter := 'test(/^requires_network_/)'
+# `(^|::)` so the convention reaches tests nested in modules, not only those at
+# an integration binary's root. A bare `^` anchors against the full path
+# (`module::tests::requires_network_x`), so nested network tests silently ran in
+# the fast gate.
+network_filter := 'test(/(^|::)requires_network_/)'
 sandbox_full_packages := trim('''
 templar-market-contract
 templar-vault-contract

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -33,6 +33,8 @@ reqwest = { workspace = true, features = ["json"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# Plan-artifact step digests (ENG-544).
+sha2.workspace = true
 sputnikdao2.workspace = true
 templar-common.workspace = true
 templar-contract-artifacts.workspace = true

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -11,6 +11,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow.workspace = true
+# Decoding `registry.deploy` init args for display (ENG-544).
+base64.workspace = true
 async-trait.workspace = true
 clap.workspace = true
 dirs.workspace = true

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -35,6 +35,8 @@ reqwest = { workspace = true, features = ["json"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+# Stable digests: plan/spec hashing must not depend on map iteration order.
+serde_json_canonicalizer.workspace = true
 sputnikdao2.workspace = true
 templar-common.workspace = true
 templar-contract-artifacts.workspace = true

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -33,8 +33,6 @@ reqwest = { workspace = true, features = ["json"] }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-# Plan-artifact step digests (ENG-544).
-sha2.workspace = true
 sputnikdao2.workspace = true
 templar-common.workspace = true
 templar-contract-artifacts.workspace = true

--- a/tools/manager/src/commands/market/mod.rs
+++ b/tools/manager/src/commands/market/mod.rs
@@ -1,9 +1,11 @@
 mod create;
 mod export;
+mod plan;
 mod remove;
 
 pub use create::Create;
 pub use export::Export;
+pub use plan::{Apply, Plan};
 pub use remove::Remove;
 
 use clap::Subcommand;
@@ -15,6 +17,10 @@ pub enum MarketNs {
     Create(Create),
     /// Reconstruct a deployment spec from a deployed market.
     Export(Export),
+    /// Generate a deployment from a spec as an editable plan file.
+    Plan(Plan),
+    /// Send a plan file produced by `market plan`.
+    Apply(Apply),
     /// Remove a market: recover its assets to a beneficiary, then delete the
     /// (signer) account.
     Remove(Remove),

--- a/tools/manager/src/commands/market/plan.rs
+++ b/tools/manager/src/commands/market/plan.rs
@@ -1,0 +1,67 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use near_account_id::AccountId;
+use near_api::PublicKey as CliPublicKey;
+use templar_gateway_types::primitive::PublicKey;
+
+use crate::commands::signer::SignerArgs;
+
+/// Generate the deployment for a spec as an editable file, without sending
+/// anything.
+///
+/// Deliberately takes no credential. Planning reads the chain and writes a file;
+/// giving it a key would mean a mistyped subcommand could spend NEAR. The
+/// operator's account and public key are still needed — the account signs each
+/// planned transaction, and the key is granted full access on every account the
+/// deploy creates — but neither is a secret.
+#[derive(Args, Debug)]
+pub struct Plan {
+    /// Path to the market spec.
+    pub(crate) path: PathBuf,
+
+    /// Where to write the plan. Omit to print it.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) out: Option<PathBuf>,
+
+    /// Account that will sign every planned transaction.
+    #[arg(long, env = "SIGNER_ID", value_name = "ACCOUNT_ID")]
+    pub(crate) signer_id: AccountId,
+
+    /// Public key granted full access on each account the deploy creates.
+    #[arg(long, value_name = "PUBLIC_KEY")]
+    public_key: CliPublicKey,
+
+    /// Ignore a named check. Every other check still runs, and every derived
+    /// value is still derived — this suppresses one verdict, not the preflight.
+    ///
+    /// For a check that is wrong or over-strict. Reach for editing the plan only
+    /// when the spec genuinely cannot express what the market needs.
+    #[arg(long = "skip-check", value_name = "CHECK_ID")]
+    pub(crate) skip_check: Vec<String>,
+
+    /// Accept a `decimals` override that disagrees with the token's metadata.
+    #[arg(long)]
+    pub(crate) accept_decimals_mismatch: bool,
+}
+
+impl Plan {
+    pub(crate) fn public_key(&self) -> PublicKey {
+        PublicKey::from(self.public_key)
+    }
+}
+
+/// Send a plan file.
+#[derive(Args, Debug)]
+pub struct Apply {
+    /// Path to a plan written by `market plan`.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) plan: PathBuf,
+
+    /// Skip the confirmation prompt.
+    #[arg(long)]
+    pub(crate) yes: bool,
+
+    #[command(flatten)]
+    pub(crate) signer: SignerArgs,
+}

--- a/tools/manager/src/commands/market/plan.rs
+++ b/tools/manager/src/commands/market/plan.rs
@@ -1,20 +1,15 @@
 use std::path::PathBuf;
 
+use crate::commands::signer::SignerArgs;
 use clap::Args;
 use near_account_id::AccountId;
 use near_api::PublicKey as CliPublicKey;
-use templar_gateway_types::primitive::PublicKey;
 
-use crate::commands::signer::SignerArgs;
-
-/// Generate the deployment for a spec as an editable file, without sending
-/// anything.
-///
-/// Deliberately takes no credential. Planning reads the chain and writes a file;
-/// giving it a key would mean a mistyped subcommand could spend NEAR. The
-/// operator's account and public key are still needed — the account signs each
-/// planned transaction, and the key is granted full access on every account the
-/// deploy creates — but neither is a secret.
+/// Deliberately takes no credential: planning reads the chain and writes a file,
+/// so a mistyped subcommand cannot spend NEAR. The account and public key are
+/// still needed — the account signs each planned transaction and the key is
+/// granted full access on the accounts created — but neither is a secret, which
+/// is why this is not [`SignerArgs`].
 #[derive(Args, Debug)]
 pub struct Plan {
     /// Path to the market spec.
@@ -30,7 +25,7 @@ pub struct Plan {
 
     /// Public key granted full access on each account the deploy creates.
     #[arg(long, value_name = "PUBLIC_KEY")]
-    public_key: CliPublicKey,
+    pub(crate) public_key: CliPublicKey,
 
     /// Ignore a named check. Every other check still runs, and every derived
     /// value is still derived — this suppresses one verdict, not the preflight.
@@ -43,12 +38,6 @@ pub struct Plan {
     /// Accept a `decimals` override that disagrees with the token's metadata.
     #[arg(long)]
     pub(crate) accept_decimals_mismatch: bool,
-}
-
-impl Plan {
-    pub(crate) fn public_key(&self) -> PublicKey {
-        PublicKey::from(self.public_key)
-    }
 }
 
 /// Send a plan file.

--- a/tools/manager/src/commands/proxy_oracle/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/create.rs
@@ -44,7 +44,10 @@ pub struct Create {
 /// contract's own ABI.
 ///
 /// [`Version::from_version_key`]: templar_gateway_types::version::Version::from_version_key
-fn check_owner_id_is_honored(version_key: &str, owner_id: &AccountId) -> anyhow::Result<()> {
+pub(crate) fn check_owner_id_is_honored(
+    version_key: &str,
+    owner_id: &AccountId,
+) -> anyhow::Result<()> {
     let version = ProxyOracleVersion::from_version_key(version_key)
         .with_context(|| format!("cannot tell whether {version_key} honors --owner-id"))?;
 

--- a/tools/manager/src/commands/proxy_oracle/governance/create.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/create.rs
@@ -42,10 +42,10 @@ pub struct GovernanceCreate {
 
 /// Init args for the governance contract's `new(proxy_oracle_id, admin_id, ttls)`.
 #[derive(serde::Serialize)]
-struct GovernanceInit {
-    proxy_oracle_id: AccountId,
-    admin_id: AccountId,
-    ttls: TtlConfig,
+pub struct GovernanceInit {
+    pub proxy_oracle_id: AccountId,
+    pub admin_id: AccountId,
+    pub ttls: TtlConfig,
 }
 
 impl GovernanceCreate {

--- a/tools/manager/src/commands/proxy_oracle/governance/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/governance/mod.rs
@@ -7,7 +7,7 @@ mod has_role;
 mod list_proposals;
 mod list_role;
 
-pub use create::GovernanceCreate;
+pub use create::{GovernanceCreate, GovernanceInit};
 pub use create_proposal::CreateProposal;
 pub use execute_proposal::ExecuteProposalArgs;
 pub use get_operation_ttl::GetOperationTtl;
@@ -102,7 +102,7 @@ impl CancelProposal {
     }
 }
 
-fn uniform_ttls(ttl: Nanoseconds) -> TtlConfig {
+pub(crate) fn uniform_ttls(ttl: Nanoseconds) -> TtlConfig {
     TtlConfig {
         set_proxy: ttl,
         configure_circuit_breakers: ttl,

--- a/tools/manager/src/commands/proxy_oracle/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/mod.rs
@@ -7,6 +7,7 @@ mod price_feed_exists;
 mod update_prices;
 mod upgrade;
 
+pub(crate) use create::check_owner_id_is_honored;
 pub use create::Create;
 pub use get_proxy::GetProxy;
 pub use get_proxy_circuit_breaker_set::GetProxyCircuitBreakerSet;

--- a/tools/manager/src/commands/proxy_oracle/mod.rs
+++ b/tools/manager/src/commands/proxy_oracle/mod.rs
@@ -1,7 +1,7 @@
 mod create;
 mod get_proxy;
 mod get_proxy_circuit_breaker_set;
-mod governance;
+pub mod governance;
 mod list_proxies;
 mod price_feed_exists;
 mod update_prices;

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -113,6 +113,20 @@ impl CliContext {
         self.finish_write(&output)
     }
 
+    /// Execute a write through a caller-chosen dispatcher, then report it.
+    ///
+    /// The execute half of [`CliContext::write`], without the `--print` branch:
+    /// `market apply` has a plan in hand and nothing left to print.
+    pub(crate) async fn execute_via<D, S>(&self, signer: &SignerArgs, body: S) -> anyhow::Result<()>
+    where
+        S: MethodSpec<Output = WriteOperationResult>,
+        D: PlanWrite<S, GatewayContext>,
+    {
+        let (account_id, client) = self.signing_client_for(signer).await?;
+        let output = client.via::<D>().execute_as(account_id, body).await?;
+        self.finish_write(&output)
+    }
+
     /// Plan or execute an `oracle.*` write through [`OracleUpdatesDispatch`],
     /// whose context carries the in-process payload sources the method fetches.
     pub(crate) async fn oracle_write<S, Ctx>(
@@ -154,7 +168,7 @@ impl CliContext {
     /// Report the tx link, print the machine-readable result, then fail unless the
     /// operation succeeded on chain. Printing precedes the status check so a reverted
     /// operation still emits its JSON on stdout.
-    pub(crate) fn finish_write(&self, output: &WriteOperationResult) -> anyhow::Result<()> {
+    fn finish_write(&self, output: &WriteOperationResult) -> anyhow::Result<()> {
         self.report_tx(output);
         print_json(output)?;
         check_operation_status(output)
@@ -257,7 +271,7 @@ fn print_plan(format: PrintFormat, plan: OperationPlan) -> anyhow::Result<()> {
     }
 }
 
-fn single_transaction(plan: OperationPlan) -> anyhow::Result<PlannedTransaction> {
+pub(crate) fn single_transaction(plan: OperationPlan) -> anyhow::Result<PlannedTransaction> {
     let [transaction] = plan.steps.try_into().map_err(|steps: Vec<_>| {
         anyhow::anyhow!(
             "--print requires exactly one planned transaction; planned {}",

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -79,6 +79,23 @@ impl CliContext {
         Ok((account_id, client))
     }
 
+    /// The public key the configured backend will actually sign with.
+    ///
+    /// Distinct from [`SignerArgs::public_key`], which for an external backend
+    /// returns the key the operator *asserted* via `--public-key`. Verifying a
+    /// full-access grant against an assertion verifies nothing, so this resolves
+    /// the backend and asks it.
+    pub(crate) async fn signing_public_key(
+        &self,
+        signer: &SignerArgs,
+    ) -> anyhow::Result<near_api::PublicKey> {
+        let (_, signing) = signer.resolve(&self.network).await?;
+        signing
+            .get_public_key()
+            .await
+            .context("ask the signing backend which key it will sign with")
+    }
+
     /// Dispatch a read and print its JSON result.
     pub(crate) async fn read<S>(&self, request: S) -> anyhow::Result<()>
     where

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -154,7 +154,7 @@ impl CliContext {
     /// Report the tx link, print the machine-readable result, then fail unless the
     /// operation succeeded on chain. Printing precedes the status check so a reverted
     /// operation still emits its JSON on stdout.
-    fn finish_write(&self, output: &WriteOperationResult) -> anyhow::Result<()> {
+    pub(crate) fn finish_write(&self, output: &WriteOperationResult) -> anyhow::Result<()> {
         self.report_tx(output);
         print_json(output)?;
         check_operation_status(output)

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -7,6 +7,7 @@
 mod aggregate;
 mod export;
 pub(crate) mod generic;
+pub(crate) mod plan;
 mod preflight;
 mod proposals;
 mod reference;
@@ -115,6 +116,8 @@ async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
     match ns {
         MarketNs::Create(a) => ctx.write(a.signer.clone(), a.try_into_spec()?).await,
         MarketNs::Export(a) => export::market(ctx, a).await,
+        MarketNs::Plan(a) => plan::plan(ctx, a).await,
+        MarketNs::Apply(a) => plan::apply(ctx, a).await,
         MarketNs::Remove(a) => {
             // `market remove` is self-signed: the signer is the market account
             // being torn down.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -189,6 +189,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         );
     }
 
+    ensure_plan_is_complete(&file)?;
     ensure_plan_is_coherent(&file)?;
     ensure_initializers_are_sound(&file)?;
     ensure_proposals_are_runnable(&file)?;
@@ -613,6 +614,63 @@ async fn occupied_targets(
         }
     }
     Ok(occupied)
+}
+
+/// A deployment must still be a deployment.
+///
+/// Every coherence check below is conditional on finding the component it
+/// validates, so *deleting* a step disables its guard rather than tripping it:
+/// remove the oracle deploy and governance and the market stay mutually
+/// consistent, the proposals fail against an account that does not exist —
+/// reporting success, because `admin_set_proxy` is detached — and the market is
+/// deployed pointing at nothing.
+///
+/// This is the same fail-open shape as the swallowed `Err`s fixed earlier, in a
+/// form the sweep for those missed: the value is absent rather than unreadable.
+fn ensure_plan_is_complete(file: &PlanFile) -> anyhow::Result<()> {
+    let (mut governance, mut oracle, mut market, mut proposals) = (0, 0, 0, 0);
+
+    for step in &file.steps {
+        for call in &step.function_calls {
+            if is_governance_proposal(call)? {
+                proposals += 1;
+                continue;
+            }
+            let Some(init) = decoded_init_args(call) else {
+                continue;
+            };
+            if init.get("admin_id").is_some() {
+                governance += 1;
+            }
+            if init.get("owner_id").is_some() {
+                oracle += 1;
+            }
+            if init.get("configuration").is_some() {
+                market += 1;
+            }
+        }
+    }
+
+    for (what, found) in [
+        ("governance deploy", governance),
+        ("proxy-oracle deploy", oracle),
+        ("market deploy", market),
+    ] {
+        anyhow::ensure!(
+            found == 1,
+            "a deployment plan needs exactly one {what}; this one has {found}. \
+             A missing component is not a smaller deployment — the remaining \
+             steps still reference it, and the checks that would catch that are \
+             skipped when the step they validate is absent."
+        );
+    }
+    anyhow::ensure!(
+        proposals >= 2,
+        "a deployment plan configures both price feeds, which needs at least a \
+         create and an execute per feed; this one has {proposals} proposal \
+         step(s). A market whose feeds are never set prices nothing."
+    );
+    Ok(())
 }
 
 /// The proposals must be executable, in this plan, in this order.
@@ -1686,6 +1744,47 @@ mod tests {
 
         let error = super::ensure_proposals_are_runnable(&file).expect_err("unrunnable");
         assert!(format!("{error:#}").contains(expected), "{error:#}");
+    }
+
+    /// Deleting a step disables the guard that validates it, so completeness is
+    /// checked before coherence. Same fail-open shape as the swallowed `Err`s,
+    /// in the form where the value is absent rather than unreadable.
+    #[test]
+    fn a_truncated_plan_is_refused() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        let deploy = |init: serde_json::Value| PlanStep {
+            label: "deploy".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "x",
+                    "version_key": "v1",
+                    "init_args": base64::engine::general_purpose::STANDARD
+                        .encode(serde_json::to_vec(&init).expect("encode")),
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        };
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        // Governance and market, but no oracle: the two survivors reference an
+        // oracle nothing deploys, and every oracle check would be skipped.
+        file.steps.push(deploy(
+            serde_json::json!({ "proxy_oracle_id": "o.near", "admin_id": "a.near" }),
+        ));
+        file.steps
+            .push(deploy(serde_json::json!({ "configuration": { "x": 1 } })));
+
+        let error = super::ensure_plan_is_complete(&file).expect_err("incomplete");
+        assert!(
+            format!("{error:#}").contains("proxy-oracle deploy"),
+            "{error:#}"
+        );
     }
 
     /// A coherent plan passes.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -123,6 +123,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // succeed and the market deploy fails, which is the half-spent deploy the
     // plan-time check exists to prevent.
     let targets = planned_targets(&file)?;
+    ensure_targets_are_distinct(&targets)?;
     ensure_targets_free(&ctx, &targets).await?;
 
     // Provenance is reported, not enforced.
@@ -189,6 +190,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     }
 
     ensure_plan_is_coherent(&file)?;
+    ensure_initializers_are_sound(&file)?;
 
     // Whoever holds these keys controls the three new accounts. A mistyped or
     // substituted `--public-key` at plan time is invisible in the artifact —
@@ -612,6 +614,57 @@ async fn occupied_targets(
     Ok(occupied)
 }
 
+/// Re-apply, against the encoded steps, the plan-time guards whose subject an
+/// edit can change.
+///
+/// `build` refuses an oracle version that ignores `owner_id` and a non-zero
+/// governance TTL, but both live in step arguments an operator may rewrite, and
+/// a plan-time refusal does not bind the file. This is the third guard in this
+/// PR whose executing value was editable after the check (`admin_id` was the
+/// first), so all of them are re-verified here rather than one at a time.
+fn ensure_initializers_are_sound(file: &PlanFile) -> anyhow::Result<()> {
+    for step in &file.steps {
+        for call in &step.function_calls {
+            let Some(init) = decoded_init_args(call) else {
+                continue;
+            };
+
+            // The oracle: its `new` must honour the owner it is given, or the
+            // registry stays owner and governance can never configure a proxy.
+            if let Some(owner_id) = init.get("owner_id").and_then(|id| id.as_str()) {
+                let bytes = call.args.to_bytes()?;
+                let args: serde_json::Value = serde_json::from_slice(&bytes)
+                    .context("a registry deploy's arguments are not JSON")?;
+                let version_key = args
+                    .get("version_key")
+                    .and_then(|key| key.as_str())
+                    .context("the oracle deploy names no version")?;
+                crate::commands::proxy_oracle::check_owner_id_is_honored(
+                    version_key,
+                    &owner_id
+                        .parse()
+                        .context("the oracle's owner is not an account")?,
+                )?;
+            }
+
+            // Governance: a non-zero TTL makes the proposals in this plan
+            // unexecutable when created, and a plan cannot wait.
+            if let Some(ttls) = init.get("ttls").and_then(|ttls| ttls.as_object()) {
+                for (kind, ttl) in ttls {
+                    anyhow::ensure!(
+                        ttl.as_str() == Some("0") || ttl.as_u64() == Some(0),
+                        "`{}` seats a {kind} TTL of {ttl}, so the proposals this \
+                         plan creates would not be executable when it runs them. \
+                         Deploy with zero TTLs and raise them afterwards.",
+                        step.label,
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
 /// The accounts a deployment creates are named in more places than they are
 /// created, and an edit to one is not an edit to the others.
 ///
@@ -817,6 +870,23 @@ fn deploy_target(
             step.label
         )
     })?))
+}
+
+/// Refuse a plan that creates the same account twice.
+///
+/// Coherent edits can still collide with each other: renaming two deploys to
+/// the same name keeps every reference consistent, and the second deploy fails
+/// after the first has spent its deposit.
+fn ensure_targets_are_distinct(targets: &[AccountId]) -> anyhow::Result<()> {
+    let mut seen = BTreeSet::new();
+    for target in targets {
+        anyhow::ensure!(
+            seen.insert(target),
+            "this plan creates `{target}` more than once; the second deploy would \
+             fail against the account the first just made"
+        );
+    }
+    Ok(())
 }
 
 /// Refuse a plan whose targets are taken.
@@ -1463,6 +1533,53 @@ mod tests {
             format!("{error:#}").contains("mkt-renamed.templar-alpha.near"),
             "{error:#}"
         );
+    }
+
+    /// A non-zero governance TTL makes this plan's own proposals unexecutable
+    /// when it runs them. Refused at plan time, and again here because the
+    /// value lives in editable step arguments.
+    #[test]
+    fn a_non_zero_ttl_in_an_edited_plan_is_refused() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        let init = base64::engine::general_purpose::STANDARD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "proxy_oracle_id": "o.near",
+                "admin_id": "a.near",
+                "ttls": { "set_proxy": "600000000000", "rearm": "0" },
+            }))
+            .expect("encode"),
+        );
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy governance".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "gov", "version_key": "v1", "init_args": init,
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(3),
+            }],
+        });
+
+        let error = super::ensure_initializers_are_sound(&file).expect_err("non-zero ttl");
+        assert!(format!("{error:#}").contains("set_proxy"), "{error:#}");
+    }
+
+    /// Two deploys renamed to the same account keep every reference coherent
+    /// and still collide with each other.
+    #[test]
+    fn duplicate_targets_are_refused() {
+        let shared: near_account_id::AccountId =
+            "same.templar-alpha.near".parse().expect("valid account");
+        let error = super::ensure_targets_are_distinct(&[shared.clone(), shared])
+            .expect_err("two deploys, one account");
+
+        assert!(format!("{error:#}").contains("more than once"), "{error:#}");
     }
 
     /// A coherent plan passes.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -187,6 +187,38 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         );
     }
 
+    ensure_oracle_is_coherent(&file)?;
+
+    // Whoever holds these keys controls the three new accounts. A mistyped or
+    // substituted `--public-key` at plan time is invisible in the artifact —
+    // the keys live inside the encoded args — so where the applier's own key is
+    // derivable it must be the one being granted.
+    if let Ok(mine) = args.signer.public_key() {
+        // Compared through the JSON encoding, which is the form the args carry.
+        let mine = serde_json::to_value(&mine)
+            .ok()
+            .and_then(|key| key.as_str().map(ToOwned::to_owned))
+            .unwrap_or_default();
+        for step in &file.steps {
+            for call in &step.function_calls {
+                let granted = granted_keys(call);
+                anyhow::ensure!(
+                    granted.is_empty() || granted.iter().any(|key| key == &mine),
+                    "`{}` grants full access to {}, not to `{mine}`. Applying this \
+                     would hand control of the new account to a key you do not \
+                     hold; re-plan with your own --public-key, or pass the key \
+                     that is named.",
+                    step.label,
+                    granted
+                        .iter()
+                        .map(|key| format!("`{key}`"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                );
+            }
+        }
+    }
+
     if !args.yes {
         confirm(&format!(
             "Send {} transaction(s) as {credential}?",
@@ -573,6 +605,87 @@ async fn occupied_targets(
     Ok(occupied)
 }
 
+/// Three steps name the oracle, and an edit to one is not an edit to the others.
+///
+/// The oracle deploy creates `{name}.{registry}`; the governance initializer
+/// names it as `proxy_oracle_id`; the market configuration points at it as its
+/// price oracle. Editing the oracle deploy's `name` — a supported edit that
+/// `planned_targets` now follows correctly — silently leaves the other two
+/// pointing at an account this plan never creates, producing a live market
+/// wired to nothing.
+fn ensure_oracle_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
+    let mut deployed: Option<AccountId> = None;
+    let mut governance_says: Option<String> = None;
+    let mut market_says: Option<String> = None;
+
+    for step in &file.steps {
+        for call in &step.function_calls {
+            let Some(init) = decoded_init_args(call) else {
+                continue;
+            };
+            // The oracle is the deploy whose initializer seats an owner.
+            if init.get("owner_id").is_some() {
+                deployed = deploy_target(step, call)?;
+            }
+            if let Some(oracle) = init.get("proxy_oracle_id").and_then(|id| id.as_str()) {
+                governance_says = Some(oracle.to_owned());
+            }
+            if let Some(oracle) = init
+                .pointer("/configuration/price_oracle_configuration/account_id")
+                .and_then(|id| id.as_str())
+            {
+                market_says = Some(oracle.to_owned());
+            }
+        }
+    }
+
+    let Some(deployed) = deployed else {
+        return Ok(());
+    };
+    for (who, named) in [
+        ("the governance initializer", governance_says),
+        ("the market configuration", market_says),
+    ] {
+        if let Some(named) = named {
+            anyhow::ensure!(
+                named == deployed.as_str(),
+                "this plan deploys the oracle as `{deployed}`, but {who} points at \
+                 `{named}`. One of them was edited without the other, and the \
+                 market would be wired to an oracle this plan never creates."
+            );
+        }
+    }
+    Ok(())
+}
+
+/// The account a single registry-deploy call would create.
+fn deploy_target(
+    step: &crate::spec::plan::PlanStep,
+    call: &crate::spec::plan::PlanFunctionCall,
+) -> anyhow::Result<Option<AccountId>> {
+    let bytes = call.args.to_bytes()?;
+    let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(None);
+    };
+    if args.get("version_key").is_none() {
+        return Ok(None);
+    }
+    let name = args.get("name").and_then(serde_json::Value::as_str);
+    let target = name.and_then(|name| {
+        format!("{name}.{}", step.receiver_id)
+            .parse::<AccountId>()
+            .ok()
+    });
+    Ok(Some(target.with_context(|| {
+        format!(
+            "`{}` deploys from a registry but names no usable sub-account \
+             ({name:?}), so the account it would create cannot be checked \
+             for a collision",
+            step.label
+        )
+    })?))
+}
+
 /// Refuse a plan whose targets are taken.
 ///
 /// Best-effort, and deliberately so. `account::Get` cannot see a target another
@@ -667,11 +780,37 @@ fn render(file: &PlanFile) {
                 "      {}  deposit {}  gas {}",
                 call.method_name, call.deposit, call.gas
             );
+            for key in granted_keys(call) {
+                eprintln!("      grants full access to: {key}");
+            }
             if let Some(init_args) = decoded_init_args(call) {
                 eprintln!("      init_args: {init_args}");
             }
         }
     }
+}
+
+/// The keys a deploy grants full access to on the account it creates.
+///
+/// Rendered because they are otherwise invisible: they sit inside the call's
+/// args, which are not printed, yet they decide who controls the three new
+/// accounts. A mistyped or substituted `--public-key` at plan time is
+/// indistinguishable from a correct one unless an operator can see it.
+fn granted_keys(call: &crate::spec::plan::PlanFunctionCall) -> Vec<String> {
+    let Ok(bytes) = call.args.to_bytes() else {
+        return Vec::new();
+    };
+    let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Vec::new();
+    };
+    args.get("full_access_keys")
+        .and_then(|keys| keys.as_array())
+        .map(|keys| {
+            keys.iter()
+                .filter_map(|key| key.as_str().map(ToOwned::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 /// One field of a registry deploy's decoded `init_args`, as a string.
@@ -981,6 +1120,93 @@ mod tests {
             Some("someone-else.near"),
             "the seated admin must be visible regardless of arg representation"
         );
+    }
+
+    /// Editing the oracle deploy's `name` without updating the two places that
+    /// reference it produces a live market wired to an oracle nobody deployed.
+    #[test]
+    fn an_inconsistently_renamed_oracle_is_refused() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        fn deploy(label: &str, name: &str, init: serde_json::Value) -> PlanStep {
+            let encoded = base64::engine::general_purpose::STANDARD
+                .encode(serde_json::to_vec(&init).expect("encode init"));
+            PlanStep {
+                label: label.to_owned(),
+                signer_id: "operator.near".parse().expect("valid account"),
+                receiver_id: "templar-alpha.near".parse().expect("valid account"),
+                function_calls: vec![PlanFunctionCall {
+                    method_name: "deploy_market".to_owned(),
+                    args: PlanArgs::Json(serde_json::json!({
+                        "name": name,
+                        "version_key": "v1",
+                        "init_args": encoded,
+                    })),
+                    gas: 300_000_000_000_000,
+                    deposit: near_api::types::NearToken::from_near(5),
+                }],
+            }
+        }
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        // The oracle is renamed...
+        file.steps.push(deploy(
+            "deploy oracle",
+            "renamed-oracle",
+            serde_json::json!({ "owner_id": "gov.templar-alpha.near" }),
+        ));
+        // ...but the market still points at the original.
+        file.steps.push(deploy(
+            "deploy market",
+            "mkt",
+            serde_json::json!({
+                "configuration": {
+                    "price_oracle_configuration": {
+                        "account_id": "proxy-oracle-original.templar-alpha.near"
+                    }
+                }
+            }),
+        ));
+
+        let error = super::ensure_oracle_is_coherent(&file).expect_err("inconsistent");
+        assert!(
+            format!("{error:#}").contains("renamed-oracle.templar-alpha.near"),
+            "{error:#}"
+        );
+        assert!(
+            format!("{error:#}").contains("market configuration"),
+            "{error:#}"
+        );
+    }
+
+    /// A coherent plan passes.
+    #[test]
+    fn a_coherent_oracle_reference_is_accepted() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        let encoded = base64::engine::general_purpose::STANDARD.encode(
+            serde_json::to_vec(&serde_json::json!({ "owner_id": "gov.near" })).expect("encode"),
+        );
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy oracle".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "o",
+                    "version_key": "v1",
+                    "init_args": encoded,
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        });
+
+        super::ensure_oracle_is_coherent(&file).expect("nothing contradicts it");
     }
 
     /// A governance proposal creates no account, so it contributes no target.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -2,6 +2,7 @@
 //! that file. Splitting the two puts a reviewable, editable artifact between
 //! them; the artifact itself is [`crate::spec::plan`].
 
+use std::collections::BTreeSet;
 use std::io::Write as _;
 
 use anyhow::Context as _;
@@ -101,6 +102,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
 
     ensure_compatible(&file, &ctx.network().to_string())?;
     render(&file);
+    report_checks(&file);
 
     // Provenance is reported, not enforced.
     let drift = file.drift()?;
@@ -112,11 +114,26 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         );
     }
 
+    // Each step names its own signer; `execute_as` only labels the store
+    // record. A credential for some other account fails at step 0 with an
+    // opaque executor error, so it is caught here instead.
+    let credential = args.signer.account_id().0;
+    let signers: BTreeSet<&AccountId> = file.steps.iter().map(|step| &step.signer_id).collect();
+    anyhow::ensure!(
+        signers.iter().all(|signer| **signer == credential),
+        "this plan is signed by {}, but the credential given is for `{credential}`. \
+         Re-run with a matching --signer-id, or re-plan.",
+        signers
+            .iter()
+            .map(|signer| format!("`{signer}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+
     if !args.yes {
         confirm(&format!(
-            "Send {} transaction(s) as {}?",
+            "Send {} transaction(s) as {credential}?",
             file.steps.len(),
-            args.signer.account_id().0,
         ))?;
     }
 
@@ -150,6 +167,20 @@ pub(crate) async fn build(
          proposal, or run the proposals by hand with `proxy-oracle governance \
          execute-proposal --when-ready`.",
         spec.governance.ttl_default.as_ns(),
+    );
+
+    // The proposals are created and executed by `signer_id`, but only
+    // `governance.admin` is granted the Admin role at init. Mismatched, the two
+    // registry deploys succeed and every proposal reverts — 8.5 NEAR spent on
+    // exactly the orphaned half-deployment this tool exists to prevent.
+    // `deploy.sh` made this unrepresentable by passing `--admin-id $SIGNER_ID`.
+    anyhow::ensure!(
+        &spec.governance.admin == signer_id,
+        "`governance.admin` is `{}` but this plan is signed by `{signer_id}`, \
+         which would not hold the Admin role. Every proxy proposal would revert \
+         after the governance and oracle deploys had already spent their \
+         deposits. Set them to the same account.",
+        spec.governance.admin,
     );
 
     let price_maximum_age = spec.market.price_maximum_age;
@@ -391,6 +422,38 @@ fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+/// The checks the plan carries.
+///
+/// `apply` is often run by someone other than whoever planned, and a plan can be
+/// hand-edited, so the verdicts travel with the artifact and are shown before
+/// the prompt. Only non-passing ones are printed: a suppressed check records the
+/// failure it overrode, and burying that in a wall of green is how an override
+/// stops being reviewed.
+fn report_checks(file: &PlanFile) {
+    let notable: Vec<_> = file
+        .checks
+        .iter()
+        .filter(|check| !matches!(check.status, Status::Passed { .. }))
+        .collect();
+
+    let failed = crate::spec::check::failures(&file.checks);
+    eprintln!(
+        "\n{} check(s): {} passed, {} not run, {failed} FAILED",
+        file.checks.len(),
+        file.checks.len() - notable.len(),
+        notable.len() - failed,
+    );
+    for check in notable {
+        eprintln!("  {} — {:?}", check.id, check.status);
+    }
+    if failed > 0 {
+        eprintln!(
+            "This plan carries FAILED checks. `market plan` refuses to write one, \
+             so this file was edited or produced by another build."
+        );
+    }
+}
+
 /// The plan, for a human about to authorize it.
 fn render(file: &PlanFile) {
     eprintln!(
@@ -405,8 +468,34 @@ fn render(file: &PlanFile) {
                 "      {}  deposit {}  gas {}",
                 call.method_name, call.deposit, call.gas
             );
+            if let Some(init_args) = decoded_init_args(call) {
+                eprintln!("      init_args: {init_args}");
+            }
         }
     }
+}
+
+/// A registry deploy's `init_args`, decoded.
+///
+/// `registry.deploy` takes them as base64 *inside* its JSON args, so the market
+/// configuration — the MCRs, the rate curve, the oracle account — is the one
+/// part of a deployment the artifact cannot show as JSON. Telling an operator to
+/// read the steps while hiding the payload that matters most would be hollow, so
+/// it is decoded for display. It stays base64 in the file: expanding it there
+/// would have to survive a byte-exact round trip, which is a schema change
+/// rather than a rendering one.
+fn decoded_init_args(call: &crate::spec::plan::PlanFunctionCall) -> Option<String> {
+    use base64::Engine as _;
+
+    let crate::spec::plan::PlanArgs::Json(args) = &call.args else {
+        return None;
+    };
+    let encoded = args.get("init_args")?.as_str()?;
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
+    serde_json::to_string(&value).ok()
 }
 
 /// Ask before spending real NEAR. Anything but `y` aborts.
@@ -537,6 +626,7 @@ mod tests {
             network: network.to_owned(),
             spec_digest: "sha256:test".to_owned(),
             step_digests: Vec::new(),
+            summary_digest: "sha256:test".to_owned(),
             derived: Derived {
                 market_id: "m.near".parse().expect("valid account"),
                 oracle_id: "o.near".parse().expect("valid account"),

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -1,19 +1,13 @@
 //! `market plan` / `market apply` — generate a deployment as a file, then send
-//! that file.
-//!
-//! The two commands exist because a spec cannot express every market and a check
-//! can be wrong. Splitting generation from execution puts a reviewable artifact
-//! between the two, and makes the concrete transactions editable when the
-//! declarative path falls short.
-//!
-//! What `plan` produces is exactly what `deploy.sh` runs today, in the same
-//! order — see [`build`].
+//! that file. Splitting the two puts a reviewable, editable artifact between
+//! them; the artifact itself is [`crate::spec::plan`].
 
 use std::io::Write as _;
 
 use anyhow::Context as _;
 use near_account_id::AccountId;
 use near_api::types::NearToken;
+use templar_common::oracle::pyth::PriceIdentifier;
 use templar_common::Nanoseconds;
 use templar_gateway_client::Client;
 use templar_gateway_core::{
@@ -25,6 +19,8 @@ use templar_gateway_methods_spec::{
 };
 use templar_gateway_types::common::{WriteOperationResult, WriteRequest};
 use templar_gateway_types::{primitive::PublicKey, Base64Bytes, MethodSpec};
+use templar_proxy_oracle_kernel::proxy::Proxy;
+use templar_proxy_oracle_near_common::input::Source;
 use templar_proxy_oracle_near_governance_common::Operation;
 
 use crate::commands::market::{Apply, Plan};
@@ -37,12 +33,10 @@ use crate::spec::{
 };
 
 /// Deposits funding each new account's storage and balance, matching
-/// `script/deploy.sh`.
-///
-/// Constants rather than spec fields: these size a *contract's* storage staking,
-/// which follows from the code being deployed, not from the market's identity.
-/// A deployment that genuinely needs more can raise one by editing the plan,
-/// which is what the artifact is for.
+/// `script/deploy.sh`. Constants rather than spec fields: these size a
+/// *contract's* storage staking, which follows from the code being deployed
+/// rather than from the market. A deployment needing more can raise one by
+/// editing the plan.
 const GOVERNANCE_DEPOSIT: NearToken = NearToken::from_millinear(3_500);
 const ORACLE_DEPOSIT: NearToken = NearToken::from_near(5);
 const MARKET_DEPOSIT: NearToken = NearToken::from_millinear(5_500);
@@ -56,10 +50,7 @@ pub(super) async fn plan(ctx: CliContext, args: Plan) -> anyhow::Result<()> {
         super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch).await?;
     apply_skips(&mut checks, &args.skip_check)?;
 
-    let failed = checks
-        .iter()
-        .filter(|check| check.status.is_failure())
-        .count();
+    let failed = crate::spec::check::failures(&checks);
     if failed > 0 {
         print_json(&checks)?;
         anyhow::bail!(
@@ -68,7 +59,13 @@ pub(super) async fn plan(ctx: CliContext, args: Plan) -> anyhow::Result<()> {
         );
     }
 
-    let steps = build(&ctx.client, &spec, &args.public_key(), &args.signer_id).await?;
+    let steps = build(
+        &ctx.client,
+        &spec,
+        &PublicKey::from(args.public_key),
+        &args.signer_id,
+    )
+    .await?;
     let file = PlanFile::new(
         spec.network()?.to_string(),
         spec_digest,
@@ -124,15 +121,8 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     }
 
     let plan = file.into_operation_plan()?;
-    let (signer, client) = ctx.signing_client_for(&args.signer).await?;
-    let output = client
-        .execute_request(WriteRequest {
-            signer_account_id: signer,
-            idempotency_key: None,
-            body: PreparedPlan { steps: plan.steps },
-        })
-        .await?;
-    ctx.finish_write(&output)
+    ctx.execute_via::<PlanDispatch, _>(&args.signer, PreparedPlan { steps: plan.steps })
+        .await
 }
 
 /// The deployment, in the order `deploy.sh` runs it.
@@ -162,7 +152,6 @@ pub(crate) async fn build(
         spec.governance.ttl_default.as_ns(),
     );
 
-    let governance_id = spec.governance_id()?;
     let price_maximum_age = spec.market.price_maximum_age;
     let full_access_keys = Some(vec![public_key.clone()]);
 
@@ -173,12 +162,21 @@ pub(crate) async fn build(
     // governance. Resuming onto existing contracts is ENG-546.
     let (collateral_proposal, borrow_proposal) = (0, 1);
 
-    let (collateral_decimals, borrow_decimals) = decimals(spec)?;
+    // Resolved by the preflight; the caller refuses before reaching here if a
+    // decimals check failed. Guessing would mis-scale every price.
+    let (Some(collateral_decimals), Some(borrow_decimals)) =
+        (spec.collateral.decimals, spec.borrow.decimals)
+    else {
+        anyhow::bail!(
+            "asset decimals are unresolved, so a market configuration cannot be \
+             built. Set `decimals` in the spec, or fix `asset.decimals.*`."
+        );
+    };
     let configuration = spec
         .clone()
-        .into_market_configuration(collateral_decimals, borrow_decimals)?;
+        .into_market_configuration(i32::from(collateral_decimals), i32::from(borrow_decimals))?;
 
-    let mut steps = Vec::from(oracle_stack(client, signer_id, spec, public_key).await?);
+    let mut steps = oracle_stack(client, signer_id, spec, public_key).await?;
 
     // Both sides project to the same `Proxy<Source>`, so one loop covers them
     // even though `AssetSpec` is generic over the asset class.
@@ -196,21 +194,7 @@ pub(crate) async fn build(
             spec.borrow.clone().into_proxy(price_maximum_age),
         ),
     ] {
-        steps.extend(
-            set_proxy(
-                client,
-                signer_id,
-                &governance_id,
-                spec.governance.ttl_default,
-                ProxyProposal {
-                    side,
-                    price_id,
-                    proposal_id,
-                    proxy,
-                },
-            )
-            .await?,
-        );
+        steps.extend(set_proxy(client, signer_id, spec, side, price_id, proposal_id, proxy).await?);
     }
 
     steps.push((
@@ -233,17 +217,14 @@ pub(crate) async fn build(
     Ok(steps)
 }
 
-/// The governance contract and the oracle it owns.
-///
-/// Emitted as a pair, in this order: the oracle names its governance as
-/// `owner_id` at init, so governance must exist first. Reversing them would
-/// deploy an oracle owned by an account that does not exist yet.
+/// The governance contract, then the oracle it owns: the oracle names its
+/// governance as `owner_id` at init, so governance must exist first.
 async fn oracle_stack(
     client: &Client,
     signer_id: &AccountId,
     spec: &MarketSpec,
     public_key: &PublicKey,
-) -> anyhow::Result<[(String, PlannedTransaction); 2]> {
+) -> anyhow::Result<Vec<(String, PlannedTransaction)>> {
     let full_access_keys = Some(vec![public_key.clone()]);
     let governance_id = spec.governance_id()?;
     let oracle_id = spec.oracle_id()?;
@@ -255,7 +236,7 @@ async fn oracle_stack(
     })
     .context("encode governance init args")?;
 
-    Ok([
+    Ok(vec![
         (
             format!("deploy governance {governance_id}"),
             step(
@@ -291,36 +272,20 @@ async fn oracle_stack(
     ])
 }
 
-/// One feed's proxy configuration, as a governance proposal.
-struct ProxyProposal {
-    side: &'static str,
-    price_id: templar_common::oracle::pyth::PriceIdentifier,
-    proposal_id: u32,
-    proxy:
-        templar_proxy_oracle_kernel::proxy::Proxy<templar_proxy_oracle_near_common::input::Source>,
-}
-
-/// Propose a feed's proxy, then execute that proposal.
-///
-/// Two transactions rather than one: a proposal is always created before it can
-/// run, even at `ttl_default = 0`. They are emitted as a pair so a plan can
-/// never carry a create without its execute, which would leave the oracle
-/// configured for one leg only.
+/// Propose a feed's proxy, then execute that proposal. Two transactions: a
+/// proposal is always created before it can run, even at `ttl_default = 0`.
 async fn set_proxy(
     client: &Client,
     signer_id: &AccountId,
-    governance_id: &AccountId,
-    requested_ttl: Nanoseconds,
-    proposal: ProxyProposal,
-) -> anyhow::Result<[(String, PlannedTransaction); 2]> {
-    let ProxyProposal {
-        side,
-        price_id,
-        proposal_id,
-        proxy,
-    } = proposal;
+    spec: &MarketSpec,
+    side: &str,
+    price_id: PriceIdentifier,
+    proposal_id: u32,
+    proxy: Proxy<Source>,
+) -> anyhow::Result<Vec<(String, PlannedTransaction)>> {
+    let governance_id = spec.governance_id()?;
 
-    Ok([
+    Ok(vec![
         (
             format!("propose {side} proxy (proposal {proposal_id})"),
             step(
@@ -333,7 +298,7 @@ async fn set_proxy(
                         id: price_id,
                         proxy: Some(proxy),
                     },
-                    requested_ttl,
+                    requested_ttl: spec.governance.ttl_default,
                 },
             )
             .await?,
@@ -344,7 +309,7 @@ async fn set_proxy(
                 client,
                 signer_id,
                 gov::ExecuteProposal {
-                    governance_id: governance_id.clone(),
+                    governance_id,
                     id: proposal_id,
                 },
             )
@@ -353,23 +318,8 @@ async fn set_proxy(
     ])
 }
 
-/// Decimals resolved by the preflight. Absent means a check failed, and the
-/// caller refuses before reaching here — but building a configuration from
-/// guessed decimals would mis-scale every price, so this never assumes.
-fn decimals(spec: &MarketSpec) -> anyhow::Result<(i32, i32)> {
-    let (Some(collateral), Some(borrow)) = (spec.collateral.decimals, spec.borrow.decimals) else {
-        anyhow::bail!(
-            "asset decimals are unresolved, so a market configuration cannot be \
-             built. Set `decimals` in the spec, or fix `asset.decimals.*`."
-        );
-    };
-    Ok((i32::from(collateral), i32::from(borrow)))
-}
-
-/// Plan one write, requiring it to be a single transaction.
-///
-/// Each of these specs plans to exactly one; a multi-transaction step would make
-/// the labels lie about what an operator is confirming.
+/// Plan one write, requiring it to be a single transaction — a multi-transaction
+/// step would make the labels lie about what an operator is confirming.
 async fn step<S>(
     client: &Client,
     signer_id: &AccountId,
@@ -387,24 +337,14 @@ where
         })
         .await?;
 
-    let [transaction] = <[PlannedTransaction; 1]>::try_from(plan.steps).map_err(|steps| {
-        anyhow::anyhow!(
-            "`{}` planned {} transactions; the plan builder assumes one per step",
-            S::RPC_METHOD,
-            steps.len()
-        )
-    })?;
-    Ok(transaction)
+    crate::context::single_transaction(plan)
+        .with_context(|| format!("planning `{}`", S::RPC_METHOD))
 }
 
-/// Mark the named checks skipped, preserving the verdict each one reached.
-///
-/// The original detail is kept in the reason: a reviewer of the plan needs to
-/// see *what* was suppressed, and a bare "skipped" would hide the failure the
-/// operator chose to override.
-///
-/// An id that matches nothing is an error. A typo would otherwise read as a
-/// successful suppression while the check kept running.
+/// Mark the named checks skipped, recording the verdict each one reached — a
+/// bare "skipped" would hide the failure the operator chose to override. An id
+/// matching nothing is an error, since a typo would otherwise read as a
+/// successful suppression.
 fn apply_skips(checks: &mut [Check], skip: &[String]) -> anyhow::Result<()> {
     for id in skip {
         let mut matched = false;
@@ -431,13 +371,9 @@ fn apply_skips(checks: &mut [Check], skip: &[String]) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// The only two hard refusals.
-///
-/// A schema mismatch means this build cannot read the file faithfully, and a
-/// network mismatch would send a mainnet deployment to testnet or the reverse.
-/// Everything else — including a plan edited beyond recognition — is reported
-/// and confirmed rather than blocked, because blocking it would defeat the
-/// artifact's purpose.
+/// The only two hard refusals: this build cannot read a foreign schema
+/// faithfully, and a network mismatch would send a mainnet deployment to testnet
+/// or the reverse. Everything else is reported and confirmed, never blocked.
 fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
     anyhow::ensure!(
         file.schema == PLAN_SCHEMA_VERSION,
@@ -491,8 +427,8 @@ fn confirm(question: &str) -> anyhow::Result<()> {
 }
 
 /// A plan that is already built, so an edited plan file rides the same executor
-/// as every other write — the store, idempotency, and recovery behaviour all
-/// come along rather than being reimplemented here.
+/// as every other write — store, idempotency and recovery come along rather than
+/// being reimplemented here.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 struct PreparedPlan {
     steps: Vec<PlannedTransaction>,
@@ -503,9 +439,7 @@ impl schemars::JsonSchema for PreparedPlan {
         "PreparedPlan".to_owned()
     }
 
-    /// Never served over the RPC surface — this spec exists only to reach the
-    /// executor from inside this binary — so an unconstrained schema is honest
-    /// rather than lazy.
+    /// Never served over the RPC surface, so there is no schema to describe.
     fn json_schema(_generator: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
         schemars::schema::Schema::Bool(true)
     }
@@ -513,11 +447,19 @@ impl schemars::JsonSchema for PreparedPlan {
 
 impl MethodSpec for PreparedPlan {
     type Output = WriteOperationResult;
-    const RPC_METHOD: &'static str = "market.apply";
+    const RPC_METHOD: &'static str = "manager.applyPlan";
 }
 
+/// A dispatcher local to this binary, reached with `Client::via`.
+///
+/// The impl deliberately does *not* target `methods_dispatch::Dispatch`: that
+/// would bolt a method onto the shared dispatcher from a leaf tool, giving it a
+/// capability `methods-spec` never declares and that never appears in
+/// `METHODS.md`. A local ZST keeps the passthrough where it belongs.
+pub(crate) struct PlanDispatch;
+
 #[async_trait::async_trait]
-impl PlanWrite<PreparedPlan, GatewayContext> for Dispatch {
+impl PlanWrite<PreparedPlan, GatewayContext> for PlanDispatch {
     async fn plan(
         request: WriteRequest<PreparedPlan>,
         _context: GatewayContext,
@@ -588,7 +530,7 @@ mod tests {
         assert!(error.to_string().contains("names no check"), "{error:#}");
     }
 
-    fn plan_file(schema: u32, network: &str) -> PlanFile {
+    fn bare_plan(schema: u32, network: &str) -> PlanFile {
         PlanFile {
             schema,
             tool_version: "0.1.0".to_owned(),
@@ -609,7 +551,7 @@ mod tests {
 
     #[test]
     fn a_matching_plan_is_accepted() {
-        ensure_compatible(&plan_file(PLAN_SCHEMA_VERSION, "mainnet"), "mainnet")
+        ensure_compatible(&bare_plan(PLAN_SCHEMA_VERSION, "mainnet"), "mainnet")
             .expect("same schema and network");
     }
 
@@ -617,7 +559,7 @@ mod tests {
     /// a confirmation prompt should be able to wave through.
     #[test]
     fn a_network_mismatch_is_refused() {
-        let error = ensure_compatible(&plan_file(PLAN_SCHEMA_VERSION, "mainnet"), "testnet")
+        let error = ensure_compatible(&bare_plan(PLAN_SCHEMA_VERSION, "mainnet"), "testnet")
             .expect_err("wrong network");
 
         assert!(
@@ -628,7 +570,7 @@ mod tests {
 
     #[test]
     fn a_schema_mismatch_is_refused() {
-        let error = ensure_compatible(&plan_file(PLAN_SCHEMA_VERSION + 1, "mainnet"), "mainnet")
+        let error = ensure_compatible(&bare_plan(PLAN_SCHEMA_VERSION + 1, "mainnet"), "mainnet")
             .expect_err("wrong schema");
 
         assert!(error.to_string().contains("Regenerate it"), "{error:#}");

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -187,13 +187,21 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         );
     }
 
-    ensure_oracle_is_coherent(&file)?;
+    ensure_plan_is_coherent(&file)?;
 
     // Whoever holds these keys controls the three new accounts. A mistyped or
     // substituted `--public-key` at plan time is invisible in the artifact —
     // the keys live inside the encoded args — so where the applier's own key is
     // derivable it must be the one being granted.
-    if let Ok(mine) = args.signer.public_key() {
+    // Not `if let Ok(..)`: an unknown key must refuse, not skip. With
+    // `--sign-with keychain` and no `--public-key` this errors, and swallowing
+    // that would disable the guard in exactly the configuration that cannot
+    // derive its own key.
+    {
+        let mine = args.signer.public_key().context(
+            "cannot tell which key this plan grants full access to without knowing \
+             yours; pass --public-key",
+        )?;
         // Compared through the JSON encoding, which is the form the args carry.
         let mine = serde_json::to_value(&mine)
             .ok()
@@ -605,53 +613,89 @@ async fn occupied_targets(
     Ok(occupied)
 }
 
-/// Three steps name the oracle, and an edit to one is not an edit to the others.
+/// The accounts a deployment creates are named in more places than they are
+/// created, and an edit to one is not an edit to the others.
 ///
-/// The oracle deploy creates `{name}.{registry}`; the governance initializer
-/// names it as `proxy_oracle_id`; the market configuration points at it as its
-/// price oracle. Editing the oracle deploy's `name` — a supported edit that
-/// `planned_targets` now follows correctly — silently leaves the other two
-/// pointing at an account this plan never creates, producing a live market
-/// wired to nothing.
-fn ensure_oracle_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
-    let mut deployed: Option<AccountId> = None;
-    let mut governance_says: Option<String> = None;
-    let mut market_says: Option<String> = None;
+/// The oracle is created by its deploy, named by the governance initializer as
+/// `proxy_oracle_id`, and pointed at by the market configuration. Governance is
+/// created by its deploy, named by the oracle initializer as `owner_id`, and
+/// addressed by every proposal step. `planned_targets` follows a renamed
+/// account correctly — which is what makes this necessary rather than
+/// redundant: the renamed account really is deployed and collision-checked,
+/// while every stale reference still points at one the plan never creates.
+fn ensure_plan_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
+    let (mut oracle, mut governance) = (None, None);
+    let (mut governance_says, mut market_says, mut oracle_says) = (None, None, None);
 
     for step in &file.steps {
         for call in &step.function_calls {
             let Some(init) = decoded_init_args(call) else {
                 continue;
             };
-            // The oracle is the deploy whose initializer seats an owner.
-            if init.get("owner_id").is_some() {
-                deployed = deploy_target(step, call)?;
+            // The oracle's initializer seats an owner; governance's seats an admin.
+            if let Some(owner) = init.get("owner_id").and_then(|id| id.as_str()) {
+                oracle = deploy_target(step, call)?;
+                oracle_says = Some(owner.to_owned());
             }
-            if let Some(oracle) = init.get("proxy_oracle_id").and_then(|id| id.as_str()) {
-                governance_says = Some(oracle.to_owned());
+            if init.get("admin_id").is_some() {
+                governance = deploy_target(step, call)?;
             }
-            if let Some(oracle) = init
+            if let Some(named) = init.get("proxy_oracle_id").and_then(|id| id.as_str()) {
+                governance_says = Some(named.to_owned());
+            }
+            if let Some(named) = init
                 .pointer("/configuration/price_oracle_configuration/account_id")
                 .and_then(|id| id.as_str())
             {
-                market_says = Some(oracle.to_owned());
+                market_says = Some(named.to_owned());
             }
         }
     }
 
-    let Some(deployed) = deployed else {
-        return Ok(());
-    };
-    for (who, named) in [
-        ("the governance initializer", governance_says),
-        ("the market configuration", market_says),
+    for (created, label, references) in [
+        (
+            oracle.as_ref(),
+            "oracle",
+            vec![
+                ("the governance initializer", governance_says),
+                ("the market configuration", market_says),
+            ],
+        ),
+        (
+            governance.as_ref(),
+            "governance contract",
+            vec![("the oracle's owner", oracle_says)],
+        ),
     ] {
-        if let Some(named) = named {
+        let Some(created) = created else { continue };
+        for (who, named) in references {
+            if let Some(named) = named {
+                anyhow::ensure!(
+                    named == created.as_str(),
+                    "this plan deploys the {label} as `{created}`, but {who} points \
+                     at `{named}`. One was edited without the other, so the \
+                     deployment would reference an account this plan never creates."
+                );
+            }
+        }
+    }
+
+    // Every step that is not a registry deploy addresses the governance
+    // contract. A renamed governance would otherwise leave the proposals
+    // pointing at the old account.
+    if let Some(governance) = governance {
+        for step in &file.steps {
+            let deploys = step
+                .function_calls
+                .iter()
+                .any(|call| matches!(deploy_target(step, call), Ok(Some(_))));
             anyhow::ensure!(
-                named == deployed.as_str(),
-                "this plan deploys the oracle as `{deployed}`, but {who} points at \
-                 `{named}`. One of them was edited without the other, and the \
-                 market would be wired to an oracle this plan never creates."
+                deploys || step.receiver_id == governance,
+                "`{}` is addressed to `{}`, but this plan deploys governance as \
+                 `{governance}`. The proposal would be sent to an account this \
+                 plan never creates.",
+                step.label,
+                step.receiver_id,
             );
         }
     }
@@ -1169,13 +1213,60 @@ mod tests {
             }),
         ));
 
-        let error = super::ensure_oracle_is_coherent(&file).expect_err("inconsistent");
+        let error = super::ensure_plan_is_coherent(&file).expect_err("inconsistent");
         assert!(
             format!("{error:#}").contains("renamed-oracle.templar-alpha.near"),
             "{error:#}"
         );
         assert!(
             format!("{error:#}").contains("market configuration"),
+            "{error:#}"
+        );
+    }
+
+    /// Renaming the governance deploy leaves the oracle owned by, and the
+    /// proposals addressed to, an account the plan never creates.
+    #[test]
+    fn a_renamed_governance_is_refused() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        let encode = |init: &serde_json::Value| {
+            base64::engine::general_purpose::STANDARD
+                .encode(serde_json::to_vec(init).expect("encode init"))
+        };
+        let deploy = |label: &str, name: &str, init: serde_json::Value| PlanStep {
+            label: label.to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": name,
+                    "version_key": "v1",
+                    "init_args": encode(&init),
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        };
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(deploy(
+            "deploy governance",
+            "gov-renamed",
+            serde_json::json!({ "proxy_oracle_id": "o.templar-alpha.near", "admin_id": "a.near" }),
+        ));
+        // The oracle still names the *old* governance as its owner.
+        file.steps.push(deploy(
+            "deploy oracle",
+            "o",
+            serde_json::json!({ "owner_id": "gov.templar-alpha.near" }),
+        ));
+
+        let error = super::ensure_plan_is_coherent(&file).expect_err("inconsistent");
+        assert!(
+            format!("{error:#}").contains("gov-renamed.templar-alpha.near"),
             "{error:#}"
         );
     }
@@ -1206,7 +1297,7 @@ mod tests {
             }],
         });
 
-        super::ensure_oracle_is_coherent(&file).expect("nothing contradicts it");
+        super::ensure_plan_is_coherent(&file).expect("nothing contradicts it");
     }
 
     /// A governance proposal creates no account, so it contributes no target.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -558,6 +558,15 @@ async fn occupied_targets(
 }
 
 /// Refuse a plan whose targets are taken.
+///
+/// Best-effort, and deliberately so. `account::Get` cannot see a target another
+/// deploy has *reserved* but not yet created: `deploy_market` writes
+/// `RegistryEntry::Reserved` before scheduling `create_account`, and no registry
+/// view exposes it — `get_deployment` and `list_deployments` both filter to
+/// `Deployed`. Seeing it would need an additive view, the same contract change
+/// the soft-deleted-version gap needs (see `preflight::versions`). The registry
+/// itself is the authoritative guard and rejects the second deploy, so the
+/// unseen case costs a failed step, not a corrupted deployment.
 async fn ensure_targets_free(ctx: &CliContext, targets: &[AccountId]) -> anyhow::Result<()> {
     let occupied = occupied_targets(ctx, targets).await?;
     anyhow::ensure!(
@@ -651,8 +660,7 @@ fn render(file: &PlanFile) {
 
 /// One field of a registry deploy's decoded `init_args`, as a string.
 fn init_arg(call: &crate::spec::plan::PlanFunctionCall, field: &str) -> Option<String> {
-    let decoded: serde_json::Value = serde_json::from_str(&decoded_init_args(call)?).ok()?;
-    Some(decoded.get(field)?.as_str()?.to_owned())
+    Some(decoded_init_args(call)?.get(field)?.as_str()?.to_owned())
 }
 
 /// A registry deploy's `init_args`, decoded.
@@ -664,18 +672,19 @@ fn init_arg(call: &crate::spec::plan::PlanFunctionCall, field: &str) -> Option<S
 /// it is decoded for display. It stays base64 in the file: expanding it there
 /// would have to survive a byte-exact round trip, which is a schema change
 /// rather than a rendering one.
-fn decoded_init_args(call: &crate::spec::plan::PlanFunctionCall) -> Option<String> {
+/// Works from the call's bytes, like [`planned_targets`], so re-encoding the
+/// *outer* args as base64 cannot hide the payload from either the display or
+/// the `admin_id` guard built on it.
+fn decoded_init_args(call: &crate::spec::plan::PlanFunctionCall) -> Option<serde_json::Value> {
     use base64::Engine as _;
 
-    let crate::spec::plan::PlanArgs::Json(args) = &call.args else {
-        return None;
-    };
+    let bytes = call.args.to_bytes().ok()?;
+    let args: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
     let encoded = args.get("init_args")?.as_str()?;
-    let bytes = base64::engine::general_purpose::STANDARD
+    let init = base64::engine::general_purpose::STANDARD
         .decode(encoded)
         .ok()?;
-    let value: serde_json::Value = serde_json::from_slice(&bytes).ok()?;
-    serde_json::to_string(&value).ok()
+    serde_json::from_slice(&init).ok()
 }
 
 /// Ask before spending real NEAR. Anything but `y` aborts.
@@ -921,6 +930,40 @@ mod tests {
         assert!(
             format!("{error:#}").contains("cannot be checked for a collision"),
             "{error:#}"
+        );
+    }
+
+    /// The `admin_id` guard reads the same bytes the executor sends, so
+    /// re-encoding the outer args as base64 cannot hide a stale admin — the
+    /// exact bypass that `planned_targets` had.
+    #[test]
+    fn the_admin_guard_sees_through_base64_args() {
+        use crate::spec::plan::PlanFunctionCall;
+        use base64::Engine as _;
+
+        let init = serde_json::to_vec(&serde_json::json!({
+            "proxy_oracle_id": "o.near",
+            "admin_id": "someone-else.near",
+        }))
+        .expect("encode init args");
+        let outer = serde_json::to_vec(&serde_json::json!({
+            "name": "gov",
+            "version_key": "v1",
+            "init_args": base64::engine::general_purpose::STANDARD.encode(&init),
+        }))
+        .expect("encode outer args");
+
+        let call = PlanFunctionCall {
+            method_name: "deploy_market".to_owned(),
+            args: PlanArgs::Base64(templar_gateway_types::Base64Bytes(outer)),
+            gas: 300_000_000_000_000,
+            deposit: near_api::types::NearToken::from_near(3),
+        };
+
+        assert_eq!(
+            super::init_arg(&call, "admin_id").as_deref(),
+            Some("someone-else.near"),
+            "the seated admin must be visible regardless of arg representation"
         );
     }
 

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -623,7 +623,7 @@ async fn occupied_targets(
 /// redundant: the renamed account really is deployed and collision-checked,
 /// while every stale reference still points at one the plan never creates.
 fn ensure_plan_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
-    let (mut oracle, mut governance) = (None, None);
+    let (mut oracle, mut governance, mut market) = (None, None, None);
     let (mut governance_says, mut market_says, mut oracle_says) = (None, None, None);
 
     for step in &file.steps {
@@ -647,6 +647,10 @@ fn ensure_plan_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
                 .and_then(|id| id.as_str())
             {
                 market_says = Some(named.to_owned());
+            }
+            // The market is the deploy whose initializer carries a configuration.
+            if init.get("configuration").is_some() {
+                market = deploy_target(step, call)?;
             }
         }
     }
@@ -674,6 +678,28 @@ fn ensure_plan_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
                     "this plan deploys the {label} as `{created}`, but {who} points \
                      at `{named}`. One was edited without the other, so the \
                      deployment would reference an account this plan never creates."
+                );
+            }
+        }
+    }
+
+    // A NEP-141 market also registers storage *for the market account*, named
+    // in the registration's own args. Editing the market deploy's `name` leaves
+    // those registrations pointing at an account this plan never creates, so the
+    // new market would be unable to receive its own assets.
+    if let Some(market) = market {
+        for step in &file.steps {
+            for call in &step.function_calls {
+                let Some(registered) = storage_registration_target(call)? else {
+                    continue;
+                };
+                anyhow::ensure!(
+                    registered == market.as_str(),
+                    "`{}` registers storage for `{registered}`, but this plan \
+                     deploys the market as `{market}`. One was edited without the \
+                     other, so the market would not be registered with its own \
+                     token.",
+                    step.label,
                 );
             }
         }
@@ -728,6 +754,30 @@ fn ensure_init_args_readable(
         step.label,
     );
     Ok(())
+}
+
+/// The account a `storage_deposit` registers, if this call is one.
+fn storage_registration_target(
+    call: &crate::spec::plan::PlanFunctionCall,
+) -> anyhow::Result<Option<String>> {
+    let bytes = call.args.to_bytes()?;
+    let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(None);
+    };
+    // Keyed on the pair, so an unrelated `account_id` argument cannot be
+    // mistaken for a registration.
+    if args.get("registration_only").is_none() {
+        return Ok(None);
+    }
+    let Some(account_id) = args.get("account_id") else {
+        return Ok(None);
+    };
+    Ok(Some(
+        account_id
+            .as_str()
+            .context("a storage registration names a non-string account")?
+            .to_owned(),
+    ))
 }
 
 /// Whether a call is a governance proposal: a numeric proposal `id`, and not a
@@ -1364,6 +1414,55 @@ mod tests {
 
         super::ensure_plan_is_coherent(&file)
             .expect("a token storage deposit is not a misrouted proposal");
+    }
+
+    /// Editing the market deploy's `name` leaves its storage registrations
+    /// pointing at an account the plan never creates, so the market could not
+    /// receive its own assets. Third instance of the same shape: one reference
+    /// edited, the rest stale.
+    #[test]
+    fn a_renamed_market_orphans_its_storage_registrations() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        let init = base64::engine::general_purpose::STANDARD.encode(
+            serde_json::to_vec(&serde_json::json!({ "configuration": { "x": 1 } }))
+                .expect("encode"),
+        );
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy market".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "mkt-renamed", "version_key": "v1", "init_args": init,
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        });
+        file.steps.push(PlanStep {
+            label: "register storage".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "usdc.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "storage_deposit".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "account_id": "mkt.templar-alpha.near",
+                    "registration_only": true,
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_millinear(10),
+            }],
+        });
+
+        let error = super::ensure_plan_is_coherent(&file).expect_err("stale registration");
+        assert!(
+            format!("{error:#}").contains("mkt-renamed.templar-alpha.near"),
+            "{error:#}"
+        );
     }
 
     /// A coherent plan passes.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -29,7 +29,7 @@ use crate::commands::proxy_oracle::governance::{uniform_ttls, GovernanceInit};
 use crate::context::{print_json, CliContext};
 use crate::spec::{
     check::{Check, Status},
-    plan::{Derived, PlanFile, PLAN_SCHEMA_VERSION},
+    plan::{Derived, PlanArgs, PlanFile, PLAN_SCHEMA_VERSION},
     MarketSpec, BORROW_PRICE_ID, COLLATERAL_PRICE_ID,
 };
 
@@ -111,22 +111,13 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     render(&file);
     report_checks(&file);
 
-    // Re-read, rather than trusting the plan's own `deployment.available.*`.
-    // A plan is written to be reviewed, and a target free at plan time can be
+    // Re-read, rather than trusting the plan's own `deployment.available.*`. A
+    // plan is written to be reviewed, and a target free at plan time can be
     // claimed while that review happens — after which the first six steps
     // succeed and the market deploy fails, which is the half-spent deploy the
     // plan-time check exists to prevent.
-    let occupied = occupied_targets(&ctx, &file.derived).await?;
-    anyhow::ensure!(
-        occupied.is_empty(),
-        "{} already exist(s), and this plan creates them. Re-plan under a \
-         different `name`, or tear the existing deployment down.",
-        occupied
-            .iter()
-            .map(|account_id| format!("`{account_id}`"))
-            .collect::<Vec<_>>()
-            .join(", "),
-    );
+    let targets = planned_targets(&file);
+    ensure_targets_free(&ctx, &targets).await?;
 
     // Provenance is reported, not enforced.
     let drift = file.drift()?;
@@ -160,6 +151,10 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
             file.steps.len(),
         ))?;
     }
+
+    // Again, immediately before sending: the prompt above has no time limit, and
+    // the check is only worth what it is worth at the moment of the send.
+    ensure_targets_free(&ctx, &targets).await?;
 
     let plan = file.into_operation_plan()?;
     ctx.execute_via::<PlanDispatch, _>(&args.signer, PreparedPlan { steps: plan.steps })
@@ -457,19 +452,60 @@ fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Which of the deployment's target accounts exist right now.
-async fn occupied_targets(ctx: &CliContext, derived: &Derived) -> anyhow::Result<Vec<AccountId>> {
+/// The accounts this plan's steps would create.
+///
+/// Read off the steps rather than `derived`, because the steps are what
+/// executes. Editing a deploy's `name` is a supported hand edit, and `derived`
+/// is metadata `into_operation_plan` never consults — checking it would check
+/// accounts the plan no longer touches while the edited one collides.
+///
+/// A registry deploy is recognised by its argument shape (`name` beside a
+/// `version_key`) rather than by a method name, and creates `{name}` beneath the
+/// registry it is addressed to.
+fn planned_targets(file: &PlanFile) -> Vec<AccountId> {
+    file.steps
+        .iter()
+        .flat_map(|step| {
+            step.function_calls.iter().filter_map(move |call| {
+                let PlanArgs::Json(args) = &call.args else {
+                    return None;
+                };
+                args.get("version_key")?;
+                let name = args.get("name")?.as_str()?;
+                format!("{name}.{}", step.receiver_id).parse().ok()
+            })
+        })
+        .collect()
+}
+
+/// Which of those accounts exist right now.
+async fn occupied_targets(
+    ctx: &CliContext,
+    targets: &[AccountId],
+) -> anyhow::Result<Vec<AccountId>> {
     let mut occupied = Vec::new();
-    for account_id in [
-        &derived.governance_id,
-        &derived.oracle_id,
-        &derived.market_id,
-    ] {
+    for account_id in targets {
         if super::preflight::exists(ctx, account_id).await? {
             occupied.push(account_id.clone());
         }
     }
     Ok(occupied)
+}
+
+/// Refuse a plan whose targets are taken.
+async fn ensure_targets_free(ctx: &CliContext, targets: &[AccountId]) -> anyhow::Result<()> {
+    let occupied = occupied_targets(ctx, targets).await?;
+    anyhow::ensure!(
+        occupied.is_empty(),
+        "{} already exist(s), and this plan creates them. Re-plan under a \
+         different `name`, or tear the existing deployment down.",
+        occupied
+            .iter()
+            .map(|account_id| format!("`{account_id}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+    Ok(())
 }
 
 /// Every account this deployment creates must be free.
@@ -634,7 +670,7 @@ impl PlanWrite<PreparedPlan, GatewayContext> for PlanDispatch {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_skips, ensure_compatible, PLAN_SCHEMA_VERSION};
+    use super::{apply_skips, ensure_compatible, PlanArgs, PLAN_SCHEMA_VERSION};
     use crate::spec::check::{Check, Status};
     use crate::spec::plan::{Derived, PlanFile};
 
@@ -710,6 +746,65 @@ mod tests {
             checks: Vec::new(),
             steps: Vec::new(),
         }
+    }
+
+    /// Editing a deploy's `name` is a supported hand edit, and the steps are
+    /// what executes — so the collision check must follow the edit, not the
+    /// `derived` metadata that `into_operation_plan` never reads.
+    #[test]
+    fn targets_come_from_the_steps_not_the_metadata() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy market".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "edited-by-hand",
+                    "version_key": "v1.3.0",
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        });
+
+        assert_eq!(
+            super::planned_targets(&file)
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["edited-by-hand.templar-alpha.near"],
+            "the edited name is what gets deployed, so it is what gets checked"
+        );
+        assert_ne!(
+            file.derived.market_id.as_str(),
+            "edited-by-hand.templar-alpha.near",
+            "and it deliberately disagrees with the stale metadata"
+        );
+    }
+
+    /// A governance proposal creates no account, so it contributes no target.
+    #[test]
+    fn only_registry_deploys_are_targets() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "propose".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "gov.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "create_proposal".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({ "id": 0, "requested_ttl": "0" })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_yoctonear(1),
+            }],
+        });
+
+        assert!(super::planned_targets(&file).is_empty());
     }
 
     #[test]

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -49,6 +49,13 @@ pub(super) async fn plan(ctx: CliContext, args: Plan) -> anyhow::Result<()> {
 
     let mut checks =
         super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch).await?;
+    // Plan-time only, deliberately not in `run_all`: `spec check` validates a
+    // spec, which stays valid after its market is deployed, while planning a
+    // deployment needs its three target accounts free. `registry deploy` fails
+    // on an occupied account, so a collision on the *market* — the last step —
+    // would otherwise be discovered only after governance and the oracle were
+    // deployed and both proposals executed.
+    checks.extend(targets_available(&ctx, &spec).await?);
     apply_skips(&mut checks, &args.skip_check)?;
 
     let failed = crate::spec::check::failures(&checks);
@@ -260,6 +267,17 @@ async fn oracle_stack(
     let governance_id = spec.governance_id()?;
     let oracle_id = spec.oracle_id()?;
 
+    // Constructing the gateway request directly bypasses the guard
+    // `proxy-oracle create` applies, so it is applied here too: a pre-0.3.0
+    // `new` ignores `owner_id`, leaving the registry as owner. Governance then
+    // cannot configure either proxy — and because `admin_set_proxy` is
+    // dispatched detached, the proposals still *report* success and the deploy
+    // reaches market creation with an unconfigured oracle.
+    crate::commands::proxy_oracle::check_owner_id_is_honored(
+        &spec.versions.proxy_oracle,
+        &governance_id,
+    )?;
+
     let governance_init = serde_json::to_vec(&GovernanceInit {
         proxy_oracle_id: oracle_id.clone(),
         admin_id: spec.governance.admin.clone(),
@@ -420,6 +438,29 @@ fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
         file.network,
     );
     Ok(())
+}
+
+/// Every account this deployment creates must be free.
+async fn targets_available(ctx: &CliContext, spec: &MarketSpec) -> anyhow::Result<Vec<Check>> {
+    let mut checks = Vec::new();
+    for (label, account_id) in [
+        ("governance", spec.governance_id()?),
+        ("oracle", spec.oracle_id()?),
+        ("market", spec.market_id()?),
+    ] {
+        checks.push(Check::new(
+            format!("deployment.available.{label}"),
+            match super::preflight::exists(ctx, &account_id).await {
+                Ok(false) => Status::passed(format!("`{account_id}` is free")),
+                Ok(true) => Status::failed(format!(
+                    "`{account_id}` already exists; the {label} deploy would fail. \
+                     Pick another `name`, or tear the existing deployment down."
+                )),
+                Err(error) => Status::failed(format!("{error:#}")),
+            },
+        ));
+    }
+    Ok(checks)
 }
 
 /// The checks the plan carries.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -29,7 +29,7 @@ use crate::commands::proxy_oracle::governance::{uniform_ttls, GovernanceInit};
 use crate::context::{print_json, CliContext};
 use crate::spec::{
     check::{Check, Status},
-    plan::{Derived, PlanArgs, PlanFile, PLAN_SCHEMA_VERSION},
+    plan::{Derived, PlanFile, PLAN_SCHEMA_VERSION},
     MarketSpec, BORROW_PRICE_ID, COLLATERAL_PRICE_ID,
 };
 
@@ -108,6 +108,12 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         serde_json::from_str(&text).with_context(|| format!("parse {}", args.plan.display()))?;
 
     ensure_compatible(&file, &ctx.network().to_string())?;
+    // Otherwise every guard below passes vacuously and a truncated file applies
+    // cleanly, reporting success for having deployed nothing.
+    anyhow::ensure!(
+        !file.steps.is_empty(),
+        "this plan has no steps; nothing would be deployed"
+    );
     render(&file);
     report_checks(&file);
 
@@ -116,7 +122,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // claimed while that review happens — after which the first six steps
     // succeed and the market deploy fails, which is the half-spent deploy the
     // plan-time check exists to prevent.
-    let targets = planned_targets(&file);
+    let targets = planned_targets(&file)?;
     ensure_targets_free(&ctx, &targets).await?;
 
     // Provenance is reported, not enforced.
@@ -144,6 +150,26 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
             .collect::<Vec<_>>()
             .join(", "),
     );
+
+    // `build` enforces this at plan time, but the value that executes lives in
+    // step 0's encoded `init_args`, not in `signer_id`. Guard 7's own advice —
+    // "re-run with a matching --signer-id" — invites rewriting the signer
+    // fields, which would satisfy it while leaving a stale `admin_id` that
+    // makes every proposal revert after the deposits are spent.
+    for step in &file.steps {
+        for call in &step.function_calls {
+            let Some(admin_id) = init_arg(call, "admin_id") else {
+                continue;
+            };
+            anyhow::ensure!(
+                admin_id == credential.as_str(),
+                "`{}` seats `{admin_id}` as governance admin, but this plan is \
+                 applied by `{credential}`, which would not hold the Admin role. \
+                 Re-plan with a spec whose `governance.admin` matches.",
+                step.label,
+            );
+        }
+    }
 
     if !args.yes {
         confirm(&format!(
@@ -247,11 +273,11 @@ pub(crate) async fn build(
         steps.extend(set_proxy(client, signer_id, spec, side, price_id, proposal_id, proxy).await?);
     }
 
-    steps.push((
-        format!("deploy market {}", spec.market_id()?),
+    steps.extend(
         step(
             client,
             signer_id,
+            &format!("deploy market {}", spec.market_id()?),
             market::Create {
                 registry_id: spec.registry.clone(),
                 name: spec.name.clone(),
@@ -262,7 +288,7 @@ pub(crate) async fn build(
             },
         )
         .await?,
-    ));
+    );
 
     Ok(steps)
 }
@@ -297,40 +323,37 @@ async fn oracle_stack(
     })
     .context("encode governance init args")?;
 
-    Ok(vec![
-        (
-            format!("deploy governance {governance_id}"),
-            step(
-                client,
-                signer_id,
-                registry::Deploy {
-                    registry_id: spec.registry.clone(),
-                    name: crate::spec::governance_name(&spec.name),
-                    version_key: spec.versions.proxy_governance.clone(),
-                    init_args: Base64Bytes(governance_init),
-                    full_access_keys: full_access_keys.clone(),
-                    deposit: GOVERNANCE_DEPOSIT,
-                },
-            )
-            .await?,
-        ),
-        (
-            format!("deploy proxy oracle {oracle_id}, owned by governance"),
-            step(
-                client,
-                signer_id,
-                proxy_oracle::Create {
-                    registry_id: spec.registry.clone(),
-                    name: crate::spec::oracle_name(&spec.name),
-                    version_key: spec.versions.proxy_oracle.clone(),
-                    owner_id: Some(governance_id),
-                    full_access_keys: full_access_keys.clone(),
-                    deposit: ORACLE_DEPOSIT,
-                },
-            )
-            .await?,
-        ),
-    ])
+    let mut steps = step(
+        client,
+        signer_id,
+        &format!("deploy governance {governance_id}"),
+        registry::Deploy {
+            registry_id: spec.registry.clone(),
+            name: crate::spec::governance_name(&spec.name),
+            version_key: spec.versions.proxy_governance.clone(),
+            init_args: Base64Bytes(governance_init),
+            full_access_keys: full_access_keys.clone(),
+            deposit: GOVERNANCE_DEPOSIT,
+        },
+    )
+    .await?;
+    steps.extend(
+        step(
+            client,
+            signer_id,
+            &format!("deploy proxy oracle {oracle_id}, owned by governance"),
+            proxy_oracle::Create {
+                registry_id: spec.registry.clone(),
+                name: crate::spec::oracle_name(&spec.name),
+                version_key: spec.versions.proxy_oracle.clone(),
+                owner_id: Some(governance_id),
+                full_access_keys: full_access_keys.clone(),
+                deposit: ORACLE_DEPOSIT,
+            },
+        )
+        .await?,
+    );
+    Ok(steps)
 }
 
 /// Propose a feed's proxy, then execute that proposal. Two transactions: a
@@ -346,46 +369,49 @@ async fn set_proxy(
 ) -> anyhow::Result<Vec<(String, PlannedTransaction)>> {
     let governance_id = spec.governance_id()?;
 
-    Ok(vec![
-        (
-            format!("propose {side} proxy (proposal {proposal_id})"),
-            step(
-                client,
-                signer_id,
-                gov::CreateProposal {
-                    governance_id: governance_id.clone(),
-                    id: proposal_id,
-                    operation: Operation::SetProxy {
-                        id: price_id,
-                        proxy: Some(proxy),
-                    },
-                    requested_ttl: spec.governance.ttl_default,
-                },
-            )
-            .await?,
-        ),
-        (
-            format!("execute {side} proxy proposal {proposal_id}"),
-            step(
-                client,
-                signer_id,
-                gov::ExecuteProposal {
-                    governance_id,
-                    id: proposal_id,
-                },
-            )
-            .await?,
-        ),
-    ])
+    let mut steps = step(
+        client,
+        signer_id,
+        &format!("propose {side} proxy (proposal {proposal_id})"),
+        gov::CreateProposal {
+            governance_id: governance_id.clone(),
+            id: proposal_id,
+            operation: Operation::SetProxy {
+                id: price_id,
+                proxy: Some(proxy),
+            },
+            requested_ttl: spec.governance.ttl_default,
+        },
+    )
+    .await?;
+    steps.extend(
+        step(
+            client,
+            signer_id,
+            &format!("execute {side} proxy proposal {proposal_id}"),
+            gov::ExecuteProposal {
+                governance_id,
+                id: proposal_id,
+            },
+        )
+        .await?,
+    );
+    Ok(steps)
 }
 
-/// Plan one write, requiring it to be a single transaction — a multi-transaction
-/// step would make the labels lie about what an operator is confirming.
+/// Plan one write, labelling every transaction it needs.
+///
+/// Not one transaction per write: `market.create` also registers storage for
+/// each NEP-141 asset, so a market with a NEP-141 side plans two or three. An
+/// earlier version required exactly one, which made `market plan` usable only
+/// for NEP-245 markets. Where a write expands, each transaction is numbered so
+/// the labels still describe what is being confirmed.
 async fn step<S>(
     client: &Client,
     signer_id: &AccountId,
+    label: &str,
     body: S,
-) -> anyhow::Result<PlannedTransaction>
+) -> anyhow::Result<Vec<(String, PlannedTransaction)>>
 where
     S: MethodSpec<Output = WriteOperationResult>,
     Dispatch: PlanWrite<S, GatewayContext>,
@@ -396,10 +422,29 @@ where
             idempotency_key: None,
             body,
         })
-        .await?;
+        .await
+        .with_context(|| format!("planning `{}`", S::RPC_METHOD))?;
 
-    crate::context::single_transaction(plan)
-        .with_context(|| format!("planning `{}`", S::RPC_METHOD))
+    anyhow::ensure!(
+        !plan.steps.is_empty(),
+        "`{}` planned no transactions for `{label}`",
+        S::RPC_METHOD
+    );
+
+    let total = plan.steps.len();
+    Ok(plan
+        .steps
+        .into_iter()
+        .enumerate()
+        .map(|(index, transaction)| {
+            let label = if total == 1 {
+                label.to_owned()
+            } else {
+                format!("{label} ({}/{total})", index + 1)
+            };
+            (label, transaction)
+        })
+        .collect())
 }
 
 /// Mark the named checks skipped, recording the verdict each one reached — a
@@ -459,23 +504,43 @@ fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
 /// is metadata `into_operation_plan` never consults — checking it would check
 /// accounts the plan no longer touches while the edited one collides.
 ///
-/// A registry deploy is recognised by its argument shape (`name` beside a
-/// `version_key`) rather than by a method name, and creates `{name}` beneath the
-/// registry it is addressed to.
-fn planned_targets(file: &PlanFile) -> Vec<AccountId> {
-    file.steps
-        .iter()
-        .flat_map(|step| {
-            step.function_calls.iter().filter_map(move |call| {
-                let PlanArgs::Json(args) = &call.args else {
-                    return None;
-                };
-                args.get("version_key")?;
-                let name = args.get("name")?.as_str()?;
-                format!("{name}.{}", step.receiver_id).parse().ok()
-            })
-        })
-        .collect()
+/// Works from each call's *bytes*, so re-encoding a deploy's args as `base64`
+/// (equally valid in this schema, and executed verbatim) cannot hide its target.
+/// A registry deploy is recognised by its argument shape — `name` beside a
+/// `version_key` — and creates `{name}` beneath the registry it is addressed to.
+///
+/// Fails closed. A call carrying a `version_key` whose target cannot be derived
+/// is an unreviewable step, not an absent one: every silent `None` here would be
+/// an unchecked account, which is exactly what this guard exists to prevent.
+fn planned_targets(file: &PlanFile) -> anyhow::Result<Vec<AccountId>> {
+    let mut targets = Vec::new();
+    for step in &file.steps {
+        for call in &step.function_calls {
+            let bytes = call.args.to_bytes()?;
+            let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+                continue;
+            };
+            if args.get("version_key").is_none() {
+                continue;
+            }
+
+            let name = args.get("name").and_then(serde_json::Value::as_str);
+            let target = name.and_then(|name| {
+                format!("{name}.{}", step.receiver_id)
+                    .parse::<AccountId>()
+                    .ok()
+            });
+            targets.push(target.with_context(|| {
+                format!(
+                    "`{}` deploys from a registry but names no usable sub-account \
+                     ({name:?}), so the account it would create cannot be checked \
+                     for a collision",
+                    step.label
+                )
+            })?);
+        }
+    }
+    Ok(targets)
 }
 
 /// Which of those accounts exist right now.
@@ -584,6 +649,12 @@ fn render(file: &PlanFile) {
     }
 }
 
+/// One field of a registry deploy's decoded `init_args`, as a string.
+fn init_arg(call: &crate::spec::plan::PlanFunctionCall, field: &str) -> Option<String> {
+    let decoded: serde_json::Value = serde_json::from_str(&decoded_init_args(call)?).ok()?;
+    Some(decoded.get(field)?.as_str()?.to_owned())
+}
+
 /// A registry deploy's `init_args`, decoded.
 ///
 /// `registry.deploy` takes them as base64 *inside* its JSON args, so the market
@@ -670,8 +741,9 @@ impl PlanWrite<PreparedPlan, GatewayContext> for PlanDispatch {
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_skips, ensure_compatible, PlanArgs, PLAN_SCHEMA_VERSION};
+    use super::{apply_skips, ensure_compatible, PLAN_SCHEMA_VERSION};
     use crate::spec::check::{Check, Status};
+    use crate::spec::plan::PlanArgs;
     use crate::spec::plan::{Derived, PlanFile};
 
     fn checks() -> Vec<Check> {
@@ -773,6 +845,7 @@ mod tests {
 
         assert_eq!(
             super::planned_targets(&file)
+                .expect("derivable")
                 .iter()
                 .map(ToString::to_string)
                 .collect::<Vec<_>>(),
@@ -783,6 +856,71 @@ mod tests {
             file.derived.market_id.as_str(),
             "edited-by-hand.templar-alpha.near",
             "and it deliberately disagrees with the stale metadata"
+        );
+    }
+
+    /// Re-encoding a deploy's args as base64 is legal in this schema and is
+    /// executed verbatim, so it must not hide the account being created.
+    #[test]
+    fn a_base64_encoded_deploy_still_yields_its_target() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+
+        let raw = serde_json::to_vec(&serde_json::json!({
+            "name": "hidden",
+            "version_key": "v1.3.0",
+        }))
+        .expect("encode");
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy market".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Base64(templar_gateway_types::Base64Bytes(raw.clone())),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        });
+
+        assert_eq!(
+            super::planned_targets(&file)
+                .expect("derivable")
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>(),
+            vec!["hidden.templar-alpha.near"],
+        );
+    }
+
+    /// A deploy whose target cannot be derived is an unreviewable step, not an
+    /// absent one — every silent skip here would be an unchecked account.
+    #[test]
+    fn an_underivable_target_fails_closed() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy market".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                // Uppercase is not a valid NEAR account label.
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "Uppercase",
+                    "version_key": "v1.3.0",
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        });
+
+        let error = super::planned_targets(&file).expect_err("must not skip silently");
+        assert!(
+            format!("{error:#}").contains("cannot be checked for a collision"),
+            "{error:#}"
         );
     }
 
@@ -804,7 +942,7 @@ mod tests {
             }],
         });
 
-        assert!(super::planned_targets(&file).is_empty());
+        assert!(super::planned_targets(&file).expect("derivable").is_empty());
     }
 
     #[test]

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -158,6 +158,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // makes every proposal revert after the deposits are spent.
     for step in &file.steps {
         for call in &step.function_calls {
+            ensure_init_args_readable(step, call)?;
             let Some(admin_id) = init_arg(call, "admin_id") else {
                 continue;
             };
@@ -193,15 +194,13 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // substituted `--public-key` at plan time is invisible in the artifact —
     // the keys live inside the encoded args — so where the applier's own key is
     // derivable it must be the one being granted.
-    // Not `if let Ok(..)`: an unknown key must refuse, not skip. With
-    // `--sign-with keychain` and no `--public-key` this errors, and swallowing
-    // that would disable the guard in exactly the configuration that cannot
-    // derive its own key.
+    // Asked of the backend, not taken from `--public-key`: for an external
+    // backend the flag is only what the operator *asserted*, and checking a
+    // grant against an assertion checks nothing. Errors propagate — an applier
+    // who cannot say which key they hold cannot verify the one being handed
+    // control of three new accounts, and that is a refusal, not a pass.
     {
-        let mine = args.signer.public_key().context(
-            "cannot tell which key this plan grants full access to without knowing \
-             yours; pass --public-key",
-        )?;
+        let mine = ctx.signing_public_key(&args.signer).await?;
         // Compared through the JSON encoding, which is the form the args carry.
         let mine = serde_json::to_value(&mine)
             .ok()
@@ -209,7 +208,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
             .unwrap_or_default();
         for step in &file.steps {
             for call in &step.function_calls {
-                let granted = granted_keys(call);
+                let granted = granted_keys(call)?;
                 anyhow::ensure!(
                     granted.is_empty() || granted.iter().any(|key| key == &mine),
                     "`{}` grants full access to {}, not to `{mine}`. Applying this \
@@ -680,26 +679,66 @@ fn ensure_plan_is_coherent(file: &PlanFile) -> anyhow::Result<()> {
         }
     }
 
-    // Every step that is not a registry deploy addresses the governance
-    // contract. A renamed governance would otherwise leave the proposals
-    // pointing at the old account.
+    // Governance proposals must address the governance account this plan
+    // deploys. Identified positively — by carrying a numeric proposal `id` —
+    // rather than as "not a deploy": a NEP-141 market also plans a
+    // `storage_deposit` addressed to the *token*, which is neither a deploy nor
+    // a proposal, and an exclusion rule would refuse every NEP-141 market.
     if let Some(governance) = governance {
         for step in &file.steps {
-            let deploys = step
-                .function_calls
-                .iter()
-                .any(|call| matches!(deploy_target(step, call), Ok(Some(_))));
-            anyhow::ensure!(
-                deploys || step.receiver_id == governance,
-                "`{}` is addressed to `{}`, but this plan deploys governance as \
-                 `{governance}`. The proposal would be sent to an account this \
-                 plan never creates.",
-                step.label,
-                step.receiver_id,
-            );
+            for call in &step.function_calls {
+                if !is_governance_proposal(call)? {
+                    continue;
+                }
+                anyhow::ensure!(
+                    step.receiver_id == governance,
+                    "`{}` is addressed to `{}`, but this plan deploys governance \
+                     as `{governance}`. The proposal would be sent to an account \
+                     this plan never creates.",
+                    step.label,
+                    step.receiver_id,
+                );
+            }
         }
     }
     Ok(())
+}
+
+/// A registry deploy must carry `init_args` this build can decode.
+///
+/// Otherwise every guard reading them — the seated `admin_id`, the oracle and
+/// governance coherence checks — skips the step silently, which is the same
+/// fail-open that has already appeared three times in this file: a guard asked
+/// "is this wrong?" and answered "no" because it could not tell.
+fn ensure_init_args_readable(
+    step: &crate::spec::plan::PlanStep,
+    call: &crate::spec::plan::PlanFunctionCall,
+) -> anyhow::Result<()> {
+    let bytes = call.args.to_bytes()?;
+    let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(());
+    };
+    if args.get("version_key").is_none() {
+        return Ok(());
+    }
+    anyhow::ensure!(
+        decoded_init_args(call).is_some(),
+        "`{}` deploys from a registry but its `init_args` cannot be decoded, so \
+         what the new contract is initialized with cannot be checked or shown",
+        step.label,
+    );
+    Ok(())
+}
+
+/// Whether a call is a governance proposal: a numeric proposal `id`, and not a
+/// registry deploy.
+fn is_governance_proposal(call: &crate::spec::plan::PlanFunctionCall) -> anyhow::Result<bool> {
+    let bytes = call.args.to_bytes()?;
+    let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
+        return Ok(false);
+    };
+    Ok(args.get("version_key").is_none()
+        && args.get("id").is_some_and(serde_json::Value::is_number))
 }
 
 /// The account a single registry-deploy call would create.
@@ -824,7 +863,7 @@ fn render(file: &PlanFile) {
                 "      {}  deposit {}  gas {}",
                 call.method_name, call.deposit, call.gas
             );
-            for key in granted_keys(call) {
+            for key in granted_keys(call).unwrap_or_default() {
                 eprintln!("      grants full access to: {key}");
             }
             if let Some(init_args) = decoded_init_args(call) {
@@ -840,21 +879,28 @@ fn render(file: &PlanFile) {
 /// args, which are not printed, yet they decide who controls the three new
 /// accounts. A mistyped or substituted `--public-key` at plan time is
 /// indistinguishable from a correct one unless an operator can see it.
-fn granted_keys(call: &crate::spec::plan::PlanFunctionCall) -> Vec<String> {
-    let Ok(bytes) = call.args.to_bytes() else {
-        return Vec::new();
-    };
+fn granted_keys(call: &crate::spec::plan::PlanFunctionCall) -> anyhow::Result<Vec<String>> {
+    let bytes = call.args.to_bytes()?;
     let Ok(args) = serde_json::from_slice::<serde_json::Value>(&bytes) else {
-        return Vec::new();
+        // Not JSON at all (borsh), so it grants no keys — as opposed to args
+        // this build could not read, which `to_bytes` already refused above.
+        return Ok(Vec::new());
     };
-    args.get("full_access_keys")
-        .and_then(|keys| keys.as_array())
-        .map(|keys| {
-            keys.iter()
-                .filter_map(|key| key.as_str().map(ToOwned::to_owned))
-                .collect()
+    let Some(keys) = args.get("full_access_keys") else {
+        return Ok(Vec::new());
+    };
+    let keys = keys.as_array().context(
+        "`full_access_keys` is not a list, so the keys granted control of this \
+         account cannot be read",
+    )?;
+    keys.iter()
+        .map(|key| {
+            key.as_str().map(ToOwned::to_owned).context(
+                "a granted full-access key is not a string, so it cannot be \
+                 checked against yours",
+            )
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 /// One field of a registry deploy's decoded `init_args`, as a string.
@@ -1269,6 +1315,55 @@ mod tests {
             format!("{error:#}").contains("gov-renamed.templar-alpha.near"),
             "{error:#}"
         );
+    }
+
+    /// A NEP-141 market plans a `storage_deposit` addressed to the *token* —
+    /// neither a deploy nor a proposal. An exclusion rule ("everything that is
+    /// not a deploy must address governance") refused every such market, which
+    /// is the case this plan builder was fixed to support in the first place.
+    #[test]
+    fn a_token_storage_deposit_does_not_have_to_address_governance() {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+        use base64::Engine as _;
+
+        let init = base64::engine::general_purpose::STANDARD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "proxy_oracle_id": "o.templar-alpha.near",
+                "admin_id": "a.near",
+            }))
+            .expect("encode"),
+        );
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(PlanStep {
+            label: "deploy governance".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": "gov", "version_key": "v1", "init_args": init,
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(3),
+            }],
+        });
+        file.steps.push(PlanStep {
+            label: "register storage for usdc.near".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "usdc.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "storage_deposit".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "account_id": "mkt.templar-alpha.near",
+                    "registration_only": true,
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_millinear(10),
+            }],
+        });
+
+        super::ensure_plan_is_coherent(&file)
+            .expect("a token storage deposit is not a misrouted proposal");
     }
 
     /// A coherent plan passes.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -111,6 +111,23 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     render(&file);
     report_checks(&file);
 
+    // Re-read, rather than trusting the plan's own `deployment.available.*`.
+    // A plan is written to be reviewed, and a target free at plan time can be
+    // claimed while that review happens — after which the first six steps
+    // succeed and the market deploy fails, which is the half-spent deploy the
+    // plan-time check exists to prevent.
+    let occupied = occupied_targets(&ctx, &file.derived).await?;
+    anyhow::ensure!(
+        occupied.is_empty(),
+        "{} already exist(s), and this plan creates them. Re-plan under a \
+         different `name`, or tear the existing deployment down.",
+        occupied
+            .iter()
+            .map(|account_id| format!("`{account_id}`"))
+            .collect::<Vec<_>>()
+            .join(", "),
+    );
+
     // Provenance is reported, not enforced.
     let drift = file.drift()?;
     eprintln!("\n{}", drift.describe());
@@ -438,6 +455,21 @@ fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
         file.network,
     );
     Ok(())
+}
+
+/// Which of the deployment's target accounts exist right now.
+async fn occupied_targets(ctx: &CliContext, derived: &Derived) -> anyhow::Result<Vec<AccountId>> {
+    let mut occupied = Vec::new();
+    for account_id in [
+        &derived.governance_id,
+        &derived.oracle_id,
+        &derived.market_id,
+    ] {
+        if super::preflight::exists(ctx, account_id).await? {
+            occupied.push(account_id.clone());
+        }
+    }
+    Ok(occupied)
 }
 
 /// Every account this deployment creates must be free.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -191,6 +191,7 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
 
     ensure_plan_is_coherent(&file)?;
     ensure_initializers_are_sound(&file)?;
+    ensure_proposals_are_runnable(&file)?;
 
     // Whoever holds these keys controls the three new accounts. A mistyped or
     // substituted `--public-key` at plan time is invisible in the artifact —
@@ -612,6 +613,67 @@ async fn occupied_targets(
         }
     }
     Ok(occupied)
+}
+
+/// The proposals must be executable, in this plan, in this order.
+///
+/// Their own arguments had gone unvalidated: every other guard here checks
+/// deploy arguments or the account references between steps. A proposal carries
+/// three editable values that decide whether the oracle ever gets configured —
+/// and an oracle that is never configured is the failure this whole guard suite
+/// exists to prevent, because `admin_set_proxy` is dispatched detached and the
+/// step still reports success.
+fn ensure_proposals_are_runnable(file: &PlanFile) -> anyhow::Result<()> {
+    let mut created: BTreeSet<u64> = BTreeSet::new();
+
+    for step in &file.steps {
+        for call in &step.function_calls {
+            if !is_governance_proposal(call)? {
+                continue;
+            }
+            let bytes = call.args.to_bytes()?;
+            let args: serde_json::Value =
+                serde_json::from_slice(&bytes).context("a proposal's arguments are not JSON")?;
+            let id = args
+                .get("id")
+                .and_then(serde_json::Value::as_u64)
+                .context("a proposal carries no numeric id")?;
+
+            // `operation` marks a create; its absence marks an execute.
+            if args.get("operation").is_some() {
+                let ttl = args.get("requested_ttl");
+                let zero = ttl.is_none()
+                    || ttl.and_then(|ttl| ttl.as_str()) == Some("0")
+                    || ttl.and_then(serde_json::Value::as_u64) == Some(0);
+                anyhow::ensure!(
+                    zero,
+                    "`{}` requests a TTL of {}, so the proposal would not be \
+                     executable when the next step tries to run it. The effective \
+                     TTL is the larger of the requested and configured values, so \
+                     raising it here delays execution regardless of the \
+                     contract's own zero TTLs.",
+                    step.label,
+                    ttl.map_or_else(|| "?".to_owned(), ToString::to_string),
+                );
+                anyhow::ensure!(
+                    created.insert(id),
+                    "`{}` creates proposal {id}, which this plan already creates. \
+                     The governance contract requires each id to be the next one, \
+                     so the second would be rejected.",
+                    step.label,
+                );
+            } else {
+                anyhow::ensure!(
+                    created.contains(&id),
+                    "`{}` executes proposal {id}, but this plan does not create it \
+                     beforehand. It would run against a proposal that does not \
+                     exist yet, leaving the feed unconfigured.",
+                    step.label,
+                );
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Re-apply, against the encoded steps, the plan-time guards whose subject an
@@ -1580,6 +1642,50 @@ mod tests {
             .expect_err("two deploys, one account");
 
         assert!(format!("{error:#}").contains("more than once"), "{error:#}");
+    }
+
+    /// Proposal arguments decide whether the oracle is ever configured, and an
+    /// unconfigured oracle still reports success (`admin_set_proxy` is
+    /// dispatched detached), so these are refused rather than discovered later.
+    #[rstest::rstest]
+    #[case::raised_ttl(
+        serde_json::json!({ "id": 0, "operation": {}, "requested_ttl": "600000000000" }),
+        None,
+        "not be executable"
+    )]
+    #[case::execute_without_create(serde_json::json!({ "id": 7 }), None, "does not create it")]
+    #[case::duplicate_create(
+        serde_json::json!({ "id": 0, "operation": {}, "requested_ttl": "0" }),
+        Some(serde_json::json!({ "id": 0, "operation": {}, "requested_ttl": "0" })),
+        "already creates"
+    )]
+    fn unrunnable_proposals_are_refused(
+        #[case] first: serde_json::Value,
+        #[case] second: Option<serde_json::Value>,
+        #[case] expected: &str,
+    ) {
+        use crate::spec::plan::{PlanFunctionCall, PlanStep};
+
+        let proposal = |args: serde_json::Value| PlanStep {
+            label: "proposal".to_owned(),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "gov.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "create_proposal".to_owned(),
+                args: PlanArgs::Json(args),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_yoctonear(1),
+            }],
+        };
+
+        let mut file = bare_plan(PLAN_SCHEMA_VERSION, "mainnet");
+        file.steps.push(proposal(first));
+        if let Some(second) = second {
+            file.steps.push(proposal(second));
+        }
+
+        let error = super::ensure_proposals_are_runnable(&file).expect_err("unrunnable");
+        assert!(format!("{error:#}").contains(expected), "{error:#}");
     }
 
     /// A coherent plan passes.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -1,0 +1,636 @@
+//! `market plan` / `market apply` — generate a deployment as a file, then send
+//! that file.
+//!
+//! The two commands exist because a spec cannot express every market and a check
+//! can be wrong. Splitting generation from execution puts a reviewable artifact
+//! between the two, and makes the concrete transactions editable when the
+//! declarative path falls short.
+//!
+//! What `plan` produces is exactly what `deploy.sh` runs today, in the same
+//! order — see [`build`].
+
+use std::io::Write as _;
+
+use anyhow::Context as _;
+use near_account_id::AccountId;
+use near_api::types::NearToken;
+use templar_common::Nanoseconds;
+use templar_gateway_client::Client;
+use templar_gateway_core::{
+    GatewayContext, GatewayResult, OperationPlan, PlanWrite, PlannedTransaction,
+};
+use templar_gateway_methods_dispatch::Dispatch;
+use templar_gateway_methods_spec::{
+    market, proxy_oracle, proxy_oracle_governance as gov, registry,
+};
+use templar_gateway_types::common::{WriteOperationResult, WriteRequest};
+use templar_gateway_types::{primitive::PublicKey, Base64Bytes, MethodSpec};
+use templar_proxy_oracle_near_governance_common::Operation;
+
+use crate::commands::market::{Apply, Plan};
+use crate::commands::proxy_oracle::governance::{uniform_ttls, GovernanceInit};
+use crate::context::{print_json, CliContext};
+use crate::spec::{
+    check::{Check, Status},
+    plan::{Derived, PlanFile, PLAN_SCHEMA_VERSION},
+    MarketSpec, BORROW_PRICE_ID, COLLATERAL_PRICE_ID,
+};
+
+/// Deposits funding each new account's storage and balance, matching
+/// `script/deploy.sh`.
+///
+/// Constants rather than spec fields: these size a *contract's* storage staking,
+/// which follows from the code being deployed, not from the market's identity.
+/// A deployment that genuinely needs more can raise one by editing the plan,
+/// which is what the artifact is for.
+const GOVERNANCE_DEPOSIT: NearToken = NearToken::from_millinear(3_500);
+const ORACLE_DEPOSIT: NearToken = NearToken::from_near(5);
+const MARKET_DEPOSIT: NearToken = NearToken::from_millinear(5_500);
+
+/// `market plan` — run the preflight, then write the deployment as a file.
+pub(super) async fn plan(ctx: CliContext, args: Plan) -> anyhow::Result<()> {
+    let mut spec = crate::spec::extends::load(&args.path)?;
+    let spec_digest = crate::spec::plan::digest(&spec)?;
+
+    let mut checks =
+        super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch).await?;
+    apply_skips(&mut checks, &args.skip_check)?;
+
+    let failed = checks
+        .iter()
+        .filter(|check| check.status.is_failure())
+        .count();
+    if failed > 0 {
+        print_json(&checks)?;
+        anyhow::bail!(
+            "{failed} check(s) failed; no plan written. Fix the spec, or re-run \
+             with `--skip-check <id>` for a check that is wrong."
+        );
+    }
+
+    let steps = build(&ctx.client, &spec, &args.public_key(), &args.signer_id).await?;
+    let file = PlanFile::new(
+        spec.network()?.to_string(),
+        spec_digest,
+        Derived {
+            market_id: spec.market_id()?,
+            oracle_id: spec.oracle_id()?,
+            governance_id: spec.governance_id()?,
+            collateral_decimals: spec.collateral.decimals,
+            borrow_decimals: spec.borrow.decimals,
+        },
+        checks,
+        steps,
+    )?;
+
+    let rendered = serde_json::to_string_pretty(&file).context("render the plan")?;
+    match &args.out {
+        Some(path) => {
+            std::fs::write(path, format!("{rendered}\n"))
+                .with_context(|| format!("write {}", path.display()))?;
+            eprintln!("Wrote {} step(s) to {}", file.steps.len(), path.display());
+        }
+        None => println!("{rendered}"),
+    }
+    Ok(())
+}
+
+/// `market apply` — send a plan file.
+pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
+    let text = std::fs::read_to_string(&args.plan)
+        .with_context(|| format!("read {}", args.plan.display()))?;
+    let file: PlanFile =
+        serde_json::from_str(&text).with_context(|| format!("parse {}", args.plan.display()))?;
+
+    ensure_compatible(&file, &ctx.network().to_string())?;
+    render(&file);
+
+    // Provenance is reported, not enforced.
+    let drift = file.drift()?;
+    eprintln!("\n{}", drift.describe());
+    if !drift.is_clean() {
+        eprintln!(
+            "An edited plan bypasses every spec-level check above — its arguments \
+             are already encoded. Read the steps before confirming."
+        );
+    }
+
+    if !args.yes {
+        confirm(&format!(
+            "Send {} transaction(s) as {}?",
+            file.steps.len(),
+            args.signer.account_id().0,
+        ))?;
+    }
+
+    let plan = file.into_operation_plan()?;
+    let (signer, client) = ctx.signing_client_for(&args.signer).await?;
+    let output = client
+        .execute_request(WriteRequest {
+            signer_account_id: signer,
+            idempotency_key: None,
+            body: PreparedPlan { steps: plan.steps },
+        })
+        .await?;
+    ctx.finish_write(&output)
+}
+
+/// The deployment, in the order `deploy.sh` runs it.
+///
+/// The order is a safety property, not a preference: `registry deploy` fails the
+/// whole transaction when the account already exists, and the governance
+/// contract must own the oracle before any feed can be configured. Deploying
+/// governance first means an oracle can never be handed to an account this plan
+/// did not create.
+pub(crate) async fn build(
+    client: &Client,
+    spec: &MarketSpec,
+    public_key: &PublicKey,
+    signer_id: &AccountId,
+) -> anyhow::Result<Vec<(String, PlannedTransaction)>> {
+    // A plan is a fixed list of transactions; it cannot encode "wait". With a
+    // non-zero TTL the two proxy proposals are not executable when they are
+    // created, and the alternative — emitting the creates and dropping the
+    // executes — would deploy a market pointing at an unconfigured oracle.
+    anyhow::ensure!(
+        spec.governance.ttl_default == Nanoseconds::from_ns(0),
+        "`governance.ttl_default` is {}ns, so the proxy proposals would not be \
+         executable when created, and a plan cannot wait. Deploy with \
+         `ttl_default = \"0s\"` and raise the TTL afterwards with a `set-action-ttl` \
+         proposal, or run the proposals by hand with `proxy-oracle governance \
+         execute-proposal --when-ready`.",
+        spec.governance.ttl_default.as_ns(),
+    );
+
+    let governance_id = spec.governance_id()?;
+    let price_maximum_age = spec.market.price_maximum_age;
+    let full_access_keys = Some(vec![public_key.clone()]);
+
+    // A plan always creates its own governance contract, so its proposal
+    // counter always starts at zero. Reading `nextProposalId` would be reading
+    // an account this very plan is about to create — and if one already exists,
+    // step 1 fails loudly rather than appending proposals to someone else's
+    // governance. Resuming onto existing contracts is ENG-546.
+    let (collateral_proposal, borrow_proposal) = (0, 1);
+
+    let (collateral_decimals, borrow_decimals) = decimals(spec)?;
+    let configuration = spec
+        .clone()
+        .into_market_configuration(collateral_decimals, borrow_decimals)?;
+
+    let mut steps = Vec::from(oracle_stack(client, signer_id, spec, public_key).await?);
+
+    // Both sides project to the same `Proxy<Source>`, so one loop covers them
+    // even though `AssetSpec` is generic over the asset class.
+    for (side, price_id, proposal_id, proxy) in [
+        (
+            "collateral",
+            COLLATERAL_PRICE_ID,
+            collateral_proposal,
+            spec.collateral.clone().into_proxy(price_maximum_age),
+        ),
+        (
+            "borrow",
+            BORROW_PRICE_ID,
+            borrow_proposal,
+            spec.borrow.clone().into_proxy(price_maximum_age),
+        ),
+    ] {
+        steps.extend(
+            set_proxy(
+                client,
+                signer_id,
+                &governance_id,
+                spec.governance.ttl_default,
+                ProxyProposal {
+                    side,
+                    price_id,
+                    proposal_id,
+                    proxy,
+                },
+            )
+            .await?,
+        );
+    }
+
+    steps.push((
+        format!("deploy market {}", spec.market_id()?),
+        step(
+            client,
+            signer_id,
+            market::Create {
+                registry_id: spec.registry.clone(),
+                name: spec.name.clone(),
+                version_key: spec.versions.market.clone(),
+                configuration,
+                full_access_keys,
+                deposit: MARKET_DEPOSIT,
+            },
+        )
+        .await?,
+    ));
+
+    Ok(steps)
+}
+
+/// The governance contract and the oracle it owns.
+///
+/// Emitted as a pair, in this order: the oracle names its governance as
+/// `owner_id` at init, so governance must exist first. Reversing them would
+/// deploy an oracle owned by an account that does not exist yet.
+async fn oracle_stack(
+    client: &Client,
+    signer_id: &AccountId,
+    spec: &MarketSpec,
+    public_key: &PublicKey,
+) -> anyhow::Result<[(String, PlannedTransaction); 2]> {
+    let full_access_keys = Some(vec![public_key.clone()]);
+    let governance_id = spec.governance_id()?;
+    let oracle_id = spec.oracle_id()?;
+
+    let governance_init = serde_json::to_vec(&GovernanceInit {
+        proxy_oracle_id: oracle_id.clone(),
+        admin_id: spec.governance.admin.clone(),
+        ttls: uniform_ttls(spec.governance.ttl_default),
+    })
+    .context("encode governance init args")?;
+
+    Ok([
+        (
+            format!("deploy governance {governance_id}"),
+            step(
+                client,
+                signer_id,
+                registry::Deploy {
+                    registry_id: spec.registry.clone(),
+                    name: crate::spec::governance_name(&spec.name),
+                    version_key: spec.versions.proxy_governance.clone(),
+                    init_args: Base64Bytes(governance_init),
+                    full_access_keys: full_access_keys.clone(),
+                    deposit: GOVERNANCE_DEPOSIT,
+                },
+            )
+            .await?,
+        ),
+        (
+            format!("deploy proxy oracle {oracle_id}, owned by governance"),
+            step(
+                client,
+                signer_id,
+                proxy_oracle::Create {
+                    registry_id: spec.registry.clone(),
+                    name: crate::spec::oracle_name(&spec.name),
+                    version_key: spec.versions.proxy_oracle.clone(),
+                    owner_id: Some(governance_id),
+                    full_access_keys: full_access_keys.clone(),
+                    deposit: ORACLE_DEPOSIT,
+                },
+            )
+            .await?,
+        ),
+    ])
+}
+
+/// One feed's proxy configuration, as a governance proposal.
+struct ProxyProposal {
+    side: &'static str,
+    price_id: templar_common::oracle::pyth::PriceIdentifier,
+    proposal_id: u32,
+    proxy:
+        templar_proxy_oracle_kernel::proxy::Proxy<templar_proxy_oracle_near_common::input::Source>,
+}
+
+/// Propose a feed's proxy, then execute that proposal.
+///
+/// Two transactions rather than one: a proposal is always created before it can
+/// run, even at `ttl_default = 0`. They are emitted as a pair so a plan can
+/// never carry a create without its execute, which would leave the oracle
+/// configured for one leg only.
+async fn set_proxy(
+    client: &Client,
+    signer_id: &AccountId,
+    governance_id: &AccountId,
+    requested_ttl: Nanoseconds,
+    proposal: ProxyProposal,
+) -> anyhow::Result<[(String, PlannedTransaction); 2]> {
+    let ProxyProposal {
+        side,
+        price_id,
+        proposal_id,
+        proxy,
+    } = proposal;
+
+    Ok([
+        (
+            format!("propose {side} proxy (proposal {proposal_id})"),
+            step(
+                client,
+                signer_id,
+                gov::CreateProposal {
+                    governance_id: governance_id.clone(),
+                    id: proposal_id,
+                    operation: Operation::SetProxy {
+                        id: price_id,
+                        proxy: Some(proxy),
+                    },
+                    requested_ttl,
+                },
+            )
+            .await?,
+        ),
+        (
+            format!("execute {side} proxy proposal {proposal_id}"),
+            step(
+                client,
+                signer_id,
+                gov::ExecuteProposal {
+                    governance_id: governance_id.clone(),
+                    id: proposal_id,
+                },
+            )
+            .await?,
+        ),
+    ])
+}
+
+/// Decimals resolved by the preflight. Absent means a check failed, and the
+/// caller refuses before reaching here — but building a configuration from
+/// guessed decimals would mis-scale every price, so this never assumes.
+fn decimals(spec: &MarketSpec) -> anyhow::Result<(i32, i32)> {
+    let (Some(collateral), Some(borrow)) = (spec.collateral.decimals, spec.borrow.decimals) else {
+        anyhow::bail!(
+            "asset decimals are unresolved, so a market configuration cannot be \
+             built. Set `decimals` in the spec, or fix `asset.decimals.*`."
+        );
+    };
+    Ok((i32::from(collateral), i32::from(borrow)))
+}
+
+/// Plan one write, requiring it to be a single transaction.
+///
+/// Each of these specs plans to exactly one; a multi-transaction step would make
+/// the labels lie about what an operator is confirming.
+async fn step<S>(
+    client: &Client,
+    signer_id: &AccountId,
+    body: S,
+) -> anyhow::Result<PlannedTransaction>
+where
+    S: MethodSpec<Output = WriteOperationResult>,
+    Dispatch: PlanWrite<S, GatewayContext>,
+{
+    let plan = client
+        .plan_request(WriteRequest {
+            signer_account_id: signer_id.clone().into(),
+            idempotency_key: None,
+            body,
+        })
+        .await?;
+
+    let [transaction] = <[PlannedTransaction; 1]>::try_from(plan.steps).map_err(|steps| {
+        anyhow::anyhow!(
+            "`{}` planned {} transactions; the plan builder assumes one per step",
+            S::RPC_METHOD,
+            steps.len()
+        )
+    })?;
+    Ok(transaction)
+}
+
+/// Mark the named checks skipped, preserving the verdict each one reached.
+///
+/// The original detail is kept in the reason: a reviewer of the plan needs to
+/// see *what* was suppressed, and a bare "skipped" would hide the failure the
+/// operator chose to override.
+///
+/// An id that matches nothing is an error. A typo would otherwise read as a
+/// successful suppression while the check kept running.
+fn apply_skips(checks: &mut [Check], skip: &[String]) -> anyhow::Result<()> {
+    for id in skip {
+        let mut matched = false;
+        for check in checks.iter_mut() {
+            if &check.id != id {
+                continue;
+            }
+            matched = true;
+            let previous = match &check.status {
+                Status::Passed { detail } => format!("would have passed: {detail}"),
+                Status::Failed { detail } => format!("would have failed: {detail}"),
+                Status::Skipped { reason } => format!("was already skipped: {reason}"),
+            };
+            check.status = Status::Skipped {
+                reason: format!("--skip-check {id} ({previous})"),
+            };
+        }
+        anyhow::ensure!(
+            matched,
+            "--skip-check `{id}` names no check in this run. Check ids are listed \
+             by `spec check`; a typo here would silently suppress nothing."
+        );
+    }
+    Ok(())
+}
+
+/// The only two hard refusals.
+///
+/// A schema mismatch means this build cannot read the file faithfully, and a
+/// network mismatch would send a mainnet deployment to testnet or the reverse.
+/// Everything else — including a plan edited beyond recognition — is reported
+/// and confirmed rather than blocked, because blocking it would defeat the
+/// artifact's purpose.
+fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
+    anyhow::ensure!(
+        file.schema == PLAN_SCHEMA_VERSION,
+        "this plan declares schema {} but this build speaks {PLAN_SCHEMA_VERSION}. \
+         Regenerate it with `market plan`.",
+        file.schema,
+    );
+    anyhow::ensure!(
+        file.network == network,
+        "this plan is for {} but the CLI is pointed at {network}. Re-run with \
+         `--network {}`.",
+        file.network,
+        file.network,
+    );
+    Ok(())
+}
+
+/// The plan, for a human about to authorize it.
+fn render(file: &PlanFile) {
+    eprintln!(
+        "Plan for {} on {} (spec {})",
+        file.derived.market_id, file.network, file.spec_digest
+    );
+    for (index, step) in file.steps.iter().enumerate() {
+        eprintln!("\n  [{index}] {}", step.label);
+        eprintln!("      {} -> {}", step.signer_id, step.receiver_id);
+        for call in &step.function_calls {
+            eprintln!(
+                "      {}  deposit {}  gas {}",
+                call.method_name, call.deposit, call.gas
+            );
+        }
+    }
+}
+
+/// Ask before spending real NEAR. Anything but `y` aborts.
+fn confirm(question: &str) -> anyhow::Result<()> {
+    eprint!("\n{question} [y/N] ");
+    std::io::stderr().flush().ok();
+
+    let mut answer = String::new();
+    std::io::stdin()
+        .read_line(&mut answer)
+        .context("read confirmation from stdin")?;
+
+    anyhow::ensure!(
+        answer.trim().eq_ignore_ascii_case("y"),
+        "aborted; nothing was sent"
+    );
+    Ok(())
+}
+
+/// A plan that is already built, so an edited plan file rides the same executor
+/// as every other write — the store, idempotency, and recovery behaviour all
+/// come along rather than being reimplemented here.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+struct PreparedPlan {
+    steps: Vec<PlannedTransaction>,
+}
+
+impl schemars::JsonSchema for PreparedPlan {
+    fn schema_name() -> String {
+        "PreparedPlan".to_owned()
+    }
+
+    /// Never served over the RPC surface — this spec exists only to reach the
+    /// executor from inside this binary — so an unconstrained schema is honest
+    /// rather than lazy.
+    fn json_schema(_generator: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::Schema::Bool(true)
+    }
+}
+
+impl MethodSpec for PreparedPlan {
+    type Output = WriteOperationResult;
+    const RPC_METHOD: &'static str = "market.apply";
+}
+
+#[async_trait::async_trait]
+impl PlanWrite<PreparedPlan, GatewayContext> for Dispatch {
+    async fn plan(
+        request: WriteRequest<PreparedPlan>,
+        _context: GatewayContext,
+    ) -> GatewayResult<OperationPlan> {
+        Ok(OperationPlan {
+            steps: request.body.steps,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_skips, ensure_compatible, PLAN_SCHEMA_VERSION};
+    use crate::spec::check::{Check, Status};
+    use crate::spec::plan::{Derived, PlanFile};
+
+    fn checks() -> Vec<Check> {
+        vec![
+            Check {
+                id: "config.validate".to_owned(),
+                status: Status::passed("ok"),
+            },
+            Check {
+                id: "reference.price.collateral".to_owned(),
+                status: Status::failed("off by 4%"),
+            },
+        ]
+    }
+
+    /// The point of `--skip-check`: one verdict is suppressed, everything else
+    /// is untouched.
+    #[test]
+    fn skipping_leaves_every_other_check_alone() {
+        let mut checks = checks();
+        apply_skips(&mut checks, &["reference.price.collateral".to_owned()])
+            .expect("a real id should skip");
+
+        assert!(matches!(checks[0].status, Status::Passed { .. }));
+        assert!(matches!(checks[1].status, Status::Skipped { .. }));
+    }
+
+    /// A suppressed failure must still say what it was.
+    ///
+    /// This is the same trap that produced four false-passes elsewhere in this
+    /// tool: `Skipped` is how "not run" is reported, and using it to hide a
+    /// known failure without recording the failure turns a red check green with
+    /// nothing left to review.
+    #[test]
+    fn a_skipped_check_records_the_verdict_it_suppressed() {
+        let mut checks = checks();
+        apply_skips(&mut checks, &["reference.price.collateral".to_owned()]).expect("skip");
+
+        let Status::Skipped { reason } = &checks[1].status else {
+            panic!("expected Skipped, got {:?}", checks[1].status);
+        };
+        assert!(
+            reason.contains("would have failed") && reason.contains("off by 4%"),
+            "the suppressed verdict must survive in the report: {reason}"
+        );
+    }
+
+    /// A typo must not read as a successful suppression.
+    #[test]
+    fn an_unknown_skip_id_is_an_error() {
+        let error = apply_skips(&mut checks(), &["config.validte".to_owned()])
+            .expect_err("a typo names no check");
+
+        assert!(error.to_string().contains("names no check"), "{error:#}");
+    }
+
+    fn plan_file(schema: u32, network: &str) -> PlanFile {
+        PlanFile {
+            schema,
+            tool_version: "0.1.0".to_owned(),
+            network: network.to_owned(),
+            spec_digest: "sha256:test".to_owned(),
+            step_digests: Vec::new(),
+            derived: Derived {
+                market_id: "m.near".parse().expect("valid account"),
+                oracle_id: "o.near".parse().expect("valid account"),
+                governance_id: "g.near".parse().expect("valid account"),
+                collateral_decimals: Some(6),
+                borrow_decimals: Some(7),
+            },
+            checks: Vec::new(),
+            steps: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_matching_plan_is_accepted() {
+        ensure_compatible(&plan_file(PLAN_SCHEMA_VERSION, "mainnet"), "mainnet")
+            .expect("same schema and network");
+    }
+
+    /// Sending a mainnet deployment to testnet, or the reverse, is not something
+    /// a confirmation prompt should be able to wave through.
+    #[test]
+    fn a_network_mismatch_is_refused() {
+        let error = ensure_compatible(&plan_file(PLAN_SCHEMA_VERSION, "mainnet"), "testnet")
+            .expect_err("wrong network");
+
+        assert!(
+            error.to_string().contains("pointed at testnet"),
+            "{error:#}"
+        );
+    }
+
+    #[test]
+    fn a_schema_mismatch_is_refused() {
+        let error = ensure_compatible(&plan_file(PLAN_SCHEMA_VERSION + 1, "mainnet"), "mainnet")
+            .expect_err("wrong schema");
+
+        assert!(error.to_string().contains("Regenerate it"), "{error:#}");
+    }
+}

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -171,6 +171,22 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         }
     }
 
+    // Every other write this tool performs is a single transaction, so this
+    // risk is new here and worth stating before the money is spent rather than
+    // after: the operation record lives in an in-memory store
+    // (`ClientBuilder`'s default), so an interrupt or an ambiguous RPC result
+    // part-way through leaves nothing to resume from or reconcile against.
+    // ENG-546 replaces the store and adds resume.
+    if file.steps.len() > 1 {
+        eprintln!(
+            "\nThis sends {} transactions in sequence. They are not journalled: \
+             if this is interrupted part-way, no record of what landed is kept, \
+             and re-running starts from the first step. Check the deployed \
+             accounts by hand before retrying.",
+            file.steps.len()
+        );
+    }
+
     if !args.yes {
         confirm(&format!(
             "Send {} transaction(s) as {credential}?",

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -36,10 +36,7 @@ pub(super) async fn check(ctx: CliContext, args: CheckArgs) -> anyhow::Result<()
         "checks": checks,
     }))?;
 
-    let failed = checks
-        .iter()
-        .filter(|check| check.status.is_failure())
-        .count();
+    let failed = crate::spec::check::failures(&checks);
     anyhow::ensure!(failed == 0, "{failed} check(s) failed");
     Ok(())
 }

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -23,9 +23,42 @@ use crate::spec::{
 /// failed, so it is usable as a gate in CI or a pre-deploy script.
 pub(super) async fn check(ctx: CliContext, args: CheckArgs) -> anyhow::Result<()> {
     let mut spec = crate::spec::extends::load(&args.path)?;
+    let checks = run_all(&ctx, &mut spec, args.offline, args.accept_decimals_mismatch).await?;
+
+    let price_maximum_age = spec.market.price_maximum_age;
+    print_json(&serde_json::json!({
+        "market_id": spec.market_id()?,
+        "oracle_id": spec.oracle_id()?,
+        "governance_id": spec.governance_id()?,
+        "network": spec.network()?.to_string(),
+        "collateral_proxy": spec.collateral.clone().into_proxy(price_maximum_age),
+        "borrow_proxy": spec.borrow.clone().into_proxy(price_maximum_age),
+        "checks": checks,
+    }))?;
+
+    let failed = checks
+        .iter()
+        .filter(|check| check.status.is_failure())
+        .count();
+    anyhow::ensure!(failed == 0, "{failed} check(s) failed");
+    Ok(())
+}
+
+/// Every check, online then offline, writing resolved decimals back into the
+/// spec as it goes.
+///
+/// Shared with `market plan` (ENG-544), which embeds the same results in its
+/// artifact — running a *different* set of checks there would let a plan be
+/// written for a spec `spec check` rejects.
+pub(super) async fn run_all(
+    ctx: &CliContext,
+    spec: &mut MarketSpec,
+    offline: bool,
+    accept_decimals_mismatch: bool,
+) -> anyhow::Result<Vec<Check>> {
     let mut checks = Vec::new();
 
-    if args.offline {
+    if offline {
         checks.push(Check::new(
             "preflight.online",
             Status::Skipped {
@@ -48,28 +81,11 @@ pub(super) async fn check(ctx: CliContext, args: CheckArgs) -> anyhow::Result<()
         // Online first, writing resolved decimals back into the spec. Otherwise
         // `config.validate` reports itself skipped for want of decimals this
         // very run just read off the chain.
-        checks.extend(run(&ctx, &mut spec, args.accept_decimals_mismatch).await);
+        checks.extend(run(ctx, spec, accept_decimals_mismatch).await);
     }
     // Offline checks run last so they see those decimals.
-    checks.extend(crate::spec::check::run_offline(&spec));
-
-    let price_maximum_age = spec.market.price_maximum_age;
-    print_json(&serde_json::json!({
-        "market_id": spec.market_id()?,
-        "oracle_id": spec.oracle_id()?,
-        "governance_id": spec.governance_id()?,
-        "network": spec.network()?.to_string(),
-        "collateral_proxy": spec.collateral.clone().into_proxy(price_maximum_age),
-        "borrow_proxy": spec.borrow.clone().into_proxy(price_maximum_age),
-        "checks": checks,
-    }))?;
-
-    let failed = checks
-        .iter()
-        .filter(|check| check.status.is_failure())
-        .count();
-    anyhow::ensure!(failed == 0, "{failed} check(s) failed");
-    Ok(())
+    checks.extend(crate::spec::check::run_offline(spec));
+    Ok(checks)
 }
 
 /// Every check that needs the chain, in a stable order so two runs of the same

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -253,6 +253,15 @@ async fn ft_decimals(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result
 
 /// Every version key must already be registered, or the deploy fails partway —
 /// which is how `deploy.sh` leaves an orphaned governance contract today.
+///
+/// Membership is all this can check. `remove_version` soft-deletes: it sets
+/// `VersionEntry::Code.code = None` but keeps the key, and `code_hash()` still
+/// answers with the stored hash — so `list_versions` and `get_version_code_hash`
+/// both report a removed version as present, while `deploy` aborts with
+/// "Version code has been deleted". No registry view distinguishes the two, so
+/// closing this needs an additive view reporting code availability (the same
+/// contract change ENG-463/464 wants for ABI validation). Until then a
+/// soft-deleted version passes here and fails mid-deploy.
 async fn versions(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
     let labelled = [
         ("market", &spec.versions.market),

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -335,7 +335,7 @@ async fn account_check(ctx: &CliContext, label: &str, account_id: &AccountId) ->
 /// Only `AccountNotFound` means "no"; every other failure propagates. A timed-out
 /// RPC reported as "this account does not exist" would send an operator off to
 /// create an account that is already there.
-async fn exists(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result<bool> {
+pub(super) async fn exists(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result<bool> {
     match ctx
         .client
         .read(account::Get {

--- a/tools/manager/src/spec/check.rs
+++ b/tools/manager/src/spec/check.rs
@@ -60,6 +60,15 @@ impl Check {
     }
 }
 
+/// How many checks failed. The gate `spec check` and `market plan` both apply,
+/// in one place so they cannot drift apart.
+pub fn failures(checks: &[Check]) -> usize {
+    checks
+        .iter()
+        .filter(|check| check.status.is_failure())
+        .count()
+}
+
 /// Run every offline check.
 ///
 /// Decimals are supplied because `config.validate` needs a full

--- a/tools/manager/src/spec/check.rs
+++ b/tools/manager/src/spec/check.rs
@@ -8,13 +8,16 @@
 //! (ENG-541), aggregation dry-run (ENG-542), and reference cross-check
 //! (ENG-543) register alongside them later.
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::MarketSpec;
 
 /// A check's verdict. `Skipped` is distinct from `Passed` so a report can never
 /// present "not run" as "fine".
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+///
+/// `Deserialize` because the plan artifact (ENG-544) embeds these and is read
+/// back on apply.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "status")]
 pub enum Status {
     Passed { detail: String },
@@ -40,7 +43,7 @@ impl Status {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Check {
     /// Stable, dotted id — e.g. `config.validate`.
     pub id: String,

--- a/tools/manager/src/spec/mod.rs
+++ b/tools/manager/src/spec/mod.rs
@@ -14,6 +14,7 @@ pub mod check;
 pub mod export;
 pub mod extends;
 pub mod oracle;
+pub mod plan;
 mod serde_util;
 
 use anyhow::Context as _;
@@ -184,11 +185,23 @@ pub fn market_account_id(name: &str, registry: &AccountId) -> anyhow::Result<Acc
 }
 
 pub fn oracle_account_id(name: &str, registry: &AccountId) -> anyhow::Result<AccountId> {
-    derived_id(&format!("proxy-oracle-{name}"), registry)
+    derived_id(&oracle_name(name), registry)
 }
 
 pub fn governance_account_id(name: &str, registry: &AccountId) -> anyhow::Result<AccountId> {
-    derived_id(&format!("proxy-gov-{name}"), registry)
+    derived_id(&governance_name(name), registry)
+}
+
+/// The sub-account *label* a registry deploy creates, as distinct from the full
+/// account id. `registry.deploy` takes the label and derives the id itself, so
+/// both forms are needed — and deriving one from the other by string surgery is
+/// how the two drifted apart in `deploy.sh`.
+pub fn oracle_name(name: &str) -> String {
+    format!("proxy-oracle-{name}")
+}
+
+pub fn governance_name(name: &str) -> String {
+    format!("proxy-gov-{name}")
 }
 
 fn derived_id(label: &str, registry: &AccountId) -> anyhow::Result<AccountId> {

--- a/tools/manager/src/spec/plan.rs
+++ b/tools/manager/src/spec/plan.rs
@@ -47,7 +47,7 @@ impl PlanArgs {
     /// rules out borsh that happens to parse as a bare scalar.
     fn from_bytes(args: Vec<u8>) -> Self {
         match serde_json::from_slice::<serde_json::Value>(&args) {
-            Ok(value) if value.is_object() => Self::Json(value),
+            Ok(value) if value.is_object() && exactly_representable(&value) => Self::Json(value),
             _ => Self::Base64(Base64Bytes(args)),
         }
     }
@@ -60,6 +60,24 @@ impl PlanArgs {
     }
 }
 
+/// Whether every number survives a decode/re-encode unchanged.
+///
+/// `serde_json` without `arbitrary_precision` demotes an integer too large for
+/// `u64` to `f64`, which re-encodes in exponent form — a different value than
+/// the operator reviewed, on a transaction that spends real money. Today every
+/// large number reaching these args is a string (`U128`, `Decimal`,
+/// `NearToken`), so nothing hits this; the classifier is method-agnostic by
+/// design, so the first one that does must fall back to opaque bytes rather
+/// than be silently rewritten.
+fn exactly_representable(value: &serde_json::Value) -> bool {
+    match value {
+        serde_json::Value::Number(number) => number.is_i64() || number.is_u64(),
+        serde_json::Value::Array(items) => items.iter().all(exactly_representable),
+        serde_json::Value::Object(fields) => fields.values().all(exactly_representable),
+        _ => true,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PlanFunctionCall {
@@ -68,6 +86,8 @@ pub struct PlanFunctionCall {
     /// Gas units, as a plain integer so editing needs no knowledge of
     /// `NearGas`'s parse format.
     pub gas: u64,
+    /// In yoctoNEAR (1 NEAR = 10^24). `render` prints the human form; this is
+    /// the raw value, and editing it by eye is how you send 6 yoctoNEAR.
     pub deposit: NearToken,
 }
 
@@ -81,8 +101,6 @@ pub struct PlanStep {
     pub label: String,
     pub signer_id: AccountId,
     pub receiver_id: AccountId,
-    #[serde(default)]
-    pub continue_on_failure: bool,
     pub function_calls: Vec<PlanFunctionCall>,
 }
 
@@ -105,11 +123,21 @@ impl PlanStep {
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
 
+        // Not carried in the artifact. A tolerated revert still completes the
+        // operation as `Succeeded`, so an editable `continue_on_failure` would
+        // let a hand-edit turn a reverted governance call into `apply` exiting
+        // zero. Nothing a deployment plans sets it, so it is refused rather
+        // than rendered.
+        anyhow::ensure!(
+            !transaction.continue_on_failure,
+            "`{label}` tolerates its own failure, which a deployment plan must \
+             never do"
+        );
+
         Ok(Self {
             label,
             signer_id: transaction.signer_account_id.0,
             receiver_id: transaction.receiver_id,
-            continue_on_failure: transaction.continue_on_failure,
             function_calls,
         })
     }
@@ -132,7 +160,7 @@ impl PlanStep {
             signer_account_id: ManagedAccountId::from(self.signer_id),
             receiver_id: self.receiver_id,
             actions,
-            continue_on_failure: self.continue_on_failure,
+            continue_on_failure: false,
         })
     }
 }
@@ -162,6 +190,11 @@ pub struct PlanFile {
     /// whole-file digest: with seven steps, "something changed" is not
     /// actionable.
     pub step_digests: Vec<String>,
+    /// Digest over everything `render` shows that is not a step — the derived
+    /// ids and the check results. Without it, editing a check from `failed` to
+    /// `passed`, or repointing `derived.market_id`, reports the plan as
+    /// unmodified.
+    pub summary_digest: String,
     pub derived: Derived,
     pub checks: Vec<Check>,
     pub steps: Vec<PlanStep>,
@@ -174,11 +207,13 @@ pub struct Drift {
     pub changed: Vec<usize>,
     /// Steps added (positive) or removed (negative).
     pub delta: isize,
+    /// The derived values or check results differ.
+    pub summary: bool,
 }
 
 impl Drift {
     pub fn is_clean(&self) -> bool {
-        self.changed.is_empty() && self.delta == 0
+        self.changed.is_empty() && self.delta == 0 && !self.summary
     }
 
     /// A plain sentence for the confirmation prompt.
@@ -203,6 +238,9 @@ impl Drift {
             0 => {}
             added if added > 0 => parts.push(format!("{added} step(s) added")),
             removed => parts.push(format!("{} step(s) removed", -removed)),
+        }
+        if self.summary {
+            parts.push("the derived values or check results differ".to_owned());
         }
         format!(
             "plan has been edited since generation: {}",
@@ -235,6 +273,7 @@ impl PlanFile {
             network,
             spec_digest,
             step_digests,
+            summary_digest: summary_digest(&derived, &checks)?,
             derived,
             checks,
             steps,
@@ -261,6 +300,7 @@ impl PlanFile {
                 .collect(),
             delta: isize::try_from(current.len()).unwrap_or(isize::MAX)
                 - isize::try_from(self.step_digests.len()).unwrap_or(isize::MAX),
+            summary: summary_digest(&self.derived, &self.checks)? != self.summary_digest,
         })
     }
 
@@ -274,6 +314,10 @@ impl PlanFile {
                 .collect::<anyhow::Result<Vec<_>>>()?,
         })
     }
+}
+
+fn summary_digest(derived: &Derived, checks: &[Check]) -> anyhow::Result<String> {
+    digest(&(derived, checks))
 }
 
 /// `sha256:…` over a value's JSON encoding.

--- a/tools/manager/src/spec/plan.rs
+++ b/tools/manager/src/spec/plan.rs
@@ -52,10 +52,24 @@ impl PlanArgs {
         }
     }
 
-    fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
+    /// The bytes this will send.
+    ///
+    /// Borrowing rather than consuming, because the collision check has to read
+    /// the same bytes the executor will. Re-checks representability: `from_bytes`
+    /// runs at generation, but it is the *edited* file that gets sent, and a
+    /// hand-written number too large for `u64` would otherwise be re-encoded in
+    /// exponent form — a value nobody wrote.
+    pub(crate) fn to_bytes(&self) -> anyhow::Result<Vec<u8>> {
         match self {
-            Self::Json(value) => serde_json::to_vec(&value).context("encode JSON args"),
-            Self::Base64(bytes) => Ok(bytes.0),
+            Self::Json(value) => {
+                anyhow::ensure!(
+                    exactly_representable(value),
+                    "these args carry a number that cannot be re-encoded exactly; \
+                     it would be sent in a different form than written"
+                );
+                serde_json::to_vec(value).context("encode JSON args")
+            }
+            Self::Base64(bytes) => Ok(bytes.0.clone()),
         }
     }
 }
@@ -149,7 +163,7 @@ impl PlanStep {
             .map(|call| {
                 Ok(Action::FunctionCall(Box::new(FunctionCallAction {
                     method_name: call.method_name,
-                    args: call.args.into_bytes()?,
+                    args: call.args.to_bytes()?,
                     gas: NearGas::from_gas(call.gas),
                     deposit: call.deposit,
                 })))
@@ -343,9 +357,14 @@ fn summary_digest(
     digest(&(schema, tool_version, network, spec_digest, derived, checks))
 }
 
-/// `sha256:…` over a value's JSON encoding.
+/// `sha256:…` over a value's *canonical* JSON encoding.
+///
+/// Canonical because a spec's `yield_weights.static` is a `HashMap`, whose
+/// iteration order is randomized per process — hashing the plain encoding gave
+/// the same spec a different `spec_digest` on every invocation, which is the
+/// opposite of the traceability the field exists for.
 pub fn digest(value: &impl Serialize) -> anyhow::Result<String> {
-    let bytes = serde_json::to_vec(value).context("serialize for digest")?;
+    let bytes = serde_json_canonicalizer::to_vec(value).context("serialize for digest")?;
     Ok(format!(
         "sha256:{}",
         templar_contract_artifacts::sha256_hex(&bytes)

--- a/tools/manager/src/spec/plan.rs
+++ b/tools/manager/src/spec/plan.rs
@@ -1,0 +1,330 @@
+//! The plan artifact: a serializable, hand-editable form of an
+//! [`OperationPlan`].
+//!
+//! This is the escape hatch. A spec cannot express every market, and a check can
+//! be wrong; when either happens, an operator needs to see the concrete
+//! transactions, change one, and send the result. So `market plan` writes this
+//! file, and `market apply` sends it.
+//!
+//! `gateway/core` is deliberately untouched. [`PlannedTransaction`] already
+//! derives `Serialize`/`Deserialize`, so the only thing missing was a *legible*
+//! encoding — which is a property of this tool, not of the gateway. The step
+//! `label` lives here for the same reason: it exists to orient a human reading a
+//! diff, and the executor has no use for it.
+//!
+//! ## Why JSON args are canonicalized
+//!
+//! `near_api` serializes `FunctionCallAction::args` as base64, which is correct
+//! on the wire and useless in a file someone has to edit. So JSON args are
+//! carried as JSON — but re-encoding through [`serde_json::Value`] sorts object
+//! keys, while the gateway produced them in struct-declaration order. The bytes
+//! therefore differ from the originals.
+//!
+//! Rather than pretend otherwise, conversion *into* this file canonicalizes.
+//! The invariant that matters is not "the bytes are untouched" but **what
+//! `apply` sends is exactly what `plan` showed** — so the canonical form is the
+//! one that gets digested, displayed, and executed. Key order carries no meaning
+//! to a contract decoding with `serde_json`, so nothing on chain can observe the
+//! difference.
+
+use anyhow::Context as _;
+use near_account_id::AccountId;
+use near_api::types::transaction::actions::{Action, FunctionCallAction};
+use near_api::types::NearToken;
+use serde::{Deserialize, Serialize};
+use templar_gateway_core::{OperationPlan, PlannedTransaction};
+use templar_gateway_types::{Base64Bytes, ManagedAccountId, NearGas};
+
+use super::check::Check;
+
+/// Bumped when this artifact's shape changes.
+///
+/// `apply` hard-refuses a mismatch. Every struct here is `deny_unknown_fields`,
+/// so a plan written by a newer tool is rejected outright rather than applied
+/// with fields this build cannot see — and this file authorizes spending real
+/// NEAR.
+pub const PLAN_SCHEMA_VERSION: u32 = 1;
+
+/// A function call's arguments, in whichever form a human can actually edit.
+///
+/// Base64 is the wire encoding and `near_api`'s native serialization, but a plan
+/// of opaque blobs cannot be edited, which is the whole point of the artifact.
+/// So JSON args — nearly all of them — are carried as JSON, and base64 is
+/// reserved for the genuinely opaque case (`registry add_version` takes borsh).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PlanArgs {
+    Json(serde_json::Value),
+    Base64(Base64Bytes),
+}
+
+impl PlanArgs {
+    /// Classify by probing the bytes, not by a list of method names — a list
+    /// would silently drift from the methods it describes, and the failure mode
+    /// is an unreadable plan rather than an error.
+    ///
+    /// Only a JSON *object* counts. Every NEAR contract takes its JSON args as
+    /// one, so requiring it costs nothing and rules out a borsh payload that
+    /// happens to parse as a bare JSON scalar (`5`, `null`, a quoted string).
+    fn from_bytes(args: Vec<u8>) -> Self {
+        match serde_json::from_slice::<serde_json::Value>(&args) {
+            Ok(value) if value.is_object() => Self::Json(value),
+            _ => Self::Base64(Base64Bytes(args)),
+        }
+    }
+
+    fn into_bytes(self) -> anyhow::Result<Vec<u8>> {
+        match self {
+            Self::Json(value) => serde_json::to_vec(&value).context("encode JSON args"),
+            Self::Base64(bytes) => Ok(bytes.0),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanFunctionCall {
+    pub method_name: String,
+    pub args: PlanArgs,
+    /// Gas units. A plain integer rather than a `NearGas` string, so editing it
+    /// needs no knowledge of that crate's parse format.
+    pub gas: u64,
+    pub deposit: NearToken,
+}
+
+/// One transaction.
+///
+/// Every step a deployment plans is one or more function calls; a plan carrying
+/// any other action kind is refused at conversion rather than silently dropped,
+/// so `function_calls` is the field rather than a general `actions` list.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanStep {
+    /// What this step is for, in words. Manager-only: the executor never reads
+    /// it, and it exists so a diff of an edited plan is legible.
+    pub label: String,
+    pub signer_id: AccountId,
+    pub receiver_id: AccountId,
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub continue_on_failure: bool,
+    pub function_calls: Vec<PlanFunctionCall>,
+}
+
+#[expect(
+    clippy::trivially_copy_pass_by_ref,
+    reason = "serde predicate signature"
+)]
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+impl PlanStep {
+    fn from_planned(label: String, transaction: PlannedTransaction) -> anyhow::Result<Self> {
+        let function_calls = transaction
+            .actions
+            .into_iter()
+            .map(|action| match action {
+                Action::FunctionCall(call) => Ok(PlanFunctionCall {
+                    method_name: call.method_name,
+                    args: PlanArgs::from_bytes(call.args),
+                    gas: call.gas.as_gas(),
+                    deposit: call.deposit,
+                }),
+                other => anyhow::bail!(
+                    "a deployment plan carries only function calls, but `{label}` \
+                     planned {other:?}. This is a bug in the plan builder, not \
+                     something an edited plan can cause."
+                ),
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Self {
+            label,
+            signer_id: transaction.signer_account_id.0,
+            receiver_id: transaction.receiver_id,
+            continue_on_failure: transaction.continue_on_failure,
+            function_calls,
+        })
+    }
+
+    fn into_planned(self) -> anyhow::Result<PlannedTransaction> {
+        let actions = self
+            .function_calls
+            .into_iter()
+            .map(|call| {
+                Ok(Action::FunctionCall(Box::new(FunctionCallAction {
+                    method_name: call.method_name,
+                    args: call.args.into_bytes()?,
+                    gas: NearGas::from_gas(call.gas),
+                    deposit: call.deposit,
+                })))
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(PlannedTransaction {
+            signer_account_id: ManagedAccountId::from(self.signer_id),
+            receiver_id: self.receiver_id,
+            actions,
+            continue_on_failure: self.continue_on_failure,
+        })
+    }
+
+    /// The digest recorded for this step at generation time.
+    fn digest(&self) -> anyhow::Result<String> {
+        digest(self)
+    }
+}
+
+/// Values the spec implies rather than states, recorded so a reader does not
+/// have to re-derive them — and so a reviewer can see what the tool concluded.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Derived {
+    pub market_id: AccountId,
+    pub oracle_id: AccountId,
+    pub governance_id: AccountId,
+    pub collateral_decimals: Option<u8>,
+    pub borrow_decimals: Option<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PlanFile {
+    pub schema: u32,
+    pub tool_version: String,
+    pub network: String,
+    /// Digest of the spec this plan came from. Reported on apply so a plan can
+    /// be traced back to its source, including after the spec has moved on.
+    pub spec_digest: String,
+    /// Per-step digests as generated.
+    ///
+    /// One per step rather than a single whole-file digest: with seven steps,
+    /// "something changed" is not actionable, and naming the changed steps is
+    /// what lets an operator confirm the edit they meant to make is the only one
+    /// present.
+    pub step_digests: Vec<String>,
+    pub derived: Derived,
+    pub checks: Vec<Check>,
+    pub steps: Vec<PlanStep>,
+}
+
+/// What changed between a plan as generated and the file as it stands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Drift {
+    /// Indices of steps whose content differs from the recorded digest.
+    pub changed: Vec<usize>,
+    pub added: usize,
+    pub removed: usize,
+}
+
+impl Drift {
+    pub fn is_clean(&self) -> bool {
+        self.changed.is_empty() && self.added == 0 && self.removed == 0
+    }
+
+    /// A plain sentence for the confirmation prompt.
+    pub fn describe(&self) -> String {
+        if self.is_clean() {
+            return "plan is unmodified since generation".to_owned();
+        }
+
+        let mut parts = Vec::new();
+        if !self.changed.is_empty() {
+            parts.push(format!(
+                "{} step(s) differ (#{})",
+                self.changed.len(),
+                self.changed
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join(", #")
+            ));
+        }
+        if self.added > 0 {
+            parts.push(format!("{} step(s) added", self.added));
+        }
+        if self.removed > 0 {
+            parts.push(format!("{} step(s) removed", self.removed));
+        }
+        format!(
+            "plan has been edited since generation: {}",
+            parts.join(", ")
+        )
+    }
+}
+
+impl PlanFile {
+    /// Build the artifact from labelled transactions, canonicalizing JSON args.
+    pub fn new(
+        network: String,
+        spec_digest: String,
+        derived: Derived,
+        checks: Vec<Check>,
+        steps: Vec<(String, PlannedTransaction)>,
+    ) -> anyhow::Result<Self> {
+        let steps = steps
+            .into_iter()
+            .map(|(label, transaction)| PlanStep::from_planned(label, transaction))
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        let step_digests = steps
+            .iter()
+            .map(PlanStep::digest)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        Ok(Self {
+            schema: PLAN_SCHEMA_VERSION,
+            tool_version: env!("CARGO_PKG_VERSION").to_owned(),
+            network,
+            spec_digest,
+            step_digests,
+            derived,
+            checks,
+            steps,
+        })
+    }
+
+    /// Recompute each step's digest and report how the file differs from what
+    /// was generated.
+    ///
+    /// Reported, never enforced. Editing the plan is the feature; refusing an
+    /// edited plan would block exactly the case this artifact exists for.
+    pub fn drift(&self) -> anyhow::Result<Drift> {
+        let current = self
+            .steps
+            .iter()
+            .map(PlanStep::digest)
+            .collect::<anyhow::Result<Vec<_>>>()?;
+
+        let changed = current
+            .iter()
+            .zip(&self.step_digests)
+            .enumerate()
+            .filter_map(|(index, (now, then))| (now != then).then_some(index))
+            .collect();
+
+        Ok(Drift {
+            changed,
+            added: current.len().saturating_sub(self.step_digests.len()),
+            removed: self.step_digests.len().saturating_sub(current.len()),
+        })
+    }
+
+    /// The transactions this plan will send.
+    pub fn into_operation_plan(self) -> anyhow::Result<OperationPlan> {
+        Ok(OperationPlan {
+            steps: self
+                .steps
+                .into_iter()
+                .map(PlanStep::into_planned)
+                .collect::<anyhow::Result<Vec<_>>>()?,
+        })
+    }
+}
+
+/// `sha256:…` over a value's canonical JSON encoding.
+pub fn digest(value: &impl Serialize) -> anyhow::Result<String> {
+    use sha2::{Digest as _, Sha256};
+
+    let bytes = serde_json::to_vec(value).context("serialize for digest")?;
+    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+}

--- a/tools/manager/src/spec/plan.rs
+++ b/tools/manager/src/spec/plan.rs
@@ -1,31 +1,16 @@
 //! The plan artifact: a serializable, hand-editable form of an
-//! [`OperationPlan`].
-//!
-//! This is the escape hatch. A spec cannot express every market, and a check can
-//! be wrong; when either happens, an operator needs to see the concrete
-//! transactions, change one, and send the result. So `market plan` writes this
-//! file, and `market apply` sends it.
-//!
-//! `gateway/core` is deliberately untouched. [`PlannedTransaction`] already
-//! derives `Serialize`/`Deserialize`, so the only thing missing was a *legible*
-//! encoding — which is a property of this tool, not of the gateway. The step
-//! `label` lives here for the same reason: it exists to orient a human reading a
-//! diff, and the executor has no use for it.
+//! [`OperationPlan`], for when the spec cannot express what a market needs or a
+//! check is wrong.
 //!
 //! ## Why JSON args are canonicalized
 //!
-//! `near_api` serializes `FunctionCallAction::args` as base64, which is correct
-//! on the wire and useless in a file someone has to edit. So JSON args are
-//! carried as JSON — but re-encoding through [`serde_json::Value`] sorts object
-//! keys, while the gateway produced them in struct-declaration order. The bytes
-//! therefore differ from the originals.
-//!
-//! Rather than pretend otherwise, conversion *into* this file canonicalizes.
-//! The invariant that matters is not "the bytes are untouched" but **what
-//! `apply` sends is exactly what `plan` showed** — so the canonical form is the
-//! one that gets digested, displayed, and executed. Key order carries no meaning
-//! to a contract decoding with `serde_json`, so nothing on chain can observe the
-//! difference.
+//! `near_api` serializes `FunctionCallAction::args` as base64, which is useless
+//! in a file someone has to edit. Carrying them as JSON means re-encoding
+//! through [`serde_json::Value`], which sorts object keys the gateway emitted in
+//! declaration order — so the original bytes cannot be preserved. Conversion
+//! into this file therefore canonicalizes, and the canonical form is what gets
+//! digested, displayed, and executed: what `apply` sends is what `plan` showed.
+//! Key order means nothing to a contract decoding with `serde_json`.
 
 use anyhow::Context as _;
 use near_account_id::AccountId;
@@ -37,20 +22,17 @@ use templar_gateway_types::{Base64Bytes, ManagedAccountId, NearGas};
 
 use super::check::Check;
 
-/// Bumped when this artifact's shape changes.
-///
-/// `apply` hard-refuses a mismatch. Every struct here is `deny_unknown_fields`,
-/// so a plan written by a newer tool is rejected outright rather than applied
-/// with fields this build cannot see — and this file authorizes spending real
-/// NEAR.
+/// Bumped when this artifact's shape changes. `apply` hard-refuses a mismatch:
+/// every struct here is `deny_unknown_fields`, and this file authorizes spending
+/// real NEAR.
 pub const PLAN_SCHEMA_VERSION: u32 = 1;
 
 /// A function call's arguments, in whichever form a human can actually edit.
 ///
-/// Base64 is the wire encoding and `near_api`'s native serialization, but a plan
-/// of opaque blobs cannot be edited, which is the whole point of the artifact.
-/// So JSON args — nearly all of them — are carried as JSON, and base64 is
-/// reserved for the genuinely opaque case (`registry add_version` takes borsh).
+/// Deliberately not [`templar_gateway_types::common::ContractArgs`], which
+/// models the same choice but serializes as `{"encoding": …, "value": …}`. This
+/// file is read and edited by hand, so the terser `{"json": …}` is the shape
+/// worth having.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PlanArgs {
@@ -59,13 +41,10 @@ pub enum PlanArgs {
 }
 
 impl PlanArgs {
-    /// Classify by probing the bytes, not by a list of method names — a list
-    /// would silently drift from the methods it describes, and the failure mode
-    /// is an unreadable plan rather than an error.
-    ///
-    /// Only a JSON *object* counts. Every NEAR contract takes its JSON args as
-    /// one, so requiring it costs nothing and rules out a borsh payload that
-    /// happens to parse as a bare JSON scalar (`5`, `null`, a quoted string).
+    /// Classify by probing the bytes rather than by a list of method names,
+    /// which would drift from the methods it describes. Only a JSON *object*
+    /// counts — every NEAR contract takes its JSON args as one, so requiring it
+    /// rules out borsh that happens to parse as a bare scalar.
     fn from_bytes(args: Vec<u8>) -> Self {
         match serde_json::from_slice::<serde_json::Value>(&args) {
             Ok(value) if value.is_object() => Self::Json(value),
@@ -86,36 +65,25 @@ impl PlanArgs {
 pub struct PlanFunctionCall {
     pub method_name: String,
     pub args: PlanArgs,
-    /// Gas units. A plain integer rather than a `NearGas` string, so editing it
-    /// needs no knowledge of that crate's parse format.
+    /// Gas units, as a plain integer so editing needs no knowledge of
+    /// `NearGas`'s parse format.
     pub gas: u64,
     pub deposit: NearToken,
 }
 
-/// One transaction.
-///
-/// Every step a deployment plans is one or more function calls; a plan carrying
-/// any other action kind is refused at conversion rather than silently dropped,
-/// so `function_calls` is the field rather than a general `actions` list.
+/// One transaction. Every step a deployment plans is a function call; any other
+/// action kind is refused at conversion rather than silently dropped.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct PlanStep {
-    /// What this step is for, in words. Manager-only: the executor never reads
-    /// it, and it exists so a diff of an edited plan is legible.
+    /// Manager-only, so a diff of an edited plan is legible. The executor never
+    /// reads it, which is why it lives here and not in [`PlannedTransaction`].
     pub label: String,
     pub signer_id: AccountId,
     pub receiver_id: AccountId,
-    #[serde(default, skip_serializing_if = "is_false")]
+    #[serde(default)]
     pub continue_on_failure: bool,
     pub function_calls: Vec<PlanFunctionCall>,
-}
-
-#[expect(
-    clippy::trivially_copy_pass_by_ref,
-    reason = "serde predicate signature"
-)]
-fn is_false(value: &bool) -> bool {
-    !*value
 }
 
 impl PlanStep {
@@ -132,8 +100,7 @@ impl PlanStep {
                 }),
                 other => anyhow::bail!(
                     "a deployment plan carries only function calls, but `{label}` \
-                     planned {other:?}. This is a bug in the plan builder, not \
-                     something an edited plan can cause."
+                     planned {other:?}"
                 ),
             })
             .collect::<anyhow::Result<Vec<_>>>()?;
@@ -168,15 +135,10 @@ impl PlanStep {
             continue_on_failure: self.continue_on_failure,
         })
     }
-
-    /// The digest recorded for this step at generation time.
-    fn digest(&self) -> anyhow::Result<String> {
-        digest(self)
-    }
 }
 
-/// Values the spec implies rather than states, recorded so a reader does not
-/// have to re-derive them — and so a reviewer can see what the tool concluded.
+/// Values the spec implies rather than states, so a reviewer can see what the
+/// tool concluded without re-deriving them.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Derived {
@@ -193,15 +155,12 @@ pub struct PlanFile {
     pub schema: u32,
     pub tool_version: String,
     pub network: String,
-    /// Digest of the spec this plan came from. Reported on apply so a plan can
-    /// be traced back to its source, including after the spec has moved on.
+    /// Digest of the spec this plan came from, so a plan can be traced back to
+    /// its source after the spec has moved on.
     pub spec_digest: String,
-    /// Per-step digests as generated.
-    ///
-    /// One per step rather than a single whole-file digest: with seven steps,
-    /// "something changed" is not actionable, and naming the changed steps is
-    /// what lets an operator confirm the edit they meant to make is the only one
-    /// present.
+    /// Per-step digests as generated. One per step rather than a single
+    /// whole-file digest: with seven steps, "something changed" is not
+    /// actionable.
     pub step_digests: Vec<String>,
     pub derived: Derived,
     pub checks: Vec<Check>,
@@ -211,15 +170,15 @@ pub struct PlanFile {
 /// What changed between a plan as generated and the file as it stands.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Drift {
-    /// Indices of steps whose content differs from the recorded digest.
+    /// Indices whose content differs from the recorded digest.
     pub changed: Vec<usize>,
-    pub added: usize,
-    pub removed: usize,
+    /// Steps added (positive) or removed (negative).
+    pub delta: isize,
 }
 
 impl Drift {
     pub fn is_clean(&self) -> bool {
-        self.changed.is_empty() && self.added == 0 && self.removed == 0
+        self.changed.is_empty() && self.delta == 0
     }
 
     /// A plain sentence for the confirmation prompt.
@@ -240,11 +199,10 @@ impl Drift {
                     .join(", #")
             ));
         }
-        if self.added > 0 {
-            parts.push(format!("{} step(s) added", self.added));
-        }
-        if self.removed > 0 {
-            parts.push(format!("{} step(s) removed", self.removed));
+        match self.delta {
+            0 => {}
+            added if added > 0 => parts.push(format!("{added} step(s) added")),
+            removed => parts.push(format!("{} step(s) removed", -removed)),
         }
         format!(
             "plan has been edited since generation: {}",
@@ -268,7 +226,7 @@ impl PlanFile {
             .collect::<anyhow::Result<Vec<_>>>()?;
         let step_digests = steps
             .iter()
-            .map(PlanStep::digest)
+            .map(digest)
             .collect::<anyhow::Result<Vec<_>>>()?;
 
         Ok(Self {
@@ -283,29 +241,26 @@ impl PlanFile {
         })
     }
 
-    /// Recompute each step's digest and report how the file differs from what
-    /// was generated.
+    /// How the file differs from what was generated.
     ///
-    /// Reported, never enforced. Editing the plan is the feature; refusing an
-    /// edited plan would block exactly the case this artifact exists for.
+    /// Reported, never enforced: editing the plan is the feature, so refusing an
+    /// edited plan would block the case this artifact exists for.
     pub fn drift(&self) -> anyhow::Result<Drift> {
         let current = self
             .steps
             .iter()
-            .map(PlanStep::digest)
+            .map(digest)
             .collect::<anyhow::Result<Vec<_>>>()?;
 
-        let changed = current
-            .iter()
-            .zip(&self.step_digests)
-            .enumerate()
-            .filter_map(|(index, (now, then))| (now != then).then_some(index))
-            .collect();
-
         Ok(Drift {
-            changed,
-            added: current.len().saturating_sub(self.step_digests.len()),
-            removed: self.step_digests.len().saturating_sub(current.len()),
+            changed: current
+                .iter()
+                .zip(&self.step_digests)
+                .enumerate()
+                .filter_map(|(index, (now, then))| (now != then).then_some(index))
+                .collect(),
+            delta: isize::try_from(current.len()).unwrap_or(isize::MAX)
+                - isize::try_from(self.step_digests.len()).unwrap_or(isize::MAX),
         })
     }
 
@@ -321,10 +276,11 @@ impl PlanFile {
     }
 }
 
-/// `sha256:…` over a value's canonical JSON encoding.
+/// `sha256:…` over a value's JSON encoding.
 pub fn digest(value: &impl Serialize) -> anyhow::Result<String> {
-    use sha2::{Digest as _, Sha256};
-
     let bytes = serde_json::to_vec(value).context("serialize for digest")?;
-    Ok(format!("sha256:{}", hex::encode(Sha256::digest(&bytes))))
+    Ok(format!(
+        "sha256:{}",
+        templar_contract_artifacts::sha256_hex(&bytes)
+    ))
 }

--- a/tools/manager/src/spec/plan.rs
+++ b/tools/manager/src/spec/plan.rs
@@ -190,10 +190,11 @@ pub struct PlanFile {
     /// whole-file digest: with seven steps, "something changed" is not
     /// actionable.
     pub step_digests: Vec<String>,
-    /// Digest over everything `render` shows that is not a step — the derived
-    /// ids and the check results. Without it, editing a check from `failed` to
-    /// `passed`, or repointing `derived.market_id`, reports the plan as
-    /// unmodified.
+    /// Digest over everything this file states except the steps themselves —
+    /// provenance, derived ids, check results. Without it, editing a check from
+    /// `failed` to `passed`, repointing `derived.market_id`, or rewriting the
+    /// `spec_digest` that `render` presents as the plan's source all report the
+    /// plan as unmodified.
     pub summary_digest: String,
     pub derived: Derived,
     pub checks: Vec<Check>,
@@ -266,6 +267,14 @@ impl PlanFile {
             .iter()
             .map(digest)
             .collect::<anyhow::Result<Vec<_>>>()?;
+        let summary_digest = summary_digest(
+            PLAN_SCHEMA_VERSION,
+            env!("CARGO_PKG_VERSION"),
+            &network,
+            &spec_digest,
+            &derived,
+            &checks,
+        )?;
 
         Ok(Self {
             schema: PLAN_SCHEMA_VERSION,
@@ -273,7 +282,7 @@ impl PlanFile {
             network,
             spec_digest,
             step_digests,
-            summary_digest: summary_digest(&derived, &checks)?,
+            summary_digest,
             derived,
             checks,
             steps,
@@ -300,7 +309,14 @@ impl PlanFile {
                 .collect(),
             delta: isize::try_from(current.len()).unwrap_or(isize::MAX)
                 - isize::try_from(self.step_digests.len()).unwrap_or(isize::MAX),
-            summary: summary_digest(&self.derived, &self.checks)? != self.summary_digest,
+            summary: summary_digest(
+                self.schema,
+                &self.tool_version,
+                &self.network,
+                &self.spec_digest,
+                &self.derived,
+                &self.checks,
+            )? != self.summary_digest,
         })
     }
 
@@ -316,8 +332,15 @@ impl PlanFile {
     }
 }
 
-fn summary_digest(derived: &Derived, checks: &[Check]) -> anyhow::Result<String> {
-    digest(&(derived, checks))
+fn summary_digest(
+    schema: u32,
+    tool_version: &str,
+    network: &str,
+    spec_digest: &str,
+    derived: &Derived,
+    checks: &[Check],
+) -> anyhow::Result<String> {
+    digest(&(schema, tool_version, network, spec_digest, derived, checks))
 }
 
 /// `sha256:…` over a value's JSON encoding.

--- a/tools/manager/src/tests.rs
+++ b/tools/manager/src/tests.rs
@@ -14,6 +14,7 @@ mod ft;
 mod market;
 mod oracle;
 mod plan;
+mod plan_file;
 mod proxy_oracle;
 mod redstone;
 mod registry;

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -339,6 +339,37 @@ async fn a_signer_that_is_not_the_governance_admin_is_refused() {
     );
 }
 
+/// A proxy-oracle version whose `new` ignores `owner_id` leaves the *registry*
+/// as owner, so governance can never configure either proxy. Because
+/// `admin_set_proxy` is dispatched detached, the proposals would still report
+/// success and the deploy would reach market creation with a dead oracle — so
+/// this is refused at plan time. Offline: the guard precedes the first read.
+#[tokio::test]
+async fn an_oracle_version_that_ignores_owner_id_is_refused() {
+    let client = Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
+        .build()
+        .expect("build client");
+    let public_key = PublicKey::from(
+        PUBLIC_KEY
+            .parse::<near_api::PublicKey>()
+            .expect("valid key"),
+    );
+    let mut spec = alpha_market();
+    let admin = spec.governance.admin.clone();
+    // Well-formed key, pre-0.3.0 version: the guard must reject it for what the
+    // version *means*, not because the key failed to parse.
+    spec.versions.proxy_oracle = spec.versions.proxy_oracle.replace("@0.3.0#", "@0.2.0#");
+
+    let error = crate::dispatch::plan::build(&client, &spec, &public_key, &admin)
+        .await
+        .expect_err("a pre-0.3.0 oracle cannot seat an owner");
+
+    assert!(
+        format!("{error:#}").contains("registry would own the oracle"),
+        "{error:#}"
+    );
+}
+
 /// The deployment `deploy.sh` performs, in the order it performs it.
 ///
 /// The order is a safety property: `registry deploy` fails when the account

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -1,15 +1,20 @@
 //! The plan artifact (ENG-544): the deployment `market plan` writes and
 //! `market apply` sends.
 //!
-//! All offline. Planning these writes needs no network, so the whole
-//! spec → plan → file → plan path is exercised without a node.
+//! The artifact layer is exercised offline against locally built transactions.
+//! `build` itself is *not* offline — planning a registry deploy reads the
+//! registry's source metadata — so the one test that calls it is named
+//! `requires_network_*` and is excluded from both the fast and sandbox gates.
 
 use std::path::Path;
 
 use near_account_id::AccountId;
+use near_api::types::transaction::actions::{Action, FunctionCallAction};
+use near_api::types::NearToken;
 use templar_gateway_client::{Client, Network, NetworkConfigBuilder};
 use templar_gateway_core::{OperationPlan, PlannedTransaction};
 use templar_gateway_types::primitive::PublicKey;
+use templar_gateway_types::NearGas;
 
 use crate::spec::{
     check::{Check, Status},
@@ -18,12 +23,6 @@ use crate::spec::{
 };
 
 const PUBLIC_KEY: &str = "ed25519:H9k5eiU4xXS3M4z8HzKJSLaZdqGdGwBG49o7orNC4eZW";
-
-fn offline_client() -> Client {
-    Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
-        .build()
-        .expect("build offline client")
-}
 
 fn alpha_market() -> MarketSpec {
     crate::spec::extends::load(
@@ -36,23 +35,55 @@ fn signer_id() -> AccountId {
     "operator.near".parse().expect("valid account")
 }
 
-fn public_key() -> PublicKey {
-    PublicKey::from(
-        PUBLIC_KEY
-            .parse::<near_api::PublicKey>()
-            .expect("valid key"),
-    )
+/// A transaction carrying one function call with the given args.
+fn transaction(method_name: &str, args: Vec<u8>) -> PlannedTransaction {
+    PlannedTransaction {
+        signer_account_id: signer_id().into(),
+        receiver_id: "templar-alpha.near".parse().expect("valid account"),
+        actions: vec![Action::FunctionCall(Box::new(FunctionCallAction {
+            method_name: method_name.to_owned(),
+            args,
+            gas: NearGas::from_tgas(300),
+            deposit: NearToken::from_near(5),
+        }))],
+        continue_on_failure: false,
+    }
 }
 
-async fn steps() -> Vec<(String, PlannedTransaction)> {
-    crate::dispatch::plan::build(
-        &offline_client(),
-        &alpha_market(),
-        &public_key(),
-        &signer_id(),
-    )
-    .await
-    .expect("the alpha fixture should plan")
+/// Two JSON steps and one borsh step — the shapes a real deploy produces.
+fn sample_steps() -> Vec<(String, PlannedTransaction)> {
+    let json = serde_json::to_vec(&serde_json::json!({
+        "registry_id": "templar-alpha.near",
+        "name": "iethfxrp-ixlmusdc",
+        "configuration": { "minimum_collateral_ratio": [3, 2] },
+    }))
+    .expect("encode json args");
+
+    vec![
+        (
+            "deploy governance".to_owned(),
+            transaction("deploy_market", json.clone()),
+        ),
+        (
+            "deploy market".to_owned(),
+            transaction("deploy_market", json),
+        ),
+        (
+            "add a version".to_owned(),
+            transaction("add_version", borsh_args()),
+        ),
+    ]
+}
+
+/// A borsh payload shape: a length-prefixed string, then bytes that are not
+/// valid UTF-8. Probing, not a method-name list, is what must classify this.
+fn borsh_args() -> Vec<u8> {
+    [
+        &6u32.to_le_bytes()[..],
+        b"v1.3.0",
+        &[0u8, 1, 2, 3, 250, 251, 252],
+    ]
+    .concat()
 }
 
 fn plan_file(steps: Vec<(String, PlannedTransaction)>) -> PlanFile {
@@ -76,30 +107,170 @@ fn plan_file(steps: Vec<(String, PlannedTransaction)>) -> PlanFile {
     .expect("plan file should build")
 }
 
+/// The headline criterion: what `apply` sends is exactly what `plan` showed.
+///
+/// Compared after conversion into the file, because that conversion
+/// canonicalizes JSON args. Asserting on the pre-canonical bytes would assert on
+/// `serde_json`'s key ordering, not on anything a contract can observe.
+#[test]
+fn round_trips_through_json() {
+    let file = plan_file(sample_steps());
+
+    let text = serde_json::to_string_pretty(&file).expect("serialize");
+    let parsed: PlanFile = serde_json::from_str(&text).expect("deserialize");
+
+    assert_eq!(parsed, file, "the artifact must survive a JSON round trip");
+    assert_eq!(
+        parsed
+            .clone()
+            .into_operation_plan()
+            .expect("parsed plan converts"),
+        file.into_operation_plan().expect("original plan converts"),
+        "the transactions sent must be the transactions planned"
+    );
+}
+
+/// JSON args stay editable; borsh stays opaque and survives byte-for-byte.
+#[test]
+fn args_are_classified_by_probing_the_bytes() {
+    let file = plan_file(sample_steps());
+
+    assert!(
+        matches!(file.steps[0].function_calls[0].args, PlanArgs::Json(_)),
+        "JSON args must stay editable: {:?}",
+        file.steps[0].function_calls[0].args
+    );
+    assert!(
+        matches!(file.steps[2].function_calls[0].args, PlanArgs::Base64(_)),
+        "borsh must not be mistaken for JSON: {:?}",
+        file.steps[2].function_calls[0].args
+    );
+
+    let text = serde_json::to_string(&file).expect("serialize");
+    let parsed: PlanFile = serde_json::from_str(&text).expect("deserialize");
+    let restored = parsed.into_operation_plan().expect("convert back");
+
+    assert_eq!(
+        restored.steps[2].actions,
+        transaction("add_version", borsh_args()).actions,
+        "opaque args must survive byte-for-byte"
+    );
+}
+
+/// Editing is the feature, so an edit is reported rather than refused — and
+/// named precisely enough to confirm it was the only one.
+#[test]
+fn an_edited_plan_names_the_steps_that_changed() {
+    let mut file = plan_file(sample_steps());
+    assert!(
+        file.drift().expect("digest").is_clean(),
+        "a freshly generated plan is unmodified"
+    );
+
+    file.steps[1].function_calls[0].gas += 1;
+    let drift = file.drift().expect("digest");
+
+    assert_eq!(drift.changed, vec![1], "only step 1 was touched");
+    assert_eq!(drift.delta, 0);
+    assert!(
+        drift.describe().contains("1 step(s) differ (#1)"),
+        "the operator must be told which step: {}",
+        drift.describe()
+    );
+}
+
+/// Removing a step is an edit too, and must not read as unmodified.
+#[test]
+fn a_removed_step_is_reported() {
+    let mut file = plan_file(sample_steps());
+    file.steps.pop();
+
+    let drift = file.drift().expect("digest");
+    assert_eq!(drift.delta, -1);
+    assert!(!drift.is_clean());
+    assert!(
+        drift.describe().contains("1 step(s) removed"),
+        "{}",
+        drift.describe()
+    );
+}
+
+/// A plan carrying an action kind the artifact cannot render is refused, not
+/// silently dropped — a dropped action would be a transaction the operator
+/// reviewed and the chain never saw.
+#[test]
+fn a_non_function_call_action_is_refused() {
+    let plan = OperationPlan {
+        steps: vec![PlannedTransaction {
+            signer_account_id: signer_id().into(),
+            receiver_id: "market.near".parse().expect("valid account"),
+            actions: vec![Action::DeleteAccount(
+                near_api::types::transaction::actions::DeleteAccountAction {
+                    beneficiary_id: "beneficiary.near".parse().expect("valid account"),
+                },
+            )],
+            continue_on_failure: false,
+        }],
+    };
+
+    let error = PlanFile::new(
+        "mainnet".to_owned(),
+        "sha256:test".to_owned(),
+        Derived {
+            market_id: "m.near".parse().expect("valid account"),
+            oracle_id: "o.near".parse().expect("valid account"),
+            governance_id: "g.near".parse().expect("valid account"),
+            collateral_decimals: Some(6),
+            borrow_decimals: Some(7),
+        },
+        Vec::new(),
+        vec![("tear down".to_owned(), plan.steps[0].clone())],
+    )
+    .expect_err("a delete-account action cannot be rendered");
+
+    assert!(
+        format!("{error:#}").contains("only function calls"),
+        "{error:#}"
+    );
+}
+
 /// The deployment `deploy.sh` performs, in the order it performs it.
 ///
 /// The order is a safety property: `registry deploy` fails when the account
 /// already exists, so governance must be created before the oracle names it as
 /// owner, and both before the market points at the oracle.
+///
+/// Needs the network: planning a registry deploy reads the registry's contract
+/// source metadata to pick the init-args encoding.
 #[tokio::test]
-async fn plans_the_deploy_script_in_order() {
-    let labelled = steps().await;
+async fn requires_network_plans_the_deploy_script_in_order() {
+    let client = Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
+        .build()
+        .expect("build client");
+    let public_key = PublicKey::from(
+        PUBLIC_KEY
+            .parse::<near_api::PublicKey>()
+            .expect("valid key"),
+    );
+
+    let labelled =
+        crate::dispatch::plan::build(&client, &alpha_market(), &public_key, &signer_id())
+            .await
+            .expect("the alpha fixture should plan");
+
     let sequence: Vec<_> = labelled
         .iter()
         .map(|(label, transaction)| {
             let method = match transaction.actions.as_slice() {
-                [near_api::types::transaction::actions::Action::FunctionCall(call)] => {
-                    call.method_name.as_str()
-                }
+                [Action::FunctionCall(call)] => call.method_name.as_str(),
                 other => panic!("expected one function call, got {other:?}"),
             };
             (transaction.receiver_id.as_str(), method, label.as_str())
         })
         .collect();
 
-    // The three registry deploys share one method (`deploy_market`), so the
-    // receiver alone cannot tell them apart either — the label is what
-    // identifies each, and is asserted here for exactly that reason.
+    // The three registry deploys share one method (`deploy_market`) and one
+    // receiver, so the label is what identifies each — asserted for that reason.
     assert_eq!(
         sequence,
         vec![
@@ -142,125 +313,4 @@ async fn plans_the_deploy_script_in_order() {
         ],
         "the plan must reproduce deploy.sh"
     );
-}
-
-/// The headline criterion: what `apply` sends is exactly what `plan` showed.
-///
-/// Compared after conversion into the file, because that conversion
-/// canonicalizes JSON args — see the module docs on `spec::plan`. Asserting on
-/// the pre-canonical bytes would be asserting on `serde_json`'s key ordering,
-/// not on anything a contract can observe.
-#[tokio::test]
-async fn round_trips_through_json() {
-    let file = plan_file(steps().await);
-
-    let text = serde_json::to_string_pretty(&file).expect("serialize");
-    let parsed: PlanFile = serde_json::from_str(&text).expect("deserialize");
-
-    assert_eq!(parsed, file, "the artifact must survive a JSON round trip");
-    assert_eq!(
-        parsed
-            .clone()
-            .into_operation_plan()
-            .expect("parsed plan converts"),
-        file.into_operation_plan().expect("original plan converts"),
-        "the transactions sent must be the transactions planned"
-    );
-}
-
-/// Args a human can edit. Every step of a market deploy takes JSON, so every
-/// step must carry JSON — a plan of base64 blobs cannot be edited, which is the
-/// point of the artifact.
-#[tokio::test]
-async fn json_args_stay_json() {
-    let file = plan_file(steps().await);
-
-    for step in &file.steps {
-        for call in &step.function_calls {
-            assert!(
-                matches!(call.args, PlanArgs::Json(_)),
-                "`{}` in `{}` should carry editable JSON, got {:?}",
-                call.method_name,
-                step.label,
-                call.args
-            );
-        }
-    }
-}
-
-/// Borsh args cannot be JSON, and must survive verbatim.
-///
-/// `registry add_version` is the real case. Probing (rather than a hardcoded
-/// method list) is what decides this, so the bytes here are a borsh payload
-/// shape — a length-prefixed string — not merely "not JSON".
-#[test]
-fn borsh_args_stay_base64_and_survive() {
-    let borsh: Vec<u8> = [
-        &6u32.to_le_bytes()[..],
-        b"v1.3.0",
-        &[0u8, 1, 2, 3, 250, 251, 252],
-    ]
-    .concat();
-
-    let plan = OperationPlan {
-        steps: vec![PlannedTransaction {
-            signer_account_id: signer_id().into(),
-            receiver_id: "registry.near".parse().expect("valid account"),
-            actions: vec![near_api::types::transaction::actions::Action::FunctionCall(
-                Box::new(near_api::types::transaction::actions::FunctionCallAction {
-                    method_name: "add_version".to_owned(),
-                    args: borsh.clone(),
-                    gas: templar_gateway_types::NearGas::from_tgas(300),
-                    deposit: near_api::types::NearToken::from_near(1),
-                }),
-            )],
-            continue_on_failure: false,
-        }],
-    };
-
-    let file = plan_file(vec![("add a version".to_owned(), plan.steps[0].clone())]);
-    assert!(
-        matches!(file.steps[0].function_calls[0].args, PlanArgs::Base64(_)),
-        "borsh args must not be mistaken for JSON: {:?}",
-        file.steps[0].function_calls[0].args
-    );
-
-    let text = serde_json::to_string(&file).expect("serialize");
-    let parsed: PlanFile = serde_json::from_str(&text).expect("deserialize");
-    let restored = parsed.into_operation_plan().expect("convert back");
-
-    assert_eq!(restored, plan, "opaque args must survive byte-for-byte");
-}
-
-/// Editing is the feature, so an edit is reported rather than refused — and
-/// reported precisely enough to confirm it was the only one.
-#[tokio::test]
-async fn an_edited_plan_names_the_steps_that_changed() {
-    let mut file = plan_file(steps().await);
-    assert!(
-        file.drift().expect("digest").is_clean(),
-        "a freshly generated plan is unmodified"
-    );
-
-    file.steps[2].function_calls[0].gas += 1;
-    let drift = file.drift().expect("digest");
-
-    assert_eq!(drift.changed, vec![2], "only step 2 was touched");
-    assert_eq!((drift.added, drift.removed), (0, 0));
-    assert!(
-        drift.describe().contains("1 step(s) differ (#2)"),
-        "the operator must be told which step: {}",
-        drift.describe()
-    );
-}
-
-/// Removing a step is an edit too, and must not read as unmodified.
-#[tokio::test]
-async fn a_removed_step_is_reported() {
-    let mut file = plan_file(steps().await);
-    file.steps.pop();
-
-    let drift = file.drift().expect("digest");
-    assert_eq!(drift.removed, 1);
-    assert!(!drift.is_clean());
 }

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -1,0 +1,266 @@
+//! The plan artifact (ENG-544): the deployment `market plan` writes and
+//! `market apply` sends.
+//!
+//! All offline. Planning these writes needs no network, so the whole
+//! spec → plan → file → plan path is exercised without a node.
+
+use std::path::Path;
+
+use near_account_id::AccountId;
+use templar_gateway_client::{Client, Network, NetworkConfigBuilder};
+use templar_gateway_core::{OperationPlan, PlannedTransaction};
+use templar_gateway_types::primitive::PublicKey;
+
+use crate::spec::{
+    check::{Check, Status},
+    plan::{Derived, PlanArgs, PlanFile},
+    MarketSpec,
+};
+
+const PUBLIC_KEY: &str = "ed25519:H9k5eiU4xXS3M4z8HzKJSLaZdqGdGwBG49o7orNC4eZW";
+
+fn offline_client() -> Client {
+    Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
+        .build()
+        .expect("build offline client")
+}
+
+fn alpha_market() -> MarketSpec {
+    crate::spec::extends::load(
+        &Path::new(env!("CARGO_MANIFEST_DIR")).join("fixtures/spec/iethfxrp-ixlmusdc.toml"),
+    )
+    .expect("fixture spec should load")
+}
+
+fn signer_id() -> AccountId {
+    "operator.near".parse().expect("valid account")
+}
+
+fn public_key() -> PublicKey {
+    PublicKey::from(
+        PUBLIC_KEY
+            .parse::<near_api::PublicKey>()
+            .expect("valid key"),
+    )
+}
+
+async fn steps() -> Vec<(String, PlannedTransaction)> {
+    crate::dispatch::plan::build(
+        &offline_client(),
+        &alpha_market(),
+        &public_key(),
+        &signer_id(),
+    )
+    .await
+    .expect("the alpha fixture should plan")
+}
+
+fn plan_file(steps: Vec<(String, PlannedTransaction)>) -> PlanFile {
+    let spec = alpha_market();
+    PlanFile::new(
+        "mainnet".to_owned(),
+        "sha256:test".to_owned(),
+        Derived {
+            market_id: spec.market_id().expect("market id"),
+            oracle_id: spec.oracle_id().expect("oracle id"),
+            governance_id: spec.governance_id().expect("governance id"),
+            collateral_decimals: spec.collateral.decimals,
+            borrow_decimals: spec.borrow.decimals,
+        },
+        vec![Check {
+            id: "config.validate".to_owned(),
+            status: Status::passed("MarketConfiguration::validate"),
+        }],
+        steps,
+    )
+    .expect("plan file should build")
+}
+
+/// The deployment `deploy.sh` performs, in the order it performs it.
+///
+/// The order is a safety property: `registry deploy` fails when the account
+/// already exists, so governance must be created before the oracle names it as
+/// owner, and both before the market points at the oracle.
+#[tokio::test]
+async fn plans_the_deploy_script_in_order() {
+    let labelled = steps().await;
+    let sequence: Vec<_> = labelled
+        .iter()
+        .map(|(label, transaction)| {
+            let method = match transaction.actions.as_slice() {
+                [near_api::types::transaction::actions::Action::FunctionCall(call)] => {
+                    call.method_name.as_str()
+                }
+                other => panic!("expected one function call, got {other:?}"),
+            };
+            (transaction.receiver_id.as_str(), method, label.as_str())
+        })
+        .collect();
+
+    // The three registry deploys share one method (`deploy_market`), so the
+    // receiver alone cannot tell them apart either — the label is what
+    // identifies each, and is asserted here for exactly that reason.
+    assert_eq!(
+        sequence,
+        vec![
+            (
+                "templar-alpha.near",
+                "deploy_market",
+                "deploy governance proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near"
+            ),
+            (
+                "templar-alpha.near",
+                "deploy_market",
+                "deploy proxy oracle proxy-oracle-iethfxrp-ixlmusdc.templar-alpha.near, \
+                 owned by governance"
+            ),
+            (
+                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
+                "create_proposal",
+                "propose collateral proxy (proposal 0)"
+            ),
+            (
+                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
+                "execute_proposal",
+                "execute collateral proxy proposal 0"
+            ),
+            (
+                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
+                "create_proposal",
+                "propose borrow proxy (proposal 1)"
+            ),
+            (
+                "proxy-gov-iethfxrp-ixlmusdc.templar-alpha.near",
+                "execute_proposal",
+                "execute borrow proxy proposal 1"
+            ),
+            (
+                "templar-alpha.near",
+                "deploy_market",
+                "deploy market iethfxrp-ixlmusdc.templar-alpha.near"
+            ),
+        ],
+        "the plan must reproduce deploy.sh"
+    );
+}
+
+/// The headline criterion: what `apply` sends is exactly what `plan` showed.
+///
+/// Compared after conversion into the file, because that conversion
+/// canonicalizes JSON args — see the module docs on `spec::plan`. Asserting on
+/// the pre-canonical bytes would be asserting on `serde_json`'s key ordering,
+/// not on anything a contract can observe.
+#[tokio::test]
+async fn round_trips_through_json() {
+    let file = plan_file(steps().await);
+
+    let text = serde_json::to_string_pretty(&file).expect("serialize");
+    let parsed: PlanFile = serde_json::from_str(&text).expect("deserialize");
+
+    assert_eq!(parsed, file, "the artifact must survive a JSON round trip");
+    assert_eq!(
+        parsed
+            .clone()
+            .into_operation_plan()
+            .expect("parsed plan converts"),
+        file.into_operation_plan().expect("original plan converts"),
+        "the transactions sent must be the transactions planned"
+    );
+}
+
+/// Args a human can edit. Every step of a market deploy takes JSON, so every
+/// step must carry JSON — a plan of base64 blobs cannot be edited, which is the
+/// point of the artifact.
+#[tokio::test]
+async fn json_args_stay_json() {
+    let file = plan_file(steps().await);
+
+    for step in &file.steps {
+        for call in &step.function_calls {
+            assert!(
+                matches!(call.args, PlanArgs::Json(_)),
+                "`{}` in `{}` should carry editable JSON, got {:?}",
+                call.method_name,
+                step.label,
+                call.args
+            );
+        }
+    }
+}
+
+/// Borsh args cannot be JSON, and must survive verbatim.
+///
+/// `registry add_version` is the real case. Probing (rather than a hardcoded
+/// method list) is what decides this, so the bytes here are a borsh payload
+/// shape — a length-prefixed string — not merely "not JSON".
+#[test]
+fn borsh_args_stay_base64_and_survive() {
+    let borsh: Vec<u8> = [
+        &6u32.to_le_bytes()[..],
+        b"v1.3.0",
+        &[0u8, 1, 2, 3, 250, 251, 252],
+    ]
+    .concat();
+
+    let plan = OperationPlan {
+        steps: vec![PlannedTransaction {
+            signer_account_id: signer_id().into(),
+            receiver_id: "registry.near".parse().expect("valid account"),
+            actions: vec![near_api::types::transaction::actions::Action::FunctionCall(
+                Box::new(near_api::types::transaction::actions::FunctionCallAction {
+                    method_name: "add_version".to_owned(),
+                    args: borsh.clone(),
+                    gas: templar_gateway_types::NearGas::from_tgas(300),
+                    deposit: near_api::types::NearToken::from_near(1),
+                }),
+            )],
+            continue_on_failure: false,
+        }],
+    };
+
+    let file = plan_file(vec![("add a version".to_owned(), plan.steps[0].clone())]);
+    assert!(
+        matches!(file.steps[0].function_calls[0].args, PlanArgs::Base64(_)),
+        "borsh args must not be mistaken for JSON: {:?}",
+        file.steps[0].function_calls[0].args
+    );
+
+    let text = serde_json::to_string(&file).expect("serialize");
+    let parsed: PlanFile = serde_json::from_str(&text).expect("deserialize");
+    let restored = parsed.into_operation_plan().expect("convert back");
+
+    assert_eq!(restored, plan, "opaque args must survive byte-for-byte");
+}
+
+/// Editing is the feature, so an edit is reported rather than refused — and
+/// reported precisely enough to confirm it was the only one.
+#[tokio::test]
+async fn an_edited_plan_names_the_steps_that_changed() {
+    let mut file = plan_file(steps().await);
+    assert!(
+        file.drift().expect("digest").is_clean(),
+        "a freshly generated plan is unmodified"
+    );
+
+    file.steps[2].function_calls[0].gas += 1;
+    let drift = file.drift().expect("digest");
+
+    assert_eq!(drift.changed, vec![2], "only step 2 was touched");
+    assert_eq!((drift.added, drift.removed), (0, 0));
+    assert!(
+        drift.describe().contains("1 step(s) differ (#2)"),
+        "the operator must be told which step: {}",
+        drift.describe()
+    );
+}
+
+/// Removing a step is an edit too, and must not read as unmodified.
+#[tokio::test]
+async fn a_removed_step_is_reported() {
+    let mut file = plan_file(steps().await);
+    file.steps.pop();
+
+    let drift = file.drift().expect("digest");
+    assert_eq!(drift.removed, 1);
+    assert!(!drift.is_clean());
+}

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -218,6 +218,15 @@ fn editing_the_summary_is_drift_too() {
         file.drift().expect("digest").summary,
         "a repointed market id is an edit"
     );
+
+    // `render` presents `spec_digest` as the plan's source, so rewriting it
+    // must not read as unmodified either.
+    let mut file = plan_file(sample_steps());
+    file.spec_digest = "sha256:something-else".to_owned();
+    assert!(
+        file.drift().expect("digest").summary,
+        "a rewritten spec digest is an edit"
+    );
 }
 
 /// A number too large for `u64` decodes as `f64` and would re-encode in

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -195,6 +195,81 @@ fn a_removed_step_is_reported() {
     );
 }
 
+/// Editing a check from `failed` to `passed`, or repointing a derived id, must
+/// not report the plan as unmodified — `render` shows those values, so a clean
+/// verdict over them is worth more than it should be.
+#[test]
+fn editing_the_summary_is_drift_too() {
+    let mut file = plan_file(sample_steps());
+
+    file.checks[0].status = Status::failed("actually broken");
+    let drift = file.drift().expect("digest");
+    assert!(drift.summary, "a rewritten check verdict is an edit");
+    assert!(!drift.is_clean());
+    assert!(
+        drift.describe().contains("check results differ"),
+        "{}",
+        drift.describe()
+    );
+
+    let mut file = plan_file(sample_steps());
+    file.derived.market_id = "elsewhere.near".parse().expect("valid account");
+    assert!(
+        file.drift().expect("digest").summary,
+        "a repointed market id is an edit"
+    );
+}
+
+/// A number too large for `u64` decodes as `f64` and would re-encode in
+/// exponent form — a different value than the operator reviewed. Such args stay
+/// opaque instead.
+#[test]
+fn args_that_would_not_survive_re_encoding_stay_opaque() {
+    let lossy = br#"{"amount":123456789012345678901234567890}"#.to_vec();
+    let file = plan_file(vec![(
+        "big number".to_owned(),
+        transaction("deposit", lossy.clone()),
+    )]);
+
+    assert!(
+        matches!(file.steps[0].function_calls[0].args, PlanArgs::Base64(_)),
+        "a value that cannot round-trip must not be presented as editable JSON"
+    );
+    assert_eq!(
+        file.into_operation_plan().expect("convert").steps[0].actions,
+        transaction("deposit", lossy).actions,
+        "and it must survive byte-for-byte"
+    );
+}
+
+/// A step that tolerates its own failure would let a hand-edit turn a reverted
+/// governance call into `apply` exiting zero.
+#[test]
+fn a_failure_tolerating_step_is_refused() {
+    let mut tolerant = transaction("deploy_market", b"{}".to_vec());
+    tolerant.continue_on_failure = true;
+
+    let error = PlanFile::new(
+        "mainnet".to_owned(),
+        "sha256:test".to_owned(),
+        Derived {
+            market_id: "m.near".parse().expect("valid account"),
+            oracle_id: "o.near".parse().expect("valid account"),
+            governance_id: "g.near".parse().expect("valid account"),
+            collateral_decimals: Some(6),
+            borrow_decimals: Some(7),
+        },
+        Vec::new(),
+        vec![("tolerant".to_owned(), tolerant)],
+    )
+    .expect_err("a deployment must not tolerate a reverted step");
+
+    assert!(
+        format!("{error:#}").contains("tolerates its own failure"),
+        "{error:#}"
+    );
+}
+
 /// A plan carrying an action kind the artifact cannot render is refused, not
 /// silently dropped — a dropped action would be a transaction the operator
 /// reviewed and the chain never saw.
@@ -234,6 +309,36 @@ fn a_non_function_call_action_is_refused() {
     );
 }
 
+/// Planning for an account that will not hold the Admin role must fail before
+/// anything is planned, not after 8.5 NEAR of deploys have succeeded and every
+/// proposal reverts. Offline: the guard runs before the first read.
+#[tokio::test]
+async fn a_signer_that_is_not_the_governance_admin_is_refused() {
+    let client = Client::builder(NetworkConfigBuilder::new(Network::Mainnet).build())
+        .build()
+        .expect("build client");
+    let public_key = PublicKey::from(
+        PUBLIC_KEY
+            .parse::<near_api::PublicKey>()
+            .expect("valid key"),
+    );
+    let spec = alpha_market();
+    assert_ne!(
+        spec.governance.admin,
+        signer_id(),
+        "the fixture must not already agree, or this proves nothing"
+    );
+
+    let error = crate::dispatch::plan::build(&client, &spec, &public_key, &signer_id())
+        .await
+        .expect_err("a non-admin signer cannot execute the proxy proposals");
+
+    assert!(
+        format!("{error:#}").contains("would not hold the Admin role"),
+        "{error:#}"
+    );
+}
+
 /// The deployment `deploy.sh` performs, in the order it performs it.
 ///
 /// The order is a safety property: `registry deploy` fails when the account
@@ -253,10 +358,14 @@ async fn requires_network_plans_the_deploy_script_in_order() {
             .expect("valid key"),
     );
 
-    let labelled =
-        crate::dispatch::plan::build(&client, &alpha_market(), &public_key, &signer_id())
-            .await
-            .expect("the alpha fixture should plan");
+    // Signed by the spec's `governance.admin`: any other account would not hold
+    // the Admin role, and `build` refuses that rather than plan a deployment
+    // whose proposals revert after the deposits are already spent.
+    let spec = alpha_market();
+    let admin = spec.governance.admin.clone();
+    let labelled = crate::dispatch::plan::build(&client, &spec, &public_key, &admin)
+        .await
+        .expect("the alpha fixture should plan");
 
     let sequence: Vec<_> = labelled
         .iter()


### PR DESCRIPTION
Closes ENG-544. Sub-PR into the ENG-537 integration branch.

```
tmplrmgr market plan spec.toml --out plan.json    # no signer, no writes
$EDITOR plan.json
tmplrmgr market apply --plan plan.json
```

The escape hatch for when the spec cannot express what a market needs, or a check is wrong.

## What it does

`market plan` runs the same preflight as `spec check`, then emits the transactions `deploy.sh` performs — governance deploy → oracle create → set-proxy propose/execute ×2 → market create (plus a storage registration per NEP-141 asset) — carrying `schema`, `tool_version`, `network`, `spec_digest`, the derived ids and decimals, and every check result.

`gateway/core` is untouched: `PlannedTransaction` already round-trips through serde, so the only thing missing was a *legible* encoding — a property of this tool, not the gateway.

## Args are a tagged union

`{"json": {…}}` where the method takes JSON, `{"base64": "…"}` only for borsh, decided by **probing the bytes** rather than a method-name list. JSON args are canonicalized on the way in (re-encoding sorts keys, so the original bytes cannot be preserved); the invariant asserted is **what `apply` sends is what `plan` showed**. Args whose numbers would not survive re-encoding stay opaque. All digests canonicalize, so a `HashMap` in the spec cannot make `spec_digest` vary between runs.

## Provenance is reported, not enforced

Per-step digests name *which* steps changed; a `summary_digest` covers everything else the file states. Hard refusals are limited to schema and network mismatch. `--skip-check <id>` records the verdict it suppressed; an unknown id errors. `apply` prints every non-passing check before the prompt.

## Guards

An edited plan bypasses spec-level validation, so `apply` re-derives what it can from the steps that will actually execute. Each of these was a path to a half-spent deploy:

| Guard | Why |
|---|---|
| signer = `governance.admin` | only the admin holds the role the proposals need |
| targets free (plan **and** immediately before send) | a collision on the last step strands the first six |
| targets distinct | two deploys renamed alike collide with each other |
| oracle version honours `owner_id` | else the registry stays owner and no proxy can be configured |
| governance TTLs zero | a plan cannot wait for a timelock |
| proposal `requested_ttl` zero, ids created before executed | else the feed is never configured |
| oracle / governance / market coherence | each is created once and referenced elsewhere; editing one is not editing the others |
| storage registrations name the deployed market | else the market cannot receive its own assets |
| granted full-access keys match the **resolved** signing key | whoever holds them controls all three new accounts |
| `continue_on_failure` refused | a tolerated revert would exit 0 |

Targets, keys and init args are all read from each call's **bytes**, so re-encoding an argument as base64 cannot hide it from any check.

## Two patterns worth knowing

Most of this PR's defects were two habits, now documented in the source:

- **guards that fail open** — answering "is this wrong?" with "no" when they could not tell. Six instances.
- **one-directional consistency checks** — binding A to B and not B to A. Three instances.

Both were eventually fixed by sweeping for the shape rather than the instance; the TTL re-verification was found that way before any reviewer reported it.

## Verified against live mainnet (read-only)

- fresh name: 29 checks pass, 7 steps, every arg legible; the deployed alpha market fails its availability checks and writes **no plan**
- `apply` renders each step, decodes `init_args`, shows granted keys, reports drift, prompts, aborts on `n`
- refused live: wrong network, occupied targets (including base64-disguised), renamed oracle, renamed governance, pre-0.3.0 oracle version, raised `requested_ttl`, execute-before-create, a key the applier does not hold

215 tests pass, 1 network test correctly skipped.

## Known limits

- **`admin_set_proxy` is dispatched detached**, so `execute_proposal` reports success even if the oracle rejected the proxy. Pre-existing; the concrete case **ENG-547 (`market verify`)** must cover.
- **`apply` is not journalled** — `ClientBuilder` defaults to `MemoryStore`, so an interrupted run leaves no record. **ENG-546**. Stated at the confirmation prompt so an operator learns it before spending, not after.
- Two registry gaps need an additive contract view (the same one ENG-463/464 wants): a soft-deleted version passes the preflight and fails mid-deploy, and a `Reserved` target is invisible. Both documented in code.
- `init_args` is decoded for display but stays base64 in the file; expanding it needs a byte-exact round trip, i.e. a schema change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/546)
<!-- Reviewable:end -->
