### PR TITLE
feat(artifacts): resolve a released wasm by its digest

### DIFF
--- a/contract/artifacts/src/catalog.rs
+++ b/contract/artifacts/src/catalog.rs
@@ -182,3 +182,49 @@ fn no_release_is_ahead_of_its_source() {
         );
     }
 }
+
+/// Total and unambiguous: every release is reachable from its own digest, and no two share one.
+///
+/// The lookup is how a caller holding only a hash — read off a registry, say — reaches
+/// `released_bytes`, so a digest that resolved to a different artifact would fetch the wrong wasm.
+#[test]
+fn every_release_resolves_from_its_digest() {
+    for artifact in ArtifactId::ALL {
+        for release in artifact.metadata().releases() {
+            let (found_artifact, found) =
+                crate::release_by_sha256(release.sha256).unwrap_or_else(|| {
+                    panic!(
+                        "{}@{} is catalogued but its digest {} resolves to nothing",
+                        artifact.metadata().package_name,
+                        release.version,
+                        release.sha256,
+                    )
+                });
+
+            assert_eq!(
+                (found_artifact, found.version),
+                (artifact, release.version),
+                "digest {} is shared by {}@{} and {}@{}",
+                release.sha256,
+                artifact.metadata().package_name,
+                release.version,
+                found_artifact.metadata().package_name,
+                found.version,
+            );
+        }
+    }
+}
+
+#[test]
+fn digest_lookup_ignores_hex_case_and_rejects_strangers() {
+    let release = ArtifactId::Registry
+        .metadata()
+        .release("1.2.4")
+        .expect("registry 1.2.4 is catalogued");
+
+    assert_eq!(
+        crate::release_by_sha256(&release.sha256.to_uppercase()).map(|(id, _)| id),
+        Some(ArtifactId::Registry),
+    );
+    assert_eq!(crate::release_by_sha256(&"0".repeat(64)), None);
+}

--- a/contract/artifacts/src/catalog.rs
+++ b/contract/artifacts/src/catalog.rs
@@ -191,19 +191,18 @@ fn no_release_is_ahead_of_its_source() {
 fn every_release_resolves_from_its_digest() {
     for artifact in ArtifactId::ALL {
         for release in artifact.metadata().releases() {
-            let (found_artifact, found) =
-                crate::release_by_sha256(release.sha256).unwrap_or_else(|| {
-                    panic!(
-                        "{}@{} is catalogued but its digest {} resolves to nothing",
-                        artifact.metadata().package_name,
-                        release.version,
-                        release.sha256,
-                    )
-                });
+            let digest = digest_of(release);
+            let (found_artifact, found) = crate::release_by_sha256(&digest).unwrap_or_else(|| {
+                panic!(
+                    "{}@{} is catalogued but its digest {} resolves to nothing",
+                    artifact.metadata().package_name,
+                    release.version,
+                    release.sha256,
+                )
+            });
 
-            assert_eq!(
-                (found_artifact, found.version),
-                (artifact, release.version),
+            assert!(
+                std::ptr::eq(found, release),
                 "digest {} is shared by {}@{} and {}@{}",
                 release.sha256,
                 artifact.metadata().package_name,
@@ -215,16 +214,26 @@ fn every_release_resolves_from_its_digest() {
     }
 }
 
+/// A registry reports base58 while the catalog records hex, so the lookup takes neither — it takes
+/// the bytes. This is the shape a caller reaching it from `VersionInfo::code_hash` arrives in.
 #[test]
-fn digest_lookup_ignores_hex_case_and_rejects_strangers() {
+fn digest_lookup_takes_bytes_and_rejects_strangers() {
     let release = ArtifactId::Registry
         .metadata()
         .release("1.2.4")
         .expect("registry 1.2.4 is catalogued");
 
     assert_eq!(
-        crate::release_by_sha256(&release.sha256.to_uppercase()).map(|(id, _)| id),
+        crate::release_by_sha256(&digest_of(release)).map(|(id, _)| id),
         Some(ArtifactId::Registry),
     );
-    assert_eq!(crate::release_by_sha256(&"0".repeat(64)), None);
+    assert_eq!(crate::release_by_sha256(&[0u8; 32]), None);
+}
+
+/// The catalog stores digests as text; `build.rs` has already rejected anything but 64 hex chars.
+fn digest_of(release: &crate::ArtifactRelease) -> [u8; 32] {
+    let mut bytes = [0u8; 32];
+    hex::decode_to_slice(release.sha256, &mut bytes)
+        .unwrap_or_else(|e| panic!("catalogued digest {} is not hex: {e}", release.sha256));
+    bytes
 }

--- a/contract/artifacts/src/fetch.rs
+++ b/contract/artifacts/src/fetch.rs
@@ -73,6 +73,12 @@ pub enum FetchError {
         version: String,
     },
 
+    #[error(
+        "no catalogued release hashes to {sha256}. Those bytes were never released, so \
+         they can only come from wherever the digest was read."
+    )]
+    UncataloguedDigest { sha256: String },
+
     #[error("failed to download {url} after {attempts} attempts: {source}")]
     Download {
         url: String,
@@ -191,6 +197,21 @@ type Memo = Mutex<HashMap<(ArtifactId, &'static str), Arc<[u8]>>>;
 fn memo() -> &'static Memo {
     static MEMO: OnceLock<Memo> = OnceLock::new();
     MEMO.get_or_init(Default::default)
+}
+
+/// Bytes of whichever catalogued release hashes to `sha256` (lowercase hex).
+///
+/// The digest-keyed entry point to [`released_bytes`], for a caller that knows a wasm's hash but
+/// not which release it is — reading `code_hash` off a registry, say. Returns
+/// [`FetchError::UncataloguedDigest`] when nothing matches, which is a routine outcome: it means
+/// the bytes were never released and must come from wherever the caller found the hash.
+pub async fn released_bytes_by_sha256(sha256: &str) -> Result<Vec<u8>, FetchError> {
+    let Some((artifact, release)) = crate::release_by_sha256(sha256) else {
+        return Err(FetchError::UncataloguedDigest {
+            sha256: sha256.to_owned(),
+        });
+    };
+    released_bytes(artifact, release.version).await
 }
 
 /// Bytes of a released contract version, from the cache or the GitHub Release.

--- a/contract/artifacts/src/fetch.rs
+++ b/contract/artifacts/src/fetch.rs
@@ -199,16 +199,16 @@ fn memo() -> &'static Memo {
     MEMO.get_or_init(Default::default)
 }
 
-/// Bytes of whichever catalogued release hashes to `sha256` (lowercase hex).
+/// Bytes of whichever catalogued release hashes to `sha256`.
 ///
 /// The digest-keyed entry point to [`released_bytes`], for a caller that knows a wasm's hash but
 /// not which release it is — reading `code_hash` off a registry, say. Returns
 /// [`FetchError::UncataloguedDigest`] when nothing matches, which is a routine outcome: it means
 /// the bytes were never released and must come from wherever the caller found the hash.
-pub async fn released_bytes_by_sha256(sha256: &str) -> Result<Vec<u8>, FetchError> {
+pub async fn released_bytes_by_sha256(sha256: &[u8; 32]) -> Result<Vec<u8>, FetchError> {
     let Some((artifact, release)) = crate::release_by_sha256(sha256) else {
         return Err(FetchError::UncataloguedDigest {
-            sha256: sha256.to_owned(),
+            sha256: hex::encode(sha256),
         });
     };
     released_bytes(artifact, release.version).await

--- a/contract/artifacts/src/ids.rs
+++ b/contract/artifacts/src/ids.rs
@@ -211,6 +211,26 @@ impl ArtifactMetadata {
     }
 }
 
+/// The catalogued release whose bytes hash to `sha256` (lowercase hex), across every artifact.
+///
+/// Lets a caller holding only a digest reach [`crate::fetch::released_bytes`]. A registry reports
+/// the hash it computed from the code itself, so it identifies a release even when the version key
+/// does not — several live keys carry no digest at all, and the `{name}@{version}#{sha}` convention
+/// is not enforced on-chain.
+///
+/// Re-releasing identical bytes under a new version would make this ambiguous; the oldest wins,
+/// and either answer yields the same wasm.
+pub fn release_by_sha256(sha256: &str) -> Option<(ArtifactId, &'static ArtifactRelease)> {
+    ArtifactId::ALL.into_iter().find_map(|artifact| {
+        artifact
+            .metadata()
+            .releases()
+            .iter()
+            .find(|release| release.sha256.eq_ignore_ascii_case(sha256))
+            .map(|release| (artifact, release))
+    })
+}
+
 /// Which catalogued artifact a release tag belongs to.
 ///
 /// Only asked of a tag release-plz just created; an existing release's tag is

--- a/contract/artifacts/src/ids.rs
+++ b/contract/artifacts/src/ids.rs
@@ -211,22 +211,26 @@ impl ArtifactMetadata {
     }
 }
 
-/// The catalogued release whose bytes hash to `sha256` (lowercase hex), across every artifact.
+/// The catalogued release whose bytes hash to `sha256`, across every artifact.
 ///
 /// Lets a caller holding only a digest reach [`crate::fetch::released_bytes`]. A registry reports
 /// the hash it computed from the code itself, so it identifies a release even when the version key
 /// does not — several live keys carry no digest at all, and the `{name}@{version}#{sha}` convention
 /// is not enforced on-chain.
 ///
+/// Raw digest rather than text because the two spellings never match and failing to match is
+/// indistinguishable from "never released": a registry serves base58, the catalog records hex.
+///
 /// Re-releasing identical bytes under a new version would make this ambiguous; the oldest wins,
 /// and either answer yields the same wasm.
-pub fn release_by_sha256(sha256: &str) -> Option<(ArtifactId, &'static ArtifactRelease)> {
+pub fn release_by_sha256(sha256: &[u8; 32]) -> Option<(ArtifactId, &'static ArtifactRelease)> {
+    let sha256 = hex::encode(sha256);
     ArtifactId::ALL.into_iter().find_map(|artifact| {
         artifact
             .metadata()
             .releases()
             .iter()
-            .find(|release| release.sha256.eq_ignore_ascii_case(sha256))
+            .find(|release| release.sha256 == sha256)
             .map(|release| (artifact, release))
     })
 }

--- a/contract/artifacts/src/lib.rs
+++ b/contract/artifacts/src/lib.rs
@@ -25,8 +25,8 @@ pub mod prebuild;
 mod workspace_loader;
 
 pub use ids::{
-    artifact_catalog, artifact_from_release_tag, ArtifactId, ArtifactMetadata, ArtifactParseError,
-    ArtifactRelease,
+    artifact_catalog, artifact_from_release_tag, release_by_sha256, ArtifactId, ArtifactMetadata,
+    ArtifactParseError, ArtifactRelease,
 };
 #[cfg(feature = "workspace-loader")]
 pub use workspace_loader::{


### PR DESCRIPTION
Second of five stacked PRs clearing the **Registry Contract** project. Stacked on #587 only for review order — it depends on nothing and could merge independently.

Adds `release_by_sha256` and its fetch-side counterpart `released_bytes_by_sha256`, so a caller holding only a hash can reach the existing cache-through loader. The catalog is version-keyed today, which is unhelpful to anyone who learned about a wasm from its digest rather than its release.

The motivating caller reads `code_hash` off a registry. That hash is computed on-chain from the code itself, so unlike the digest embedded in a version key it identifies a release even where the key convention was not followed — and several live version keys carry no digest at all. Resolving through the cache first also keeps the slow path (reading a blob back out of registry state a chunk at a time) genuinely last-resort.

A miss is routine rather than exceptional: uncatalogued bytes were simply never released, hence a distinct `UncataloguedDigest` error the caller is expected to handle by falling through.

`every_release_resolves_from_its_digest` pins both halves of what the lookup needs to be true — total over the catalog, and free of shared digests, since a collision would silently fetch the wrong contract.

Relates to ENG-464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/588)
<!-- Reviewable:end -->
