### PR TITLE
test(artifacts): replace the newest-version pin with an ordering invariant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12912,6 +12912,7 @@ dependencies = [
  "reqwest 0.12.28",
  "rstest",
  "schemars 0.8.22",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/contract/artifacts/Cargo.toml
+++ b/contract/artifacts/Cargo.toml
@@ -32,6 +32,7 @@ tokio = { workspace = true, optional = true }
 
 [dev-dependencies]
 rstest.workspace = true
+semver = "1"
 serde_json.workspace = true
 tokio.workspace = true
 # Release policy is asserted against parsed TOML, not a substring search: a

--- a/contract/artifacts/src/catalog.rs
+++ b/contract/artifacts/src/catalog.rs
@@ -24,6 +24,37 @@ fn mocks_are_never_released() {
     }
 }
 
+/// `current()` is the last entry of `releases()`, so it names the newest
+/// release only while each list ascends — an order `build.rs` imposes rather
+/// than inherits from `read_dir`. By version, not by date: a 3.1.0 backported
+/// after 4.0.0 sorts before it, leaving `current()` at 4.0.0.
+#[test]
+fn releases_ascend_by_version() {
+    for artifact in ArtifactId::ALL.iter().map(|id| id.metadata()) {
+        let versions = artifact
+            .releases()
+            .iter()
+            .map(|release| {
+                // `build.rs` rejects any spelling this cannot parse.
+                semver::Version::parse(release.version).unwrap_or_else(|error| {
+                    panic!(
+                        "{}: release {} is not valid semver: {error}",
+                        artifact.package_name, release.version,
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+
+        assert!(
+            versions.is_sorted_by(|a, b| a < b),
+            "{}'s releases are not in strictly ascending version order: {:?}. \
+             `current()` would not be the newest release.",
+            artifact.package_name,
+            versions.iter().map(ToString::to_string).collect::<Vec<_>>(),
+        );
+    }
+}
+
 /// Parsed `release-plz.toml`.
 fn release_plz_config() -> toml::Value {
     let path = std::path::Path::new(env!("CARGO_WORKSPACE_DIR")).join("release-plz.toml");

--- a/contract/artifacts/src/lib.rs
+++ b/contract/artifacts/src/lib.rs
@@ -247,7 +247,5 @@ mod tests {
         // shape — the gateway's DTO projects what it needs.
         assert!(parsed.get("releases").is_none());
         assert_eq!(meta.releases()[0].version, "1.0.0");
-        // Newest *released* version — the crate's Cargo.toml is further ahead.
-        assert_eq!(meta.version(), Some("1.3.0"));
     }
 }


### PR DESCRIPTION
`test_artifact_metadata_serde` asserted `meta.version() == Some("1.3.0")` — the newest market release at the time it was written. Every release-recording PR moves that value, so recording market 1.4.2 (#557) turned both **Fast Tests** and the **Artifact Drift Check** red:

```
thread 'tests::test_artifact_metadata_serde' panicked at contract/artifacts/src/lib.rs:251:9:
  left: Some("1.4.2")
 right: Some("1.3.0")
```

Those PRs are generated by `release-artifacts.yml`, so nobody hand-authors the change that breaks the assertion — it gets rediscovered on every release.

## What this does

- **Drops the pin.** Newest-version was never that test's subject; it asserts serialized shape. The neighbouring `releases()[0].version == "1.0.0"` stays, because the *oldest* release never changes.
- **Adds `releases_ascend_by_version`** to `catalog.rs` — every artifact's releases ascend strictly by version. That is the property `current()` actually depends on, since it returns the last entry, and it holds no matter how many releases are recorded later.

Ordering is imposed by `build.rs` rather than inherited from `read_dir`, so it is by version and not by date: a 3.1.0 backported after 4.0.0 sorts before it, leaving `current()` at 4.0.0. The test's doc comment records that, since it isn't obvious from `current()`'s signature.

`catalog.rs` is the home because the invariant spans `build.rs` (which orders) and `ids.rs` (where `current()` takes the last element) — the compiled catalog is the only place both meet, and a build script has no access to `ArtifactId`.

## Verification

- Drift check green: 48 passed, 0 failed.
- Green with #557's `market@1.4.2.tsv` applied locally — the original failure is gone.
- **Teeth check:** reversing `build.rs`'s sort fails the new test with `templar-registry-contract's releases are not in strictly ascending version order: ["1.1.0", "1.0.0", "0.1.0"]`. Reverted; `build.rs` is untouched here.
- `cargo fmt` clean, clippy `-D warnings` exits 0.

`semver` is a dev-dependency only and was already in the graph via `cargo_metadata`, so `Cargo.lock` gains an edge, not a package.

## Note for #557

#557 needs a rebase or a check re-run once this lands — it was left as a pure one-file release record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/567)
<!-- Reviewable:end -->
