### PR TITLE
ci: label the release PR

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -27,6 +27,10 @@ release_always = false
 # changelog; the title's job is to make the release lever recognisable.
 pr_name = "chore: release"
 
+# The label the repo's release filters key off. release-plz reapplies it on
+# every update, so a hand-removed label comes back on the next push to `dev`.
+pr_labels = ["release"]
+
 # Per-crate tags: `templar-gateway-client-v0.2.0`. Required for independent
 # versioning — a bare `v0.2.0` cannot say which crate it refers to.
 git_tag_name = "{{ package }}-v{{ version }}"


### PR DESCRIPTION
Sets `pr_labels = ["release"]` in `release-plz.toml` so the standing `chore: release` PR always carries the `release` label.

The label already exists in the repo, so nothing needs creating. release-plz reapplies labels on every PR update, not just on creation — a hand-removed label comes back on the next push to `dev`.

Verified the key against release-plz 0.3.160 (the version pinned by both jobs in `.github/workflows/release-plz.yml`): the config parses, and misspelling the key locally is rejected at parse time, so this isn't a silently-ignored field. The `release-plz-pr` job already has `pull-requests: write`, so it can apply the label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/574)
<!-- Reviewable:end -->
