### PR TITLE
feat(gateway-client): add Network::hermes_url

### DIFF
--- a/gateway/client/src/network.rs
+++ b/gateway/client/src/network.rs
@@ -3,6 +3,12 @@
 use std::fmt;
 
 use near_api::NetworkConfig;
+use url::Url;
+
+/// Pyth's public Hermes endpoints. A VAA is only accepted by the Pyth receiver whose
+/// guardian set signed it, so the endpoint has to follow the NEAR network.
+const HERMES_MAINNET_URL: &str = "https://hermes.pyth.network";
+const HERMES_TESTNET_URL: &str = "https://hermes-beta.pyth.network";
 
 /// A NEAR network, used by off-chain consumers (CLIs, bots, services) to pick
 /// the default RPC endpoint when constructing a [`crate::Client`].
@@ -31,6 +37,20 @@ impl Network {
             Network::Mainnet => "https://rpc.mainnet.fastnear.com",
             Network::Testnet => "https://rpc.testnet.fastnear.com",
         }
+    }
+
+    /// Pyth's public Hermes endpoint for this network, for consumers that submit or read
+    /// Pyth price updates. Overridable the same way as [`rpc_url`](Self::rpc_url).
+    // The endpoint constants are compile-time literals known to be valid.
+    #[allow(clippy::expect_used)]
+    #[must_use]
+    pub fn hermes_url(self) -> Url {
+        match self {
+            Network::Mainnet => HERMES_MAINNET_URL,
+            Network::Testnet => HERMES_TESTNET_URL,
+        }
+        .parse()
+        .expect("Hermes endpoint constants must be valid URLs")
     }
 }
 
@@ -166,7 +186,20 @@ impl NetworkConfigBuilder {
 
 #[cfg(test)]
 mod tests {
-    use super::NetworkConfigBuilder;
+    use super::{Network, NetworkConfigBuilder};
+
+    /// A mainnet Pyth receiver rejects a VAA signed by the testnet guardian set.
+    #[test]
+    fn each_network_gets_its_own_hermes_endpoint() {
+        assert_eq!(
+            Network::Mainnet.hermes_url().as_str(),
+            "https://hermes.pyth.network/"
+        );
+        assert_eq!(
+            Network::Testnet.hermes_url().as_str(),
+            "https://hermes-beta.pyth.network/"
+        );
+    }
 
     #[test]
     fn embedded_api_key_moves_to_header() {


### PR DESCRIPTION
Pyth's Hermes endpoints are per-network: a VAA served by the beta endpoint carries the testnet guardian set's signatures, which a mainnet Pyth receiver rejects. Every consumer that submits or reads Pyth updates needs the same mapping, so it belongs beside `Network::rpc_url` rather than duplicated in each of them.

Additive — no existing caller changes. Split out of the ENG-462 stack so this crate takes its own non-breaking bump (`templar-gateway-client` 0.2.0 → 0.2.1) instead of inheriting the `!` from the breaking commit that consumes it.

**Merge first.** ENG-462 is stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/585)
<!-- Reviewable:end -->
