### PR TITLE
test(manager): drive the migrated-spec test from the recordings (ENG-573)

### DIFF
--- a/tools/manager/fixtures/deployed/README.md
+++ b/tools/manager/fixtures/deployed/README.md
@@ -11,12 +11,16 @@ recording *and* decrementing both: the `#[case]`s on
 `migrated_specs_reproduce_their_deployed_configurations`
 (`tools/manager/src/tests/spec.rs`) and the total in
 `contract/market/src/tests.rs::parse_configurations`. Delete the market's
-subdirectory too, if it has one — nothing counts those files.
+subdirectory with it — no count covers those files, so nothing will tell you one
+is orphaned.
 
-Proxy-mode deployments also keep their `proxy-collateral.json` /
-`proxy-borrow.json` in such a subdirectory. Only the two alpha markets named in
-`src/tests/export.rs` and `derived_proxies_match_the_deployed_proxy_files` are
-read; the rest are kept as a record of what was deployed.
+Proxy-mode deployments keep their `proxy-collateral.json` / `proxy-borrow.json`
+in that subdirectory. Only `iethfxrp-ixlmusdc` and `iethwbtc-ixlmusdc` are read:
+by `derived_proxies_match_the_deployed_proxy_files`, and by
+`src/tests/export.rs`, which round-trips against a `market-args.json` those two
+keep as a duplicate of their top-level recording — edit one copy and not the
+other and both tests stay green on inconsistent data. The other eleven
+subdirectories are read by nothing.
 
 This is **test data, not a deployment path**. The files that made it one —
 `script/deploy.sh` and each market's `env.sh` — were deleted with the migration;

--- a/tools/manager/fixtures/deployed/README.md
+++ b/tools/manager/fixtures/deployed/README.md
@@ -1,12 +1,22 @@
 # Deployed configurations, as they were at migration
 
-The `market-args.json` each market was deployed with — 18 under `alpha/`, 27
-under `v1/` — kept as the regression corpus for ENG-548: every spec under
-`deployments/` must still reproduce the configuration recorded here.
+One `<market>.<registry>.json` per market — the init args it was deployed with —
+kept as the regression corpus for ENG-548: every configuration recorded here
+must still be reproduced by its spec under `deployments/`. The converse does not
+hold; a spec whose market is not yet on chain has nothing to record and is
+covered by no test.
+
+Two tests pin the size of this corpus, so retiring a market means deleting its
+recording *and* decrementing both: the `#[case]`s on
+`migrated_specs_reproduce_their_deployed_configurations`
+(`tools/manager/src/tests/spec.rs`) and the total in
+`contract/market/src/tests.rs::parse_configurations`. Delete the market's
+subdirectory too, if it has one — nothing counts those files.
 
 Proxy-mode deployments also keep their `proxy-collateral.json` /
-`proxy-borrow.json` in a subdirectory, so the derived oracle configuration is
-checked against the deployed one too.
+`proxy-borrow.json` in such a subdirectory. Only the two alpha markets named in
+`src/tests/export.rs` and `derived_proxies_match_the_deployed_proxy_files` are
+read; the rest are kept as a record of what was deployed.
 
 This is **test data, not a deployment path**. The files that made it one —
 `script/deploy.sh` and each market's `env.sh` — were deleted with the migration;

--- a/tools/manager/src/tests/spec.rs
+++ b/tools/manager/src/tests/spec.rs
@@ -508,8 +508,11 @@ fn sources_check_catches_an_unsatisfiable_minimum() {
     );
 }
 
-/// Every migrated market must reproduce the configuration it was generated
-/// from. Counts are asserted so an empty directory fails rather than passing
+/// A spec must not drift from the market it already deploys — `market apply`
+/// would turn that drift into an unintended config change.
+///
+/// Driven by the recordings, so a spec with no recording is exercised by no test
+/// at all. Counts are asserted so an empty directory fails rather than passing
 /// vacuously.
 #[rstest]
 #[case("alpha", "templar-alpha.near", 18)]
@@ -522,23 +525,27 @@ fn migrated_specs_reproduce_their_deployed_configurations(
     let manifest = Path::new(env!("CARGO_MANIFEST_DIR"));
     let specs = manifest.join("../../deployments").join(suite);
     let configs = manifest.join("fixtures/deployed").join(suite);
+    let suffix = format!(".{registry}.json");
 
     let mut checked = 0;
-    for entry in std::fs::read_dir(&specs).unwrap_or_else(|e| panic!("read {suite} specs: {e}")) {
-        let path = entry.expect("readable entry").path();
-        if path.extension().is_none_or(|ext| ext != "toml") {
+    for entry in std::fs::read_dir(&configs).unwrap_or_else(|e| panic!("read {suite} configs: {e}"))
+    {
+        let recorded = entry.expect("readable entry").path();
+        // Proxy-mode markets keep their `proxy-*.json` in a subdirectory.
+        if recorded.is_dir() {
             continue;
         }
-        let name = path
-            .file_stem()
-            .expect("spec has a stem")
-            .to_string_lossy()
-            .to_string();
+        // Skipping an unrecognized name instead would leave it uncompared.
+        let name = recorded
+            .file_name()
+            .and_then(|name| name.to_str())
+            .and_then(|name| name.strip_suffix(&suffix))
+            .unwrap_or_else(|| panic!("{} is not named <market>{suffix}", recorded.display()));
 
-        let spec = extends::load(&path).unwrap_or_else(|e| panic!("load {name}: {e:#}"));
-        let source = configs.join(format!("{name}.{registry}.json"));
+        let spec = extends::load(&specs.join(format!("{name}.toml")))
+            .unwrap_or_else(|e| panic!("load {name}: {e:#}"));
         let deployed: Value = serde_json::from_str(
-            &std::fs::read_to_string(&source)
+            &std::fs::read_to_string(&recorded)
                 .unwrap_or_else(|e| panic!("read config for {name}: {e}")),
         )
         .unwrap_or_else(|e| panic!("parse config for {name}: {e}"));
@@ -572,5 +579,8 @@ fn migrated_specs_reproduce_their_deployed_configurations(
         checked += 1;
     }
 
-    assert_eq!(checked, expected, "every {suite} market must be covered");
+    assert_eq!(
+        checked, expected,
+        "every recorded {suite} configuration must be covered"
+    );
 }


### PR DESCRIPTION
Closes ENG-573. Unblocks ENG-485 / #570.

`migrated_specs_reproduce_their_deployed_configurations` walked `deployments/<suite>/*.toml` and demanded a recorded deploy-args fixture at `fixtures/deployed/<suite>/<name>.<registry>.json` for every spec it found, plus a hardcoded count (18 alpha / 27 v1). That held only while every spec was migrated from a market already on chain. #570 authors two specs before their markets exist, and the fast gate fails:

```
read config for ixlmdejaaa-ixlmusdc-1: No such file or directory (os error 2)
```

Both target accounts are `UNKNOWN_ACCOUNT` on mainnet, so there is nothing to record, and adding fixtures would trip the count anyway (29 vs 27).

This iterates the recordings instead and looks up the spec. The invariant that matters is preserved — a spec must not drift from the market it already deploys, which `market apply` would otherwise turn into an unintended config change — and the counts stop needing a bump per deployment.

## Stricter than the issue asked

A recording whose filename does not match `<market>.<registry>.json` is a panic naming the file, not a skip. Under a plain skip, a misnamed recording (`.JSON`, wrong suite directory) would leave the count at 27 and pass uncompared — a hole the old spec-driven walk did not have.

## The corpus is untouched

It is also the serde regression corpus for `contract/market/src/tests.rs::parse_configurations` (45 configs), and the oracle for `reproduces_the_live_alpha_market_configuration`, `derived_proxies_match_the_deployed_proxy_files`, and the `market export` round-trip. All still green.

Its README stated the invariant this change inverts, so it is rewritten. Two pre-existing inaccuracies went with it: the files are not named `market-args.json`, and only 2 of the 13 proxy subdirectories are read by any test. The second commit corrects a claim I got wrong on the first pass — those two alpha subdirectories *do* carry a `market-args.json`, byte-identical to the top-level recording, which `src/tests/export.rs` reads instead of the original.

## Verification

| Criterion | Evidence |
|---|---|
| Driven by `fixtures/deployed/` | `read_dir(&configs)`; no `read_dir` on `deployments` |
| Counts unchanged 18/27 | both `#[case]`s pass; a vacuous run trips the count assert |
| Missing spec still fails | `load izec-ixlmusdc: spec file not found: …/deployments/v1/izec-ixlmusdc.toml` |
| Drifted spec still fails | `assertion left == right failed: spec 'izec-isolusdc' differs from what is deployed` |
| Misnamed recording fails | `…/izec-ixlmusdc.v1.tmplr.near.JSON is not named <market>.v1.tmplr.near.json` |
| #570 unblocked | its two `-1` specs checked into the tree → both cases pass, `checked == 27` |

Each failure mode was produced by breaking the tree deliberately and restoring it. Full fast gate: 5266 passed. `cargo fmt --all --check` and `cargo clippy -p templar-manager --tests -- -D warnings` clean. The sandbox gate was not run — the change is confined to the fast partition and touches no node-backed test.

#570 still needs its own rebase to go green in CI; what is verified here is that its specs no longer trip this test.

## Known gap, deliberately not closed

A spec with no recording is now exercised by no test, so a new spec with a typo'd key or a bad `extends` reaches CI green. ENG-573 scopes the fix out by name (a `deployments/*` sweep asserting every spec loads, converts, and passes `check::run_offline`, with no count coupling). The test's doc comment states the gap outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/572)
<!-- Reviewable:end -->
