### PR TITLE
chore(artifacts): record templar-proxy-oracle-near-governance-contract 0.3.0 release

### DIFF
--- a/contract/artifacts/releases/proxy-governance@0.3.0.tsv
+++ b/contract/artifacts/releases/proxy-governance@0.3.0.tsv
@@ -1,0 +1,1 @@
+proxy-governance	0.3.0	templar-proxy-oracle-near-governance-contract-v0.3.0	templar_proxy_oracle_near_governance_contract-0.3.0.wasm	6fe34f668a24a61f1c9c36bbb14b12a40471617ac78f7c4868b7b9a53f7f9074


### PR DESCRIPTION
Records the release of `templar-proxy-oracle-near-governance-contract` 0.3.0, built for
`templar-proxy-oracle-near-governance-contract-v0.3.0`:

    6fe34f668a24a61f1c9c36bbb14b12a40471617ac78f7c4868b7b9a53f7f9074

Until this merges, `templar-contract-artifacts` will not serve
templar-proxy-oracle-near-governance-contract 0.3.0 — an unrecorded version has no reviewed hash to
check downloaded bytes against.

Reproduce the bytes from a fresh clone:

    git checkout templar-proxy-oracle-near-governance-contract-v0.3.0
    cargo near build reproducible-wasm --manifest-path contract/proxy-oracle/near/governance-contract/Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/559)
<!-- Reviewable:end -->
