### PR TITLE
fix(universal-account): decouple the EIP-712 domain version from the package version

### DIFF
--- a/universal-account/src/lib.rs
+++ b/universal-account/src/lib.rs
@@ -7,6 +7,9 @@ use near_sdk::{
 pub const NEAR_MAINNET_CHAIN_ID: u128 = 397;
 pub const NEAR_TESTNET_CHAIN_ID: u128 = 398;
 
+/// Deliberately not the package version: changing this invalidates every existing signature.
+const EIP712_DOMAIN_VERSION: &str = "1.2.1";
+
 pub mod authentication;
 pub mod encoding;
 mod event;
@@ -209,7 +212,7 @@ impl PayloadExecutionParametersBuilder<(), (), (), (), ()> {
             index: (),
             nonce: (),
             name: Some("Templar Universal Account".to_string()),
-            version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+            version: Some(EIP712_DOMAIN_VERSION.to_owned()),
             chain_id: Some(chain_id),
             verifying_contract: (),
             salt: (),


### PR DESCRIPTION
The EIP-712 domain `version` field was wired to `env!("CARGO_PKG_VERSION")` (`universal-account/src/lib.rs:212`), so any package bump silently changed a signature-verification input — including the dependency-cascade patch bumps release-plz issues routinely. Every signature produced against the old domain stops verifying.

The two values have different cadences and blast radii:

- **Package version** — semver over the Rust API. Must move on every release and every cascade. Routine.
- **EIP-712 domain version** — baked into signature verification. Should move only on a deliberate payload-semantics change, with coordinated rollout, because it invalidates in-flight signatures.

This pins the domain version as a named constant at its current value, `1.2.1`, so the package version is free to move independently.

## Why now

`templar-universal-account` was excluded from the #552 release to protect the signed fixtures, so it was never tagged at that commit. Its only tag stayed at the pre-automation seed commit, which left `#528` inside its unreleased range — and release-plz has been re-proposing a bogus `2.0.0` for it ever since (#553). Because the crate sits below `templar-gateway-types`, that one bump cascaded across the whole workspace.

The stale tag has been moved to the #552 release commit separately. This change removes the reason the crate had to be held out of releases at all: it can now ride the release train like every other crate, taking normal version bumps without touching the signing domain.

## Verification

- `cargo clippy -p templar-universal-account --tests -- -D warnings` — clean.
- Fast-partition tests for the crate: 145 passed, 1 skipped, including every signed fixture in `execute_args.rs` across passkey/P256, Ed25519Raw, EIP-712, SEP-53 and EIP-191.
- No behaviour change: the constant equals the current package version, so the fixtures and the on-chain assertion in `contract/universal-account/tests/universal_account.rs:200` are unaffected. Those fixtures are also the guard — they fail loudly if the constant is ever changed.

## Merging

Keep the squash title as-is and **clear any `BREAKING CHANGE:` footer** from the squash body. `fix` maps to a patch bump (1.2.1 → 1.2.2), which is what this needs; a breaking marker would send the crate to 2.0.0 and rebuild the cascade this is meant to end.

Merging this is also what regenerates #553 — the release workflow only fires on push to `dev`, so the PR will still show the old `2.0.0` proposal until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/554)
<!-- Reviewable:end -->
