### PR TITLE
fix(manager): raise GOVERNANCE_DEPOSIT to 4.5 NEAR (ENG-574)

### DIFF
--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -39,11 +39,11 @@ use crate::spec::{
 /// rather than from the market.
 ///
 /// The registry refuses a deposit below `1e19 * code.len()`, and the market's is
-/// the last step — undersized there, it fails after 8.5 NEAR is spent. Each keeps
+/// the last step — undersized there, it fails after 9.9 NEAR is spent. Each keeps
 /// 50 KB of headroom over its pinned release, held there by
 /// `requires_network_deposits_cover_the_released_artifacts`. Over-provisioning
 /// burns nothing: the deposit is forwarded to the account being created.
-const GOVERNANCE_DEPOSIT: NearToken = NearToken::from_near(4);
+const GOVERNANCE_DEPOSIT: NearToken = NearToken::from_millinear(4_500);
 const ORACLE_DEPOSIT: NearToken = NearToken::from_millinear(5_400);
 const MARKET_DEPOSIT: NearToken = NearToken::from_millinear(5_800);
 
@@ -449,7 +449,7 @@ pub(crate) async fn build(
 
         // The proposals are created and executed by `signer_id`, but only
         // `governance.admin` is granted the Admin role at init. Mismatched, the two
-        // registry deploys succeed and every proposal reverts — 8.5 NEAR spent on
+        // registry deploys succeed and every proposal reverts — 9.9 NEAR spent on
         // exactly the orphaned half-deployment this tool exists to prevent.
         // The retired shell deploy made this unrepresentable: it passed the
         // signer as the admin.
@@ -482,7 +482,7 @@ pub(crate) async fn build(
 
     // Re-run here, not left to the `config.validate` check: that check is
     // skippable, and the market enforces this at init. Skipping it can only buy
-    // an 8.5 NEAR half-deployment that reverts on the last step.
+    // a 9.9 NEAR half-deployment that reverts on the last step.
     configuration
         .validate()
         .map_err(|error| anyhow::anyhow!("{error}"))
@@ -1259,7 +1259,7 @@ mod tests {
 
     /// The registry refuses `deposit < 1e19 * code.len()`, so a contract that
     /// outgrows its constant fails the deploy — the market's on the last step,
-    /// after 8.5 NEAR is spent. Releasing a larger contract must therefore break
+    /// after 9.9 NEAR is spent. Releasing a larger contract must therefore break
     /// a test, not a deployment.
     ///
     /// Network-gated: the released bytes are fetched, not vendored. Cached after


### PR DESCRIPTION
## What

`GOVERNANCE_DEPOSIT` 4 NEAR → 4.5 NEAR.

ProxyGovernance 0.3.0 is 354,904 bytes, so the registry's `1e19 * code.len()` floor is 3.54904 NEAR. A 4 NEAR deposit left 45,096 bytes of headroom against the 50 KB the constant promises, so `requires_network_deposits_cover_the_released_artifacts::case_1` was red on `dev`. 4.5 NEAR restores ~95 KB.

Introduced by the 0.3.0 governance release (`b2cf4aef`), not by any market work. Deploys were never broken — 4 NEAR still cleared the floor. The guard fires early by design: governance is the first step, the market is the last, and an undersized deposit there fails after 9.9 NEAR is already spent.

Sibling headroom, for context: ProxyOracle 0.3.0 is 484,112 B against 5.4 NEAR (~55.9 KB); Market 1.4.2 is 521,031 B against 5.8 NEAR (~59.0 KB).

Also corrects four comments still quoting the pre-market total as 8.5 NEAR. It is 9.9 (governance + oracle), and 8.5 was already stale before this change.

## Verification

- `requires_network_deposits_cover_the_released_artifacts` — 3/3 (`case_1` was the failure)
- full `templar-manager` suite — 265/265
- `cargo fmt --all --check`; `cargo clippy -p templar-manager --all-targets -- -D warnings`

`GOVERNANCE_DEPOSIT` is a private const referenced only in `plan.rs`, and no fixture pins the old yoctoNEAR value, so the blast radius is this crate.

## Not in scope

The guard runs in no CI gate — `requires_network_*` is excluded from both `fast_filter` and `sandbox_test_filter` (`justfile:29-30`) and no workflow runs the network partition — which is why a release outgrew the constant unnoticed. Tracked in ENG-575, which closes that gap by recording asset byte length in the artifact catalog so the guard drops its network dependency and moves into the fast gate.

Closes ENG-574.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/571)
<!-- Reviewable:end -->
