### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4435,7 +4435,7 @@ dependencies = [
 
 [[package]]
 name = "harvest-static-yield"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -12857,7 +12857,7 @@ dependencies = [
 
 [[package]]
 name = "templar-accumulator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -12950,7 +12950,7 @@ dependencies = [
 
 [[package]]
 name = "templar-funding-bridge"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13020,7 +13020,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-artifacts-dispatch"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-trait",
  "near-account-id",
@@ -13038,7 +13038,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-artifacts-spec"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "near-account-id",
  "schemars 0.8.22",
@@ -13062,7 +13062,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-client"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "near-api",
@@ -13080,7 +13080,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-core"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13127,7 +13127,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-methods-dispatch"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
@@ -13149,7 +13149,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-methods-spec"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "near-account-id",
  "schemars 0.8.22",
@@ -13167,7 +13167,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13205,7 +13205,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "hex",
  "near-account-id",
@@ -13220,7 +13220,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-runtime"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "actix",
  "async-trait",
@@ -13234,7 +13234,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-service"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13284,7 +13284,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-store"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "async-trait",
  "borsh 1.6.1",
@@ -13339,7 +13339,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "borsh 1.6.1",
@@ -13362,7 +13362,7 @@ dependencies = [
 
 [[package]]
 name = "templar-liquidator"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13412,7 +13412,7 @@ dependencies = [
 
 [[package]]
 name = "templar-manager"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -13448,7 +13448,7 @@ dependencies = [
 
 [[package]]
 name = "templar-market-contract"
-version = "1.4.1"
+version = "1.4.2"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13512,7 +13512,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-governance-kernel"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "borsh 1.6.1",
  "rstest",
@@ -13574,7 +13574,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "clap",
  "near-sdk",
@@ -13588,7 +13588,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-governance-contract"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13632,7 +13632,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-governance-common"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "soroban-sdk",
  "templar-primitives",
@@ -13642,7 +13642,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-soroban-governance-contract"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "soroban-sdk",
  "stellar-access",
@@ -13741,7 +13741,7 @@ dependencies = [
 
 [[package]]
 name = "templar-registry-contract"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "getrandom 0.2.17",
@@ -13760,7 +13760,7 @@ dependencies = [
 
 [[package]]
 name = "templar-relayer"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -13906,7 +13906,7 @@ dependencies = [
 
 [[package]]
 name = "templar-tools-common"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",
@@ -13926,7 +13926,7 @@ dependencies = [
 
 [[package]]
 name = "templar-universal-account"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "alloy",
  "alloy-primitives",
@@ -13950,7 +13950,7 @@ dependencies = [
 
 [[package]]
 name = "templar-universal-account-contract"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,29 +137,29 @@ templar-common = { path = "./common", version = "1.4.1" }
 templar-contract-artifacts = { path = "./contract/artifacts" }
 templar-gateway-artifacts-dispatch = { path = "./gateway/artifacts-dispatch" }
 templar-gateway-artifacts-spec = { path = "./gateway/artifacts-spec" }
-templar-gateway-client = { path = "./gateway/client", version = "0.1.1" }
-templar-gateway-core = { path = "./gateway/core", version = "0.1.1" }
+templar-gateway-client = { path = "./gateway/client", version = "0.1.2" }
+templar-gateway-core = { path = "./gateway/core", version = "0.2.0" }
 templar-gateway-macros = { path = "./gateway/macros", version = "0.1.1" }
-templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.1.1" }
-templar-gateway-methods-spec = { path = "./gateway/methods-spec", version = "0.1.1" }
+templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.2.0" }
+templar-gateway-methods-spec = { path = "./gateway/methods-spec", version = "0.2.0" }
 templar-gateway-oracle-updates-dispatch = { path = "./gateway/oracle-updates-dispatch" }
 templar-gateway-oracle-updates-spec = { path = "./gateway/oracle-updates-spec" }
 templar-gateway-runtime = { path = "./gateway/runtime" }
-templar-gateway-store = { path = "./gateway/store", version = "0.1.1" }
+templar-gateway-store = { path = "./gateway/store", version = "0.1.2" }
 templar-gateway-testing = { path = "./gateway/testing" }
-templar-gateway-types = { path = "./gateway/types", version = "0.1.1" }
+templar-gateway-types = { path = "./gateway/types", version = "0.1.2" }
 templar-primitives = { path = "./primitives", version = "0.1.1" }
-templar-proxy-oracle-governance-kernel = { path = "./contract/proxy-oracle/governance-kernel", version = "0.1.1" }
+templar-proxy-oracle-governance-kernel = { path = "./contract/proxy-oracle/governance-kernel", version = "0.2.0" }
 templar-proxy-oracle-kernel = { path = "./contract/proxy-oracle/kernel", version = "0.1.1" }
 templar-proxy-oracle-near-common = { path = "./contract/proxy-oracle/near/common", version = "0.1.1" }
 templar-proxy-oracle-near-contract = { path = "./contract/proxy-oracle/near/contract" }
-templar-proxy-oracle-near-governance-common = { path = "./contract/proxy-oracle/near/governance-common", version = "0.1.1" }
+templar-proxy-oracle-near-governance-common = { path = "./contract/proxy-oracle/near/governance-common", version = "0.2.0" }
 templar-proxy-oracle-near-governance-contract = { path = "./contract/proxy-oracle/near/governance-contract" }
 templar-pyth-lazer-adapter-contract = { path = "./contract/pyth-lazer/contract" }
 templar-pyth-lazer-verifier = { path = "./contract/pyth-lazer/verifier" }
 templar-redstone-bridge = { path = "./service/redstone-bridge" }
 templar-tools-common = { path = "./tools/tools-common" }
-templar-universal-account = { path = "./universal-account", version = "1.2.1" }
+templar-universal-account = { path = "./universal-account", version = "1.2.2" }
 templar-vault-contract = { path = "./contract/vault/near" }
 templar-vault-kernel = { path = "./contract/vault/kernel", version = "1.0.1", features = [
     "near",

--- a/contract/market/Cargo.toml
+++ b/contract/market/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-market-contract"
 repository.workspace = true
-version = "1.4.1"
+version = "1.4.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/governance-kernel/CHANGELOG.md
+++ b/contract/proxy-oracle/governance-kernel/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-governance-kernel-v0.1.1...templar-proxy-oracle-governance-kernel-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-governance-kernel-v0.1.0...templar-proxy-oracle-governance-kernel-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/governance-kernel/Cargo.toml
+++ b/contract/proxy-oracle/governance-kernel/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.2.0"
 description = "Storage-agnostic governance kernel for Templar proxy oracles"
 
 [dependencies]

--- a/contract/proxy-oracle/near/governance-common/CHANGELOG.md
+++ b/contract/proxy-oracle/near/governance-common/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-common-v0.1.1...templar-proxy-oracle-near-governance-common-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+- *(proxy-oracle-governance)* accept borsh-serialized proposals (ENG-557) ([#556](https://github.com/Templar-Protocol/contracts/pull/556))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-common-v0.1.0...templar-proxy-oracle-near-governance-common-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/near/governance-common/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-common/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.2.0"
 description = "Shared NEAR-facing types for the Templar proxy oracle governance contract"
 
 [dependencies]

--- a/contract/proxy-oracle/near/governance-contract/CHANGELOG.md
+++ b/contract/proxy-oracle/near/governance-contract/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.2.0...templar-proxy-oracle-near-governance-contract-v0.3.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+- *(proxy-oracle-governance)* accept borsh-serialized proposals (ENG-557) ([#556](https://github.com/Templar-Protocol/contracts/pull/556))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.1.0...templar-proxy-oracle-near-governance-contract-v0.2.0) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/near/governance-contract/Cargo.toml
+++ b/contract/proxy-oracle/near/governance-contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-governance-contract"
 repository.workspace = true
-version = "0.2.0"
+version = "0.3.0"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/proxy-oracle/soroban/governance-common/CHANGELOG.md
+++ b/contract/proxy-oracle/soroban/governance-common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-common-v0.1.1...templar-proxy-oracle-soroban-governance-common-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-common-v0.1.0...templar-proxy-oracle-soroban-governance-common-v0.1.1) - 2026-08-03
 
 ### Added

--- a/contract/proxy-oracle/soroban/governance-common/Cargo.toml
+++ b/contract/proxy-oracle/soroban/governance-common/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.2.0"
 
 [lib]
 crate-type = ["rlib"]

--- a/contract/proxy-oracle/soroban/governance-contract/Cargo.toml
+++ b/contract/proxy-oracle/soroban/governance-contract/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/registry/Cargo.toml
+++ b/contract/registry/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-registry-contract"
 repository.workspace = true
-version = "1.2.2"
+version = "1.2.3"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/contract/universal-account/Cargo.toml
+++ b/contract/universal-account/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-universal-account-contract"
 repository.workspace = true
-version = "0.5.1"
+version = "0.5.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/gateway/artifacts-dispatch/Cargo.toml
+++ b/gateway/artifacts-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-artifacts-dispatch"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/artifacts-spec/Cargo.toml
+++ b/gateway/artifacts-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-artifacts-spec"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/client/Cargo.toml
+++ b/gateway/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-client"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/core/CHANGELOG.md
+++ b/gateway/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.1.1...templar-gateway-core-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.1.0...templar-gateway-core-v0.1.1) - 2026-08-03
 
 ### Added

--- a/gateway/core/Cargo.toml
+++ b/gateway/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-core"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/methods-dispatch/CHANGELOG.md
+++ b/gateway/methods-dispatch/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.1.1...templar-gateway-methods-dispatch-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.1.0...templar-gateway-methods-dispatch-v0.1.1) - 2026-08-03
 
 ### Added

--- a/gateway/methods-dispatch/Cargo.toml
+++ b/gateway/methods-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-methods-dispatch"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/methods-spec/CHANGELOG.md
+++ b/gateway/methods-spec/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.1.1...templar-gateway-methods-spec-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.1.0...templar-gateway-methods-spec-v0.1.1) - 2026-08-03
 
 ### Added

--- a/gateway/methods-spec/Cargo.toml
+++ b/gateway/methods-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-methods-spec"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-dispatch/Cargo.toml
+++ b/gateway/oracle-updates-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-spec/Cargo.toml
+++ b/gateway/oracle-updates-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/runtime/Cargo.toml
+++ b/gateway/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-runtime"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/store/Cargo.toml
+++ b/gateway/store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-store"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/types/Cargo.toml
+++ b/gateway/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-types"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/accumulator/Cargo.toml
+++ b/service/accumulator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [[bin]]
 name = "accumulator"

--- a/service/funding-bridge/Cargo.toml
+++ b/service/funding-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-funding-bridge"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/service/gateway/CHANGELOG.md
+++ b/service/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.1.1...templar-gateway-service-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.1.0...templar-gateway-service-v0.1.1) - 2026-08-03
 
 ### Added

--- a/service/gateway/Cargo.toml
+++ b/service/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-service"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/liquidator/Cargo.toml
+++ b/service/liquidator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [lib]
 path = "src/liquidator.rs"

--- a/service/relayer/Cargo.toml
+++ b/service/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-relayer"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tools/harvest-static-yield/Cargo.toml
+++ b/tools/harvest-static-yield/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.1"
+version = "0.1.2"
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/manager/CHANGELOG.md
+++ b/tools/manager/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.1.1...templar-manager-v0.2.0) - 2026-08-03
+
+### Added
+
+- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.1.0...templar-manager-v0.1.1) - 2026-08-03
 
 ### Added

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-manager"
-version = "0.1.1"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/tools/tools-common/Cargo.toml
+++ b/tools/tools-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-tools-common"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/universal-account/CHANGELOG.md
+++ b/universal-account/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-universal-account-v1.2.1...templar-universal-account-v1.2.2) - 2026-08-03
+
+### Fixed
+
+- *(universal-account)* decouple the EIP-712 domain version from the package version ([#554](https://github.com/Templar-Protocol/contracts/pull/554))

--- a/universal-account/Cargo.toml
+++ b/universal-account/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "1.2.1"
+version = "1.2.2"
 description = "Chain-abstraction account identifiers and EIP-712 signature payloads for Templar Protocol"
 
 [dependencies]


### PR DESCRIPTION



## 🤖 New release

* `templar-universal-account`: 1.2.1 -> 1.2.2
* `templar-proxy-oracle-governance-kernel`: 0.1.1 -> 0.2.0
* `templar-proxy-oracle-near-governance-common`: 0.1.1 -> 0.2.0
* `templar-gateway-core`: 0.1.1 -> 0.2.0
* `templar-gateway-methods-spec`: 0.1.1 -> 0.2.0
* `templar-gateway-methods-dispatch`: 0.1.1 -> 0.2.0
* `templar-proxy-oracle-near-governance-contract`: 0.2.0 -> 0.3.0
* `templar-proxy-oracle-soroban-governance-common`: 0.1.1 -> 0.2.0
* `templar-manager`: 0.1.1 -> 0.2.0
* `templar-gateway-service`: 0.1.1 -> 0.2.0
* `templar-gateway-types`: 0.1.1 -> 0.1.2
* `templar-gateway-artifacts-spec`: 0.2.0 -> 0.2.1
* `templar-gateway-artifacts-dispatch`: 0.2.0 -> 0.2.1
* `templar-gateway-store`: 0.1.1 -> 0.1.2
* `templar-gateway-client`: 0.1.1 -> 0.1.2
* `templar-gateway-runtime`: 0.1.1 -> 0.1.2
* `templar-gateway-oracle-updates-spec`: 0.1.1 -> 0.1.2
* `templar-gateway-oracle-updates-dispatch`: 0.1.1 -> 0.1.2
* `templar-market-contract`: 1.4.1 -> 1.4.2
* `templar-relayer`: 0.1.1 -> 0.1.2
* `templar-proxy-oracle-soroban-governance-contract`: 0.1.1 -> 0.1.2
* `templar-registry-contract`: 1.2.2 -> 1.2.3
* `templar-universal-account-contract`: 0.5.1 -> 0.5.2
* `harvest-static-yield`: 0.1.1 -> 0.1.2
* `templar-tools-common`: 0.1.1 -> 0.1.2
* `templar-accumulator`: 0.1.1 -> 0.1.2
* `templar-funding-bridge`: 0.1.1 -> 0.1.2
* `templar-liquidator`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `templar-universal-account`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-universal-account-v1.2.1...templar-universal-account-v1.2.2) - 2026-08-03

### Fixed

- *(universal-account)* decouple the EIP-712 domain version from the package version ([#554](https://github.com/Templar-Protocol/contracts/pull/554))
</blockquote>

## `templar-proxy-oracle-governance-kernel`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-governance-kernel-v0.1.1...templar-proxy-oracle-governance-kernel-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-proxy-oracle-near-governance-common`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-common-v0.1.1...templar-proxy-oracle-near-governance-common-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
- *(proxy-oracle-governance)* accept borsh-serialized proposals (ENG-557) ([#556](https://github.com/Templar-Protocol/contracts/pull/556))
</blockquote>

## `templar-gateway-core`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-core-v0.1.1...templar-gateway-core-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-gateway-methods-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-spec-v0.1.1...templar-gateway-methods-spec-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-gateway-methods-dispatch`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-methods-dispatch-v0.1.1...templar-gateway-methods-dispatch-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-proxy-oracle-near-governance-contract`

<blockquote>

## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-governance-contract-v0.2.0...templar-proxy-oracle-near-governance-contract-v0.3.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
- *(proxy-oracle-governance)* accept borsh-serialized proposals (ENG-557) ([#556](https://github.com/Templar-Protocol/contracts/pull/556))
</blockquote>

## `templar-proxy-oracle-soroban-governance-common`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-common-v0.1.1...templar-proxy-oracle-soroban-governance-common-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-manager`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.1.1...templar-manager-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-gateway-service`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.1.1...templar-gateway-service-v0.2.0) - 2026-08-03

### Added

- *(proxy-oracle-governance)* [**breaking**] reflexive vs. target-function-call operations (ENG-516) ([#527](https://github.com/Templar-Protocol/contracts/pull/527))
</blockquote>

## `templar-gateway-types`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-types-v0.1.0...templar-gateway-types-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-gateway-artifacts-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-spec-v0.1.0...templar-gateway-artifacts-spec-v0.2.0) - 2026-08-03

### Added

- *(release)* [**breaking**] automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-gateway-artifacts-dispatch`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-artifacts-dispatch-v0.1.0...templar-gateway-artifacts-dispatch-v0.2.0) - 2026-08-03

### Added

- *(release)* [**breaking**] automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-gateway-store`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-store-v0.1.0...templar-gateway-store-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-gateway-client`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.1.0...templar-gateway-client-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-gateway-runtime`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-runtime-v0.1.0...templar-gateway-runtime-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-gateway-oracle-updates-spec`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-spec-v0.1.0...templar-gateway-oracle-updates-spec-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-gateway-oracle-updates-dispatch`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-dispatch-v0.1.0...templar-gateway-oracle-updates-dispatch-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-market-contract`

<blockquote>

## [1.4.1](https://github.com/Templar-Protocol/contracts/compare/templar-market-contract-v1.4.0...templar-market-contract-v1.4.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Deployments

- *(market)* iethfxrp-ixlmusdc alpha market ([#536](https://github.com/Templar-Protocol/contracts/pull/536))

### Performance

- *(testing)* faster local sandbox gate + CI pool robustness ([#526](https://github.com/Templar-Protocol/contracts/pull/526))
</blockquote>

## `templar-relayer`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.1.0...templar-relayer-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-proxy-oracle-soroban-governance-contract`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-soroban-governance-contract-v0.1.0...templar-proxy-oracle-soroban-governance-contract-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-registry-contract`

<blockquote>

## [1.2.2](https://github.com/Templar-Protocol/contracts/compare/templar-registry-contract-v1.2.1...templar-registry-contract-v1.2.2) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-universal-account-contract`

<blockquote>

## [0.5.1](https://github.com/Templar-Protocol/contracts/compare/templar-universal-account-contract-v0.5.0...templar-universal-account-contract-v0.5.1) - 2026-08-03

### Added

- add Kani invariant coverage ([#477](https://github.com/Templar-Protocol/contracts/pull/477))
- *(gateway)* configure transaction finality policy (ENG-468) ([#517](https://github.com/Templar-Protocol/contracts/pull/517))
- *(versioned-state)* run a chained list of migrations in one upgrade (ENG-517) ([#522](https://github.com/Templar-Protocol/contracts/pull/522))
- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `harvest-static-yield`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/harvest-static-yield-v0.1.0...harvest-static-yield-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-tools-common`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-tools-common-v0.1.0...templar-tools-common-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-accumulator`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-accumulator-v0.1.0...templar-accumulator-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-funding-bridge`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-funding-bridge-v0.1.0...templar-funding-bridge-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-liquidator`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.0...templar-liquidator-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/553)
<!-- Reviewable:end -->
