### PR TITLE
feat(gateway)!: oracle.updatePyth fetches its own payload (ENG-462)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13334,6 +13334,8 @@ dependencies = [
  "templar-gateway-client",
  "templar-gateway-core",
  "templar-gateway-methods-spec",
+ "templar-gateway-oracle-updates-dispatch",
+ "templar-gateway-oracle-updates-spec",
  "templar-gateway-testing",
  "templar-gateway-types",
  "templar-proxy-oracle-near-common",
@@ -13342,6 +13344,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/gateway/METHODS.md
+++ b/gateway/METHODS.md
@@ -128,7 +128,7 @@
 | `oracle.resolvePrices` | read | `ResolvePrices` → `ResolvePricesResult` | Resolve multiple prices from supplied inputs. |
 | `oracle.updateLazer` | write | `UpdateLazer` → `WriteOperationResult` | Submit a Pyth Lazer oracle update for a single feed. |
 | `oracle.updatePrices` | write | `UpdatePrices` → `WriteOperationResult` | Submit all updates needed for prices. |
-| `oracle.updatePyth` | write | `UpdatePyth` → `WriteOperationResult` | Submit a Pyth oracle update. |
+| `oracle.updatePyth` | write | `UpdatePyth` → `WriteOperationResult` | Submit a Pyth oracle update for one or more feeds. |
 | `oracle.updateRedStone` | write | `UpdateRedStone` → `WriteOperationResult` | Submit a RedStone oracle update for one or more feeds. |
 
 ## `owner`

--- a/gateway/oracle-updates-dispatch/src/lib.rs
+++ b/gateway/oracle-updates-dispatch/src/lib.rs
@@ -20,4 +20,4 @@ pub use redstone_client::{RedStoneBridgeClient, RedStoneBridgeError, RedStoneRes
 pub use source_provider_impl::{ProvidesLazerSource, ProvidesPythSource, ProvidesRedStoneSource};
 pub use sources::{build_oracle_updates_context, OracleSourceConfig, OracleUpdatesContext};
 #[cfg(feature = "clap")]
-pub use sources::{LazerSourceArgs, OracleSourceArgs, RedStoneSourceArgs};
+pub use sources::{LazerSourceArgs, OracleSourceArgs, PythSourceArgs, RedStoneSourceArgs};

--- a/gateway/oracle-updates-dispatch/src/oracle_impl.rs
+++ b/gateway/oracle-updates-dispatch/src/oracle_impl.rs
@@ -7,7 +7,7 @@ use templar_gateway_core::{
     client::{proxy_oracle::UpdatePricesArgs, ContractWriteOptions},
     plan_pyth_lazer_update, plan_pyth_update, plan_redstone_write_prices, query_oracle_kind,
     resolve_price_dependencies, GatewayError, GatewayResult, HasNearClient, OperationPlan,
-    OraclePayloadSource, PlanWrite,
+    OraclePayloadSource, PlanWrite, PlannedTransaction,
 };
 use templar_gateway_oracle_updates_spec::oracle::{
     UpdateLazer, UpdatePrices, UpdatePyth, UpdateRedStone,
@@ -17,27 +17,30 @@ use templar_proxy_oracle_near_common::request::{LazerRequest, OracleRequest};
 
 use crate::{Dispatch, ProvidesLazerSource, ProvidesPythSource, ProvidesRedStoneSource};
 
-/// The VAA arrives in the request body, so this is the one oracle update that reaches no
-/// payload source — and, submitting the caller's bytes verbatim, a duplicate of
-/// `pyth.updatePriceFeeds`. That is a wart, not a design: ENG-462 reshapes the body to
-/// `price_ids` and fetches from Hermes like the other three, restoring the
-/// `ProvidesPythSource` bound this impl would then actually use.
 #[async_trait]
 impl<C> PlanWrite<UpdatePyth, C> for Dispatch
 where
-    C: HasNearClient,
+    C: HasNearClient + ProvidesPythSource,
 {
     async fn plan(
         request: templar_gateway_types::common::WriteRequest<UpdatePyth>,
         ctx: C,
     ) -> GatewayResult<OperationPlan> {
         let body = request.body;
-        plan_pyth_update(
-            ctx.near_client(),
+        if body.price_ids.is_empty() {
+            tracing::warn!(
+                oracle_id = %body.oracle_id,
+                "oracle.updatePyth requested with no price ids; nothing to update"
+            );
+            return Ok(OperationPlan { steps: Vec::new() });
+        }
+        plan_pyth_feed_update(
+            &ctx,
             request.signer_account_id,
             body.oracle_id,
-            body.vaa.0,
+            &body.price_ids,
         )
+        .await
         .map(OperationPlan::from)
     }
 }
@@ -145,6 +148,27 @@ where
     }
 }
 
+/// Fetch the VAA covering `price_ids` from Hermes and plan the adapter write.
+async fn plan_pyth_feed_update<C>(
+    ctx: &C,
+    signer_account_id: ManagedAccountId,
+    oracle_id: AccountId,
+    price_ids: &[PriceIdentifier],
+) -> GatewayResult<PlannedTransaction>
+where
+    C: HasNearClient + ProvidesPythSource,
+{
+    tracing::debug!(
+        %oracle_id,
+        price_count = price_ids.len(),
+        "fetching Pyth payload for gateway oracle update"
+    );
+    let vaa = OraclePayloadSource::fetch_payload(ctx.pyth_source(), price_ids)
+        .await
+        .map_err(|error| GatewayError::HttpRequest(error.to_string()))?;
+    plan_pyth_update(ctx.near_client(), signer_account_id, oracle_id, vaa)
+}
+
 async fn plan_grouped_updates<C>(
     ctx: &C,
     signer_account_id: ManagedAccountId,
@@ -187,20 +211,9 @@ where
 
     for (oracle_id, price_ids) in pyth_updates {
         let price_ids = price_ids.into_iter().collect::<Vec<_>>();
-        tracing::debug!(
-            %oracle_id,
-            price_count = price_ids.len(),
-            "fetching Pyth payload for gateway oracle update"
+        steps.push(
+            plan_pyth_feed_update(ctx, signer_account_id.clone(), oracle_id, &price_ids).await?,
         );
-        let vaa = OraclePayloadSource::fetch_payload(ctx.pyth_source(), &price_ids)
-            .await
-            .map_err(|error| GatewayError::HttpRequest(error.to_string()))?;
-        steps.push(plan_pyth_update(
-            ctx.near_client(),
-            signer_account_id.clone(),
-            oracle_id,
-            vaa,
-        )?);
     }
 
     for (oracle_id, feed_ids) in redstone_updates {
@@ -268,14 +281,14 @@ mod tests {
     use base64::Engine as _;
     use near_api::types::transaction::actions::Action;
     use near_api::NetworkConfig;
-    use templar_gateway_core::{NearClient, PlannedTransaction};
+    use templar_gateway_core::NearClient;
     use templar_gateway_types::common::WriteRequest;
     use thiserror::Error;
 
-    // Every source error is mapped identically to `GatewayError::ExternalService(err.to_string())`,
-    // so one variant exercises that path; the tests differ by entry point, not error kind.
+    // Every source error carries `err.to_string()` into its gateway variant, so one
+    // variant exercises that path; the tests differ by entry point, not error kind.
     #[derive(Debug, Clone, Error)]
-    #[error("fake lazer source unavailable")]
+    #[error("fake source unavailable")]
     struct FakeError;
 
     #[derive(Clone)]
@@ -295,7 +308,7 @@ mod tests {
 
     #[derive(Clone)]
     struct FakePythSource {
-        payload: Vec<u8>,
+        outcome: Result<Vec<u8>, FakeError>,
     }
 
     #[async_trait]
@@ -307,7 +320,7 @@ mod tests {
             &self,
             _price_ids: &[PriceIdentifier],
         ) -> Result<Vec<u8>, FakeError> {
-            Ok(self.payload.clone())
+            self.outcome.clone()
         }
     }
 
@@ -391,21 +404,111 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn update_lazer_plans_one_adapter_write() {
-        let payload = vec![0xAA, 0xBB, 0xCC, 0xDD];
-        let ctx = TestCtx {
+    /// A `TestCtx` whose every source succeeds with an empty payload. Override the one
+    /// source under test with struct-update syntax.
+    fn inert_ctx() -> TestCtx {
+        TestCtx {
             near_client: test_client(),
             pyth_source: FakePythSource {
-                payload: Vec::new(),
+                outcome: Ok(Vec::new()),
             },
             redstone_source: FakeRedStoneSource {
                 payload: Vec::new(),
             },
             lazer_source: FakeLazerSource {
-                outcome: Ok(payload.clone()),
+                outcome: Ok(Vec::new()),
             },
-        };
+        }
+    }
+
+    fn pyth_ctx(outcome: Result<Vec<u8>, FakeError>) -> TestCtx {
+        TestCtx {
+            pyth_source: FakePythSource { outcome },
+            ..inert_ctx()
+        }
+    }
+
+    fn lazer_ctx(outcome: Result<Vec<u8>, FakeError>) -> TestCtx {
+        TestCtx {
+            lazer_source: FakeLazerSource { outcome },
+            ..inert_ctx()
+        }
+    }
+
+    fn update_pyth_request(
+        oracle_id: AccountId,
+        price_ids: Vec<PriceIdentifier>,
+    ) -> WriteRequest<UpdatePyth> {
+        WriteRequest {
+            signer_account_id: signer_id(),
+            idempotency_key: None,
+            body: UpdatePyth {
+                oracle_id,
+                price_ids,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn update_pyth_writes_the_vaa_it_fetched() {
+        let vaa = vec![0x01, 0x02, 0x03, 0x04];
+        let oracle_id: AccountId = "pyth.near".parse().expect("valid account id");
+        let request = update_pyth_request(oracle_id.clone(), vec![PriceIdentifier([0xAA; 32])]);
+
+        let plan =
+            <Dispatch as PlanWrite<UpdatePyth, TestCtx>>::plan(request, pyth_ctx(Ok(vaa.clone())))
+                .await
+                .expect("UpdatePyth plan must succeed with a fresh payload");
+
+        assert_eq!(plan.steps.len(), 1, "UpdatePyth must plan exactly one step");
+        let step = &plan.steps[0];
+        assert_eq!(step.receiver_id, oracle_id);
+
+        let (method, args_bytes) = unpack_function_call(step);
+        assert_eq!(method, "update_price_feeds");
+        let args_json: serde_json::Value =
+            serde_json::from_slice(&args_bytes).expect("args must be valid json");
+        assert_eq!(
+            args_json["data"],
+            hex::encode(&vaa),
+            "the adapter must receive the fetched VAA as hex; got: {args_json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_pyth_with_no_price_ids_plans_nothing() {
+        let request = update_pyth_request("pyth.near".parse().unwrap(), Vec::new());
+
+        let plan =
+            <Dispatch as PlanWrite<UpdatePyth, TestCtx>>::plan(request, pyth_ctx(Err(FakeError)))
+                .await
+                .expect("an empty UpdatePyth must not reach the source");
+
+        assert!(plan.steps.is_empty(), "expected a step-less plan");
+    }
+
+    #[tokio::test]
+    async fn update_pyth_propagates_source_error() {
+        let request = update_pyth_request(
+            "pyth.near".parse().unwrap(),
+            vec![PriceIdentifier([0xAA; 32])],
+        );
+
+        let error =
+            <Dispatch as PlanWrite<UpdatePyth, TestCtx>>::plan(request, pyth_ctx(Err(FakeError)))
+                .await
+                .expect_err("a Hermes error must surface as a plan error");
+
+        assert!(
+            matches!(error, GatewayError::HttpRequest(ref msg) if msg.contains("unavailable")),
+            "expected HttpRequest carrying the source-error detail, got {error:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_lazer_plans_one_adapter_write() {
+        let payload = vec![0xAA, 0xBB, 0xCC, 0xDD];
+        let ctx = lazer_ctx(Ok(payload.clone()));
         let oracle_id: AccountId = "pyth-lazer.near".parse().expect("valid account id");
         let request = WriteRequest {
             signer_account_id: signer_id(),
@@ -456,18 +559,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_lazer_propagates_source_error() {
-        let ctx = TestCtx {
-            near_client: test_client(),
-            pyth_source: FakePythSource {
-                payload: Vec::new(),
-            },
-            redstone_source: FakeRedStoneSource {
-                payload: Vec::new(),
-            },
-            lazer_source: FakeLazerSource {
-                outcome: Err(FakeError),
-            },
-        };
+        let ctx = lazer_ctx(Err(FakeError));
         let request = WriteRequest {
             signer_account_id: signer_id(),
             idempotency_key: None,
@@ -492,16 +584,13 @@ mod tests {
         let pyth_payload = vec![0x11_u8; 16];
         let lazer_payload = vec![0x22_u8; 24];
         let ctx = TestCtx {
-            near_client: test_client(),
             pyth_source: FakePythSource {
-                payload: pyth_payload.clone(),
-            },
-            redstone_source: FakeRedStoneSource {
-                payload: Vec::new(),
+                outcome: Ok(pyth_payload.clone()),
             },
             lazer_source: FakeLazerSource {
                 outcome: Ok(lazer_payload.clone()),
             },
+            ..inert_ctx()
         };
         let pyth_oracle: AccountId = "pyth.near".parse().unwrap();
         let lazer_oracle: AccountId = "pyth-lazer.near".parse().unwrap();
@@ -569,18 +658,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_prices_lazer_source_error_is_hard_error() {
-        let ctx = TestCtx {
-            near_client: test_client(),
-            pyth_source: FakePythSource {
-                payload: vec![0x11_u8; 16],
-            },
-            redstone_source: FakeRedStoneSource {
-                payload: Vec::new(),
-            },
-            lazer_source: FakeLazerSource {
-                outcome: Err(FakeError),
-            },
-        };
+        let ctx = lazer_ctx(Err(FakeError));
         let lazer_oracle: AccountId = "pyth-lazer.near".parse().unwrap();
         let requests = vec![OracleRequest::lazer(lazer_oracle, 7)];
 
@@ -600,18 +678,7 @@ mod tests {
     // gateway sandbox test `oracle_update_prices_endpoint_resolves_and_updates_dependencies`.
     #[test]
     fn proxy_reaggregation_step_calls_proxy_update_prices() {
-        let ctx = TestCtx {
-            near_client: test_client(),
-            pyth_source: FakePythSource {
-                payload: Vec::new(),
-            },
-            redstone_source: FakeRedStoneSource {
-                payload: Vec::new(),
-            },
-            lazer_source: FakeLazerSource {
-                outcome: Ok(Vec::new()),
-            },
-        };
+        let ctx = inert_ctx();
         let oracle_id: AccountId = "proxy.near".parse().expect("valid account id");
         let price_ids = vec![PriceIdentifier([0x11; 32]), PriceIdentifier([0x22; 32])];
 

--- a/gateway/oracle-updates-dispatch/src/pyth_client.rs
+++ b/gateway/oracle-updates-dispatch/src/pyth_client.rs
@@ -1,9 +1,14 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use serde::Deserialize;
 use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_core::OraclePayloadSource;
 use thiserror::Error;
 use url::Url;
+
+/// A plan that blocks on Hermes holds up every step behind it.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Error)]
 pub enum PythClientError {
@@ -47,16 +52,19 @@ impl OraclePayloadSource for PythHttpClient {
         #[derive(Deserialize)]
         struct Data(#[serde(deserialize_with = "hex::deserialize")] Vec<u8>);
 
-        let mut request = self.http.get(format!(
-            "{}/v2/updates/price/latest",
-            self.hermes_url.as_str().trim_end_matches('/'),
-        ));
+        let ids = price_ids
+            .iter()
+            .map(|price_id| ("ids[]", price_id))
+            .collect::<Vec<_>>();
 
-        for price_id in price_ids {
-            request = request.query(&[("ids[]", price_id)]);
-        }
-
-        let response = request
+        let response = self
+            .http
+            .get(format!(
+                "{}/v2/updates/price/latest",
+                self.hermes_url.as_str().trim_end_matches('/'),
+            ))
+            .query(&ids)
+            .timeout(FETCH_TIMEOUT)
             .send()
             .await
             .map_err(|error| PythClientError::HttpRequest(error.to_string()))?

--- a/gateway/oracle-updates-dispatch/src/sources.rs
+++ b/gateway/oracle-updates-dispatch/src/sources.rs
@@ -42,7 +42,7 @@ pub fn build_oracle_updates_context(
 }
 
 #[cfg(feature = "clap")]
-pub use args::{LazerSourceArgs, OracleSourceArgs, RedStoneSourceArgs};
+pub use args::{LazerSourceArgs, OracleSourceArgs, PythSourceArgs, RedStoneSourceArgs};
 
 #[cfg(feature = "clap")]
 mod args {
@@ -54,6 +54,26 @@ mod args {
 
     use super::OracleSourceConfig;
     use crate::{LazerSourceConfig, LazerSubscriptionConfig};
+
+    /// CLI surface for the in-process Pyth Hermes payload source.
+    #[derive(Args, Debug, Clone)]
+    pub struct PythSourceArgs {
+        /// Pyth Hermes API URL. Defaults to Pyth's public endpoint for the network
+        /// the consumer targets.
+        /// See: <https://docs.pyth.network/price-feeds/core/api-reference>
+        #[arg(long = "pyth-hermes-url", env = "PYTH_HERMES_URL")]
+        pub pyth_hermes_url: Option<Url>,
+    }
+
+    impl PythSourceArgs {
+        /// The configured endpoint, or `default` when `--pyth-hermes-url` is unset.
+        /// `default` must match the network the caller submits updates to, as
+        /// `Network::hermes_url` returns.
+        #[must_use]
+        pub fn hermes_url(&self, default: Url) -> Url {
+            self.pyth_hermes_url.clone().unwrap_or(default)
+        }
+    }
 
     /// CLI surface for the in-process RedStone bridge payload source.
     #[derive(Args, Debug, Clone)]
@@ -129,19 +149,11 @@ mod args {
 
     /// Every in-process oracle payload source at once. Flatten it into a consumer's
     /// `clap` configuration and call [`OracleSourceArgs::build`]; flatten a single
-    /// member instead when only one source is reachable. The Pyth Hermes URL is inline
-    /// because no consumer builds a Hermes source on its own today — only because
-    /// `oracle.updatePyth` takes its VAA from the request body instead of fetching it,
-    /// which ENG-462 fixes. Expect a `PythSourceArgs` sibling then.
+    /// member instead when only one source is reachable.
     #[derive(Args, Debug, Clone)]
     pub struct OracleSourceArgs {
-        /// Pyth Hermes API URL. See: <https://docs.pyth.network/price-feeds/core/api-reference>
-        #[arg(
-            long = "pyth-hermes-url",
-            env = "PYTH_HERMES_URL",
-            default_value = "https://hermes-beta.pyth.network"
-        )]
-        pub pyth_hermes_url: Url,
+        #[command(flatten)]
+        pub pyth: PythSourceArgs,
         #[command(flatten)]
         pub redstone: RedStoneSourceArgs,
         #[command(flatten)]
@@ -149,14 +161,16 @@ mod args {
     }
 
     impl OracleSourceArgs {
-        /// Validate and assemble the runtime [`OracleSourceConfig`].
+        /// Validate and assemble the runtime [`OracleSourceConfig`], falling back to
+        /// `hermes_default` when `--pyth-hermes-url` is unset — see
+        /// [`PythSourceArgs::hermes_url`].
         ///
         /// # Errors
         /// Returns an error if the Lazer websocket configuration is invalid — see
         /// [`LazerSourceArgs::build`].
-        pub fn build(&self) -> anyhow::Result<OracleSourceConfig> {
+        pub fn build(&self, hermes_default: Url) -> anyhow::Result<OracleSourceConfig> {
             Ok(OracleSourceConfig {
-                pyth_hermes_url: self.pyth_hermes_url.clone(),
+                pyth_hermes_url: self.pyth.hermes_url(hermes_default),
                 redstone_node_path: self.redstone.redstone_node_path.clone(),
                 lazer: self.lazer.build()?,
             })

--- a/gateway/oracle-updates-spec/src/oracle.rs
+++ b/gateway/oracle-updates-spec/src/oracle.rs
@@ -2,14 +2,15 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use templar_common::oracle::{pyth::PriceIdentifier, redstone};
 use templar_gateway_macros::MethodSpec;
-use templar_gateway_types::Base64Bytes;
 
-/// Submit a Pyth oracle update.
+/// Submit a Pyth oracle update for one or more feeds.
 #[derive(MethodSpec, Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[method(write = "oracle.updatePyth")]
 pub struct UpdatePyth {
     pub oracle_id: near_account_id::AccountId,
-    pub vaa: Base64Bytes,
+    /// Fetched from Hermes as one VAA and written in a single `update_price_feeds`
+    /// call. Empty is a no-op.
+    pub price_ids: Vec<PriceIdentifier>,
 }
 
 /// Submit a RedStone oracle update for one or more feeds.

--- a/service/gateway/src/config.rs
+++ b/service/gateway/src/config.rs
@@ -80,6 +80,7 @@ pub struct Config {
     pub migrate_database: bool,
 
     /// In-process oracle payload sources (Pyth Hermes, RedStone bridge, Pyth Lazer).
+    /// A mainnet deployment must set `--pyth-hermes-url`; it defaults to testnet's.
     #[command(flatten)]
     pub oracle_sources: OracleSourceArgs,
 
@@ -131,6 +132,7 @@ mod tests {
 
     use super::*;
     use rstest::rstest;
+    use templar_gateway_client::Network;
 
     #[test]
     fn parses_minimal_config() {
@@ -154,10 +156,6 @@ mod tests {
         );
         assert_eq!(config.database_url, None);
         assert!(!config.migrate_database);
-        assert_eq!(
-            config.oracle_sources.pyth_hermes_url.as_str(),
-            "https://hermes-beta.pyth.network/"
-        );
         assert_eq!(
             config.oracle_sources.redstone.redstone_node_path,
             PathBuf::from("node")
@@ -231,13 +229,13 @@ mod tests {
             Ok(()) => {
                 config
                     .oracle_sources
-                    .build()
+                    .build(Network::Testnet.hermes_url())
                     .expect("valid Lazer config should build");
             }
             Err(expected_msg) => {
                 let error = config
                     .oracle_sources
-                    .build()
+                    .build(Network::Testnet.hermes_url())
                     .expect_err("invalid Lazer config should fail");
                 assert!(error.to_string().contains(expected_msg));
             }

--- a/service/gateway/src/main.rs
+++ b/service/gateway/src/main.rs
@@ -6,7 +6,7 @@ mod rpc;
 use crate::rpc::attach_gateway;
 use clap::Parser;
 use jsonrpsee::server::ServerBuilder;
-use templar_gateway_client::NetworkConfigBuilder;
+use templar_gateway_client::{Network, NetworkConfigBuilder};
 use templar_gateway_core::GatewayContext;
 use templar_gateway_oracle_updates_dispatch::GatewayContextBuilderOracleExt;
 use tokio::signal;
@@ -23,7 +23,7 @@ async fn main() -> anyhow::Result<()> {
 
     let signers = config.build_signers()?;
     let store = config.build_store().await?;
-    let sources = config.oracle_sources.build()?;
+    let sources = config.oracle_sources.build(Network::Testnet.hermes_url())?;
     let network = NetworkConfigBuilder::from_url("gateway", config.near_rpc_url)
         .api_key(
             config

--- a/service/gateway/src/rpc/tests.rs
+++ b/service/gateway/src/rpc/tests.rs
@@ -86,7 +86,7 @@ struct TestStack {
 
 impl TestStack {
     async fn start() -> Result<Self> {
-        Self::start_with_oracle_update_config("https://hermes-beta.pyth.network".parse().unwrap())
+        Self::start_with_oracle_update_config(templar_gateway_client::Network::Testnet.hermes_url())
             .await
     }
 

--- a/service/gateway/src/rpc/tests/oracle_tests.rs
+++ b/service/gateway/src/rpc/tests/oracle_tests.rs
@@ -18,7 +18,7 @@ async fn oracle_update_endpoints_work_against_sandbox() -> Result<()> {
             idempotency_key: None,
             body: oracle_updates::UpdatePyth {
                 oracle_id: pyth_oracle_id.clone(),
-                vaa: Base64Bytes(vec![0xde, 0xad, 0xbe, 0xef]),
+                price_ids: vec![PriceIdentifier([0x11; 32])],
             },
         })
         .await?;
@@ -37,7 +37,8 @@ async fn oracle_update_endpoints_work_against_sandbox() -> Result<()> {
     .await?;
     assert_eq!(
         last_pyth_update,
-        serde_json::Value::String("deadbeef".to_owned())
+        serde_json::Value::String("cafebabe".to_owned()),
+        "the adapter must receive the VAA the gateway fetched from Hermes"
     );
 
     let redstone_result = stack

--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -172,7 +172,7 @@ RUST_LOG=info
 # Mainnet: https://hermes.pyth.network
 # Testnet: https://hermes-beta.pyth.network
 # Default: the endpoint matching NEAR_NETWORK
-PYTH_HERMES_URL=https://hermes.pyth.network
+# PYTH_HERMES_URL=
 
 # RedStone gateway URL for fetching fresh prices
 # Gateways: https://oracle-gateway-1.a.redstone.vip, https://oracle-gateway-2.a.redstone.finance

--- a/service/liquidator/.env.example
+++ b/service/liquidator/.env.example
@@ -171,7 +171,7 @@ RUST_LOG=info
 # Pyth Hermes API URL for fetching latest price data
 # Mainnet: https://hermes.pyth.network
 # Testnet: https://hermes-beta.pyth.network
-# Default: https://hermes.pyth.network
+# Default: the endpoint matching NEAR_NETWORK
 PYTH_HERMES_URL=https://hermes.pyth.network
 
 # RedStone gateway URL for fetching fresh prices

--- a/service/liquidator/Cargo.toml
+++ b/service/liquidator/Cargo.toml
@@ -30,12 +30,15 @@ templar-common = { workspace = true, features = ["rpc"] }
 templar-gateway-client = { workspace = true, features = ["clap"] }
 templar-gateway-core = { workspace = true }
 templar-gateway-methods-spec = { workspace = true }
+templar-gateway-oracle-updates-dispatch = { workspace = true }
+templar-gateway-oracle-updates-spec = { workspace = true }
 templar-gateway-types = { workspace = true }
 templar-proxy-oracle-near-common = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+url = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/service/liquidator/docker-compose.yml
+++ b/service/liquidator/docker-compose.yml
@@ -17,7 +17,7 @@ services:
       - RUST_BACKTRACE=${RUST_BACKTRACE:-1}
 
     command: [
-      "--network", "${NETWORK:-mainnet}",
+      "--network", "${NEAR_NETWORK:-mainnet}",
       "--signer-account", "${SIGNER_ACCOUNT_ID}",
       "--signer-key", "${SIGNER_KEY}",
       "--registries", "${REGISTRY_ACCOUNT_IDS:-v1.tmplr.near}",
@@ -29,7 +29,6 @@ services:
       "--transaction-timeout", "${TRANSACTION_TIMEOUT:-60}",
       "--collateral-strategy", "${COLLATERAL_STRATEGY:-hold}",
       "--max-loop-iterations", "${MAX_LOOP_ITERATIONS:-10}",
-      "--hermes-url", "${PYTH_HERMES_URL:-https://hermes.pyth.network}",
       "--redstone-gateway-url", "${REDSTONE_GATEWAY_URL:-https://oracle-gateway-1.a.redstone.vip}",
       # Uncomment to enable loop liquidation (repeatedly liquidate until healthy):
       # "--loop-liquidation",

--- a/service/liquidator/scripts/run-mainnet.sh
+++ b/service/liquidator/scripts/run-mainnet.sh
@@ -64,7 +64,7 @@ IGNORED_COLLATERAL_ASSETS="${IGNORED_COLLATERAL_ASSETS}"
 IGNORED_MARKETS="${IGNORED_MARKETS}"
 
 # Oracle price update configuration
-PYTH_HERMES_URL="${PYTH_HERMES_URL:-https://hermes.pyth.network}"
+PYTH_HERMES_URL="${PYTH_HERMES_URL}"
 REDSTONE_GATEWAY_URL="${REDSTONE_GATEWAY_URL:-https://oracle-gateway-1.a.redstone.vip}"
 
 # Build binary
@@ -197,7 +197,7 @@ if [ -n "$IGNORED_MARKETS" ]; then
 fi
 
 # Add oracle price update arguments
-CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
+[ -n "$PYTH_HERMES_URL" ] && CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
 CMD_ARGS+=("--redstone-gateway-url" "$REDSTONE_GATEWAY_URL")
 
 # Add Telegram notification arguments (use = syntax because chat IDs start with -)

--- a/service/liquidator/scripts/run-testnet.sh
+++ b/service/liquidator/scripts/run-testnet.sh
@@ -64,7 +64,7 @@ IGNORED_COLLATERAL_ASSETS="${IGNORED_COLLATERAL_ASSETS}"
 IGNORED_MARKETS="${IGNORED_MARKETS}"
 
 # Oracle price update configuration
-PYTH_HERMES_URL="${PYTH_HERMES_URL:-https://hermes-beta.pyth.network}"
+PYTH_HERMES_URL="${PYTH_HERMES_URL}"
 REDSTONE_GATEWAY_URL="${REDSTONE_GATEWAY_URL:-https://oracle-gateway-1.a.redstone.vip}"
 
 # Build binary
@@ -198,7 +198,7 @@ if [ -n "$IGNORED_MARKETS" ]; then
 fi
 
 # Add oracle price update arguments
-CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
+[ -n "$PYTH_HERMES_URL" ] && CMD_ARGS+=("--hermes-url" "$PYTH_HERMES_URL")
 CMD_ARGS+=("--redstone-gateway-url" "$REDSTONE_GATEWAY_URL")
 
 # Add Telegram notification arguments (use = syntax because chat IDs start with -)

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -471,6 +471,27 @@ mod tests {
         }
     }
 
+    /// A VAA is only accepted by the Pyth receiver whose guardian set signed it.
+    #[test]
+    fn hermes_url_defaults_to_the_selected_networks_endpoint() {
+        for network in [Network::Mainnet, Network::Testnet] {
+            let mut args = create_test_args();
+            args.network = network;
+            args.hermes_url = None;
+
+            assert_eq!(args.build_config().hermes_url, network.hermes_url());
+        }
+    }
+
+    #[test]
+    fn an_explicit_hermes_url_overrides_the_network_default() {
+        let override_url: Url = "https://hermes.example/".parse().expect("a valid endpoint");
+        let mut args = create_test_args();
+        args.hermes_url = Some(override_url.clone());
+
+        assert_eq!(args.build_config().hermes_url, override_url);
+    }
+
     #[test]
     fn test_parse_collateral_strategy_swap_to_borrow() {
         let mut args = create_test_args();

--- a/service/liquidator/src/config.rs
+++ b/service/liquidator/src/config.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use clap::Parser;
 use near_sdk::AccountId;
 use templar_gateway_client::Network;
+use url::Url;
 
 use crate::{
     notifier::{Notifier, TelegramConfig},
@@ -141,13 +142,10 @@ pub struct Args {
     #[arg(long, env = "MAX_LOOP_ITERATIONS", default_value_t = 10)]
     pub max_loop_iterations: u32,
 
-    /// Pyth Hermes API URL for fetching price data
-    #[arg(
-        long,
-        env = "PYTH_HERMES_URL",
-        default_value = "https://hermes.pyth.network"
-    )]
-    pub hermes_url: String,
+    /// Pyth Hermes API URL for fetching price data. Defaults to Pyth's endpoint for
+    /// `--network`.
+    #[arg(long, env = "PYTH_HERMES_URL")]
+    pub hermes_url: Option<Url>,
 
     /// RedStone gateway URL for fetching fresh prices
     #[arg(
@@ -397,7 +395,10 @@ impl Args {
             ignored_markets,
             loop_liquidation: self.loop_liquidation,
             max_loop_iterations: self.max_loop_iterations,
-            hermes_url: self.hermes_url.clone(),
+            hermes_url: self
+                .hermes_url
+                .clone()
+                .unwrap_or_else(|| self.network.hermes_url()),
             redstone_gateway_url: self.redstone_gateway_url.clone(),
             min_swap_value_usd: self.min_swap_value_usd,
             batch_swap_on_cycle_start: self.batch_swap_on_cycle_start,
@@ -456,7 +457,7 @@ mod tests {
             ignored_markets: vec![],
             loop_liquidation: false,
             max_loop_iterations: 10,
-            hermes_url: "https://hermes.pyth.network".to_string(),
+            hermes_url: None,
             redstone_gateway_url: "https://oracle-gateway-1.a.redstone.vip".to_string(),
             min_swap_value_usd: 10.0,
             batch_swap_on_cycle_start: true,

--- a/service/liquidator/src/liquidator.rs
+++ b/service/liquidator/src/liquidator.rs
@@ -361,6 +361,7 @@ impl Liquidator {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         client: &SigningClient,
+        pyth_updates: &oracle::PythUpdatesClient,
         inventory: &inventory::SharedInventory,
         market: AccountId,
         market_config: MarketConfiguration,
@@ -370,7 +371,7 @@ impl Liquidator {
         swap_provider: Option<crate::swap::SwapProviderImpl>,
         loop_liquidation: bool,
         max_loop_iterations: u32,
-        hermes_url: Option<String>,
+        hermes_url: url::Url,
         redstone_gateway_url: Option<String>,
         swap_retry_config: crate::swap::SwapRetryConfig,
         min_swap_value_usd: f64,
@@ -380,6 +381,7 @@ impl Liquidator {
         let scanner = scanner::MarketScanner::new(client.clone(), market.clone());
         let oracle_fetcher = oracle::OracleFetcher::new(
             client.clone(),
+            pyth_updates.clone(),
             hermes_url,
             redstone_gateway_url,
             proxy_oracle_cache,

--- a/service/liquidator/src/oracle.rs
+++ b/service/liquidator/src/oracle.rs
@@ -13,7 +13,10 @@ use templar_common::{
     Decimal,
 };
 use templar_gateway_client::SigningClient;
+use templar_gateway_core::GatewayContext;
 use templar_gateway_methods_spec::{contract, lst_oracle, proxy_oracle, pyth as pyth_spec};
+use templar_gateway_oracle_updates_dispatch::{Dispatch as OracleUpdatesDispatch, WithPythSource};
+use templar_gateway_oracle_updates_spec::oracle as oracle_updates;
 use templar_gateway_types::{
     common::ContractArgs, Base64Bytes, ContractMethodName, OperationStatus,
 };
@@ -22,6 +25,7 @@ use templar_proxy_oracle_near_common::{
     price_transformer::{Call, PriceTransformer},
     request::OracleRequest,
 };
+use url::Url;
 
 use crate::{
     rpc::{gateway_is_method_not_found, RpcError},
@@ -50,18 +54,11 @@ struct HermesParsedPrice {
     publish_time: i64,
 }
 
-/// Binary (VAA) response from Pyth Hermes for on-chain price updates.
-#[derive(serde::Deserialize)]
-struct HermesBinaryResponse {
-    binary: HermesBinaryData,
-}
-
-#[derive(serde::Deserialize)]
-struct HermesBinaryData {
-    data: Vec<String>,
-}
-
 // ── Shared types ─────────────────────────────────────────────────────────────
+
+/// A gateway client bound to the oracle-updates dispatcher, over a context carrying
+/// the in-process Hermes payload source that `oracle.updatePyth` fetches from.
+pub type PythUpdatesClient = SigningClient<OracleUpdatesDispatch, WithPythSource<GatewayContext>>;
 
 /// Shared cache of detected proxy oracle accounts.
 pub type ProxyOracleCache =
@@ -74,6 +71,7 @@ pub type ProxyOracleCache =
 /// aggregation.
 pub struct OracleFetcher {
     client: SigningClient,
+    pyth_updates: PythUpdatesClient,
     /// Cache of which oracles are LST oracles (`oracle_account` -> `underlying_oracle`)
     lst_oracle_cache: std::sync::Arc<tokio::sync::RwLock<HashMap<AccountId, Option<AccountId>>>>,
     /// Cache of detected proxy oracles (oracles that use cross-contract calls).
@@ -83,7 +81,7 @@ pub struct OracleFetcher {
     /// HTTP client for API calls
     http_client: reqwest::Client,
     /// Pyth Hermes API URL (e.g., <https://hermes.pyth.network>)
-    hermes_url: String,
+    hermes_url: Url,
 }
 
 impl OracleFetcher {
@@ -96,18 +94,20 @@ impl OracleFetcher {
     /// [`SigningClient`].
     pub fn new(
         client: SigningClient,
-        hermes_url: Option<String>,
+        pyth_updates: PythUpdatesClient,
+        hermes_url: Url,
         _redstone_gateway_url: Option<String>,
         proxy_oracle_cache: Option<ProxyOracleCache>,
     ) -> Self {
         Self {
             client,
+            pyth_updates,
             lst_oracle_cache: std::sync::Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             proxy_oracle_cache: proxy_oracle_cache.unwrap_or_else(|| {
                 std::sync::Arc::new(tokio::sync::RwLock::new(std::collections::HashSet::new()))
             }),
             http_client: reqwest::Client::new(),
-            hermes_url: hermes_url.unwrap_or_else(|| "https://hermes.pyth.network".to_string()),
+            hermes_url,
         }
     }
 
@@ -203,7 +203,10 @@ impl OracleFetcher {
         &self,
         price_ids: &[PriceIdentifier],
     ) -> Option<OracleResponse> {
-        let url = format!("{}/v2/updates/price/latest", self.hermes_url);
+        let url = format!(
+            "{}/v2/updates/price/latest",
+            self.hermes_url.as_str().trim_end_matches('/')
+        );
         let mut query_params: Vec<(&str, String)> = price_ids
             .iter()
             .map(|id| ("ids[]", id.to_string()))
@@ -456,8 +459,8 @@ impl OracleFetcher {
         Ok(true)
     }
 
-    /// Pushes fresh Pyth prices on-chain by fetching a VAA from Hermes and
-    /// submitting an `update_price_feeds` transaction to the oracle contract.
+    /// Pushes fresh Pyth prices on-chain via `oracle.updatePyth`, which fetches the
+    /// VAA covering `price_ids` from Hermes inside the gateway.
     ///
     /// The market contract reads prices from the on-chain oracle during
     /// liquidation execution, so prices must be fresh there — not just in the
@@ -473,59 +476,14 @@ impl OracleFetcher {
         tracing::info!(
             oracle = %oracle,
             price_ids = ?price_ids,
-            "Fetching VAA from Hermes for on-chain price update"
-        );
-
-        // Fetch binary VAA from Hermes
-        let url = format!("{}/v2/updates/price/latest", self.hermes_url);
-        let query_params: Vec<_> = price_ids
-            .iter()
-            .map(|id| ("ids[]", id.to_string()))
-            .collect();
-
-        let response = self
-            .http_client
-            .get(&url)
-            .query(&query_params)
-            .timeout(std::time::Duration::from_secs(10))
-            .send()
-            .await
-            .map_err(|e| LiquidatorError::OracleUpdateError(format!("Hermes API error: {e}")))?;
-
-        if !response.status().is_success() {
-            return Err(LiquidatorError::OracleUpdateError(format!(
-                "Hermes API returned status: {}",
-                response.status()
-            )));
-        }
-
-        let body: HermesBinaryResponse = response.json().await.map_err(|e| {
-            LiquidatorError::OracleUpdateError(format!("Failed to parse Hermes response: {e}"))
-        })?;
-
-        let vaa_hex = body.binary.data.first().ok_or_else(|| {
-            LiquidatorError::OracleUpdateError("No VAA data in Hermes response".to_string())
-        })?;
-
-        // Hermes returns the update payload as a hex string. The gateway's
-        // `pyth.updatePriceFeeds` carries the raw bytes (`Base64Bytes`) and
-        // re-hex-encodes them for the on-chain `update_price_feeds` call, so the
-        // hex string is decoded here to keep the on-chain bytes identical to the
-        // pre-migration behaviour.
-        let vaa_bytes = hex::decode(vaa_hex).map_err(|e| {
-            LiquidatorError::OracleUpdateError(format!("Invalid VAA hex from Hermes: {e}"))
-        })?;
-
-        tracing::info!(
-            vaa_size = vaa_bytes.len(),
-            "Fetched VAA from Hermes, submitting to oracle"
+            "Requesting on-chain Pyth price update"
         );
 
         match self
-            .client
-            .execute(pyth_spec::UpdatePriceFeeds {
+            .pyth_updates
+            .execute(oracle_updates::UpdatePyth {
                 oracle_id: oracle.clone(),
-                data: Base64Bytes(vaa_bytes),
+                price_ids: price_ids.to_vec(),
             })
             .await
         {

--- a/service/liquidator/src/service.rs
+++ b/service/liquidator/src/service.rs
@@ -8,8 +8,12 @@
 use std::{collections::HashMap, num::NonZeroU32, sync::Arc, time::Duration};
 
 use near_sdk::AccountId;
-use templar_gateway_client::{collect_paginated, Network, NetworkConfigBuilder, SigningClient};
+use templar_gateway_client::{
+    collect_paginated, Client, Network, NetworkConfigBuilder, SigningClient,
+};
+use templar_gateway_core::GatewayContextBuilder;
 use templar_gateway_methods_spec::{contract, market, registry};
+use templar_gateway_oracle_updates_dispatch::GatewayContextBuilderOracleExt as _;
 use templar_gateway_types::common::Pagination;
 use tokio::{
     select,
@@ -24,8 +28,8 @@ use templar_common::{
 };
 
 use crate::{
-    inventory::InventoryManager, liquidation_strategy::LiquidationStrategy, swap::SwapProvider,
-    CollateralStrategy, Liquidator, LiquidatorError,
+    inventory::InventoryManager, liquidation_strategy::LiquidationStrategy,
+    oracle::PythUpdatesClient, swap::SwapProvider, CollateralStrategy, Liquidator, LiquidatorError,
 };
 
 /// Page size for listing registry deployments.
@@ -95,7 +99,7 @@ pub struct ServiceConfig {
     /// Maximum iterations for loop liquidation (safety limit)
     pub max_loop_iterations: u32,
     /// Pyth Hermes API URL for fetching price data
-    pub hermes_url: String,
+    pub hermes_url: url::Url,
     /// RedStone gateway URL for fetching fresh prices
     pub redstone_gateway_url: String,
     /// Minimum USD value to attempt a swap (JIT or batch)
@@ -114,6 +118,8 @@ pub struct ServiceConfig {
 pub struct LiquidatorService {
     config: ServiceConfig,
     client: SigningClient,
+    /// Shares the methods client's operation driver; see [`LiquidatorService::new`].
+    pyth_updates: PythUpdatesClient,
     inventory: Arc<RwLock<InventoryManager>>,
     markets: HashMap<AccountId, Liquidator>,
     /// Swap provider passed to liquidators for immediate post-liquidation swaps
@@ -157,8 +163,30 @@ impl LiquidatorService {
             .parse()
             .expect("invalid signer secret key");
 
-        let client = SigningClient::connect(network, config.signer_account.clone(), secret_key)
+        // The methods client and the oracle-updates client share one operation driver
+        // (store, signer pool, executor) and a base context, so idempotency and replay
+        // span both.
+        let (base_context, driver, signer_account_ids) = Client::builder(network)
+            .secret_key(config.signer_account.clone(), secret_key)
+            .expect("failed to register gateway signer")
+            .build_parts()
             .expect("failed to construct gateway client");
+        let client = Client::from_parts(
+            base_context.clone(),
+            driver.clone(),
+            signer_account_ids.clone(),
+        )
+        .into_signing(config.signer_account.clone())
+        .expect("failed to bind gateway signer");
+        let pyth_updates: PythUpdatesClient = Client::from_parts(
+            GatewayContextBuilder::new(base_context)
+                .with_pyth_source(config.hermes_url.clone())
+                .build(),
+            driver,
+            signer_account_ids,
+        )
+        .into_signing(config.signer_account.clone())
+        .expect("failed to bind gateway signer");
 
         let inventory = Arc::new(RwLock::new(InventoryManager::new(
             client.clone(),
@@ -171,7 +199,8 @@ impl LiquidatorService {
         // Create oracle fetcher for batch swap price checks
         let oracle_fetcher = crate::OracleFetcher::new(
             client.clone(),
-            Some(config.hermes_url.clone()),
+            pyth_updates.clone(),
+            config.hermes_url.clone(),
             Some(config.redstone_gateway_url.clone()),
             None,
         );
@@ -188,6 +217,7 @@ impl LiquidatorService {
         Self {
             config,
             client,
+            pyth_updates,
             inventory,
             markets: HashMap::new(),
             oneclick_provider,
@@ -558,6 +588,7 @@ impl LiquidatorService {
 
                 let mut liquidator = Liquidator::new(
                     &self.client,
+                    &self.pyth_updates,
                     &self.inventory,
                     market.clone(),
                     config,
@@ -567,7 +598,7 @@ impl LiquidatorService {
                     self.oneclick_provider.clone(),
                     self.config.loop_liquidation,
                     self.config.max_loop_iterations,
-                    Some(self.config.hermes_url.clone()),
+                    self.config.hermes_url.clone(),
                     Some(self.config.redstone_gateway_url.clone()),
                     self.config.swap_retry_config.clone(),
                     self.config.min_swap_value_usd,

--- a/service/relayer/src/app/args.rs
+++ b/service/relayer/src/app/args.rs
@@ -25,6 +25,8 @@ pub struct Configuration {
     pub relay: Relay,
     #[clap(flatten)]
     pub ua: UniversalAccount,
+    /// In-process oracle payload sources. A mainnet deployment must set
+    /// `--pyth-hermes-url`; it defaults to testnet's.
     #[clap(flatten)]
     pub oracle_sources: OracleSourceArgs,
     /// Broom batch size.

--- a/service/relayer/src/app/mod.rs
+++ b/service/relayer/src/app/mod.rs
@@ -12,7 +12,9 @@ use templar_common::{
     market::DepositMsg,
     oracle::pyth,
 };
-use templar_gateway_client::{collect_paginated, Client as GatewayClient, NetworkConfigBuilder};
+use templar_gateway_client::{
+    collect_paginated, Client as GatewayClient, Network, NetworkConfigBuilder,
+};
 use templar_gateway_core::{
     FinalityPolicy, GatewayContext, GatewayError, GatewayResult, PlanWrite, PooledSigner,
 };
@@ -128,8 +130,10 @@ impl App {
             driver.clone(),
             signer_account_ids.clone(),
         );
-        let oracle_context =
-            build_oracle_updates_context(base_context, args.oracle_sources.build()?)?;
+        let oracle_context = build_oracle_updates_context(
+            base_context,
+            args.oracle_sources.build(Network::Testnet.hermes_url())?,
+        )?;
         let oracle_updates =
             OracleUpdatesClient::from_parts(oracle_context, driver, signer_account_ids);
 

--- a/tools/manager/src/commands/mod.rs
+++ b/tools/manager/src/commands/mod.rs
@@ -32,11 +32,23 @@ pub use spec::SpecNs;
 pub use storage::StorageNs;
 
 use anyhow::Context as _;
+use std::collections::BTreeSet;
 use std::path::PathBuf;
+use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_types::Base64Bytes;
 
+/// Drop repeats from a repeatable `--price-id`, which would otherwise widen a Hermes
+/// query or resolve the same dependency twice.
+pub(crate) fn dedup_price_ids(price_ids: Vec<PriceIdentifier>) -> Vec<PriceIdentifier> {
+    price_ids
+        .into_iter()
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
+}
+
 /// Resolve a base64-encoded binary argument supplied either inline or by file path.
-/// `what` names the payload in error messages (e.g. "Pyth VAA").
+/// `what` names the payload in error messages (e.g. "Pyth update data").
 ///
 /// Callers pair the two options in a required [`clap::ArgGroup`], so "neither" is a
 /// parse error rather than a runtime one.

--- a/tools/manager/src/commands/oracle/mod.rs
+++ b/tools/manager/src/commands/oracle/mod.rs
@@ -12,12 +12,11 @@ use clap::Subcommand;
 
 /// The gateway's `oracle.*` update methods. Each fetches its payload inside the
 /// gateway, so a subcommand carries only the source flags its own method reaches:
-/// `update-pyth` takes the VAA directly and needs none, and only `update-lazer` and
-/// `update-prices` require `--pyth-lazer-api-key`.
+/// only `update-lazer` and `update-prices` require `--pyth-lazer-api-key`.
 #[derive(Subcommand, Debug)]
 #[command(rename_all = "kebab-case")]
 pub enum OracleNs {
-    /// Submit a caller-supplied Pyth VAA to a Pyth oracle.
+    /// Fetch a Pyth VAA from Hermes and write it to a Pyth oracle.
     #[command(name = "update-pyth")]
     Pyth(UpdatePyth),
     /// Fetch signed prices from the RedStone bridge and write them to a RedStone adapter.

--- a/tools/manager/src/commands/oracle/update_prices.rs
+++ b/tools/manager/src/commands/oracle/update_prices.rs
@@ -1,12 +1,10 @@
-use std::collections::BTreeSet;
-
 use clap::Args;
 use near_account_id::AccountId;
 use templar_common::oracle::pyth::PriceIdentifier;
 use templar_gateway_oracle_updates_dispatch::OracleSourceArgs;
 use templar_gateway_oracle_updates_spec::oracle as spec;
 
-use crate::commands::{proxy_oracle::parse_price_identifier, signer::SignerArgs};
+use crate::commands::{dedup_price_ids, proxy_oracle::parse_price_identifier, signer::SignerArgs};
 
 /// Resolves the oracle's price dependencies at plan time, so it may reach any of the
 /// three payload sources and carries all of their flags.
@@ -27,12 +25,9 @@ pub struct UpdatePrices {
 
 impl UpdatePrices {
     pub fn into_spec(self) -> spec::UpdatePrices {
-        // A repeated `--price-id` would resolve its dependencies twice, planning the
-        // same underlying update again.
-        let price_ids: BTreeSet<PriceIdentifier> = self.price_ids.into_iter().collect();
         spec::UpdatePrices {
             oracle_id: self.oracle_id,
-            price_ids: price_ids.into_iter().collect(),
+            price_ids: dedup_price_ids(self.price_ids),
         }
     }
 }

--- a/tools/manager/src/commands/oracle/update_pyth.rs
+++ b/tools/manager/src/commands/oracle/update_pyth.rs
@@ -1,36 +1,31 @@
-use std::path::PathBuf;
-
 use clap::Args;
 use near_account_id::AccountId;
+use templar_common::oracle::pyth::PriceIdentifier;
+use templar_gateway_oracle_updates_dispatch::PythSourceArgs;
 use templar_gateway_oracle_updates_spec::oracle as spec;
 
-use crate::commands::{resolve_base64_arg, signer::SignerArgs};
+use crate::commands::{dedup_price_ids, proxy_oracle::parse_price_identifier, signer::SignerArgs};
 
-/// Takes the VAA in the request body, so this command reaches no payload source and
-/// needs no source flags.
 #[derive(Args, Debug)]
-#[command(group(
-    clap::ArgGroup::new("vaa").args(["vaa_base64", "vaa_base64_file"]).required(true)
-))]
 pub struct UpdatePyth {
     /// Pyth oracle account to update.
     #[arg(long, value_name = "ACCOUNT_ID")]
     oracle_id: AccountId,
-    /// Base64-encoded Pyth VAA.
-    #[arg(long, value_name = "BASE64")]
-    vaa_base64: Option<String>,
-    /// Path to a file containing a base64-encoded Pyth VAA.
-    #[arg(long, value_name = "PATH")]
-    vaa_base64_file: Option<PathBuf>,
+    /// Price identifier (32-byte hex) to fetch and update; repeat the flag per feed.
+    /// Duplicates are dropped.
+    #[arg(long = "price-id", value_name = "HEX", value_parser = parse_price_identifier, required = true)]
+    price_ids: Vec<PriceIdentifier>,
+    #[command(flatten)]
+    pub(crate) sources: PythSourceArgs,
     #[command(flatten)]
     pub(crate) signer: SignerArgs,
 }
 
 impl UpdatePyth {
-    pub fn try_into_spec(self) -> anyhow::Result<spec::UpdatePyth> {
-        Ok(spec::UpdatePyth {
+    pub fn into_spec(self) -> spec::UpdatePyth {
+        spec::UpdatePyth {
             oracle_id: self.oracle_id,
-            vaa: resolve_base64_arg(self.vaa_base64, self.vaa_base64_file, "Pyth VAA")?,
-        })
+            price_ids: dedup_price_ids(self.price_ids),
+        }
     }
 }

--- a/tools/manager/src/commands/pyth/mod.rs
+++ b/tools/manager/src/commands/pyth/mod.rs
@@ -9,8 +9,8 @@ pub use update_price_feeds::UpdatePriceFeeds;
 use clap::Subcommand;
 
 /// Direct reads and writes against a Pyth oracle contract. Unlike `oracle update-pyth`,
-/// these do not resolve price dependencies and fetch no payload — `update-price-feeds`
-/// submits caller-supplied update data verbatim.
+/// these fetch no payload — `update-price-feeds` submits caller-supplied update data
+/// verbatim.
 #[derive(Subcommand, Debug)]
 #[command(rename_all = "kebab-case")]
 pub enum PythNs {

--- a/tools/manager/src/context.rs
+++ b/tools/manager/src/context.rs
@@ -16,7 +16,7 @@ use templar_gateway_methods_dispatch::Dispatch;
 use templar_gateway_oracle_updates_dispatch::{
     build_oracle_updates_context, Dispatch as OracleUpdatesDispatch,
     GatewayContextBuilderOracleExt as _, LazerSourceArgs, OracleSourceArgs, OracleUpdatesContext,
-    RedStoneSourceArgs, WithLazerSource, WithRedStoneSource,
+    PythSourceArgs, RedStoneSourceArgs, WithLazerSource, WithPythSource, WithRedStoneSource,
 };
 use templar_gateway_types::{
     common::{WriteOperationResult, WriteRequest},
@@ -213,6 +213,17 @@ impl CliContext {
     }
 }
 
+/// `layer_sources` for `oracle.updatePyth`.
+pub(crate) fn pyth_source(
+    base: GatewayContext,
+    args: &PythSourceArgs,
+    network: Network,
+) -> WithPythSource<GatewayContext> {
+    GatewayContextBuilder::new(base)
+        .with_pyth_source(args.hermes_url(network.hermes_url()))
+        .build()
+}
+
 /// `layer_sources` for `oracle.updateRedStone`.
 pub(crate) fn redstone_source(
     base: GatewayContext,
@@ -238,8 +249,12 @@ pub(crate) fn lazer_source(
 pub(crate) fn all_sources(
     base: GatewayContext,
     args: &OracleSourceArgs,
+    network: Network,
 ) -> anyhow::Result<OracleUpdatesContext> {
-    Ok(build_oracle_updates_context(base, args.build()?)?)
+    Ok(build_oracle_updates_context(
+        base,
+        args.build(network.hermes_url())?,
+    )?)
 }
 
 /// Succeed only when a submitted write reached a `Succeeded` terminal status.

--- a/tools/manager/src/dispatch/generic.rs
+++ b/tools/manager/src/dispatch/generic.rs
@@ -8,7 +8,7 @@ use templar_gateway_oracle_updates_spec::oracle as oracle_spec;
 use templar_gateway_types::MethodSpec;
 
 use crate::cli::{GenericMethodCall, WriteMethodCall};
-use crate::context::{all_sources, lazer_source, redstone_source, CliContext};
+use crate::context::{all_sources, lazer_source, pyth_source, redstone_source, CliContext};
 
 pub(super) async fn read(ctx: CliContext, call: GenericMethodCall) -> anyhow::Result<()> {
     let method = call.method.clone();
@@ -70,10 +70,13 @@ pub(super) async fn write(ctx: CliContext, call: WriteMethodCall) -> anyhow::Res
     }
 
     if let Some(route) = oracle_route(&method) {
+        let network = ctx.network();
         return match route {
             OracleRoute::Pyth => {
-                ctx.oracle_write(signer, body!(oracle_spec::UpdatePyth), Ok)
-                    .await
+                ctx.oracle_write(signer, body!(oracle_spec::UpdatePyth), |base| {
+                    Ok(pyth_source(base, &oracle_sources.pyth, network))
+                })
+                .await
             }
             OracleRoute::RedStone => {
                 ctx.oracle_write(signer, body!(oracle_spec::UpdateRedStone), |base| {
@@ -89,7 +92,7 @@ pub(super) async fn write(ctx: CliContext, call: WriteMethodCall) -> anyhow::Res
             }
             OracleRoute::Prices => {
                 ctx.oracle_write(signer, body!(oracle_spec::UpdatePrices), |base| {
-                    all_sources(base, &oracle_sources)
+                    all_sources(base, &oracle_sources, network)
                 })
                 .await
             }

--- a/tools/manager/src/dispatch/mod.rs
+++ b/tools/manager/src/dispatch/mod.rs
@@ -30,7 +30,9 @@ use crate::commands::{
     spec::SpecNs,
     storage::StorageNs,
 };
-use crate::context::{all_sources, lazer_source, print_json, redstone_source, CliContext};
+use crate::context::{
+    all_sources, lazer_source, print_json, pyth_source, redstone_source, CliContext,
+};
 
 /// A kernel price as a plain number.
 ///
@@ -172,10 +174,14 @@ async fn proxy_oracle(ctx: CliContext, ns: ProxyOracleNs) -> anyhow::Result<()> 
 /// The `oracle.*` updates, served by the oracle-updates dispatcher. Each arm layers
 /// only the payload sources its method fetches from — see [`CliContext::oracle_write`].
 async fn oracle(ctx: CliContext, ns: OracleNs) -> anyhow::Result<()> {
+    let network = ctx.network();
     match ns {
         OracleNs::Pyth(a) => {
-            let signer = a.signer.clone();
-            ctx.oracle_write(signer, a.try_into_spec()?, Ok).await
+            let (signer, sources) = (a.signer.clone(), a.sources.clone());
+            ctx.oracle_write(signer, a.into_spec(), |base| {
+                Ok(pyth_source(base, &sources, network))
+            })
+            .await
         }
         OracleNs::RedStone(a) => {
             let (signer, sources) = (a.signer.clone(), a.sources.clone());
@@ -191,8 +197,10 @@ async fn oracle(ctx: CliContext, ns: OracleNs) -> anyhow::Result<()> {
         }
         OracleNs::Prices(a) => {
             let (signer, sources) = (a.signer.clone(), a.sources.clone());
-            ctx.oracle_write(signer, a.into_spec(), |base| all_sources(base, &sources))
-                .await
+            ctx.oracle_write(signer, a.into_spec(), |base| {
+                all_sources(base, &sources, network)
+            })
+            .await
         }
     }
 }

--- a/tools/manager/src/tests/oracle.rs
+++ b/tools/manager/src/tests/oracle.rs
@@ -151,9 +151,11 @@ fn update_prices_deduplicates_repeated_price_ids() {
     );
 }
 
+/// A repeated `--price-id` only widens the Hermes query for the same VAA.
 #[test]
-fn update_pyth_decodes_its_vaa() {
-    // "hello" encoded as standard base64.
+fn update_pyth_deduplicates_repeated_price_ids() {
+    const OTHER_PRICE_ID: &str = "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee";
+
     let cli = Cli::try_parse_from(
         [
             "tmplrmgr",
@@ -161,8 +163,12 @@ fn update_pyth_decodes_its_vaa() {
             "update-pyth",
             "--oracle-id",
             "pyth.testnet",
-            "--vaa-base64",
-            "aGVsbG8=",
+            "--price-id",
+            OTHER_PRICE_ID,
+            "--price-id",
+            PRICE_ID,
+            "--price-id",
+            OTHER_PRICE_ID,
         ]
         .into_iter()
         .chain(CREDS),
@@ -175,12 +181,20 @@ fn update_pyth_decodes_its_vaa() {
     else {
         panic!("expected oracle update-pyth");
     };
-    let spec = cmd.try_into_spec().expect("a valid base64 VAA");
-    assert_eq!(spec.vaa.0, b"hello");
+    let spec = cmd.into_spec();
+    assert_eq!(spec.oracle_id.as_str(), "pyth.testnet");
+    assert_eq!(
+        spec.price_ids,
+        vec![
+            parse_price_identifier(PRICE_ID).expect("a valid price id"),
+            parse_price_identifier(OTHER_PRICE_ID).expect("a valid price id"),
+        ],
+        "duplicates dropped, and the remainder ordered by identifier"
+    );
 }
 
 #[test]
-fn update_pyth_requires_a_vaa() {
+fn update_pyth_requires_a_price_id() {
     let error = Cli::try_parse_from(
         [
             "tmplrmgr",
@@ -192,7 +206,7 @@ fn update_pyth_requires_a_vaa() {
         .into_iter()
         .chain(CREDS),
     )
-    .expect_err("oracle update-pyth should require a VAA");
+    .expect_err("oracle update-pyth should require a price id");
 
     assert_eq!(
         error.kind(),
@@ -205,9 +219,9 @@ fn update_pyth_requires_a_vaa() {
 /// A parse-succeeds assertion could not catch a regression here: the token is optional
 /// at parse time, so flattening it everywhere would still parse.
 #[rstest]
-#[case::update_pyth(&["update-pyth", "--oracle-id", "pyth.testnet", "--vaa-base64", "aGVsbG8="])]
+#[case::update_pyth(&["update-pyth", "--oracle-id", "pyth.testnet", "--price-id", PRICE_ID])]
 #[case::update_red_stone(&["update-red-stone", "--oracle-id", "redstone.testnet", "--feed-id", "BTC"])]
-fn sourceless_and_redstone_updates_reject_lazer_flags(#[case] subcommand: &[&str]) {
+fn pyth_and_redstone_updates_reject_lazer_flags(#[case] subcommand: &[&str]) {
     let error = Cli::try_parse_from(
         ["tmplrmgr", "oracle"]
             .into_iter()

--- a/tools/manager/src/tests/plan.rs
+++ b/tools/manager/src/tests/plan.rs
@@ -16,12 +16,10 @@ use templar_gateway_types::{
     ManagedAccountId, MethodSpec,
 };
 
-use templar_gateway_oracle_updates_dispatch::Dispatch as OracleUpdatesDispatch;
-
 use super::{parse_governance, CREDS};
 use crate::cli::{Cli, Command};
 use crate::commands::proxy_oracle::ProxyOracleGovernanceNs;
-use crate::commands::{FtNs, OracleNs, RedstoneNs, StorageNs};
+use crate::commands::{FtNs, RedstoneNs, StorageNs};
 
 const TGAS: u64 = 1_000_000_000_000;
 
@@ -35,14 +33,16 @@ fn signer() -> ManagedAccountId {
     ManagedAccountId::from("signer.testnet".parse::<AccountId>().unwrap())
 }
 
-/// Plan `body` through dispatcher `D` against a source-free [`GatewayContext`].
-async fn plan_via<D, S>(body: S) -> OperationPlan
+/// Plan `body` against a source-free [`GatewayContext`]. The `oracle.*` updates each
+/// fetch a payload from an in-process source before building any step, so none of them
+/// plans offline; their arg→spec mapping is covered by the CLI tests instead.
+async fn plan<S>(body: S) -> OperationPlan
 where
     S: MethodSpec<Output = WriteOperationResult>,
-    D: PlanWrite<S, GatewayContext>,
+    Dispatch: PlanWrite<S, GatewayContext>,
 {
     offline_client()
-        .via::<D>()
+        .via::<Dispatch>()
         .plan_request(WriteRequest {
             signer_account_id: signer(),
             idempotency_key: None,
@@ -50,24 +50,6 @@ where
         })
         .await
         .expect("offline plan")
-}
-
-async fn plan<S>(body: S) -> OperationPlan
-where
-    S: MethodSpec<Output = WriteOperationResult>,
-    Dispatch: PlanWrite<S, GatewayContext>,
-{
-    plan_via::<Dispatch, S>(body).await
-}
-
-/// Only `oracle.updatePyth` can be planned offline: the other three fetch a payload
-/// from an in-process source before they build any step.
-async fn oracle_plan<S>(body: S) -> OperationPlan
-where
-    S: MethodSpec<Output = WriteOperationResult>,
-    OracleUpdatesDispatch: PlanWrite<S, GatewayContext>,
-{
-    plan_via::<OracleUpdatesDispatch, S>(body).await
 }
 
 struct Call {
@@ -252,38 +234,4 @@ async fn redstone_set_role_plans_set_role_action() {
     // `--revoke` absent ⇒ grant the role.
     assert_eq!(call.args["set"], true);
     assert_eq!(call.deposit, 1);
-}
-
-/// `oracle update-pyth` takes its VAA from the CLI, so its plan is offline: the base64
-/// argument must reach the contract as the hex `data` the Pyth adapter expects.
-#[tokio::test]
-async fn oracle_update_pyth_plans_update_price_feeds_action() {
-    let cli = Cli::try_parse_from(
-        [
-            "tmplrmgr",
-            "oracle",
-            "update-pyth",
-            "--oracle-id",
-            "pyth.testnet",
-            // "hello" encoded as standard base64.
-            "--vaa-base64",
-            "aGVsbG8=",
-        ]
-        .into_iter()
-        .chain(CREDS),
-    )
-    .expect("oracle update-pyth should parse");
-    let body = match cli.command {
-        Command::Oracle {
-            command: OracleNs::Pyth(a),
-        } => a.try_into_spec().expect("a valid base64 VAA"),
-        _ => panic!("expected oracle update-pyth"),
-    };
-
-    let call = single_call(&oracle_plan(body).await);
-    assert_eq!(call.receiver_id, "pyth.testnet");
-    assert_eq!(call.method_name, "update_price_feeds");
-    assert_eq!(call.args["data"], hex::encode("hello"));
-    assert_eq!(call.deposit, 10_000_000_000_000_000_000_000);
-    assert_eq!(call.gas, 300 * TGAS);
 }


### PR DESCRIPTION
Closes ENG-462.

`oracle.updatePyth` took a caller-supplied VAA in the request body, which made it a duplicate of `pyth.updatePriceFeeds` and the only oracle update that reached no payload source. It now takes `price_ids` and fetches the VAA from Hermes itself, like `updateRedStone`, `updateLazer`, and `updatePrices`.

- The standalone method and the Pyth branch of `plan_grouped_updates` share one fetch-and-plan helper, so the resolved and direct paths cannot drift.
- `pyth.updatePriceFeeds` keeps the opaque-bytes passthrough for operators who already hold a VAA.
- The liquidator's bespoke binary-VAA Hermes client is gone; its remaining Hermes usage is the parsed-price read path.

**The Hermes endpoint now follows the selected network.** `tmplrmgr --network mainnet oracle update-pyth` previously defaulted to Pyth's *beta* endpoint, fetching a testnet-guardian VAA and submitting it on mainnet, where the receiver rejects the signature. `--pyth-hermes-url` still overrides. The gateway service and relayer configure by raw RPC URL with no network to derive from, so they name testnet's endpoint explicitly and must set `--pyth-hermes-url` for a mainnet deployment. The liquidator derives from `--network` and its URL is typed, so a malformed value is a parse error rather than a startup panic.

### Breaking

- `templar-gateway-oracle-updates-spec`: `oracle.updatePyth` request body `vaa` → `price_ids`
- `templar-gateway-oracle-updates-dispatch`: `PythSourceArgs::pyth_hermes_url` is now `Option<Url>`; `OracleSourceArgs::build` takes a fallback endpoint
- `tmplrmgr oracle update-pyth`: `--vaa-base64` replaced by a repeatable `--price-id`

### Releasing

Stacked on #585 — **merge that first**, then rebase this branch onto `dev` to drop the duplicated commit.

The `!` applies to every crate in this diff, since release-plz attributes commits to crates by file path. Four are right on their own: `oracle-updates-spec` 0.2.0, `oracle-updates-dispatch` 0.2.0, `gateway-service` 0.4.0, `manager` 0.4.0 (the last two genuinely break their RPC and CLI surfaces). Two overshoot and want an override on the Release PR, shortly before merging it:

```bash
release-plz set-version templar-liquidator@0.1.4
release-plz set-version templar-relayer@0.2.1
```

### Verification

`cargo check --workspace --all-targets` and `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `gateway/METHODS.md` regenerated and its sync test passes; 535 tests pass across the five affected crates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/586)
<!-- Reviewable:end -->
