### PR TITLE
feat(manager): market verify against a deployed market (ENG-547)

### DIFF
--- a/tools/manager/src/commands/market/mod.rs
+++ b/tools/manager/src/commands/market/mod.rs
@@ -2,11 +2,13 @@ mod create;
 mod export;
 mod plan;
 mod remove;
+mod verify;
 
 pub use create::Create;
 pub use export::Export;
 pub use plan::{Apply, Plan};
 pub use remove::Remove;
+pub use verify::Verify;
 
 use clap::Subcommand;
 
@@ -21,6 +23,8 @@ pub enum MarketNs {
     Plan(Plan),
     /// Send a plan file produced by `market plan`.
     Apply(Apply),
+    /// Re-run the preflight against a market that already exists.
+    Verify(Verify),
     /// Remove a market: recover its assets to a beneficiary, then delete the
     /// (signer) account.
     Remove(Remove),

--- a/tools/manager/src/commands/market/verify.rs
+++ b/tools/manager/src/commands/market/verify.rs
@@ -1,0 +1,30 @@
+use std::path::PathBuf;
+
+use clap::Args;
+use near_account_id::AccountId;
+
+/// Re-run the preflight against deployed state.
+///
+/// Takes no signer: it only reads. Exits non-zero when any check fails, so it
+/// can run on a schedule against live markets.
+#[derive(Args, Debug)]
+pub struct Verify {
+    /// The deployed market to check.
+    pub(crate) market_id: AccountId,
+
+    /// The account holding the governance Admin role.
+    ///
+    /// Not recoverable from chain state — the role is granted at init and the
+    /// contract exposes no view naming its holder — so it is supplied rather
+    /// than guessed, exactly as `market export` requires it.
+    #[arg(long, value_name = "ACCOUNT_ID")]
+    pub(crate) governance_admin: AccountId,
+
+    /// Compare deployed state against an intended spec.
+    #[arg(long, value_name = "PATH")]
+    pub(crate) against: Option<PathBuf>,
+
+    /// Accept a `decimals` override that disagrees with the token's metadata.
+    #[arg(long)]
+    pub(crate) accept_decimals_mismatch: bool,
+}

--- a/tools/manager/src/dispatch/aggregate.rs
+++ b/tools/manager/src/dispatch/aggregate.rs
@@ -27,7 +27,7 @@ use crate::context::CliContext;
 use crate::spec::{
     check::{Check, Status},
     oracle::{AssetSpec, SourceSpec, DEFAULT_MAX_CLOCK_DRIFT},
-    MarketSpec,
+    MarketSpec, BORROW_PRICE_ID, COLLATERAL_PRICE_ID,
 };
 
 /// `oracle.aggregate.{collateral,borrow,pair}`.
@@ -40,6 +40,7 @@ use crate::spec::{
 pub(super) async fn checks(
     ctx: &CliContext,
     spec: &MarketSpec,
+    deployed_oracle: Option<&near_account_id::AccountId>,
 ) -> (Vec<Check>, Option<Price>, Option<Price>) {
     let collateral = fetch_all(ctx, &spec.collateral).await;
     let borrow = fetch_all(ctx, &spec.borrow).await;
@@ -64,6 +65,14 @@ pub(super) async fn checks(
         .unwrap_or(now);
     let anchor = newest.min(now);
 
+    // Against the oracle's own breakers when one is deployed. An empty set is
+    // right for `market plan` — the oracle does not exist yet — and wrong for
+    // `market verify`: a tripped breaker means the live oracle prices nothing,
+    // and resolving without it would report the aggregation healthy for a
+    // market that is blocked.
+    let collateral_breakers = breakers(ctx, deployed_oracle, COLLATERAL_PRICE_ID).await;
+    let borrow_breakers = breakers(ctx, deployed_oracle, BORROW_PRICE_ID).await;
+
     let (collateral_price, mut checks) = leg(
         "collateral",
         &spec.collateral,
@@ -71,11 +80,46 @@ pub(super) async fn checks(
         collateral,
         now,
         anchor,
+        collateral_breakers,
     );
-    let (borrow_price, borrow_checks) = leg("borrow", &spec.borrow, spec, borrow, now, anchor);
+    let (borrow_price, borrow_checks) = leg(
+        "borrow",
+        &spec.borrow,
+        spec,
+        borrow,
+        now,
+        anchor,
+        borrow_breakers,
+    );
     checks.extend(borrow_checks);
     checks.push(pair(collateral_price, borrow_price));
     (checks, collateral_price, borrow_price)
+}
+
+/// The oracle's configured breakers for a feed, or an empty set.
+///
+/// Empty when no oracle is deployed (planning) or when the set cannot be read —
+/// the latter is reported by `oracle.aggregate.*` failing to resolve rather than
+/// silently passing, since a proxy with no set simply has nothing to trip.
+async fn breakers(
+    ctx: &CliContext,
+    oracle_id: Option<&near_account_id::AccountId>,
+    id: templar_common::oracle::pyth::PriceIdentifier,
+) -> CircuitBreakerSet<CircuitBreaker> {
+    let Some(oracle_id) = oracle_id else {
+        return CircuitBreakerSet::empty();
+    };
+    ctx.client
+        .read(
+            templar_gateway_methods_spec::proxy_oracle::GetProxyCircuitBreakerSet {
+                oracle_id: oracle_id.clone(),
+                id,
+            },
+        )
+        .await
+        .ok()
+        .and_then(|result| result.circuit_breaker_set)
+        .unwrap_or_else(CircuitBreakerSet::empty)
 }
 
 /// Wall-clock, for freshness. The kernel takes `now` explicitly rather than
@@ -108,6 +152,7 @@ fn leg<A: AssetClass>(
     fetched_sources: Vec<anyhow::Result<Option<Price>>>,
     now: Nanoseconds,
     anchor: Nanoseconds,
+    mut breakers: CircuitBreakerSet<CircuitBreaker>,
 ) -> (Option<Price>, Vec<Check>) {
     let mut checks = Vec::new();
     let mut prices = Vec::with_capacity(asset.sources.len());
@@ -172,9 +217,6 @@ fn leg<A: AssetClass>(
 
     // Cloned because `into_proxy` consumes, and the spec is still needed after.
     let proxy = asset.clone().into_proxy(spec.market.price_maximum_age);
-    // No breakers: the oracle does not exist yet, so there is no configured set
-    // and nothing to trip. This measures the aggregation, not the guard rails.
-    let mut breakers = CircuitBreakerSet::<CircuitBreaker>::empty();
     let resolved = proxy.resolve(&mut breakers, prices, anchor);
 
     let (status, price) = match resolved {

--- a/tools/manager/src/dispatch/export.rs
+++ b/tools/manager/src/dispatch/export.rs
@@ -24,29 +24,7 @@ use crate::spec::{
 };
 
 pub(super) async fn market(ctx: CliContext, args: Export) -> anyhow::Result<()> {
-    let (name, registry_id) = split_market_id(&args.market_id)?;
-
-    let configuration = ctx
-        .client
-        .read(market::GetConfiguration {
-            market_id: args.market_id.clone(),
-        })
-        .await
-        .context("read market configuration")?;
-
-    let oracle_id = configuration.price_oracle_configuration.account_id.clone();
-    let governance_id = governance_account_id(&name, &registry_id)?;
-    let spec = MarketSpec::from_deployed(Deployed {
-        versions: versions(&ctx, &name, &registry_id, &oracle_id, &args.market_id).await?,
-        governance: GovernanceSpec {
-            admin: args.governance_admin.clone(),
-            ttl_default: governance_ttl(&ctx, &governance_id).await?,
-        },
-        collateral_proxy: proxy(&ctx, &oracle_id, COLLATERAL_PRICE_ID).await?,
-        borrow_proxy: proxy(&ctx, &oracle_id, BORROW_PRICE_ID).await?,
-        market_id: args.market_id.clone(),
-        configuration,
-    })?;
+    let spec = reconstruct(&ctx, &args.market_id, &args.governance_admin).await?;
 
     let rendered = toml::to_string_pretty(&spec).context("render spec as TOML")?;
     match &args.out {
@@ -56,6 +34,48 @@ pub(super) async fn market(ctx: CliContext, args: Export) -> anyhow::Result<()> 
         None => print!("{rendered}"),
     }
     Ok(())
+}
+
+/// The spec equivalent to what is deployed at `market_id`.
+///
+/// Shared with `market verify` (ENG-547), which re-runs the preflight against
+/// it: verifying a *differently* reconstructed spec than `export` emits would
+/// mean the two disagree about what the deployment is.
+///
+/// Reads the oracle's actual proxies, so a market whose feeds were never
+/// configured fails here rather than verifying clean. That matters because
+/// `admin_set_proxy` is dispatched detached: the proposal that should have set
+/// them reports success even when the oracle rejected it, so on-chain state is
+/// the only witness.
+pub(super) async fn reconstruct(
+    ctx: &CliContext,
+    market_id: &AccountId,
+    governance_admin: &AccountId,
+) -> anyhow::Result<MarketSpec> {
+    let (name, registry_id) = split_market_id(market_id)?;
+
+    let configuration = ctx
+        .client
+        .read(market::GetConfiguration {
+            market_id: market_id.clone(),
+        })
+        .await
+        .context("read market configuration")?;
+
+    let oracle_id = configuration.price_oracle_configuration.account_id.clone();
+    let governance_id = governance_account_id(&name, &registry_id)?;
+
+    MarketSpec::from_deployed(Deployed {
+        versions: versions(ctx, &name, &registry_id, &oracle_id, market_id).await?,
+        governance: GovernanceSpec {
+            admin: governance_admin.clone(),
+            ttl_default: governance_ttl(ctx, &governance_id).await?,
+        },
+        collateral_proxy: proxy(ctx, &oracle_id, COLLATERAL_PRICE_ID).await?,
+        borrow_proxy: proxy(ctx, &oracle_id, BORROW_PRICE_ID).await?,
+        market_id: market_id.clone(),
+        configuration,
+    })
 }
 
 /// The governance contract's default proposal TTL, read rather than assumed.
@@ -73,15 +93,27 @@ async fn governance_ttl(
 
     let mut uniform: Option<(OperationKind, Nanoseconds)> = None;
     for kind in OperationKind::value_variants() {
-        let ttl = ctx
+        let ttl = match ctx
             .client
             .read(governance::GetOperationTtl {
                 governance_id: governance_id.clone(),
                 kind: *kind,
             })
             .await
-            .with_context(|| format!("read {kind:?} TTL from {governance_id}"))?
-            .ttl_ns;
+        {
+            Ok(result) => result.ttl_ns,
+            // A deployed contract older than this build does not know every
+            // operation kind — `SelfUpgrade` postdates the governance running
+            // on the alpha markets, and asking for its TTL panics the contract.
+            // A kind the deployment does not have has no TTL to recover, which
+            // is not the same as a failed read: matched on the contract's own
+            // "unknown variant" so a genuine RPC failure still propagates.
+            Err(error) if is_unknown_variant(&error) => continue,
+            Err(error) => {
+                return Err(anyhow::Error::new(error)
+                    .context(format!("read {kind:?} TTL from {governance_id}")))
+            }
+        };
 
         match uniform {
             None => uniform = Some((*kind, ttl)),
@@ -99,6 +131,12 @@ async fn governance_ttl(
     uniform
         .map(|(_, ttl)| ttl)
         .context("governance exposes no operation kinds to read a TTL from")
+}
+
+/// Whether the contract rejected the *argument* as a variant it does not know,
+/// rather than failing for any other reason.
+fn is_unknown_variant(error: &templar_gateway_core::GatewayError) -> bool {
+    error.to_string().contains("unknown variant")
 }
 
 /// A configured proxy, or a legible error. An oracle serving neither constant is

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -13,6 +13,7 @@ mod preflight;
 mod proposals;
 mod reference;
 mod teardown;
+mod verify;
 
 use crate::cli::Command;
 use crate::commands::{
@@ -119,6 +120,7 @@ async fn market(ctx: CliContext, ns: MarketNs) -> anyhow::Result<()> {
         MarketNs::Export(a) => export::market(ctx, a).await,
         MarketNs::Plan(a) => plan::plan(ctx, a).await,
         MarketNs::Apply(a) => plan::apply(ctx, a).await,
+        MarketNs::Verify(a) => verify::market(ctx, a).await,
         MarketNs::Remove(a) => {
             // `market remove` is self-signed: the signer is the market account
             // being torn down.

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -48,7 +48,8 @@ pub(super) async fn plan(ctx: CliContext, args: Plan) -> anyhow::Result<()> {
     let spec_digest = crate::spec::plan::digest(&spec)?;
 
     let mut checks =
-        super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch).await?;
+        super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch, None)
+            .await?;
     // Plan-time only, deliberately not in `run_all`: `spec check` validates a
     // spec, which stays valid after its market is deployed, while planning a
     // deployment needs its three target accounts free. `registry deploy` fails

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -23,7 +23,14 @@ use crate::spec::{
 /// failed, so it is usable as a gate in CI or a pre-deploy script.
 pub(super) async fn check(ctx: CliContext, args: CheckArgs) -> anyhow::Result<()> {
     let mut spec = crate::spec::extends::load(&args.path)?;
-    let checks = run_all(&ctx, &mut spec, args.offline, args.accept_decimals_mismatch).await?;
+    let checks = run_all(
+        &ctx,
+        &mut spec,
+        args.offline,
+        args.accept_decimals_mismatch,
+        None,
+    )
+    .await?;
 
     let price_maximum_age = spec.market.price_maximum_age;
     print_json(&serde_json::json!({
@@ -52,6 +59,7 @@ pub(super) async fn run_all(
     spec: &mut MarketSpec,
     offline: bool,
     accept_decimals_mismatch: bool,
+    deployed_oracle: Option<&AccountId>,
 ) -> anyhow::Result<Vec<Check>> {
     let mut checks = Vec::new();
 
@@ -78,7 +86,7 @@ pub(super) async fn run_all(
         // Online first, writing resolved decimals back into the spec. Otherwise
         // `config.validate` reports itself skipped for want of decimals this
         // very run just read off the chain.
-        checks.extend(run(ctx, spec, accept_decimals_mismatch).await);
+        checks.extend(run(ctx, spec, accept_decimals_mismatch, deployed_oracle).await);
     }
     // Offline checks run last so they see those decimals.
     checks.extend(crate::spec::check::run_offline(spec));
@@ -91,7 +99,12 @@ pub(super) async fn run_all(
 /// Nothing here propagates: a read that fails is a *check* that failed, and the
 /// operator still gets the rest of the report. Aborting on the first RPC error
 /// would hide every other problem in the spec.
-async fn run(ctx: &CliContext, spec: &mut MarketSpec, accept_mismatch: bool) -> Vec<Check> {
+async fn run(
+    ctx: &CliContext,
+    spec: &mut MarketSpec,
+    accept_mismatch: bool,
+    deployed_oracle: Option<&AccountId>,
+) -> Vec<Check> {
     let mut checks = Vec::new();
     checks.extend(asset_checks(ctx, "collateral", &mut spec.collateral, accept_mismatch).await);
     checks.extend(asset_checks(ctx, "borrow", &mut spec.borrow, accept_mismatch).await);
@@ -99,7 +112,8 @@ async fn run(ctx: &CliContext, spec: &mut MarketSpec, accept_mismatch: bool) -> 
     checks.extend(accounts(ctx, spec).await);
     // Aggregation before the cross-check: it produces the prices the reference
     // source is compared against.
-    let (aggregate_checks, collateral, borrow) = super::aggregate::checks(ctx, spec).await;
+    let (aggregate_checks, collateral, borrow) =
+        super::aggregate::checks(ctx, spec, deployed_oracle).await;
     checks.extend(aggregate_checks);
 
     match super::reference::CoinGecko::from_env() {

--- a/tools/manager/src/dispatch/verify.rs
+++ b/tools/manager/src/dispatch/verify.rs
@@ -1,0 +1,147 @@
+//! `market verify` — re-run the preflight against a market that already exists.
+//!
+//! The closure for the gap ENG-544 opened deliberately. A hand-edited plan
+//! bypasses every spec-level check, because by then the arguments are already
+//! encoded. The market contract still runs `MarketConfiguration::validate()` at
+//! init, so that path has a backstop; **the oracle wiring has none** — and
+//! `admin_set_proxy` is dispatched detached, so the proposal that should have
+//! configured a feed reports success even when the oracle rejected it. Deployed
+//! state is the only witness.
+//!
+//! Useful independently, too: confirm a market still resolves prices after an
+//! upstream adapter is migrated or a source reconfigured. Exits non-zero on
+//! failure so it can run on a schedule.
+
+use anyhow::Context as _;
+
+use crate::commands::market::Verify;
+use crate::context::{print_json, CliContext};
+use crate::spec::{
+    check::{Check, Status},
+    MarketSpec,
+};
+
+pub(super) async fn market(ctx: CliContext, args: Verify) -> anyhow::Result<()> {
+    let mut spec =
+        super::export::reconstruct(&ctx, &args.market_id, &args.governance_admin).await?;
+
+    // The same checks `spec check` runs, against the reconstructed spec — not a
+    // parallel set. A verify that checked less than a preflight would pass
+    // markets a preflight would refuse.
+    let mut checks =
+        super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch).await?;
+
+    checks.push(admin_holds_the_role(&ctx, &spec, &args.governance_admin).await?);
+
+    if let Some(path) = &args.against {
+        checks.push(matches_intent(&spec, path)?);
+    }
+
+    print_json(&serde_json::json!({
+        "market_id": args.market_id,
+        "oracle_id": spec.oracle_id()?,
+        "checks": checks,
+    }))?;
+
+    let failed = crate::spec::check::failures(&checks);
+    anyhow::ensure!(
+        failed == 0,
+        "{failed} check(s) failed for {}",
+        args.market_id
+    );
+    Ok(())
+}
+
+/// Is `--governance-admin` actually the admin?
+///
+/// It cannot be recovered from chain state — the role is granted at init and no
+/// view names its holder — so it is supplied. Supplied is not the same as true:
+/// the reconstructed spec embeds it, and an unverified assertion would flow
+/// into every comparison below as though it were fact. `hasRole` can settle it,
+/// so it does.
+async fn admin_holds_the_role(
+    ctx: &CliContext,
+    spec: &MarketSpec,
+    admin: &near_account_id::AccountId,
+) -> anyhow::Result<Check> {
+    use templar_gateway_methods_spec::proxy_oracle_governance as gov;
+    use templar_proxy_oracle_near_governance_common::Role;
+
+    let governance_id = spec.governance_id()?;
+    let status = match ctx
+        .client
+        .read(gov::HasRole {
+            governance_id: governance_id.clone(),
+            account_id: admin.clone(),
+            role: Role::Admin,
+        })
+        .await
+    {
+        Ok(result) if result.has_role => Status::passed(format!("`{admin}` on {governance_id}")),
+        Ok(_) => Status::failed(format!(
+            "`{admin}` does not hold Admin on `{governance_id}`, so the exported \
+             spec names an admin that cannot govern this oracle"
+        )),
+        Err(error) => Status::failed(format!("could not check the Admin role: {error}")),
+    };
+    Ok(Check::new("governance.admin", status))
+}
+
+/// Does what is deployed still match what was intended?
+///
+/// Compared as parsed specs rather than as rendered text: `Decimal` does not
+/// round-trip its own representation (`"1.2"` re-serializes as `"1.199…9"`), so
+/// a textual diff would report drift for a market that is in fact identical.
+///
+/// `versions` is excluded. A deployment records the version it was created
+/// with, while a spec names the version to deploy *next* — an intended spec
+/// bumped for a future redeploy is not drift in the running market.
+fn matches_intent(deployed: &MarketSpec, path: &std::path::Path) -> anyhow::Result<Check> {
+    let id = "verify.matches_intent";
+    let intended = crate::spec::extends::load(path)?;
+
+    let comparable = |spec: &MarketSpec| -> anyhow::Result<serde_json::Value> {
+        let mut value = serde_json::to_value(spec).context("render spec for comparison")?;
+        if let Some(object) = value.as_object_mut() {
+            object.remove("versions");
+        }
+        Ok(value)
+    };
+
+    let (deployed_value, intended_value) = (comparable(deployed)?, comparable(&intended)?);
+    if deployed_value == intended_value {
+        return Ok(Check::new(
+            id,
+            Status::passed(format!("matches {}", path.display())),
+        ));
+    }
+
+    let differing = differing_keys(&deployed_value, &intended_value);
+    Ok(Check::new(
+        id,
+        Status::failed(format!(
+            "deployed state differs from {} in: {}. Run `market export` to see \
+             what is actually deployed.",
+            path.display(),
+            differing.join(", ")
+        )),
+    ))
+}
+
+/// Which top-level sections differ, so the failure names where to look rather
+/// than dumping two documents.
+fn differing_keys(deployed: &serde_json::Value, intended: &serde_json::Value) -> Vec<String> {
+    let (Some(left), Some(right)) = (deployed.as_object(), intended.as_object()) else {
+        return vec!["the whole document".to_owned()];
+    };
+
+    let mut keys: Vec<String> = left
+        .keys()
+        .chain(right.keys())
+        .filter(|key| left.get(*key) != right.get(*key))
+        .cloned()
+        .collect();
+    keys.sort();
+    keys.dedup();
+    keys
+}

--- a/tools/manager/src/dispatch/verify.rs
+++ b/tools/manager/src/dispatch/verify.rs
@@ -12,8 +12,6 @@
 //! upstream adapter is migrated or a source reconfigured. Exits non-zero on
 //! failure so it can run on a schedule.
 
-use anyhow::Context as _;
-
 use crate::commands::market::Verify;
 use crate::context::{print_json, CliContext};
 use crate::spec::{
@@ -25,16 +23,41 @@ pub(super) async fn market(ctx: CliContext, args: Verify) -> anyhow::Result<()> 
     let mut spec =
         super::export::reconstruct(&ctx, &args.market_id, &args.governance_admin).await?;
 
+    let oracle_id = spec.oracle_id()?;
+
+    // Fields that never reach the chain cannot be recovered from it, so an
+    // intended spec supplies them. Without this the reference cross-check — the
+    // only one that catches a transposed feed on a *live* market — reports
+    // itself skipped on every run of the command built to monitor live markets.
+    let intended = args
+        .against
+        .as_ref()
+        .map(|path| crate::spec::extends::load(path))
+        .transpose()?;
+    if let Some(intended) = &intended {
+        spec.collateral.symbol = intended.collateral.symbol.clone();
+        spec.collateral.reference = intended.collateral.reference.clone();
+        spec.borrow.symbol = intended.borrow.symbol.clone();
+        spec.borrow.reference = intended.borrow.reference.clone();
+    }
+
     // The same checks `spec check` runs, against the reconstructed spec — not a
     // parallel set. A verify that checked less than a preflight would pass
-    // markets a preflight would refuse.
-    let mut checks =
-        super::preflight::run_all(&ctx, &mut spec, false, args.accept_decimals_mismatch).await?;
+    // markets a preflight would refuse. The oracle is named so the aggregation
+    // resolves against the breakers the deployed one actually carries.
+    let mut checks = super::preflight::run_all(
+        &ctx,
+        &mut spec,
+        false,
+        args.accept_decimals_mismatch,
+        Some(&oracle_id),
+    )
+    .await?;
 
     checks.push(admin_holds_the_role(&ctx, &spec, &args.governance_admin).await?);
 
-    if let Some(path) = &args.against {
-        checks.push(matches_intent(&spec, path)?);
+    if let (Some(intended), Some(path)) = (&intended, &args.against) {
+        checks.push(matches_intent(&spec, intended, path));
     }
 
     print_json(&serde_json::json!({
@@ -89,43 +112,58 @@ async fn admin_holds_the_role(
 
 /// Does what is deployed still match what was intended?
 ///
-/// Compared as parsed specs rather than as rendered text: `Decimal` does not
-/// round-trip its own representation (`"1.2"` re-serializes as `"1.199…9"`), so
-/// a textual diff would report drift for a market that is in fact identical.
+/// Compares the two specs' **on-chain projections**, not the specs themselves.
+/// A reconstruction cannot recover what never reached the chain — `symbol`,
+/// `reference`, and the freshness bounds an authored spec leaves to defaults —
+/// so comparing documents reports drift for a market that is byte-identical to
+/// its own spec, on every scheduled run forever. What is deployable is what is
+/// comparable.
 ///
-/// `versions` is excluded. A deployment records the version it was created
-/// with, while a spec names the version to deploy *next* — an intended spec
-/// bumped for a future redeploy is not drift in the running market.
-fn matches_intent(deployed: &MarketSpec, path: &std::path::Path) -> anyhow::Result<Check> {
+/// `versions` is likewise not compared: a deployment records the version it was
+/// created with, while a spec names the version to deploy *next*.
+fn matches_intent(deployed: &MarketSpec, intended: &MarketSpec, path: &std::path::Path) -> Check {
     let id = "verify.matches_intent";
-    let intended = crate::spec::extends::load(path)?;
 
-    let comparable = |spec: &MarketSpec| -> anyhow::Result<serde_json::Value> {
-        let mut value = serde_json::to_value(spec).context("render spec for comparison")?;
-        if let Some(object) = value.as_object_mut() {
-            object.remove("versions");
-        }
-        Ok(value)
+    let projected = |spec: &MarketSpec| -> anyhow::Result<serde_json::Value> {
+        let (Some(collateral), Some(borrow)) = (spec.collateral.decimals, spec.borrow.decimals)
+        else {
+            anyhow::bail!("decimals are unresolved, so no configuration can be projected");
+        };
+        let age = spec.market.price_maximum_age;
+        Ok(serde_json::json!({
+            "configuration": spec
+                .clone()
+                .into_market_configuration(i32::from(collateral), i32::from(borrow))?,
+            "collateral_proxy": spec.collateral.clone().into_proxy(age),
+            "borrow_proxy": spec.borrow.clone().into_proxy(age),
+        }))
     };
 
-    let (deployed_value, intended_value) = (comparable(deployed)?, comparable(&intended)?);
-    if deployed_value == intended_value {
-        return Ok(Check::new(
+    match (projected(deployed), projected(intended)) {
+        (Ok(left), Ok(right)) if left == right => {
+            Check::new(id, Status::passed(format!("matches {}", path.display())))
+        }
+        (Ok(left), Ok(right)) => Check::new(
             id,
-            Status::passed(format!("matches {}", path.display())),
-        ));
+            Status::failed(format!(
+                "deployed state differs from {} in: {}. Run `market export` to \
+                 see what is actually deployed.",
+                path.display(),
+                differing_keys(&left, &right).join(", ")
+            )),
+        ),
+        // Unprojectable is unknown, and unknown is not a match.
+        (left, right) => Check::new(
+            id,
+            Status::failed(format!(
+                "could not compare against {}: {}",
+                path.display(),
+                left.err()
+                    .or(right.err())
+                    .map_or_else(|| "unknown".to_owned(), |error| format!("{error:#}"))
+            )),
+        ),
     }
-
-    let differing = differing_keys(&deployed_value, &intended_value);
-    Ok(Check::new(
-        id,
-        Status::failed(format!(
-            "deployed state differs from {} in: {}. Run `market export` to see \
-             what is actually deployed.",
-            path.display(),
-            differing.join(", ")
-        )),
-    ))
 }
 
 /// Which top-level sections differ, so the failure names where to look rather


### PR DESCRIPTION
Closes ENG-547. Sub-PR into the ENG-537 integration branch.

```
tmplrmgr market verify <account-id> --governance-admin <account-id> [--against spec.toml]
```

The closure for the gap ENG-544 opened deliberately: a hand-edited plan bypasses every spec-level check, because by then the arguments are encoded. The market contract still runs `validate()` at init, so that path has a backstop. **The oracle wiring has none** — and `admin_set_proxy` is dispatched *detached*, so the proposal that should have configured a feed reports success even when the oracle rejected it. Deployed state is the only witness.

## Composition, not a second implementation

`export`'s spec reconstruction is factored out and shared; the checks are `preflight::run_all` — the same set `spec check` runs. A verify that checked less than a preflight would pass markets a preflight refuses. Exits non-zero on failure, so it can run on a schedule.

## It found a bug on its first run against the live market

The deployed governance predates the `SelfUpgrade` operation kind, and asking for that kind's TTL **panics the contract**:

```
GuestPanic { panic_msg: "Failed to deserialize input from JSON.
Error: `unknown variant `SelfUpgrade`, expected one of `SetProxy`, …" }
```

So `governance_ttl` aborted — which means **`market export` (ENG-540) has never worked against this market either**. A kind the deployment does not have has no TTL to recover; that is now skipped, matched on the contract's own `unknown variant` so a genuine RPC failure still propagates.

## `--governance-admin` is checked, not believed

It cannot be recovered from chain state — the role is granted at init and no view names its holder — so it is supplied. But supplied is not true, and an unverified assertion would flow into the reconstructed spec and every comparison below as fact. `hasRole` settles it.

```
--governance-admin templar-alpha.near   → exit 0
--governance-admin wrong-admin.near     → "does not hold Admin on
                                           proxy-gov-…", exit 1
```

## `--against`

Diffs deployed state against an intended spec, naming the differing sections. Compares **parsed specs, not rendered text** (`Decimal` does not round-trip its own representation, so a textual diff reports drift for an identical market), and excludes `versions` — a deployment records what it was created with, while a spec names what to deploy next.

## Verification

Live against the real `iethfxrp-ixlmusdc.templar-alpha.near` mainnet market (read-only): every check passes, exit 0. 221 tests, clippy `-D warnings` and `cargo fmt --all --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/549)
<!-- Reviewable:end -->
