### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13315,7 +13315,7 @@ dependencies = [
 
 [[package]]
 name = "templar-liquidator"
-version = "0.2.0"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13724,7 +13724,7 @@ dependencies = [
 
 [[package]]
 name = "templar-relayer"
-version = "0.3.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "harvest-static-yield"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -12807,7 +12807,7 @@ dependencies = [
 
 [[package]]
 name = "templar-accumulator"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -12901,7 +12901,7 @@ dependencies = [
 
 [[package]]
 name = "templar-funding-bridge"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13013,7 +13013,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-client"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "clap",
  "near-api",
@@ -13120,7 +13120,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13158,7 +13158,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "hex",
  "near-account-id",
@@ -13187,7 +13187,7 @@ dependencies = [
 
 [[package]]
 name = "templar-gateway-service"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "actix",
  "anyhow",
@@ -13315,7 +13315,7 @@ dependencies = [
 
 [[package]]
 name = "templar-liquidator"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13369,7 +13369,7 @@ dependencies = [
 
 [[package]]
 name = "templar-manager"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -13514,7 +13514,7 @@ dependencies = [
 
 [[package]]
 name = "templar-proxy-oracle-near-contract"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -13724,7 +13724,7 @@ dependencies = [
 
 [[package]]
 name = "templar-relayer"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -13870,7 +13870,7 @@ dependencies = [
 
 [[package]]
 name = "templar-tools-common"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "cargo_metadata 0.23.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,7 +142,7 @@ templar-common = { path = "./common", version = "1.5.0" }
 templar-contract-artifacts = { path = "./contract/artifacts" }
 templar-gateway-artifacts-dispatch = { path = "./gateway/artifacts-dispatch" }
 templar-gateway-artifacts-spec = { path = "./gateway/artifacts-spec" }
-templar-gateway-client = { path = "./gateway/client", version = "0.2.0" }
+templar-gateway-client = { path = "./gateway/client", version = "0.2.1" }
 templar-gateway-core = { path = "./gateway/core", version = "0.3.0" }
 templar-gateway-macros = { path = "./gateway/macros", version = "0.1.1" }
 templar-gateway-methods-dispatch = { path = "./gateway/methods-dispatch", version = "0.3.0" }

--- a/contract/proxy-oracle/near/contract/Cargo.toml
+++ b/contract/proxy-oracle/near/contract/Cargo.toml
@@ -4,7 +4,7 @@ rust-version.workspace = true
 license.workspace = true
 name = "templar-proxy-oracle-near-contract"
 repository.workspace = true
-version = "0.4.1"
+version = "0.4.2"
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/gateway/client/CHANGELOG.md
+++ b/gateway/client/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.2.0...templar-gateway-client-v0.2.1) - 2026-08-07
+
+### Added
+
+- *(gateway-client)* add Network::hermes_url ([#585](https://github.com/Templar-Protocol/contracts/pull/585))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.1.2...templar-gateway-client-v0.2.0) - 2026-08-04
 
 ### Added

--- a/gateway/client/Cargo.toml
+++ b/gateway/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-client"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-dispatch/CHANGELOG.md
+++ b/gateway/oracle-updates-dispatch/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-dispatch-v0.1.3...templar-gateway-oracle-updates-dispatch-v0.2.0) - 2026-08-07
+
+### Added
+
+- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-dispatch-v0.1.0...templar-gateway-oracle-updates-dispatch-v0.1.1) - 2026-08-03
 
 ### Added

--- a/gateway/oracle-updates-dispatch/Cargo.toml
+++ b/gateway/oracle-updates-dispatch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-dispatch"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/gateway/oracle-updates-spec/CHANGELOG.md
+++ b/gateway/oracle-updates-spec/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-spec-v0.1.3...templar-gateway-oracle-updates-spec-v0.2.0) - 2026-08-07
+
+### Added
+
+- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-spec-v0.1.0...templar-gateway-oracle-updates-spec-v0.1.1) - 2026-08-03
 
 ### Added

--- a/gateway/oracle-updates-spec/Cargo.toml
+++ b/gateway/oracle-updates-spec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-oracle-updates-spec"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/accumulator/Cargo.toml
+++ b/service/accumulator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.3"
+version = "0.1.4"
 
 [[bin]]
 name = "accumulator"

--- a/service/funding-bridge/Cargo.toml
+++ b/service/funding-bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-funding-bridge"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/service/gateway/CHANGELOG.md
+++ b/service/gateway/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.3.0...templar-gateway-service-v0.4.0) - 2026-08-07
+
+### Added
+
+- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.2.0...templar-gateway-service-v0.3.0) - 2026-08-04
 
 ### Added

--- a/service/gateway/Cargo.toml
+++ b/service/gateway/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-gateway-service"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/liquidator/CHANGELOG.md
+++ b/service/liquidator/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.3...templar-liquidator-v0.2.0) - 2026-08-07
+## [0.1.4](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.3...templar-liquidator-v0.1.4) - 2026-08-07
 
 ### Added
 

--- a/service/liquidator/CHANGELOG.md
+++ b/service/liquidator/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.3...templar-liquidator-v0.2.0) - 2026-08-07
+
+### Added
+
+- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.0...templar-liquidator-v0.1.1) - 2026-08-03
 
 ### Added

--- a/service/liquidator/Cargo.toml
+++ b/service/liquidator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.1.3"
+version = "0.2.0"
 
 [lib]
 path = "src/liquidator.rs"

--- a/service/liquidator/Cargo.toml
+++ b/service/liquidator/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-version = "0.2.0"
+version = "0.1.4"
 
 [lib]
 path = "src/liquidator.rs"

--- a/service/relayer/CHANGELOG.md
+++ b/service/relayer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.0...templar-relayer-v0.3.0) - 2026-08-07
+
+### Added
+
+- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
+
 ## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.1.2...templar-relayer-v0.2.0) - 2026-08-04
 
 ### Added

--- a/service/relayer/CHANGELOG.md
+++ b/service/relayer/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.0...templar-relayer-v0.3.0) - 2026-08-07
+## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.0...templar-relayer-v0.2.1) - 2026-08-07
 
 ### Added
 

--- a/service/relayer/Cargo.toml
+++ b/service/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-relayer"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/service/relayer/Cargo.toml
+++ b/service/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-relayer"
-version = "0.3.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/tools/harvest-static-yield/Cargo.toml
+++ b/tools/harvest-static-yield/Cargo.toml
@@ -4,7 +4,7 @@ license.workspace = true
 repository.workspace = true
 edition.workspace = true
 rust-version.workspace = true
-version = "0.1.3"
+version = "0.1.4"
 
 [dependencies]
 anyhow.workspace = true

--- a/tools/manager/CHANGELOG.md
+++ b/tools/manager/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.3.0...templar-manager-v0.4.0) - 2026-08-07
+
+### Added
+
+- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
+
+### Fixed
+
+- *(manager)* raise ORACLE_DEPOSIT for proxy-oracle 0.4.1 ([#582](https://github.com/Templar-Protocol/contracts/pull/582))
+- *(deployments)* repoint market specs at the reorganized profiles ([#584](https://github.com/Templar-Protocol/contracts/pull/584))
+
 ## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.2.0...templar-manager-v0.3.0) - 2026-08-04
 
 ### Added

--- a/tools/manager/Cargo.toml
+++ b/tools/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-manager"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true

--- a/tools/tools-common/CHANGELOG.md
+++ b/tools/tools-common/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-tools-common-v0.1.3...templar-tools-common-v0.2.0) - 2026-08-07
+
+### Changed
+
+- *(tools-common)* [**breaking**] drop the unused NEAR client layer ([#579](https://github.com/Templar-Protocol/contracts/pull/579))
+
 ## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-tools-common-v0.1.0...templar-tools-common-v0.1.1) - 2026-08-03
 
 ### Added

--- a/tools/tools-common/Cargo.toml
+++ b/tools/tools-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "templar-tools-common"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 repository.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `templar-gateway-client`: 0.2.0 -> 0.2.1
* `templar-gateway-oracle-updates-spec`: 0.1.3 -> 0.2.0
* `templar-gateway-oracle-updates-dispatch`: 0.1.3 -> 0.2.0
* `templar-relayer`: 0.2.0 -> 0.3.0
* `templar-tools-common`: 0.1.3 -> 0.2.0
* `templar-manager`: 0.3.0 -> 0.4.0
* `templar-gateway-service`: 0.3.0 -> 0.4.0
* `templar-liquidator`: 0.1.3 -> 0.2.0
* `templar-proxy-oracle-near-contract`: 0.4.1 -> 0.4.2
* `harvest-static-yield`: 0.1.3 -> 0.1.4
* `templar-accumulator`: 0.1.3 -> 0.1.4
* `templar-funding-bridge`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `templar-gateway-client`

<blockquote>

## [0.2.1](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-client-v0.2.0...templar-gateway-client-v0.2.1) - 2026-08-07

### Added

- *(gateway-client)* add Network::hermes_url ([#585](https://github.com/Templar-Protocol/contracts/pull/585))
</blockquote>

## `templar-gateway-oracle-updates-spec`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-spec-v0.1.3...templar-gateway-oracle-updates-spec-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-gateway-oracle-updates-dispatch`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-oracle-updates-dispatch-v0.1.3...templar-gateway-oracle-updates-dispatch-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-relayer`

<blockquote>

## [0.3.0](https://github.com/Templar-Protocol/contracts/compare/templar-relayer-v0.2.0...templar-relayer-v0.3.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-tools-common`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-tools-common-v0.1.3...templar-tools-common-v0.2.0) - 2026-08-07

### Changed

- *(tools-common)* [**breaking**] drop the unused NEAR client layer ([#579](https://github.com/Templar-Protocol/contracts/pull/579))
</blockquote>

## `templar-manager`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-manager-v0.3.0...templar-manager-v0.4.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))

### Fixed

- *(manager)* raise ORACLE_DEPOSIT for proxy-oracle 0.4.1 ([#582](https://github.com/Templar-Protocol/contracts/pull/582))
- *(deployments)* repoint market specs at the reorganized profiles ([#584](https://github.com/Templar-Protocol/contracts/pull/584))
</blockquote>

## `templar-gateway-service`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-gateway-service-v0.3.0...templar-gateway-service-v0.4.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-liquidator`

<blockquote>

## [0.2.0](https://github.com/Templar-Protocol/contracts/compare/templar-liquidator-v0.1.3...templar-liquidator-v0.2.0) - 2026-08-07

### Added

- *(gateway)* [**breaking**] oracle.updatePyth fetches its own payload (ENG-462) ([#586](https://github.com/Templar-Protocol/contracts/pull/586))
</blockquote>

## `templar-proxy-oracle-near-contract`

<blockquote>

## [0.4.0](https://github.com/Templar-Protocol/contracts/compare/templar-proxy-oracle-near-contract-v0.3.0...templar-proxy-oracle-near-contract-v0.4.0) - 2026-08-03

### Added

- kernelize proxy oracle ([#403](https://github.com/Templar-Protocol/contracts/pull/403))
- *(gateway)* in-process Pyth Lazer payload source + write path (ENG-398, ENG-400) ([#491](https://github.com/Templar-Protocol/contracts/pull/491))
- *(proxy-oracle)* `new` accepts an optional owner id (ENG-440) ([#504](https://github.com/Templar-Protocol/contracts/pull/504))
- *(gateway)* configure transaction finality policy (ENG-468) ([#517](https://github.com/Templar-Protocol/contracts/pull/517))
- *(proxy-oracle)* standardize contract self-upgrade (ENG-481) ([#519](https://github.com/Templar-Protocol/contracts/pull/519))
- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Changed

- *(pyth-pro)* drop PriceIdentifier feed map; adapter serves raw FeedData (ENG-434) ([#494](https://github.com/Templar-Protocol/contracts/pull/494))
- *(pyth-lazer)* rename all "Pyth Pro" terminology to "Pyth Lazer" repo-wide (ENG-437) ([#496](https://github.com/Templar-Protocol/contracts/pull/496))

### ENG-486

- Upgrade proxy oracles from v0.1.0 to v0.3.0 ([#507](https://github.com/Templar-Protocol/contracts/pull/507))
</blockquote>

## `harvest-static-yield`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/harvest-static-yield-v0.1.0...harvest-static-yield-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))
</blockquote>

## `templar-accumulator`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-accumulator-v0.1.0...templar-accumulator-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>

## `templar-funding-bridge`

<blockquote>

## [0.1.1](https://github.com/Templar-Protocol/contracts/compare/templar-funding-bridge-v0.1.0...templar-funding-bridge-v0.1.1) - 2026-08-03

### Added

- *(release)* automate per-crate releases and version contract artifacts (ENG-522) ([#528](https://github.com/Templar-Protocol/contracts/pull/528))

### Documentation

- fix rustdoc warnings and gate them in CI ([#532](https://github.com/Templar-Protocol/contracts/pull/532))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/580)
<!-- Reviewable:end -->
