### PR TITLE
feat(manager): journal + resume so a partial deploy is recoverable (ENG-546)

### DIFF
--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -130,25 +130,6 @@ impl CliContext {
         self.finish_write(&output)
     }
 
-    /// Execute a write through a caller-chosen dispatcher, then report it.
-    ///
-    /// The execute half of [`CliContext::write`], without the `--print` branch:
-    /// `market apply` has a plan in hand and nothing left to print.
-    pub(crate) async fn execute_via<D, S>(
-        &self,
-        signer: &SignerArgs,
-        body: S,
-    ) -> anyhow::Result<WriteOperationResult>
-    where
-        S: MethodSpec<Output = WriteOperationResult>,
-        D: PlanWrite<S, GatewayContext>,
-    {
-        let (account_id, client) = self.signing_client_for(signer).await?;
-        let output = client.via::<D>().execute_as(account_id, body).await?;
-        self.finish_write(&output)?;
-        Ok(output)
-    }
-
     /// Plan or execute an `oracle.*` write through [`OracleUpdatesDispatch`],
     /// whose context carries the in-process payload sources the method fetches.
     pub(crate) async fn oracle_write<S, Ctx>(
@@ -190,7 +171,7 @@ impl CliContext {
     /// Report the tx link, print the machine-readable result, then fail unless the
     /// operation succeeded on chain. Printing precedes the status check so a reverted
     /// operation still emits its JSON on stdout.
-    fn finish_write(&self, output: &WriteOperationResult) -> anyhow::Result<()> {
+    pub(crate) fn finish_write(&self, output: &WriteOperationResult) -> anyhow::Result<()> {
         self.report_tx(output);
         print_json(output)?;
         check_operation_status(output)

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -134,14 +134,19 @@ impl CliContext {
     ///
     /// The execute half of [`CliContext::write`], without the `--print` branch:
     /// `market apply` has a plan in hand and nothing left to print.
-    pub(crate) async fn execute_via<D, S>(&self, signer: &SignerArgs, body: S) -> anyhow::Result<()>
+    pub(crate) async fn execute_via<D, S>(
+        &self,
+        signer: &SignerArgs,
+        body: S,
+    ) -> anyhow::Result<WriteOperationResult>
     where
         S: MethodSpec<Output = WriteOperationResult>,
         D: PlanWrite<S, GatewayContext>,
     {
         let (account_id, client) = self.signing_client_for(signer).await?;
         let output = client.via::<D>().execute_as(account_id, body).await?;
-        self.finish_write(&output)
+        self.finish_write(&output)?;
+        Ok(output)
     }
 
     /// Plan or execute an `oracle.*` write through [`OracleUpdatesDispatch`],

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -27,6 +27,7 @@ use templar_proxy_oracle_near_governance_common::Operation;
 use crate::commands::market::{Apply, Plan};
 use crate::commands::proxy_oracle::governance::{uniform_ttls, GovernanceInit};
 use crate::context::{print_json, CliContext};
+use crate::spec::journal::{self, Journal};
 use crate::spec::{
     check::{Check, Status},
     plan::{Derived, PlanFile, PLAN_SCHEMA_VERSION},
@@ -119,6 +120,31 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         !file.steps.is_empty(),
         "this plan has no steps; nothing would be deployed"
     );
+    // Reconciled before anything else that reads the steps: if the journal and
+    // the plan disagree, nothing below is meaningful.
+    let journal_path = journal::path_for(&args.plan);
+    let mut journal = Journal::load(&journal_path)?;
+    let remaining = journal.remaining(&file)?;
+
+    if remaining.len() < file.steps.len() {
+        eprintln!(
+            "\nResuming: {} of {} step(s) already completed per {}.",
+            file.steps.len() - remaining.len(),
+            file.steps.len(),
+            journal_path.display(),
+        );
+    }
+    if remaining.is_empty() {
+        eprintln!("Every step in this plan has already been applied.");
+        return Ok(());
+    }
+
+    // Against the remaining steps only — a resume must not demand the deposits
+    // it has already paid.
+    let outstanding: Vec<_> = remaining
+        .iter()
+        .filter_map(|index| file.steps.get(*index).cloned())
+        .collect();
     render(&file);
     report_checks(&file);
 
@@ -238,12 +264,11 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     if !args.yes {
         confirm(&format!(
             "Send {} transaction(s) as {credential}?",
-            file.steps.len(),
+            remaining.len(),
         ))?;
     }
 
-    // Balances drift, and the plan-time answer was only good at that moment.
-    let mut funding = super::funding::checks(&ctx, &file.steps).await?;
+    let mut funding = super::funding::checks(&ctx, &outstanding).await?;
     let matched = apply_skips(&mut funding, &args.skip_check);
     ensure_every_skip_matched(&args.skip_check, &matched)?;
     let short = crate::spec::check::failures(&funding);
@@ -261,9 +286,46 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // the check is only worth what it is worth at the moment of the send.
     ensure_targets_free(&ctx, &targets).await?;
 
-    let plan = file.into_operation_plan()?;
-    ctx.execute_via::<PlanDispatch, _>(&args.signer, PreparedPlan { steps: plan.steps })
-        .await
+    // One transaction per call, so every outcome can be journalled as it
+    // happens. Batching them would leave an interrupted run with nothing
+    // recorded — which is the only run a journal exists for.
+    let plan = file.clone().into_operation_plan()?;
+    for index in remaining {
+        let step = &file.steps[index];
+        let transaction = plan.steps[index].clone();
+        eprintln!("\n[{index}] {}", step.label);
+
+        let output = ctx
+            .execute_via::<PlanDispatch, _>(
+                &args.signer,
+                PreparedPlan {
+                    steps: vec![transaction],
+                },
+            )
+            .await
+            .with_context(|| {
+                format!(
+                    "step {index} (`{}`) failed. Completed steps are recorded in \
+                     {}; re-run `market apply` to resume from here.",
+                    step.label,
+                    journal_path.display(),
+                )
+            })?;
+
+        journal.append(
+            &journal_path,
+            journal::Entry {
+                step: index,
+                digest: crate::spec::plan::digest(step)?,
+                label: step.label.clone(),
+                tx_hash: output
+                    .operation
+                    .latest_tx_hash()
+                    .map(|hash| hash.to_string()),
+            },
+        )?;
+    }
+    Ok(())
 }
 
 /// The deployment, in the order `deploy.sh` runs it.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -204,19 +204,16 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
         }
     }
 
-    // Every other write this tool performs is a single transaction, so this
-    // risk is new here and worth stating before the money is spent rather than
-    // after: the operation record lives in an in-memory store
-    // (`ClientBuilder`'s default), so an interrupt or an ambiguous RPC result
-    // part-way through leaves nothing to resume from or reconcile against.
-    // ENG-546 replaces the store and adds resume.
-    if file.steps.len() > 1 {
+    // Still worth stating before the money moves: the operator should know a
+    // partial run is recoverable *and* where the record lives, rather than
+    // discovering both after an interruption.
+    if remaining.len() > 1 {
         eprintln!(
-            "\nThis sends {} transactions in sequence. They are not journalled: \
-             if this is interrupted part-way, no record of what landed is kept, \
-             and re-running starts from the first step. Check the deployed \
-             accounts by hand before retrying.",
-            file.steps.len()
+            "\nThis sends {} transactions in sequence. Each is recorded in {} as \
+             it lands, so an interruption resumes from the next incomplete step \
+             rather than restarting.",
+            remaining.len(),
+            journal_path.display(),
         );
     }
 

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -153,8 +153,19 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // claimed while that review happens — after which the first six steps
     // succeed and the market deploy fails, which is the half-spent deploy the
     // plan-time check exists to prevent.
-    let targets = planned_targets(&file)?;
-    ensure_targets_are_distinct(&targets)?;
+    // Distinctness over the whole plan — creating an account twice is broken
+    // however far the run got. Freeness over the *outstanding* steps only: a
+    // resume has already created the accounts its completed steps made, and
+    // checking those would abort every resume that has anything to resume.
+    // Scoping rather than skipping keeps the guard where it still bites: a step
+    // whose outcome was ambiguous is not journalled, so it stays outstanding and
+    // its target is still checked.
+    ensure_targets_are_distinct(&planned_targets(&file)?)?;
+    let outstanding_file = PlanFile {
+        steps: outstanding.clone(),
+        ..file.clone()
+    };
+    let targets = planned_targets(&outstanding_file)?;
     ensure_targets_free(&ctx, &targets).await?;
 
     // Provenance is reported, not enforced.
@@ -283,42 +294,61 @@ pub(super) async fn apply(ctx: CliContext, args: Apply) -> anyhow::Result<()> {
     // the check is only worth what it is worth at the moment of the send.
     ensure_targets_free(&ctx, &targets).await?;
 
-    // One transaction per call, so every outcome can be journalled as it
-    // happens. Batching them would leave an interrupted run with nothing
-    // recorded — which is the only run a journal exists for.
+    // One transaction per call, so every outcome is journalled as it happens.
+    // Batching would leave an interrupted run with nothing recorded — the only
+    // run a journal exists for.
     let plan = file.clone().into_operation_plan()?;
+    // One signing client for the whole run: near-api caches nonces on the
+    // `Signer`, and rebuilding it per step would start each from an empty cache
+    // and risk signing a nonce the chain has already consumed.
+    let (signer, client) = ctx.signing_client_for(&args.signer).await?;
+
     for index in remaining {
         let step = &file.steps[index];
-        let transaction = plan.steps[index].clone();
         eprintln!("\n[{index}] {}", step.label);
 
-        let output = ctx
-            .execute_via::<PlanDispatch, _>(
-                &args.signer,
+        // Recorded before submission. A step that was sent and never resolved
+        // must not read as one that never ran: re-sending a registry deploy
+        // that actually succeeded strands its deposit, since the failed
+        // `create_account` refunds to the registry, not to the operator.
+        let entry = journal::Entry {
+            step: index,
+            digest: journal::executable_digest(step)?,
+            label: step.label.clone(),
+            outcome: journal::Outcome::Attempted,
+            tx_hash: None,
+        };
+        journal.record(&journal_path, entry.clone())?;
+
+        let output = client
+            .via::<PlanDispatch>()
+            .execute_as(
+                signer.clone(),
                 PreparedPlan {
-                    steps: vec![transaction],
+                    steps: vec![plan.steps[index].clone()],
                 },
             )
             .await
             .with_context(|| {
                 format!(
-                    "step {index} (`{}`) failed. Completed steps are recorded in \
-                     {}; re-run `market apply` to resume from here.",
+                    "step {index} (`{}`) did not complete. It is recorded as \
+                     attempted in {}; re-run `market apply`, which will stop and \
+                     ask you to confirm what happened to it.",
                     step.label,
                     journal_path.display(),
                 )
             })?;
+        ctx.finish_write(&output)?;
 
-        journal.append(
+        journal.record(
             &journal_path,
             journal::Entry {
-                step: index,
-                digest: crate::spec::plan::digest(step)?,
-                label: step.label.clone(),
+                outcome: journal::Outcome::Completed,
                 tx_hash: output
                     .operation
                     .latest_tx_hash()
                     .map(|hash| hash.to_string()),
+                ..entry
             },
         )?;
     }
@@ -676,7 +706,7 @@ fn ensure_compatible(file: &PlanFile, network: &str) -> anyhow::Result<()> {
 /// Fails closed. A call carrying a `version_key` whose target cannot be derived
 /// is an unreviewable step, not an absent one: every silent `None` here would be
 /// an unchecked account, which is exactly what this guard exists to prevent.
-fn planned_targets(file: &PlanFile) -> anyhow::Result<Vec<AccountId>> {
+pub(crate) fn planned_targets(file: &PlanFile) -> anyhow::Result<Vec<AccountId>> {
     let mut targets = Vec::new();
     for step in &file.steps {
         for call in &step.function_calls {

--- a/tools/manager/src/spec/journal.rs
+++ b/tools/manager/src/spec/journal.rs
@@ -21,15 +21,29 @@ use serde::{Deserialize, Serialize};
 
 use super::plan::PlanFile;
 
-/// One completed step. Only successes are appended: a step that failed did not
-/// happen, and recording it would make resume skip work still to do.
+/// What happened to a step.
+///
+/// `Attempted` is written *before* the transaction is submitted. Without it, a
+/// step whose outcome is unknown — a timeout, or an operation that never
+/// reached a terminal state — is indistinguishable from one that never ran, and
+/// resume would re-send it. For a registry deploy that is not a free retry: the
+/// deposit is transferred into the batch, and a failed `create_account` refunds
+/// it to the registry, not to the operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Outcome {
+    Attempted,
+    Completed,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Entry {
     pub step: usize,
-    /// The digest of the step as executed, for reconciliation on resume.
+    /// Digest of the step's executable content, for reconciliation on resume.
     pub digest: String,
     pub label: String,
+    pub outcome: Outcome,
     /// Absent when the step completed without the executor reporting a hash.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tx_hash: Option<String>,
@@ -52,6 +66,11 @@ pub fn path_for(plan: &Path) -> PathBuf {
     plan.with_file_name(name)
 }
 
+/// A step's digest over everything but its label.
+pub fn executable_digest(step: &super::plan::PlanStep) -> anyhow::Result<String> {
+    super::plan::digest(&(&step.signer_id, &step.receiver_id, &step.function_calls))
+}
+
 impl Journal {
     /// Read the journal beside `plan`, or an empty one if this is a first run.
     pub fn load(path: &Path) -> anyhow::Result<Self> {
@@ -67,16 +86,32 @@ impl Journal {
         }
     }
 
-    /// Append an entry and persist immediately.
+    /// Record an entry and persist immediately.
     ///
-    /// Written after every step rather than at the end: a journal that is only
-    /// flushed on completion records nothing about the run that was interrupted,
-    /// which is the only run it exists for.
-    pub fn append(&mut self, path: &Path, entry: Entry) -> anyhow::Result<()> {
-        self.entries.push(entry);
+    /// Written around every step rather than at the end: a journal flushed only
+    /// on completion records nothing about the run that was interrupted, which
+    /// is the only run it exists for.
+    ///
+    /// Rewrites through a temporary file and renames, because this is a
+    /// whole-file format: a truncating write re-risks the entire history on
+    /// every step, and a crash inside that window — precisely the scenario this
+    /// module exists for — would leave unparseable JSON and no record at all.
+    pub fn record(&mut self, path: &Path, entry: Entry) -> anyhow::Result<()> {
+        match self
+            .entries
+            .iter_mut()
+            .find(|existing| existing.step == entry.step)
+        {
+            Some(existing) => *existing = entry,
+            None => self.entries.push(entry),
+        }
+
         let rendered = serde_json::to_string_pretty(self).context("render the journal")?;
-        std::fs::write(path, format!("{rendered}\n"))
-            .with_context(|| format!("write the journal at {}", path.display()))
+        let temporary = path.with_extension("tmp");
+        std::fs::write(&temporary, format!("{rendered}\n"))
+            .with_context(|| format!("write {}", temporary.display()))?;
+        std::fs::rename(&temporary, path)
+            .with_context(|| format!("replace the journal at {}", path.display()))
     }
 
     /// Which steps of `file` still have to run.
@@ -97,7 +132,10 @@ impl Journal {
                 )
             })?;
 
-            let current = super::plan::digest(step)?;
+            // Digested without the label: it is manager-only and the executor
+            // never reads it, so renaming a completed step would otherwise block
+            // a resume over a change that alters nothing executable.
+            let current = executable_digest(step)?;
             anyhow::ensure!(
                 current == entry.digest,
                 "step {} (`{}`) already ran, but the plan has changed under it. \
@@ -109,8 +147,45 @@ impl Journal {
             );
         }
 
+        // An attempt whose outcome was never resolved is not progress and not
+        // absence. Re-sending it can strand a deposit; skipping it deploys
+        // nothing. Only a human can tell which, so the run stops.
+        if let Some(entry) = self
+            .entries
+            .iter()
+            .find(|entry| entry.outcome == Outcome::Attempted)
+        {
+            anyhow::bail!(
+                "step {} (`{}`) was submitted but its outcome was never recorded{}. \
+                 It may or may not have run. Check the account on chain, then \
+                 either mark it `completed` in the journal or remove the entry \
+                 to re-send it — re-sending a deploy that succeeded strands its \
+                 deposit in the registry.",
+                entry.step,
+                entry.label,
+                entry
+                    .tx_hash
+                    .as_ref()
+                    .map_or_else(String::new, |hash| format!(" (tx {hash})")),
+            );
+        }
+
         let done: std::collections::BTreeSet<usize> =
             self.entries.iter().map(|entry| entry.step).collect();
+
+        // Steps run in order and only completions are recorded, so the done set
+        // is always a prefix. A journal that skips one — hand-edited, or
+        // partially recovered — would make `apply` step over work that never
+        // happened, and every plan-level check would still pass because the
+        // *plan* is intact. Only the executed set is wrong.
+        anyhow::ensure!(
+            done.iter().copied().eq(0..done.len()),
+            "this journal records steps {:?} as done, which is not a prefix of \
+             the plan. Steps run in order, so a gap means an entry was removed \
+             or invented; resuming would skip a step that never ran.",
+            done,
+        );
+
         Ok((0..file.steps.len())
             .filter(|index| !done.contains(index))
             .collect())

--- a/tools/manager/src/spec/journal.rs
+++ b/tools/manager/src/spec/journal.rs
@@ -1,0 +1,118 @@
+//! An append-only record of what a deploy actually did, so an interrupted one
+//! can be resumed instead of restarted.
+//!
+//! `script/deploy.sh` is not re-runnable, and its own comment documents the
+//! cost: a stale version key aborts at the oracle step and leaves an orphaned
+//! governance contract to be deleted by hand. Ordering was the only safety
+//! property. This replaces it with a mechanism.
+//!
+//! ## Keyed on the plan, not the spec
+//!
+//! Each entry records the digest of the step it completed. Resuming recomputes
+//! those digests and refuses if one changed — so a hand-edited plan resumes
+//! correctly, and an edit *under a completed step* is named rather than
+//! silently re-run or silently skipped. Editing a step that has not run yet is
+//! fine, which is the point: the artifact exists to be edited.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context as _;
+use serde::{Deserialize, Serialize};
+
+use super::plan::PlanFile;
+
+/// One completed step. Only successes are appended: a step that failed did not
+/// happen, and recording it would make resume skip work still to do.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Entry {
+    pub step: usize,
+    /// The digest of the step as executed, for reconciliation on resume.
+    pub digest: String,
+    pub label: String,
+    /// Absent when the step completed without the executor reporting a hash.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tx_hash: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct Journal {
+    pub entries: Vec<Entry>,
+}
+
+/// Where a plan's journal lives: beside the plan, named after it.
+///
+/// Derived rather than configurable, so resuming cannot be defeated by
+/// forgetting a flag — the failure mode that matters is re-running a deploy
+/// from step one, not writing a file to the wrong place.
+pub fn path_for(plan: &Path) -> PathBuf {
+    let mut name = plan.file_name().unwrap_or_default().to_os_string();
+    name.push(".journal.json");
+    plan.with_file_name(name)
+}
+
+impl Journal {
+    /// Read the journal beside `plan`, or an empty one if this is a first run.
+    pub fn load(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(text) => serde_json::from_str(&text)
+                .with_context(|| format!("parse the journal at {}", path.display())),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            // Anything else — a permissions problem, a directory in the way — is
+            // not "no journal". Treating it as one would restart a deploy that
+            // may be half-done.
+            Err(error) => Err(anyhow::Error::new(error)
+                .context(format!("read the journal at {}", path.display()))),
+        }
+    }
+
+    /// Append an entry and persist immediately.
+    ///
+    /// Written after every step rather than at the end: a journal that is only
+    /// flushed on completion records nothing about the run that was interrupted,
+    /// which is the only run it exists for.
+    pub fn append(&mut self, path: &Path, entry: Entry) -> anyhow::Result<()> {
+        self.entries.push(entry);
+        let rendered = serde_json::to_string_pretty(self).context("render the journal")?;
+        std::fs::write(path, format!("{rendered}\n"))
+            .with_context(|| format!("write the journal at {}", path.display()))
+    }
+
+    /// Which steps of `file` still have to run.
+    ///
+    /// Refuses rather than guessing when the journal and the plan disagree:
+    /// every recorded step must still exist and still hash the same. Silently
+    /// re-running a completed step would double-spend a deposit; silently
+    /// skipping an edited one would deploy something nobody reviewed.
+    pub fn remaining(&self, file: &PlanFile) -> anyhow::Result<Vec<usize>> {
+        for entry in &self.entries {
+            let step = file.steps.get(entry.step).with_context(|| {
+                format!(
+                    "the journal records step {} (`{}`) as done, but this plan has \
+                     only {} step(s). It is a journal for a different plan.",
+                    entry.step,
+                    entry.label,
+                    file.steps.len()
+                )
+            })?;
+
+            let current = super::plan::digest(step)?;
+            anyhow::ensure!(
+                current == entry.digest,
+                "step {} (`{}`) already ran, but the plan has changed under it. \
+                 Re-running it would repeat work that is already done; skipping \
+                 it would apply a step nobody executed. Restore that step, or \
+                 start from a fresh plan and journal.",
+                entry.step,
+                entry.label,
+            );
+        }
+
+        let done: std::collections::BTreeSet<usize> =
+            self.entries.iter().map(|entry| entry.step).collect();
+        Ok((0..file.steps.len())
+            .filter(|index| !done.contains(index))
+            .collect())
+    }
+}

--- a/tools/manager/src/spec/mod.rs
+++ b/tools/manager/src/spec/mod.rs
@@ -13,6 +13,7 @@
 pub mod check;
 pub mod export;
 pub mod extends;
+pub mod journal;
 pub mod oracle;
 pub mod plan;
 mod serde_util;

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -475,6 +475,7 @@ mod journal {
             step,
             digest,
             label: format!("step {step}"),
+            outcome: crate::spec::journal::Outcome::Completed,
             tx_hash: None,
         }
     }
@@ -483,7 +484,13 @@ mod journal {
         Journal {
             entries: steps
                 .iter()
-                .map(|index| entry(*index, file.step_digests[*index].clone()))
+                .map(|index| {
+                    entry(
+                        *index,
+                        crate::spec::journal::executable_digest(&file.steps[*index])
+                            .expect("digest"),
+                    )
+                })
                 .collect(),
         }
     }
@@ -551,6 +558,94 @@ mod journal {
 
         let error = journal.remaining(&file).expect_err("out of range");
         assert!(format!("{error:#}").contains("different plan"), "{error:#}");
+    }
+
+    /// A step that was submitted but never resolved is neither progress nor
+    /// absence: re-sending a deploy that actually landed strands its deposit,
+    /// skipping it deploys nothing. Only a human can tell, so the run stops.
+    #[test]
+    fn an_unresolved_attempt_stops_the_run() {
+        use crate::spec::journal::Outcome;
+
+        let file = plan_file(sample_steps());
+        let mut journal = done(&file, &[0]);
+        journal.entries[0].outcome = Outcome::Attempted;
+        journal.entries[0].tx_hash = Some("SOMEHASH".to_owned());
+
+        let error = journal.remaining(&file).expect_err("outcome unknown");
+        let rendered = format!("{error:#}");
+        assert!(rendered.contains("never recorded"), "{rendered}");
+        assert!(rendered.contains("SOMEHASH"), "{rendered}");
+    }
+
+    /// Steps run in order and only completions are recorded, so the done set is
+    /// always a prefix. A gap means an entry was removed or invented — and
+    /// resuming would step over work that never happened while every
+    /// plan-level check still passed, because the *plan* is intact.
+    #[test]
+    fn a_journal_with_a_gap_is_refused() {
+        let file = plan_file(sample_steps());
+        let journal = done(&file, &[0, 2]);
+
+        let error = journal.remaining(&file).expect_err("not a prefix");
+        assert!(format!("{error:#}").contains("not a prefix"), "{error:#}");
+    }
+
+    /// Renaming a completed step changes nothing executable, so it must not
+    /// block a resume.
+    #[test]
+    fn relabelling_a_completed_step_does_not_block_resume() {
+        let mut file = plan_file(sample_steps());
+        let journal = done(&file, &[0]);
+        file.steps[0].label = "renamed by hand".to_owned();
+
+        assert_eq!(journal.remaining(&file).expect("reconciles"), vec![1, 2]);
+    }
+
+    /// The showstopper this review caught: a resume has already created the
+    /// accounts its completed steps made, so checking the *whole* plan's targets
+    /// for freeness aborts every resume that has anything to resume. Freeness
+    /// must be asked of the outstanding steps only — and asking it of those is
+    /// what keeps the guard biting when a step's outcome was ambiguous and it
+    /// therefore stayed outstanding.
+    #[test]
+    fn freeness_is_asked_only_of_the_steps_still_to_run() {
+        use crate::spec::plan::{PlanArgs, PlanFile, PlanFunctionCall, PlanStep};
+
+        let deploy = |name: &str| PlanStep {
+            label: format!("deploy {name}"),
+            signer_id: "operator.near".parse().expect("valid account"),
+            receiver_id: "templar-alpha.near".parse().expect("valid account"),
+            function_calls: vec![PlanFunctionCall {
+                method_name: "deploy_market".to_owned(),
+                args: PlanArgs::Json(serde_json::json!({
+                    "name": name, "version_key": "v1",
+                })),
+                gas: 300_000_000_000_000,
+                deposit: near_api::types::NearToken::from_near(5),
+            }],
+        };
+
+        let mut file = plan_file(sample_steps());
+        file.steps = vec![deploy("gov"), deploy("oracle"), deploy("market")];
+
+        let all = crate::dispatch::plan::planned_targets(&file).expect("targets");
+        assert_eq!(all.len(), 3, "three deploys, three accounts");
+
+        // Step 0 completed, so its target already exists and must not be asked
+        // to be free.
+        let outstanding = PlanFile {
+            steps: file.steps[1..].to_vec(),
+            ..file.clone()
+        };
+        let remaining_targets =
+            crate::dispatch::plan::planned_targets(&outstanding).expect("targets");
+
+        assert!(
+            remaining_targets.len() < all.len(),
+            "a completed deploy's target must drop out of the freeness check: \
+             {all:?} vs {remaining_targets:?}"
+        );
     }
 
     /// The journal lives beside its plan, derived rather than configurable.

--- a/tools/manager/src/tests/plan_file.rs
+++ b/tools/manager/src/tests/plan_file.rs
@@ -463,3 +463,102 @@ async fn requires_network_plans_the_deploy_script_in_order() {
         "the plan must reproduce deploy.sh"
     );
 }
+
+/// Journal reconciliation (ENG-546). All offline: the journal keys on the plan's
+/// own per-step digests, so nothing here needs a chain.
+mod journal {
+    use super::{plan_file, sample_steps};
+    use crate::spec::journal::{Entry, Journal};
+
+    fn entry(step: usize, digest: String) -> Entry {
+        Entry {
+            step,
+            digest,
+            label: format!("step {step}"),
+            tx_hash: None,
+        }
+    }
+
+    fn done(file: &crate::spec::plan::PlanFile, steps: &[usize]) -> Journal {
+        Journal {
+            entries: steps
+                .iter()
+                .map(|index| entry(*index, file.step_digests[*index].clone()))
+                .collect(),
+        }
+    }
+
+    /// The point of the journal: an interrupted deploy continues instead of
+    /// repeating work that already spent its deposit.
+    #[test]
+    fn completed_steps_are_skipped() {
+        let file = plan_file(sample_steps());
+        let journal = done(&file, &[0]);
+
+        assert_eq!(
+            journal.remaining(&file).expect("reconciles"),
+            vec![1, 2],
+            "only the steps that have not run"
+        );
+    }
+
+    #[test]
+    fn a_fresh_journal_runs_everything() {
+        let file = plan_file(sample_steps());
+        assert_eq!(
+            Journal::default().remaining(&file).expect("reconciles"),
+            vec![0, 1, 2]
+        );
+    }
+
+    /// Editing a step that has *already run* is the case that must be refused:
+    /// re-running it repeats a completed transaction, skipping it applies
+    /// something nobody executed. Named rather than silently resolved either way.
+    #[test]
+    fn an_edit_under_a_completed_step_is_refused() {
+        let mut file = plan_file(sample_steps());
+        let journal = done(&file, &[0]);
+        file.steps[0].function_calls[0].gas += 1;
+
+        let error = journal
+            .remaining(&file)
+            .expect_err("the plan changed under a completed step");
+        assert!(
+            format!("{error:#}").contains("changed under it"),
+            "{error:#}"
+        );
+    }
+
+    /// Editing a step that has *not* run is fine — the artifact exists to be
+    /// edited, and only completed steps are frozen.
+    #[test]
+    fn an_edit_ahead_of_the_cursor_is_allowed() {
+        let mut file = plan_file(sample_steps());
+        let journal = done(&file, &[0]);
+        file.steps[2].function_calls[0].gas += 1;
+
+        assert_eq!(journal.remaining(&file).expect("reconciles"), vec![1, 2]);
+    }
+
+    /// A journal from a different plan must not be mistaken for progress on
+    /// this one.
+    #[test]
+    fn a_journal_for_another_plan_is_refused() {
+        let file = plan_file(sample_steps());
+        let journal = Journal {
+            entries: vec![entry(99, "sha256:whatever".to_owned())],
+        };
+
+        let error = journal.remaining(&file).expect_err("out of range");
+        assert!(format!("{error:#}").contains("different plan"), "{error:#}");
+    }
+
+    /// The journal lives beside its plan, derived rather than configurable.
+    #[test]
+    fn the_journal_sits_beside_its_plan() {
+        assert_eq!(
+            crate::spec::journal::path_for(std::path::Path::new("/tmp/mkt/plan.json")),
+            std::path::PathBuf::from("/tmp/mkt/plan.json.journal.json")
+        );
+    }
+}


### PR DESCRIPTION
Closes ENG-546. Sub-PR into the ENG-537 integration branch.

`deploy.sh` is not re-runnable, and its own comment documents the cost: a stale version key aborts at the oracle step and leaves an orphaned governance contract to be deleted by hand. **Ordering was the only safety property.** This replaces it with a mechanism.

An append-only journal beside the plan (`plan.json.journal.json`) records each completed step, its digest and its tx hash. `market apply` reconciles it, skips what is done, and continues from the first incomplete step.

## Keyed on the plan, not the spec

Reconciliation uses ENG-544's per-step digests, so a hand-edited plan resumes correctly and the three cases stay distinct rather than being conflated:

| Edit | Behaviour |
|---|---|
| a step that has **not** run | allowed — the artifact exists to be edited |
| a step that **has** run | **refused by name** — re-running repeats a completed transaction; skipping applies something nobody executed |
| a journal whose steps aren't in this plan | refused as belonging to a different plan |

## One transaction per call

Deliberately not batched: a journal flushed only on completion records nothing about the run that was interrupted, which is the only run it exists for. Each step is journalled as it lands, and a failure names the journal and tells the operator to re-run to resume.

## Interaction with ENG-545

Per the issue's note, the funding check on a resume runs against the **remaining** steps only — a resume must not demand deposits it has already paid.

## Fails closed

`Journal::load` treats only `NotFound` as "no journal". A permissions error is not an empty journal, and reading it as one would restart a half-done deploy.

## Verification

227 tests (6 new, covering skip, fresh, edit-behind, edit-ahead, foreign journal, and path derivation). Live against a real 7-step mainnet plan (read-only, aborted at the prompt):

```
Resuming: 4 of 7 step(s) already completed per …/resume.json.journal.json.
Send 3 transaction(s) as templar-alpha.near? [y/N]
```

and with step 1 edited under that journal:

```
Error: step 1 (`deploy proxy oracle …, owned by governance`) already ran, but the
plan has changed under it. Re-running it would repeat work that is already done;
skipping it would apply a step nobody executed.
```

`cargo fmt --all --check`, clippy `-D warnings` clean.

## Follow-on

This closes the "`market apply` is not journalled" gap ENG-544 recorded at its confirmation prompt — that warning should come out when this lands. It's still in place here because it is accurate until this merges; I'll remove it in ENG-548 alongside `deploy.sh`, whose ordering comment this also makes obsolete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/548)
<!-- Reviewable:end -->
