### PR TITLE
fix(manager): raise ORACLE_DEPOSIT for proxy-oracle 0.4.1

### DIFF
--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -40,12 +40,12 @@ use crate::spec::{
 /// rather than from the market.
 ///
 /// The registry refuses a deposit below `1e19 * code.len()`, and the market's is
-/// the last step — undersized there, it fails after 9.9 NEAR is spent. Each keeps
+/// the last step — undersized there, it fails after 10.5 NEAR is spent. Each keeps
 /// 50 KB of headroom over its pinned release, held there by
 /// `deposits_cover_the_released_artifacts`. Over-provisioning burns nothing:
 /// the deposit is forwarded to the account being created.
 const GOVERNANCE_DEPOSIT: NearToken = NearToken::from_millinear(4_500);
-const ORACLE_DEPOSIT: NearToken = NearToken::from_millinear(5_400);
+const ORACLE_DEPOSIT: NearToken = NearToken::from_millinear(6_000);
 const MARKET_DEPOSIT: NearToken = NearToken::from_millinear(5_800);
 
 /// `market plan` — run the preflight, then write the deployment as a file.
@@ -467,7 +467,7 @@ pub(crate) async fn build(
 
         // The proposals are created and executed by `signer_id`, but only
         // `governance.admin` is granted the Admin role at init. Mismatched, the two
-        // registry deploys succeed and every proposal reverts — 9.9 NEAR spent on
+        // registry deploys succeed and every proposal reverts — 10.5 NEAR spent on
         // exactly the orphaned half-deployment this tool exists to prevent.
         // The retired shell deploy made this unrepresentable: it passed the
         // signer as the admin.
@@ -500,7 +500,7 @@ pub(crate) async fn build(
 
     // Re-run here, not left to the `config.validate` check: that check is
     // skippable, and the market enforces this at init. Skipping it can only buy
-    // a 9.9 NEAR half-deployment that reverts on the last step.
+    // a 10.5 NEAR half-deployment that reverts on the last step.
     configuration
         .validate()
         .map_err(|error| anyhow::anyhow!("{error}"))
@@ -1141,7 +1141,7 @@ mod tests {
 
     /// The registry refuses `deposit < 1e19 * code.len()`, so a contract that
     /// outgrows its constant fails the deploy — the market's on the last step,
-    /// after 9.9 NEAR is spent. Releasing a larger contract must therefore break
+    /// after 10.5 NEAR is spent. Releasing a larger contract must therefore break
     /// a test, not a deployment.
     ///
     /// Sized from the catalog's recorded byte length, which `fetch` verifies


### PR DESCRIPTION
Unblocks #581. Recording proxy-oracle 0.4.1 turns
`deposits_cover_the_released_artifacts` red, which is what that test is
for — `plan.rs` says a contract outgrowing its constant "must therefore
break a test, not a deployment".

| Constant | Covers | Release | Headroom | 50 KB floor |
| --- | --- | --- | --- | --- |
| `GOVERNANCE_DEPOSIT` 4,500 | 450,000 B | 354,922 B | 95,078 | ✅ |
| `ORACLE_DEPOSIT` 5,400 | 540,000 B | **494,092 B** | **45,908** | ❌ short 4,092 |
| `MARKET_DEPOSIT` 5,800 | 580,000 B | 521,039 B | 58,961 | ✅ |

The registry refuses a deposit below `1e19 * code.len()` and the market
deploy is the last step, so shipping this unfixed trades a red test for an
orphaned half-deployment after ~10 NEAR is spent.

## Why 6 NEAR and not 5.5

5.5 clears the floor and matches how `MARKET_DEPOSIT` looks sized, but
leaves under 6 KB — the next proxy-oracle release likely trips this again.
6 NEAR gives 105,908 bytes of headroom, near the margin governance already
carries. Safety is identical either way: the 50 KB floor still fires well
before the deposit is genuinely insufficient, and the deposit is forwarded
to the account being created rather than burnt.

`9.9 NEAR` appeared in four comments and was `GOVERNANCE_DEPOSIT +
ORACLE_DEPOSIT`; it is now 10.5.

## Verification

Tested against #581's rows overlaid, since `dev`'s newest proxy-oracle row
is 0.3.0 and the test passes trivially without them:

- with 5,400 — reproduces CI exactly, `case_2` at `plan.rs:1168`
- with 6,000 — all three cases pass

Overlay removed; this branch carries only the constant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/582)
<!-- Reviewable:end -->
