### PR TITLE
feat(artifacts): record released artifact byte length in the catalog

### DIFF
--- a/.github/workflows/catalog-pr.yml
+++ b/.github/workflows/catalog-pr.yml
@@ -139,10 +139,10 @@ jobs:
           # an exact replay. That is what lets every run consider every live row
           # without having to know which ones it has already recorded.
           for row in "${rows[@]}"; do
-            IFS=$'\t' read -r artifact version tag asset sha < "$row"
+            IFS=$'\t' read -r artifact version tag asset sha length < "$row"
             cargo run --quiet -p templar-contract-artifacts \
               --features workspace-loader,clap --bin record-release -- \
-              "$artifact" "$version" "$tag" "$asset" "$sha"
+              "$artifact" "$version" "$tag" "$asset" "$sha" "$length"
           done
 
           # build.rs validates the rows, but only at compile time — so compile,
@@ -164,7 +164,7 @@ jobs:
             git diff --cached --name-only --diff-filter=A -- contract/artifacts/releases |
               sort |
               while read -r file; do
-                IFS=$'\t' read -r artifact version tag _asset _sha < "$file"
+                IFS=$'\t' read -r artifact version tag _asset _sha _length < "$file"
                 printf -- '- %s %s (%s)\n' "$artifact" "$version" "$tag"
               done
           } > "${RUNNER_TEMP}/commit-message"
@@ -183,13 +183,14 @@ jobs:
               "published, one file per release under" \
               "\`contract/artifacts/releases/\`:" \
               "" \
-              "| Artifact | Version | Tag | SHA-256 |" \
-              "| --- | --- | --- | --- |"
+              "| Artifact | Version | Tag | SHA-256 | Bytes |" \
+              "| --- | --- | --- | --- | --- |"
             git diff --name-only --diff-filter=A origin/dev HEAD -- contract/artifacts/releases |
               sort |
               while read -r file; do
-                IFS=$'\t' read -r artifact version tag _asset sha < "$file"
-                printf '| `%s` | %s | `%s` | `%s` |\n' "$artifact" "$version" "$tag" "$sha"
+                IFS=$'\t' read -r artifact version tag _asset sha length < "$file"
+                printf '| `%s` | %s | `%s` | `%s` | %s |\n' \
+                  "$artifact" "$version" "$tag" "$sha" "$length"
               done
             printf '%s\n' \
               "" \

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -3,7 +3,8 @@ name: Release Artifacts
 # Cuts a contract's canonical WASM — the only way a release blob is produced.
 # On a release tag: build in the pinned NEP-330 image at that tag's commit,
 # upload it to the GitHub Release, and hand the catalog row — tag, asset,
-# digest — to `catalog-pr.yml`, which records the whole release batch at once.
+# digest, length — to `catalog-pr.yml`, which records the whole release batch at
+# once.
 # Why at the tag, and why the record lands a commit later, are in "Contract WASM
 # artifacts" in RELEASING.md.
 
@@ -94,8 +95,12 @@ jobs:
           # From checksums.txt, so the digest pinned in the catalog is by
           # construction the one published on the Release.
           sha=$(cut -d' ' -f1 < dist/checksums.txt)
-          echo "sha256=${sha}" >> "$GITHUB_OUTPUT"
-          echo "Built ${TARGET} ${VERSION} at $(git rev-parse HEAD): ${sha}"
+          length=$(wc -c < "dist/${ASSET}")
+          {
+            echo "sha256=${sha}"
+            echo "length=${length}"
+          } >> "$GITHUB_OUTPUT"
+          echo "Built ${TARGET} ${VERSION} at $(git rev-parse HEAD): ${sha} (${length} bytes)"
 
       - name: Attach the WASM to the release
         if: steps.catalog.outputs.build == 'true'
@@ -150,8 +155,8 @@ jobs:
             gh release upload "$REF_NAME" "$file"
           done
 
-      # The hash is taken from the bytes this job just built, so the catalog
-      # entry attests the CI build output rather than a re-download.
+      # The hash and length are taken from the bytes this job just built, so the
+      # catalog entry attests the CI build output rather than a re-download.
       - name: Write the catalog row
         id: row
         if: steps.catalog.outputs.build == 'true'
@@ -161,6 +166,7 @@ jobs:
           VERSION: ${{ steps.catalog.outputs.version }}
           ASSET: ${{ steps.catalog.outputs.asset }}
           SHA256: ${{ steps.build.outputs.sha256 }}
+          LENGTH: ${{ steps.build.outputs.length }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           set -euo pipefail
@@ -169,7 +175,7 @@ jobs:
           # would recompile from cold rather than relink.
           cargo run --quiet -p templar-contract-artifacts \
             --features workspace-loader,clap --bin record-release -- \
-            "$ARTIFACT" "$VERSION" "$REF_NAME" "$ASSET" "$SHA256"
+            "$ARTIFACT" "$VERSION" "$REF_NAME" "$ASSET" "$SHA256" "$LENGTH"
 
           # build.rs validates the row, but only at compile time — so compile
           # here, where the failure names the release that caused it.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -169,7 +169,8 @@ does not recognise.
    builds the contract in the pinned NEP-330 Docker image **at that tag's
    commit**, uploads `<target>-<version>.wasm` plus `checksums.txt` to the
    GitHub Release, and hands over one catalog row — the version, the tag, the
-   asset, and the digest of the bytes it just built, each recorded as observed.
+   asset, and the digest and byte length of the bytes it just built, each
+   recorded as observed.
 
 3. Each of those builds finishing fires
    [`catalog-pr.yml`](.github/workflows/catalog-pr.yml), which commits every row

--- a/contract/artifacts/README.md
+++ b/contract/artifacts/README.md
@@ -22,7 +22,7 @@ Templar Protocol smart contracts.
 |----------------------|-------------------------------------------------------------------|
 | *(default)*          | Artifact IDs and metadata only. No dependencies beyond `sha2`, `hex`, `thiserror`. No WASM bytes. |
 | `workspace-loader`   | Read WASM from `target/near/{name}/{name}.wasm` at runtime. Provides `cargo near build` helper. |
-| `fetch`              | Download *released* WASM from its GitHub Release into a shared local cache, verified against the catalog's SHA-256 pin. |
+| `fetch`              | Download *released* WASM from its GitHub Release into a shared local cache, verified against the catalog's byte length and SHA-256 pin. |
 | `clap`               | CLI-friendly `ValueEnum` parsing for artifact IDs and package-name aliases. |
 
 Default features do **not** embed WASM bytes or depend on heavy build
@@ -111,11 +111,11 @@ the current checkout did not ask for.
 
 ### Trust
 
-Downloaded bytes are verified against the SHA-256 pinned in the catalog and
-discarded on mismatch. That pin is a reviewed, in-repo value, so artifact
-integrity does **not** rest on GitHub serving the right file — the same standard
-git already gives the source, whose objects are content-addressed and mirrored
-by every clone.
+Downloaded bytes are verified against the byte length and SHA-256 pinned in the
+catalog and discarded on mismatch. That pin is a reviewed, in-repo value, so
+artifact integrity does **not** rest on GitHub serving the right file — the same
+standard git already gives the source, whose objects are content-addressed and
+mirrored by every clone.
 
 A version that has not been recorded as a release cannot be fetched at all:
 there is no reviewed hash to check it against.
@@ -171,9 +171,10 @@ Seconds, no contract builds:
 | `internal_crates_are_excluded_from_releases` | a crate whose manifest forbids publishing that release-plz would still tag |
 | `no_tier_can_reach_a_registry` | `release-plz.toml` losing the one setting that defers crates.io |
 
-Each file's own shape — column count, canonical artifact and version spelling,
-URL-safe tag and asset, digest, and agreement with its filename — is checked by
-`build.rs`, so a malformed record fails the build rather than a download.
+Each file's own shape — column count, canonical artifact, version and length
+spelling, URL-safe tag and asset, digest, and agreement with its filename — is
+checked by `build.rs`, so a malformed record fails the build rather than a
+download.
 
 What this does **not** check is whether the bytes match what the source actually
 compiles to. That needs a reproducible rebuild, which runs on release tags in

--- a/contract/artifacts/RELEASES.md
+++ b/contract/artifacts/RELEASES.md
@@ -4,14 +4,15 @@ Under `releases/`, one file per release named `<artifact>@<version>.tsv`, holdin
 tab-separated row:
 
 ```text
-artifact  version  tag  asset  sha256
+artifact  version  tag  asset  sha256  length
 ```
 
 Appended to by CI when a release tag is cut — never edited by hand. `tag` and
-`asset` are recorded as observed rather than derived; see `ArtifactRelease` in
-`src/ids.rs`. Everything here was recovered from code actually deployed on
-NEAR mainnet, each tag pointing at the commit its WASM names in NEP-330
-metadata.
+`asset` are recorded as observed rather than derived, and `length` is the
+asset's size in bytes, which is what lets a deposit be sized without
+downloading it; see `ArtifactRelease` in `src/ids.rs`. Everything here was
+recovered from code actually deployed on NEAR mainnet, each tag pointing at the
+commit its WASM names in NEP-330 metadata.
 
 `build.rs` reads this directory, validates every row, and compiles the
 catalog. Filenames are for uniqueness and browsing only: each file is

--- a/contract/artifacts/build.rs
+++ b/contract/artifacts/build.rs
@@ -7,7 +7,7 @@
 use std::{collections::BTreeMap, fmt::Write as _, path::Path};
 
 const SOURCE: &str = "releases";
-const COLUMNS: usize = 5;
+const COLUMNS: usize = 6;
 
 fn main() {
     println!("cargo:rerun-if-changed={SOURCE}");
@@ -54,8 +54,13 @@ fn main() {
         for release in releases {
             write!(
                 generated,
-                "ArtifactRelease {{ version: {:?}, tag: {:?}, asset: {:?}, sha256: {:?} }},",
-                release.version, release.tag, release.asset, release.sha256,
+                "ArtifactRelease {{ version: {:?}, tag: {:?}, asset: {:?}, sha256: {:?}, \
+                 length: {} }},",
+                release.version,
+                release.tag,
+                release.asset,
+                release.sha256,
+                digit_groups(release.length),
             )
             .expect("writing to a String");
         }
@@ -77,6 +82,7 @@ struct Release {
     tag: String,
     asset: String,
     sha256: String,
+    length: usize,
 }
 
 fn parse(path: &Path) -> Release {
@@ -88,7 +94,7 @@ fn parse(path: &Path) -> Release {
     assert!(
         fields.len() == COLUMNS,
         "{name}: expected {COLUMNS} tab-separated fields, found {}. Columns are \
-         artifact, version, tag, asset, sha256.",
+         artifact, version, tag, asset, sha256, length.",
         fields.len()
     );
 
@@ -98,6 +104,8 @@ fn parse(path: &Path) -> Release {
         tag: fields[2].to_owned(),
         asset: fields[3].to_owned(),
         sha256: fields[4].to_ascii_lowercase(),
+        length: byte_length(fields[5])
+            .unwrap_or_else(|| panic!("{name}: length `{}` is not a plain byte count", fields[5])),
     };
 
     assert!(
@@ -139,6 +147,30 @@ fn parse(path: &Path) -> Release {
     );
 
     release
+}
+
+/// `221984` -> `221_984`, the spelling `clippy::unreadable_literal` asks for in
+/// the generated catalog.
+fn digit_groups(value: usize) -> String {
+    let digits = value.to_string();
+    let mut grouped = String::with_capacity(digits.len() + (digits.len() - 1) / 3);
+    for (index, digit) in digits.chars().enumerate() {
+        if index > 0 && (digits.len() - index) % 3 == 0 {
+            grouped.push('_');
+        }
+        grouped.push(digit);
+    }
+    grouped
+}
+
+/// A released asset's size in bytes.
+///
+/// `None` unless canonically spelled, and never zero: `0400000` and `+400000`
+/// parse, but neither is what `wc -c` reports, so both mean the row was written
+/// by something other than the release build.
+fn byte_length(length: &str) -> Option<usize> {
+    let value = length.parse::<usize>().ok()?;
+    (value.to_string() == length && value > 0).then_some(value)
 }
 
 /// Orders versions numerically, so `0.10.0` follows `0.9.0`.

--- a/contract/artifacts/releases/lst-oracle@1.0.0.tsv
+++ b/contract/artifacts/releases/lst-oracle@1.0.0.tsv
@@ -1,1 +1,1 @@
-lst-oracle	1.0.0	templar-lst-oracle-contract-v1.0.0	templar_lst_oracle_contract-1.0.0.wasm	4d650b07ec9ccc3aaafc765f6970e2c60dde1ba23f25ef05d23ddd2178a157a3
+lst-oracle	1.0.0	templar-lst-oracle-contract-v1.0.0	templar_lst_oracle_contract-1.0.0.wasm	4d650b07ec9ccc3aaafc765f6970e2c60dde1ba23f25ef05d23ddd2178a157a3	221984

--- a/contract/artifacts/releases/market@1.0.0.tsv
+++ b/contract/artifacts/releases/market@1.0.0.tsv
@@ -1,1 +1,1 @@
-market	1.0.0	templar-market-contract-v1.0.0	templar_market_contract-1.0.0.wasm	0b78aefdae1bb76148602252dd6b7db2014d99ef3b7f93a764c54d7ebe97a392
+market	1.0.0	templar-market-contract-v1.0.0	templar_market_contract-1.0.0.wasm	0b78aefdae1bb76148602252dd6b7db2014d99ef3b7f93a764c54d7ebe97a392	488494

--- a/contract/artifacts/releases/market@1.1.0.tsv
+++ b/contract/artifacts/releases/market@1.1.0.tsv
@@ -1,1 +1,1 @@
-market	1.1.0	templar-market-contract-v1.1.0	templar_market_contract-1.1.0.wasm	2bc028a722ccacd8aa23fe50a83c395716c920bf724b0d054a1ede3f2e4fae77
+market	1.1.0	templar-market-contract-v1.1.0	templar_market_contract-1.1.0.wasm	2bc028a722ccacd8aa23fe50a83c395716c920bf724b0d054a1ede3f2e4fae77	488329

--- a/contract/artifacts/releases/market@1.2.1.tsv
+++ b/contract/artifacts/releases/market@1.2.1.tsv
@@ -1,1 +1,1 @@
-market	1.2.1	templar-market-contract-v1.2.1	templar_market_contract-1.2.1.wasm	c9752de38ed140645e9a8d4a55dc89835b113609e27bb63ce134b5e598bc69b8
+market	1.2.1	templar-market-contract-v1.2.1	templar_market_contract-1.2.1.wasm	c9752de38ed140645e9a8d4a55dc89835b113609e27bb63ce134b5e598bc69b8	507746

--- a/contract/artifacts/releases/market@1.3.0.tsv
+++ b/contract/artifacts/releases/market@1.3.0.tsv
@@ -1,1 +1,1 @@
-market	1.3.0	templar-market-contract-v1.3.0	templar_market_contract-1.3.0.wasm	40e56aaf3627f1cb13656e696d382e64d7bb3e97420a049c20ae294d4f64fe97
+market	1.3.0	templar-market-contract-v1.3.0	templar_market_contract-1.3.0.wasm	40e56aaf3627f1cb13656e696d382e64d7bb3e97420a049c20ae294d4f64fe97	508680

--- a/contract/artifacts/releases/market@1.4.2.tsv
+++ b/contract/artifacts/releases/market@1.4.2.tsv
@@ -1,1 +1,1 @@
-market	1.4.2	templar-market-contract-v1.4.2	templar_market_contract-1.4.2.wasm	843cbf0dfe1affa6f1ec413b0d0732eb24b8d341bba152a5a4b92f671be123bd
+market	1.4.2	templar-market-contract-v1.4.2	templar_market_contract-1.4.2.wasm	843cbf0dfe1affa6f1ec413b0d0732eb24b8d341bba152a5a4b92f671be123bd	521031

--- a/contract/artifacts/releases/proxy-governance@0.1.0.tsv
+++ b/contract/artifacts/releases/proxy-governance@0.1.0.tsv
@@ -1,1 +1,1 @@
-proxy-governance	0.1.0	templar-proxy-oracle-near-governance-contract-v0.1.0	templar_proxy_oracle_near_governance_contract-0.1.0.wasm	09ecfafa86bfdca5e05b9174590cd056d59bf3a9d8727e9d452cfb98701334b0
+proxy-governance	0.1.0	templar-proxy-oracle-near-governance-contract-v0.1.0	templar_proxy_oracle_near_governance_contract-0.1.0.wasm	09ecfafa86bfdca5e05b9174590cd056d59bf3a9d8727e9d452cfb98701334b0	347426

--- a/contract/artifacts/releases/proxy-governance@0.3.0.tsv
+++ b/contract/artifacts/releases/proxy-governance@0.3.0.tsv
@@ -1,1 +1,1 @@
-proxy-governance	0.3.0	templar-proxy-oracle-near-governance-contract-v0.3.0	templar_proxy_oracle_near_governance_contract-0.3.0.wasm	6fe34f668a24a61f1c9c36bbb14b12a40471617ac78f7c4868b7b9a53f7f9074
+proxy-governance	0.3.0	templar-proxy-oracle-near-governance-contract-v0.3.0	templar_proxy_oracle_near_governance_contract-0.3.0.wasm	6fe34f668a24a61f1c9c36bbb14b12a40471617ac78f7c4868b7b9a53f7f9074	354904

--- a/contract/artifacts/releases/proxy-oracle@0.1.0.tsv
+++ b/contract/artifacts/releases/proxy-oracle@0.1.0.tsv
@@ -1,1 +1,1 @@
-proxy-oracle	0.1.0	templar-proxy-oracle-near-contract-v0.1.0	templar_proxy_oracle_near_contract-0.1.0.wasm	e877687e2d6f51db824bde12348938b3374f526301811df3ee118af38b856f35
+proxy-oracle	0.1.0	templar-proxy-oracle-near-contract-v0.1.0	templar_proxy_oracle_near_contract-0.1.0.wasm	e877687e2d6f51db824bde12348938b3374f526301811df3ee118af38b856f35	329084

--- a/contract/artifacts/releases/proxy-oracle@0.3.0.tsv
+++ b/contract/artifacts/releases/proxy-oracle@0.3.0.tsv
@@ -1,1 +1,1 @@
-proxy-oracle	0.3.0	templar-proxy-oracle-near-contract-v0.3.0	templar_proxy_oracle_near_contract-0.3.0.wasm	d2e62c4566c98e55121a5aad32e0e5b8cfb911f82aca71dbaeaa83794fed9e8e
+proxy-oracle	0.3.0	templar-proxy-oracle-near-contract-v0.3.0	templar_proxy_oracle_near_contract-0.3.0.wasm	d2e62c4566c98e55121a5aad32e0e5b8cfb911f82aca71dbaeaa83794fed9e8e	484112

--- a/contract/artifacts/releases/pyth-lazer-adapter@0.1.0.tsv
+++ b/contract/artifacts/releases/pyth-lazer-adapter@0.1.0.tsv
@@ -1,1 +1,1 @@
-pyth-lazer-adapter	0.1.0	templar-pyth-lazer-adapter-contract-v0.1.0	templar_pyth_lazer_adapter_contract-0.1.0.wasm	ff51847ea292271775db9bf8207e7f30c5a6a426b277a71ebe78f8c4850a451f
+pyth-lazer-adapter	0.1.0	templar-pyth-lazer-adapter-contract-v0.1.0	templar_pyth_lazer_adapter_contract-0.1.0.wasm	ff51847ea292271775db9bf8207e7f30c5a6a426b277a71ebe78f8c4850a451f	306526

--- a/contract/artifacts/releases/redstone-adapter@0.1.0.tsv
+++ b/contract/artifacts/releases/redstone-adapter@0.1.0.tsv
@@ -1,1 +1,1 @@
-redstone-adapter	0.1.0	templar-redstone-adapter-contract-v0.1.0	templar_redstone_adapter_contract-0.1.0.wasm	debbf6f631422ad44fb3bf323503f378cdaff1cd6c63661846cb56828e23c461
+redstone-adapter	0.1.0	templar-redstone-adapter-contract-v0.1.0	templar_redstone_adapter_contract-0.1.0.wasm	debbf6f631422ad44fb3bf323503f378cdaff1cd6c63661846cb56828e23c461	288251

--- a/contract/artifacts/releases/registry@0.1.0.tsv
+++ b/contract/artifacts/releases/registry@0.1.0.tsv
@@ -1,1 +1,1 @@
-registry	0.1.0	templar-registry-contract-v0.1.0	templar_registry_contract-0.1.0.wasm	c07b38a29202da247da12515d3b2e7a93855619209a76d73e5ae12b2facc6255
+registry	0.1.0	templar-registry-contract-v0.1.0	templar_registry_contract-0.1.0.wasm	c07b38a29202da247da12515d3b2e7a93855619209a76d73e5ae12b2facc6255	210917

--- a/contract/artifacts/releases/registry@1.0.0.tsv
+++ b/contract/artifacts/releases/registry@1.0.0.tsv
@@ -1,1 +1,1 @@
-registry	1.0.0	templar-registry-contract-v1.0.0	templar_registry_contract-1.0.0.wasm	bafbec54bff4f07147c5e317966ec34c500331f02c64eefd5da1aa5dc778e339
+registry	1.0.0	templar-registry-contract-v1.0.0	templar_registry_contract-1.0.0.wasm	bafbec54bff4f07147c5e317966ec34c500331f02c64eefd5da1aa5dc778e339	210917

--- a/contract/artifacts/releases/registry@1.1.0.tsv
+++ b/contract/artifacts/releases/registry@1.1.0.tsv
@@ -1,1 +1,1 @@
-registry	1.1.0	templar-registry-contract-v1.1.0	templar_registry_contract-1.1.0.wasm	0f315a008969013f44575b16374c115e972f421d1061fd6cafc8b4f63e5c65f3
+registry	1.1.0	templar-registry-contract-v1.1.0	templar_registry_contract-1.1.0.wasm	0f315a008969013f44575b16374c115e972f421d1061fd6cafc8b4f63e5c65f3	224876

--- a/contract/artifacts/releases/registry@1.2.3.tsv
+++ b/contract/artifacts/releases/registry@1.2.3.tsv
@@ -1,1 +1,1 @@
-registry	1.2.3	templar-registry-contract-v1.2.3	templar_registry_contract-1.2.3.wasm	6c940164a6900a9b80183fb2dd8896dd0329004b5993462691c2d26086f5c6d4
+registry	1.2.3	templar-registry-contract-v1.2.3	templar_registry_contract-1.2.3.wasm	6c940164a6900a9b80183fb2dd8896dd0329004b5993462691c2d26086f5c6d4	237426

--- a/contract/artifacts/releases/universal-account@0.2.0.tsv
+++ b/contract/artifacts/releases/universal-account@0.2.0.tsv
@@ -1,1 +1,1 @@
-universal-account	0.2.0	templar-universal-account-contract-v0.2.0	templar_universal_account_contract-0.2.0.wasm	30e8baf1bd5de0308c510c0e5ff77b9aeb25306bf6ab922e5e25f8a24d6f3efd
+universal-account	0.2.0	templar-universal-account-contract-v0.2.0	templar_universal_account_contract-0.2.0.wasm	30e8baf1bd5de0308c510c0e5ff77b9aeb25306bf6ab922e5e25f8a24d6f3efd	317788

--- a/contract/artifacts/releases/universal-account@0.3.0.tsv
+++ b/contract/artifacts/releases/universal-account@0.3.0.tsv
@@ -1,1 +1,1 @@
-universal-account	0.3.0	templar-universal-account-contract-v0.3.0	templar_universal_account_contract-0.3.0.wasm	99e7ee1e559b2a0e966ef91e572007d71a6998b6a8d8ca0330e6c308652de505
+universal-account	0.3.0	templar-universal-account-contract-v0.3.0	templar_universal_account_contract-0.3.0.wasm	99e7ee1e559b2a0e966ef91e572007d71a6998b6a8d8ca0330e6c308652de505	561592

--- a/contract/artifacts/releases/universal-account@0.3.1.tsv
+++ b/contract/artifacts/releases/universal-account@0.3.1.tsv
@@ -1,1 +1,1 @@
-universal-account	0.3.1	templar-universal-account-contract-v0.3.1	templar_universal_account_contract-0.3.1.wasm	1b470283a0393f083463c95086de3046a94b626de45270fc108c1658fc7679a0
+universal-account	0.3.1	templar-universal-account-contract-v0.3.1	templar_universal_account_contract-0.3.1.wasm	1b470283a0393f083463c95086de3046a94b626de45270fc108c1658fc7679a0	562858

--- a/contract/artifacts/releases/universal-account@0.5.0.tsv
+++ b/contract/artifacts/releases/universal-account@0.5.0.tsv
@@ -1,1 +1,1 @@
-universal-account	0.5.0	templar-universal-account-contract-v0.5.0	templar_universal_account_contract-0.5.0.wasm	22d1efca17929ef7148f62b9a32f1dcf9a5aa6bf1646df2190817e8cb9e961ef
+universal-account	0.5.0	templar-universal-account-contract-v0.5.0	templar_universal_account_contract-0.5.0.wasm	22d1efca17929ef7148f62b9a32f1dcf9a5aa6bf1646df2190817e8cb9e961ef	601435

--- a/contract/artifacts/releases/universal-account@0.5.2.tsv
+++ b/contract/artifacts/releases/universal-account@0.5.2.tsv
@@ -1,1 +1,1 @@
-universal-account	0.5.2	templar-universal-account-contract-v0.5.2	templar_universal_account_contract-0.5.2.wasm	1cf9aa452033295638d476829f3e5feeefecd078cf5bb8318a422d7ff55f4414
+universal-account	0.5.2	templar-universal-account-contract-v0.5.2	templar_universal_account_contract-0.5.2.wasm	1cf9aa452033295638d476829f3e5feeefecd078cf5bb8318a422d7ff55f4414	618407

--- a/contract/artifacts/src/bin/record-release.rs
+++ b/contract/artifacts/src/bin/record-release.rs
@@ -92,22 +92,25 @@ fn record(args: &Args) -> Result<String, String> {
     match created {
         Ok(()) => Ok(format!("recorded {artifact}@{version} as {sha} ({tag})")),
         Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
-            // Compare the recorded digest rather than the raw line: a replay is
-            // still a replay if the file was reformatted.
+            // Compare the recorded fields rather than the raw line: a replay is
+            // still a replay if the file was reformatted. Both are derived from
+            // the released bytes, so a row agreeing on one and not the other
+            // describes bytes that never existed — `fetch` would refuse the
+            // asset, and the deposit guard would size a deploy from a length
+            // nothing was ever built at.
             let existing =
                 std::fs::read_to_string(&path).map_err(|error| format!("{path:?}: {error}"))?;
-            let recorded = existing
-                .trim()
-                .split('\t')
-                .nth(4)
-                .unwrap_or_default()
-                .to_ascii_lowercase();
-            if recorded == sha {
+            let fields = existing.trim().split('\t').collect::<Vec<_>>();
+            let recorded_sha = fields.get(4).unwrap_or(&"").to_ascii_lowercase();
+            let recorded_length = *fields.get(5).unwrap_or(&"");
+
+            if recorded_sha == sha && recorded_length == length.to_string() {
                 Ok(format!("{artifact}@{version} is already recorded as {sha}"))
             } else {
                 Err(format!(
-                    "{artifact}@{version} is already recorded as {recorded}, \
-                     refusing to rewrite it to {sha}. Released bytes are immutable."
+                    "{artifact}@{version} is already recorded as {recorded_sha} \
+                     ({recorded_length} bytes), refusing to rewrite it to {sha} \
+                     ({length} bytes). Released bytes are immutable."
                 ))
             }
         }
@@ -153,6 +156,22 @@ mod tests {
 
         let message = record(&replay).expect("a replay is not an error");
         assert!(message.contains("already recorded"), "{message}");
+    }
+
+    /// Digest and length describe the same bytes, so a replay agreeing on one
+    /// and not the other is not a replay.
+    #[test]
+    fn recording_a_different_length_for_a_recorded_digest_is_refused() {
+        let release = ArtifactId::ProxyOracle
+            .metadata()
+            .release("0.3.0")
+            .expect("0.3.0 is catalogued");
+        let mut replay = args("0.3.0", release.tag, release.asset);
+        replay.sha256 = release.sha256.to_owned();
+        replay.length = release.length + 1;
+
+        let error = record(&replay).expect_err("the recorded length is immutable too");
+        assert!(error.contains("refusing to rewrite"), "{error}");
     }
 
     #[test]

--- a/contract/artifacts/src/bin/record-release.rs
+++ b/contract/artifacts/src/bin/record-release.rs
@@ -9,7 +9,7 @@
 //! ```bash
 //! cargo run -p templar-contract-artifacts --features clap --bin record-release -- \
 //!   proxy-oracle 0.3.0 templar-proxy-oracle-near-contract-v0.3.0 \
-//!   templar_proxy_oracle_near_contract-0.3.0.wasm <sha256>
+//!   templar_proxy_oracle_near_contract-0.3.0.wasm <sha256> <length>
 //! ```
 
 use std::process::ExitCode;
@@ -33,6 +33,9 @@ struct Args {
 
     /// SHA-256 of the released bytes, as 64 hex characters.
     sha256: String,
+
+    /// Byte length of those same bytes.
+    length: usize,
 }
 
 /// Directory of per-release files, relative to this crate's manifest.
@@ -58,6 +61,7 @@ fn record(args: &Args) -> Result<String, String> {
         tag,
         asset,
         sha256: sha,
+        length,
     } = args;
     let sha = sha.to_ascii_lowercase();
 
@@ -69,7 +73,7 @@ fn record(args: &Args) -> Result<String, String> {
         ));
     }
 
-    let row = format!("{artifact}\t{version}\t{tag}\t{asset}\t{sha}\n");
+    let row = format!("{artifact}\t{version}\t{tag}\t{asset}\t{sha}\t{length}\n");
     let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
         .join(RELEASES)
         .join(format!("{artifact}@{version}.tsv"));
@@ -123,6 +127,7 @@ mod tests {
             tag,
             asset,
             &"a".repeat(64),
+            "1",
         ])
         .expect("clap takes these as opaque strings")
     }
@@ -144,6 +149,7 @@ mod tests {
             .expect("0.3.0 is catalogued");
         let mut replay = args("0.3.0", release.tag, release.asset);
         replay.sha256 = release.sha256.to_owned();
+        replay.length = release.length;
 
         let message = record(&replay).expect("a replay is not an error");
         assert!(message.contains("already recorded"), "{message}");

--- a/contract/artifacts/src/fetch.rs
+++ b/contract/artifacts/src/fetch.rs
@@ -4,9 +4,10 @@
 //! `contract/artifacts/releases/` records the tag and asset it shipped as.
 //! See `RELEASING.md` for why they are built at the tag's own commit.
 //!
-//! Every read is verified against the catalog's SHA-256 pin, including of an
-//! existing cache entry — so a branch whose catalog disagrees re-downloads
-//! rather than reusing wrong bytes, and offline that mismatch is an error.
+//! Every read is verified against the catalog's byte length and SHA-256 pin,
+//! including of an existing cache entry — so a branch whose catalog disagrees
+//! re-downloads rather than reusing wrong bytes, and offline that mismatch is
+//! an error.
 //!
 //! ```text
 //! ${TEMPLAR_ARTIFACT_CACHE:-${XDG_CACHE_HOME:-$HOME/.cache}}/templar-contract-artifacts
@@ -84,6 +85,18 @@ pub enum FetchError {
         url: String,
         status: u16,
         attempts: u32,
+    },
+
+    #[error(
+        "{artifact}@{version} downloaded from {url} is {actual} bytes, but the \
+         catalog records {expected}. Refusing the bytes."
+    )]
+    LengthMismatch {
+        artifact: ArtifactId,
+        version: String,
+        url: String,
+        expected: usize,
+        actual: usize,
     },
 
     #[error(
@@ -211,7 +224,7 @@ pub async fn released_bytes(artifact: ArtifactId, version: &str) -> Result<Vec<u
     // cache entry, not as evidence of tampering: re-download and let the
     // verification below decide.
     if let Ok(cached) = std::fs::read(&path) {
-        if sha256_hex(&cached) == expected {
+        if cached.len() == release.length && sha256_hex(&cached) == expected {
             return Ok(remember(key, cached));
         }
     }
@@ -225,6 +238,18 @@ pub async fn released_bytes(artifact: ArtifactId, version: &str) -> Result<Vec<u
 
     let url = asset_url(release);
     let bytes = download(&url).await?;
+
+    // Before the digest, so a size disagreement reports bytes a reader can
+    // check against the Release rather than an opaque hash.
+    if bytes.len() != release.length {
+        return Err(FetchError::LengthMismatch {
+            artifact,
+            version: version.to_owned(),
+            url,
+            expected: release.length,
+            actual: bytes.len(),
+        });
+    }
 
     let actual = sha256_hex(&bytes);
     if actual != expected {

--- a/contract/artifacts/src/ids.rs
+++ b/contract/artifacts/src/ids.rs
@@ -164,6 +164,11 @@ pub struct ArtifactRelease {
     /// Root of trust: [`crate::fetch`] refuses bytes that do not match this
     /// reviewed, in-repo value.
     pub sha256: &'static str,
+    /// Byte length of the released asset.
+    ///
+    /// Recorded so that sizing a release — what a deploy deposit has to cover —
+    /// needs no download.
+    pub length: usize,
 }
 
 /// Canonical metadata for a single contract artifact.

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -61,10 +61,6 @@ tracing-subscriber.workspace = true
 
 [dev-dependencies]
 rstest.workspace = true
-# `fetch` only here: `requires_network_deposits_cover_the_released_artifacts`
-# downloads the pinned releases to size them, and no other code path needs the
-# bytes.
-templar-contract-artifacts = { workspace = true, features = ["fetch"] }
 
 [lints]
 workspace = true

--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -41,8 +41,8 @@ use crate::spec::{
 /// The registry refuses a deposit below `1e19 * code.len()`, and the market's is
 /// the last step — undersized there, it fails after 9.9 NEAR is spent. Each keeps
 /// 50 KB of headroom over its pinned release, held there by
-/// `requires_network_deposits_cover_the_released_artifacts`. Over-provisioning
-/// burns nothing: the deposit is forwarded to the account being created.
+/// `deposits_cover_the_released_artifacts`. Over-provisioning burns nothing:
+/// the deposit is forwarded to the account being created.
 const GOVERNANCE_DEPOSIT: NearToken = NearToken::from_millinear(4_500);
 const ORACLE_DEPOSIT: NearToken = NearToken::from_millinear(5_400);
 const MARKET_DEPOSIT: NearToken = NearToken::from_millinear(5_800);
@@ -1262,37 +1262,34 @@ mod tests {
     /// after 9.9 NEAR is spent. Releasing a larger contract must therefore break
     /// a test, not a deployment.
     ///
-    /// Network-gated: the released bytes are fetched, not vendored. Cached after
-    /// the first run.
+    /// Sized from the catalog's recorded byte length, which `fetch` verifies
+    /// against the released asset, so this runs offline and on every PR.
     #[rstest]
     #[case(ArtifactId::ProxyGovernance, GOVERNANCE_DEPOSIT)]
     #[case(ArtifactId::ProxyOracle, ORACLE_DEPOSIT)]
     #[case(ArtifactId::Market, MARKET_DEPOSIT)]
-    #[tokio::test]
-    async fn requires_network_deposits_cover_the_released_artifacts(
+    fn deposits_cover_the_released_artifacts(
         #[case] artifact: ArtifactId,
         #[case] deposit: near_api::types::NearToken,
     ) {
         const YOCTO_PER_BYTE: u128 = 10u128.pow(19);
         const HEADROOM_BYTES: u128 = 50_000;
 
-        let version = artifact
+        let release = artifact
             .metadata()
-            .version()
+            .current()
             .expect("a released version is catalogued for this artifact");
-        let bytes = templar_contract_artifacts::fetch::released_bytes(artifact, version)
-            .await
-            .expect("fetch the released wasm");
 
-        let required = bytes.len() as u128 * YOCTO_PER_BYTE;
+        let required = release.length as u128 * YOCTO_PER_BYTE;
         let covered = deposit.as_yoctonear();
 
         assert!(
             covered >= required + HEADROOM_BYTES * YOCTO_PER_BYTE,
-            "{artifact:?} {version} is {} bytes, needing {required} yocto, and the \
+            "{artifact:?} {} is {} bytes, needing {required} yocto, and the \
              deposit is {covered}; raise the constant so it keeps 50 KB of room \
              to grow",
-            bytes.len(),
+            release.version,
+            release.length,
         );
     }
 


### PR DESCRIPTION
Closes ENG-575.

A release record carried `artifact / version / tag / asset / sha256` and no length, so sizing a released WASM meant downloading it. That download was the only reason the deploy-deposit guard was named `requires_network_*`, and that partition is excluded from both gates (`fast_filter` / `sandbox_test_filter`) and run by no workflow — so the guard only fired when someone ran it by hand. ENG-574 is what that cost: ProxyGovernance 0.3.0 outgrew `GOVERNANCE_DEPOSIT` and nothing caught it.

Recording the byte length removes the download. `deposits_cover_the_released_artifacts` is now an offline test in the fast gate, running on every PR.

## What changed

- **Catalog** — a sixth `length` column on every release row; `ArtifactRelease.length`; `build.rs` parses, validates (canonical spelling, non-zero) and emits it. The generated literals are underscore-grouped, since the workspace denies `clippy::unreadable_literal`.
- **Recording** — `record-release` takes a required `length`; `release-artifacts.yml` emits it from the bytes it just built, alongside the digest it already reports. `build.rs`'s column-count check then makes an omitted length a build failure, which both workflows hit — each compiles the crate before committing a row — so `catalog-pr.yml` needs no guard of its own.
- **`catalog-pr.yml`** — reads six fields in all three places it parses a row: the replay loop, the commit message, and the PR body (now with a `Bytes` column). Without this the trailing variable would have swallowed `sha<TAB>length`.
- **Trust** — `fetch` verifies the length alongside the SHA-256 pin, on both the download and cache-hit paths, so a record disagreeing with the bytes is an error rather than a silently wrong size.
- **Guard** — renamed, no longer `async`, sized from `release.length`. The manager's `templar-contract-artifacts` dev-dependency is deleted outright: the normal dependency already provided the crate, and nothing else there needed `fetch`.

The 21 existing records are backfilled from the released assets, each verified against its pinned digest on the way in.

## Merging this needs an append-only bypass

The backfill modifies files under `contract/artifacts/releases/`, which the **Released versions are append-only** check in `test.yml` refuses — it compares file identity, not release identity. This PR is merged past it deliberately. No recorded digest, tag or asset changes; the diff on each row is one appended field.

## Verification

| Claim | Evidence |
| --- | --- |
| Every record's length matches the real asset | `just artifacts-fetch` passes on all 21 |
| A wrong length is refused | Bumping one by 1: `registry@1.1.0 ... is 224876 bytes, but the catalog records 224877. Refusing the bytes.` |
| A missing length fails the build | `releases/registry@1.1.0.tsv: expected 6 tab-separated fields, found 5.` |
| A non-canonical length fails the build | `0224876` → `is not a plain byte count` |
| The guard runs offline | 3 cases pass in 5 ms with `TEMPLAR_ARTIFACT_OFFLINE=1` and an empty cache |
| The guard is in the fast gate | `cargo nextest list -E "$(just --evaluate fast_filter)"` lists all 3 cases |

`cargo fmt --all --check`, clippy `-D warnings` on both crates, and the fast gate scoped to the two crates (288 passed) are green.

## Reviewer note

`catalog-pr.yml`'s parsing changes cannot be exercised on a branch — `workflow_run` only fires from the default branch — so they take effect when this merges. The three `read` calls are worth a second pair of eyes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/573)
<!-- Reviewable:end -->
