### PR TITLE
test(proxy-oracle): expect unserved price ids to be absent

### DIFF
--- a/contract/proxy-oracle/near/contract/tests/proxy_oracle.rs
+++ b/contract/proxy-oracle/near/contract/tests/proxy_oracle.rs
@@ -462,8 +462,8 @@ async fn update_and_list(
 fn assert_no_price(result: &OracleResponse, price_id: PriceIdentifier) {
     assert_eq!(
         result.get(&price_id),
-        Some(&None),
-        "{price_id:?} must read back with no price",
+        None,
+        "{price_id:?} is not served here, so it must be absent from the response",
     );
 }
 
@@ -577,10 +577,7 @@ async fn proxy_oracle(#[case] method: TestMethod) -> Result<()> {
     let result = harness
         .oracle_ema_prices(&proxy_oracle, vec![btc_proxy_id, CRYPTO_BTC_USD], 60)
         .await?;
-    assert_eq!(
-        result,
-        HashMap::from_iter([(btc_proxy_id, None), (CRYPTO_BTC_USD, None)]),
-    );
+    assert_eq!(result, HashMap::from_iter([(btc_proxy_id, None)]));
 
     // Step 1: Only redstone has a price. Single source -> same for both methods.
     harness
@@ -597,7 +594,7 @@ async fn proxy_oracle(#[case] method: TestMethod) -> Result<()> {
         60,
     )
     .await?;
-    assert_eq!(result.len(), 2);
+    assert_eq!(result.len(), 1);
     assert_eq!(
         result.get(&btc_proxy_id).unwrap().as_ref().map(norm_price),
         Some(100_000),
@@ -636,8 +633,9 @@ async fn proxy_oracle(#[case] method: TestMethod) -> Result<()> {
         60,
     )
     .await?;
-    // Four distinct ids requested: the repeats collapse in the response map.
-    assert_eq!(result.len(), 4);
+    // Four distinct ids requested: the repeats collapse in the response map, and the
+    // one that is not a proxy here is absent.
+    assert_eq!(result.len(), 3);
     assert_no_price(&result, CRYPTO_BTC_USD);
     let expected_btc_2source = match method {
         TestMethod::MedianLow => 90_000,
@@ -681,7 +679,7 @@ async fn proxy_oracle(#[case] method: TestMethod) -> Result<()> {
         60,
     )
     .await?;
-    assert_eq!(result.len(), 2);
+    assert_eq!(result.len(), 1);
     assert_no_price(&result, CRYPTO_BTC_USD);
     let expected_btc_3source = match method {
         TestMethod::MedianLow => 90_000,
@@ -706,7 +704,7 @@ async fn proxy_oracle(#[case] method: TestMethod) -> Result<()> {
         60,
     )
     .await?;
-    assert_eq!(result.len(), 2);
+    assert_eq!(result.len(), 1);
     assert_eq!(
         result.get(&btc_proxy_id).unwrap().as_ref().map(norm_price),
         Some(80_000),


### PR DESCRIPTION
Fixes the two red tests on `dev`: `proxy_oracle::case_1_median_low` and `proxy_oracle::case_2_priority` (NEAR Integration Tests, run 30914867854).

## Cause

A semantic conflict between two PRs that merged about an hour apart, neither of which ran CI against the other:

- **#564** (`d0f98a8c`, ENG-472) ported the proxy-oracle tests onto the gateway client. Its assertions assume `pyth.listEmaPricesNoOlderThan` returns one entry per *requested* id, filling `None` where the raw view omits one. Its own Test run was cancelled as superseded, so it merged unverified.
- **#540** (`d05006af`, ENG-537) changed exactly that in `prices_in_request_order`, from `.map(… unwrap_or(None))` to `.filter_map(…)`, so an identifier the oracle does not serve is distinguishable from one it serves with no recent price.

Git merged both cleanly. First red run is `d05006af`; last green is `ca860b4a`.

## Change

Tests only. `CRYPTO_BTC_USD` is requested throughout as a negative control — a *source* price id on the underlying pyth mock, never a proxy configured on this oracle — so it is now expected to be absent from the response rather than present with `None`:

- `assert_no_price` asserts absence.
- The first negative-control assertion drops its `(CRYPTO_BTC_USD, None)` entry.
- Four `result.len()` counts adjusted (2→1 ×3, 4→3).

#540's semantics are the deliberate ones and are kept. The contract is unchanged and needed no change: `list_ema_prices_no_older_than` has skipped ids with no configured proxy since `bdce73a2` (2026-05-28) — the gateway used to paper over that.

CI only ever reached the first assertion before aborting, so the four `len()` counts further down were fixed in the same pass rather than surfacing on the next run.

## Verification

`just test-sandbox -p templar-proxy-oracle-near-contract` → 25 passed, 2 skipped, both previously-failing cases green. `cargo fmt` and `cargo clippy --tests -- -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/569)
<!-- Reviewable:end -->
