### PR TITLE
chore(artifacts): record templar-registry-contract 1.2.3 release

### DIFF
--- a/contract/artifacts/releases/registry@1.2.3.tsv
+++ b/contract/artifacts/releases/registry@1.2.3.tsv
@@ -1,0 +1,1 @@
+registry	1.2.3	templar-registry-contract-v1.2.3	templar_registry_contract-1.2.3.wasm	6c940164a6900a9b80183fb2dd8896dd0329004b5993462691c2d26086f5c6d4


### PR DESCRIPTION
Records the release of `templar-registry-contract` 1.2.3, built for
`templar-registry-contract-v1.2.3`:

    6c940164a6900a9b80183fb2dd8896dd0329004b5993462691c2d26086f5c6d4

Until this merges, `templar-contract-artifacts` will not serve
templar-registry-contract 1.2.3 — an unrecorded version has no reviewed hash to
check downloaded bytes against.

Reproduce the bytes from a fresh clone:

    git checkout templar-registry-contract-v1.2.3
    cargo near build reproducible-wasm --manifest-path contract/registry/Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/558)
<!-- Reviewable:end -->
