### PR TITLE
chore(artifacts): record templar-universal-account-contract 0.5.2 release

### DIFF
--- a/contract/artifacts/releases/universal-account@0.5.2.tsv
+++ b/contract/artifacts/releases/universal-account@0.5.2.tsv
@@ -1,0 +1,1 @@
+universal-account	0.5.2	templar-universal-account-contract-v0.5.2	templar_universal_account_contract-0.5.2.wasm	1cf9aa452033295638d476829f3e5feeefecd078cf5bb8318a422d7ff55f4414


### PR DESCRIPTION
Records the release of `templar-universal-account-contract` 0.5.2, built for
`templar-universal-account-contract-v0.5.2`:

    1cf9aa452033295638d476829f3e5feeefecd078cf5bb8318a422d7ff55f4414

Until this merges, `templar-contract-artifacts` will not serve
templar-universal-account-contract 0.5.2 — an unrecorded version has no reviewed hash to
check downloaded bytes against.

Reproduce the bytes from a fresh clone:

    git checkout templar-universal-account-contract-v0.5.2
    cargo near build reproducible-wasm --manifest-path contract/universal-account/Cargo.toml

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/560)
<!-- Reviewable:end -->
