### PR TITLE
ci: install cargo-near from a shared composite action

### DIFF
--- a/.github/actions/cargo-near/action.yml
+++ b/.github/actions/cargo-near/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: cargo-near release to install
     required: false
     default: 0.19.2
+  sha256:
+    description: SHA-256 of that release's x86_64-unknown-linux-gnu tarball
+    required: false
+    default: 4be2fef36808d94fbe224277add6183cb42f395bb2ce272aa35be8cc09bf3206
 runs:
   using: composite
   steps:
@@ -12,4 +16,19 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
-      run: curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/near/cargo-near/releases/download/cargo-near-v${VERSION}/cargo-near-installer.sh" | sh
+        SHA256: ${{ inputs.sha256 }}
+      run: |
+        set -euo pipefail
+        target=x86_64-unknown-linux-gnu
+        tarball="$(mktemp -d)/cargo-near.tar.gz"
+        bin="${HOME}/.cargo/bin"
+
+        curl --proto '=https' --tlsv1.2 -fsSL -o "$tarball" \
+          "https://github.com/near/cargo-near/releases/download/cargo-near-v${VERSION}/cargo-near-${target}.tar.gz"
+        # Upstream's own .sha256 gets replaced alongside a replaced tarball; the pin has to be ours.
+        echo "${SHA256}  ${tarball}" | sha256sum -c -
+
+        mkdir -p "$bin"
+        tar -xzf "$tarball" --strip-components=1 -C "$bin" "cargo-near-${target}/cargo-near"
+        echo "$bin" >> "$GITHUB_PATH"
+        "${bin}/cargo-near" --version

--- a/.github/actions/cargo-near/action.yml
+++ b/.github/actions/cargo-near/action.yml
@@ -1,0 +1,15 @@
+name: Install cargo-near
+description: Install the pinned cargo-near CLI from upstream's prebuilt release binaries.
+inputs:
+  version:
+    description: cargo-near release to install
+    required: false
+    default: 0.19.2
+runs:
+  using: composite
+  steps:
+    - name: Install cargo-near
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: curl --proto '=https' --tlsv1.2 -LsSf "https://github.com/near/cargo-near/releases/download/cargo-near-v${VERSION}/cargo-near-installer.sh" | sh

--- a/.github/workflows/gas-report.yml
+++ b/.github/workflows/gas-report.yml
@@ -42,8 +42,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - uses: ./.github/actions/rust
-      - name: Install cargo-near CLI
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.19.2/cargo-near-installer.sh | sh
+      - name: Install cargo-near
+        uses: ./.github/actions/cargo-near
       - name: Generate gas report
         id: generate
         env:

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -73,10 +73,7 @@ jobs:
 
       - name: Install cargo-near
         if: steps.catalog.outputs.build == 'true'
-        uses: taiki-e/install-action@cde8c9e634f4a17bc06b61413ac0ef75450eac46
-        with:
-          # Same version the rest of CI pins.
-          tool: cargo-near@0.19.2
+        uses: ./.github/actions/cargo-near
 
       - name: Build reproducibly at the tag
         id: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
         with:
           filters: |
             near_integration:
-              # This job is the only consumer of the cargo-near action.
+              # Every other cargo-near consumer gates on contract paths or tags.
               - '.github/actions/cargo-near/**'
               - '.github/workflows/test.yml'
               - '.config/nextest.toml'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -496,7 +496,7 @@ jobs:
           tool: nextest,just
 
       - name: Install cargo-near
-        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/near/cargo-near/releases/download/cargo-near-v0.19.2/cargo-near-installer.sh | sh
+        uses: ./.github/actions/cargo-near
 
       # Migration and upgrade tests deploy real historical bytes. Not an
       # `actions/cache` entry: a couple of MB from GitHub's own CDN, and the

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,8 @@ jobs:
         with:
           filters: |
             near_integration:
+              # This job is the only consumer of the cargo-near action.
+              - '.github/actions/cargo-near/**'
               - '.github/workflows/test.yml'
               - '.config/nextest.toml'
               - 'justfile'


### PR DESCRIPTION
The Release Artifacts workflow has been failing on every release tag
([run 30831832295](https://github.com/Templar-Protocol/contracts/actions/runs/30831832295/job/91747416373)):

```
error: cannot install package `cargo-near 0.19.2`, it requires rustc 1.88 or newer,
while the currently active rustc version is 1.86.0
```

## Cause

That job installed cargo-near through `taiki-e/install-action`. The action has no
prebuilt manifest entry for cargo-near, so it fell back to
`cargo install cargo-near --version 0.19.2 --locked` — building the CLI from source
under the toolchain the job pins at 1.86.0. cargo-near 0.19.2 requires rustc 1.88+,
so the install aborted before the reproducible build ever started.

The `test` and `gas-report` jobs were unaffected: both install upstream's prebuilt
binary via the release installer script, which does not care what rustc is active.

## Change

Extract that install into `.github/actions/cargo-near`, alongside the existing
`./.github/actions/rust`, and point all three call sites at it. The version is now
pinned once as an input default (`0.19.2`, overridable per-caller) rather than
duplicated across three URLs, and the "never build it from source" constraint lives
with the pin instead of being folklore one workflow had already drifted from.

## Verification

Workflows are only triggerable in CI, so this cannot be exercised locally. All four
files parse as YAML; actionlint is CI's check. The release path is confirmed by the
next release tag — note that tag-triggered workflows run from the tag's own commit,
so re-running the existing failed job will still use the old file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/555)
<!-- Reviewable:end -->
