### PR TITLE
feat(registry)!: versioned state, self-upgrade, and views for sound preflight

### DIFF
--- a/contract/registry/src/lib.rs
+++ b/contract/registry/src/lib.rs
@@ -1,18 +1,24 @@
 #![allow(clippy::needless_pass_by_value)]
 
+mod state;
+
+use std::ops::{Deref, DerefMut};
+
 use near_sdk::{
     assert_one_yocto, env,
     json_types::{Base58CryptoHash, Base64VecU8},
-    near, require,
-    store::{IterableMap, IterableSet},
-    AccountId, CryptoHash, Gas, NearToken, PanicOnDefault, Promise, PromiseOrValue,
+    near, require, AccountId, CryptoHash, Gas, NearToken, PanicOnDefault, Promise, PromiseOrValue,
 };
 use near_sdk_contract_tools::{owner::Owner, Owner};
 use templar_common::{
     contract::list,
-    registry::{DeployMode, Deployment},
+    registry::{DeployMode, Deployment, RegistryEntryView, VersionAvailability, VersionInfo},
     self_ext,
+    upgrade::{UpgradeSource, MIGRATE_METHOD},
+    versioned_state::{impl_versioned_state, StateVersion, VersionedState},
 };
+
+type State = state::V1;
 
 #[derive(Debug, Clone)]
 #[near(serializers = [json, borsh])]
@@ -30,6 +36,19 @@ impl VersionEntry {
             Self::Code { hash, .. } | Self::GlobalHash(hash) => *hash,
         }
     }
+
+    fn availability(&self) -> VersionAvailability {
+        match self {
+            Self::Code {
+                code: Some(code), ..
+            } => VersionAvailability::Stored {
+                // Unreachable: a stored value cannot exceed the 4 MiB storage-value limit.
+                code_len: u32::try_from(code.len()).unwrap_or(u32::MAX),
+            },
+            Self::Code { code: None, .. } => VersionAvailability::Removed,
+            Self::GlobalHash(_) => VersionAvailability::Global,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -42,24 +61,71 @@ pub enum RegistryEntry {
 #[derive(PanicOnDefault, Owner)]
 #[near(contract_state)]
 pub struct Contract {
-    versions: IterableMap<String, VersionEntry>,
-    global_contract_hashes: IterableSet<CryptoHash>,
-    registry: IterableMap<AccountId, RegistryEntry>,
+    pub state: VersionedState<State>,
+}
+
+// Generates the private `migrate()` entrypoint plus the `get_stored_state_version` /
+// `get_target_state_version` / `needs_migration` views.
+impl_versioned_state!(Contract, State, crate::state::Migration);
+
+// `versions` and `registry` live on `State`; deref so the methods below keep reaching them
+// directly.
+impl Deref for Contract {
+    type Target = State;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
+}
+
+impl DerefMut for Contract {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.state
+    }
 }
 
 #[near]
 impl Contract {
+    /// Gas reserved for the batched `migrate` in [`Self::upgrade`].
+    ///
+    /// Enough for any migration this method can be asked to run. The expensive one — rewriting
+    /// every stored version blob out of a pre-1.1.0 layout, several MB on the live registries —
+    /// is not among them: those releases have no `upgrade`, so they are migrated by a batch their
+    /// key holder signs, where the gas is on the transaction rather than reserved here.
+    pub const GAS_FOR_MIGRATE: Gas = Gas::from_tgas(250);
+
+    /// Most a single [`Self::get_version_code_chunk`] will return.
+    ///
+    /// A view's return value reaches the caller as a JSON array of one integer per byte, so the
+    /// response body runs several times the payload; this keeps it inside what RPC providers serve.
+    pub const MAX_CODE_CHUNK_LEN: u32 = 128 * 1024;
+
     #[init]
     pub fn new() -> Self {
         let mut self_ = Self {
-            versions: IterableMap::new(b"v"),
-            global_contract_hashes: IterableSet::new(b"g"),
-            registry: IterableMap::new(b"r"),
+            state: State::new(()),
         };
 
         self_.init(&env::predecessor_account_id());
 
         self_
+    }
+
+    /// Atomically deploy new code and run its `migrate` in one receipt, so a failed migration
+    /// reverts the deploy with it. `migrate_args` selects the `state::Migration` matching the
+    /// layout this registry actually holds.
+    ///
+    /// The only way to replace the code of a registry whose full-access keys have been removed.
+    #[payable]
+    pub fn upgrade(&mut self, code: UpgradeSource, migrate_args: Base64VecU8) -> Promise {
+        assert_one_yocto();
+        self.assert_owner();
+
+        require!(!code.is_empty_code(), "Upgrade code must not be empty");
+
+        near_sdk::log!("Upgrading registry to {:?}", code.summary());
+
+        code.deploy_and_migrate(MIGRATE_METHOD, migrate_args, Self::GAS_FOR_MIGRATE)
     }
 
     pub fn list_versions(&self, count: Option<u32>, offset: Option<u32>) -> Vec<&String> {
@@ -71,6 +137,60 @@ impl Contract {
             .get(&version_key)
             .map(VersionEntry::code_hash)
             .map(Into::into)
+    }
+
+    /// A registered version's hash and whether [`Self::deploy`] can still use it.
+    ///
+    /// `list_versions` keeps listing a version whose code `remove_version` cleared, and
+    /// `get_version_code_hash` keeps answering for it, so membership alone cannot tell a
+    /// deployable version from one that will panic partway through a deploy.
+    pub fn get_version(&self, version_key: String) -> Option<VersionInfo> {
+        self.versions.get(&version_key).map(|entry| VersionInfo {
+            code_hash: entry.code_hash().into(),
+            availability: entry.availability(),
+        })
+    }
+
+    /// Whether a name is taken, and by what.
+    ///
+    /// [`Self::deploy`] refuses any name already present, so a `Reserved` name is as unusable as a
+    /// deployed one — a state [`Self::get_deployment`] reports as absent.
+    pub fn get_registry_entry(&self, account_id: AccountId) -> Option<RegistryEntryView> {
+        self.registry.get(&account_id).map(|entry| match entry {
+            RegistryEntry::Reserved => RegistryEntryView::Reserved,
+            RegistryEntry::Deployed(deployment) => RegistryEntryView::Deployed(deployment.clone()),
+        })
+    }
+
+    /// Bytes `[offset, offset + len)` of a version's stored code, or `None` if it has none.
+    ///
+    /// Borsh-serialized and chunked: the JSON encoding would base64 the blob and the RPC would
+    /// then re-expand it to one integer per byte. Reading a whole contract back is the last
+    /// resort anyway — [`Self::get_version`] reports the hash, which usually resolves against a
+    /// released artifact without touching this at all.
+    ///
+    /// An `offset` past the end reads empty, so a caller can loop until it stops making progress.
+    #[result_serializer(borsh)]
+    pub fn get_version_code_chunk(
+        &self,
+        version_key: String,
+        offset: u32,
+        len: u32,
+    ) -> Option<Vec<u8>> {
+        require!(
+            len <= Self::MAX_CODE_CHUNK_LEN,
+            format!("len exceeds maximum of {}", Self::MAX_CODE_CHUNK_LEN),
+        );
+
+        let code = match self.versions.get(&version_key)? {
+            VersionEntry::Code { code, .. } => code.as_ref()?,
+            VersionEntry::GlobalHash(_) => return None,
+        };
+
+        let start = (offset as usize).min(code.len());
+        let end = start.saturating_add(len as usize).min(code.len());
+
+        Some(code[start..end].to_vec())
     }
 
     pub fn list_deployments(&self, count: Option<u32>, offset: Option<u32>) -> Vec<&AccountId> {
@@ -182,7 +302,11 @@ impl Contract {
         require!(!name.is_empty(), "Name must not be empty");
         self.assert_owner();
 
-        let Some(version) = self.versions.get(&version_key) else {
+        // Through `Deref` every field access borrows the whole contract, so the read of `versions`
+        // held across the write to `registry` needs them named as the disjoint fields they are.
+        let state = &mut *self.state;
+
+        let Some(version) = state.versions.get(&version_key) else {
             templar_common::panic_with_message("Version key does not exist");
         };
 
@@ -201,11 +325,12 @@ impl Contract {
         );
 
         require!(
-            !self.registry.contains_key(&market_id),
+            !state.registry.contains_key(&market_id),
             "Market ID collision",
         );
 
-        self.registry
+        state
+            .registry
             .insert(market_id.clone(), RegistryEntry::Reserved);
 
         near_sdk::log!("Deploying market to {market_id}");
@@ -288,6 +413,238 @@ impl Contract {
     #[private]
     pub fn fail(&self, message: String) {
         templar_common::panic_with_message(&message);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use near_sdk::{
+        mock::MockAction,
+        test_utils::{get_created_receipts, VMContextBuilder},
+        testing_env,
+    };
+    use rstest::rstest;
+
+    use super::*;
+
+    const STORED: &str = "market@1.5.0";
+    const REMOVED: &str = "market@1.0.0";
+    const GLOBAL: &str = "oracle@0.4.1";
+
+    fn contract() -> Contract {
+        testing_env!(VMContextBuilder::new().build());
+        let mut contract = Contract::new();
+        contract.versions.insert(
+            STORED.to_string(),
+            VersionEntry::Code {
+                hash: [1u8; 32],
+                code: Some(vec![0xau8; 300]),
+            },
+        );
+        contract.versions.insert(
+            REMOVED.to_string(),
+            VersionEntry::Code {
+                hash: [2u8; 32],
+                code: None,
+            },
+        );
+        contract
+            .versions
+            .insert(GLOBAL.to_string(), VersionEntry::GlobalHash([3u8; 32]));
+        contract
+    }
+
+    #[rstest]
+    #[case(STORED, Some(VersionAvailability::Stored { code_len: 300 }))]
+    #[case(REMOVED, Some(VersionAvailability::Removed))]
+    #[case(GLOBAL, Some(VersionAvailability::Global))]
+    #[case("nothing@0.0.0", None)]
+    fn get_version_separates_all_four_states(
+        #[case] key: &str,
+        #[case] expected: Option<VersionAvailability>,
+    ) {
+        let info = contract().get_version(key.to_string());
+        assert_eq!(info.map(|info| info.availability), expected);
+    }
+
+    /// `get_deployment` maps a reserved name to `None`, which reads as "free" — but `deploy`
+    /// refuses it just as firmly as a deployed one.
+    #[test]
+    fn get_registry_entry_reports_reserved_that_get_deployment_hides() {
+        let mut contract = contract();
+        let reserved: AccountId = "reserved.registry.near".parse().unwrap();
+        let deployed: AccountId = "deployed.registry.near".parse().unwrap();
+        let deployment = Deployment {
+            version_key: STORED.to_string(),
+            code_hash: [1u8; 32].into(),
+            block_height: 1.into(),
+        };
+        contract
+            .registry
+            .insert(reserved.clone(), RegistryEntry::Reserved);
+        contract.registry.insert(
+            deployed.clone(),
+            RegistryEntry::Deployed(deployment.clone()),
+        );
+
+        assert_eq!(contract.get_deployment(reserved.clone()), None);
+        assert_eq!(
+            contract.get_registry_entry(reserved),
+            Some(RegistryEntryView::Reserved),
+        );
+        assert_eq!(
+            contract.get_registry_entry(deployed),
+            Some(RegistryEntryView::Deployed(deployment)),
+        );
+        assert_eq!(
+            contract.get_registry_entry("free.registry.near".parse().unwrap()),
+            None,
+        );
+    }
+
+    #[rstest]
+    #[case::whole(0, 300, 300)]
+    #[case::prefix(0, 10, 10)]
+    #[case::tail(290, 64, 10)]
+    #[case::past_the_end_reads_empty(300, 64, 0)]
+    #[case::far_past_the_end_reads_empty(9_999, 64, 0)]
+    fn code_chunk_clamps_to_the_blob(
+        #[case] offset: u32,
+        #[case] len: u32,
+        #[case] expected: usize,
+    ) {
+        let chunk = contract()
+            .get_version_code_chunk(STORED.to_string(), offset, len)
+            .expect("a stored version yields bytes");
+        assert_eq!(chunk.len(), expected);
+        assert!(chunk.iter().all(|byte| *byte == 0xau8));
+    }
+
+    /// Reassembly is the point: chunks concatenated in order must equal the stored blob.
+    #[test]
+    fn code_chunks_reassemble_exactly() {
+        let contract = contract();
+        let mut reassembled = Vec::new();
+        let mut offset = 0;
+        loop {
+            let chunk = contract
+                .get_version_code_chunk(STORED.to_string(), offset, 128)
+                .expect("a stored version yields bytes");
+            if chunk.is_empty() {
+                break;
+            }
+            offset += u32::try_from(chunk.len()).unwrap();
+            reassembled.extend(chunk);
+        }
+        assert_eq!(reassembled, vec![0xau8; 300]);
+    }
+
+    /// Neither a global version nor one whose code was removed has bytes to read, so the caller
+    /// has to resolve those by hash instead.
+    #[rstest]
+    #[case(GLOBAL)]
+    #[case(REMOVED)]
+    #[case("nothing@0.0.0")]
+    fn code_chunk_is_absent_without_stored_code(#[case] key: &str) {
+        assert_eq!(
+            contract().get_version_code_chunk(key.to_string(), 0, 64),
+            None,
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "len exceeds maximum")]
+    fn code_chunk_refuses_an_oversized_read() {
+        contract().get_version_code_chunk(STORED.to_string(), 0, Contract::MAX_CODE_CHUNK_LEN + 1);
+    }
+
+    /// Deploy and `migrate` must share one receipt, which is what makes a failed migration revert
+    /// the code with it. Two receipts would leave the new code deployed over unmigrated state.
+    #[test]
+    fn upgrade_batches_deploy_then_migrate_into_one_self_receipt() {
+        testing_env!(VMContextBuilder::new()
+            .current_account_id("registry.near".parse().unwrap())
+            .predecessor_account_id("registry.near".parse().unwrap())
+            .attached_deposit(NearToken::from_yoctonear(1))
+            .build());
+        let mut contract = Contract::new();
+        let code = vec![0xde, 0xad, 0xbe, 0xef];
+        let migrate_args = br#"{"from_version":"pre_global_contracts"}"#.to_vec();
+
+        contract
+            .upgrade(
+                UpgradeSource::Code(Base64VecU8(code.clone())),
+                Base64VecU8(migrate_args.clone()),
+            )
+            .detach();
+
+        let receipts = get_created_receipts();
+        assert_eq!(receipts.len(), 1, "the upgrade must not fan out");
+        let receipt = &receipts[0];
+        assert_eq!(receipt.receiver_id.as_str(), "registry.near");
+        assert_eq!(receipt.actions.len(), 2);
+
+        let receipt_index = match &receipt.actions[0] {
+            MockAction::DeployContract {
+                receipt_index,
+                code: deployed,
+            } => {
+                assert_eq!(deployed, &code);
+                *receipt_index
+            }
+            action => panic!("expected the deploy first, got {action:?}"),
+        };
+        match &receipt.actions[1] {
+            MockAction::FunctionCallWeight {
+                receipt_index: migrate_index,
+                method_name,
+                args,
+                prepaid_gas,
+                ..
+            } => {
+                assert_eq!(
+                    *migrate_index, receipt_index,
+                    "migrate must ride the deploy"
+                );
+                assert_eq!(method_name, b"migrate");
+                assert_eq!(args, &migrate_args);
+                assert_eq!(*prepaid_gas, Contract::GAS_FOR_MIGRATE);
+            }
+            action => panic!("expected the migrate second, got {action:?}"),
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Requires attached deposit of exactly 1 yoctoNEAR")]
+    fn upgrade_requires_one_yocto() {
+        testing_env!(VMContextBuilder::new()
+            .current_account_id("registry.near".parse().unwrap())
+            .predecessor_account_id("registry.near".parse().unwrap())
+            .build());
+        let mut contract = Contract::new();
+        contract
+            .upgrade(
+                UpgradeSource::Code(Base64VecU8(vec![1, 2, 3])),
+                Base64VecU8(Vec::new()),
+            )
+            .detach();
+    }
+
+    #[test]
+    #[should_panic(expected = "Upgrade code must not be empty")]
+    fn upgrade_refuses_an_empty_blob() {
+        testing_env!(VMContextBuilder::new()
+            .current_account_id("registry.near".parse().unwrap())
+            .predecessor_account_id("registry.near".parse().unwrap())
+            .attached_deposit(NearToken::from_yoctonear(1))
+            .build());
+        let mut contract = Contract::new();
+        contract
+            .upgrade(
+                UpgradeSource::Code(Base64VecU8(Vec::new())),
+                Base64VecU8(Vec::new()),
+            )
+            .detach();
     }
 }
 

--- a/contract/registry/src/state/legacy.rs
+++ b/contract/registry/src/state/legacy.rs
@@ -1,0 +1,80 @@
+//! The state layouts of registries deployed before versioning existed.
+//!
+//! Both declare `VERSION = 0`, because none of the releases that produced them wrote the version
+//! key: a registry holding either layout reports a stored version of 0, so that is the only input
+//! version a migration out of one can declare. Which layout a given registry holds is therefore
+//! not something the contract can infer — the operator names it.
+//!
+//! What refuses a wrong name is the stored version, not borsh: a transform only runs from the
+//! version it declares, so nothing here can run against state that has already moved on. Borsh
+//! separates these two from *each other* — they differ by a whole collection, and it rejects the
+//! leftover or missing bytes that produces — but it cannot separate either from [`super::V1`],
+//! which is likewise two `IterableMap`s. A map's borsh footprint is its prefix and length, never
+//! its values.
+
+use near_sdk::{
+    near,
+    store::{IterableMap, IterableSet},
+    AccountId, CryptoHash,
+};
+use templar_common::versioned_state::{StateVersion, VersionedState};
+
+use crate::{RegistryEntry, VersionEntry};
+
+/// Retired with [`WithGlobalContracts`]. Recorded so it is never reused for something else.
+const GLOBAL_CONTRACT_HASHES_PREFIX: &[u8] = b"g";
+
+/// A `versions` value before 1.1.0, when stored code was the only kind of version there was.
+///
+/// [`crate::VersionEntry`] is an enum and borsh prefixes it with a discriminant, so the two
+/// encodings differ by a leading byte and every entry has to be rewritten rather than
+/// reinterpreted. Which byte it is cannot be detected either: the legacy encoding opens with the
+/// first byte of a sha256, and that aliases both of the enum's tags.
+#[near(serializers = [borsh])]
+pub struct StoredVersionEntry {
+    pub hash: CryptoHash,
+    pub code: Option<Vec<u8>>,
+}
+
+/// Registry 0.1.0 and 1.0.0.
+#[near(serializers = [borsh])]
+pub struct PreGlobalContracts {
+    pub versions: IterableMap<String, StoredVersionEntry>,
+    pub registry: IterableMap<AccountId, RegistryEntry>,
+}
+
+impl StateVersion for PreGlobalContracts {
+    const VERSION: u32 = 0;
+
+    type NewArgs = ();
+
+    fn new((): ()) -> VersionedState<Self> {
+        VersionedState::new(Self {
+            versions: IterableMap::new(super::VERSIONS_PREFIX),
+            registry: IterableMap::new(super::REGISTRY_PREFIX),
+        })
+    }
+}
+
+/// Registry 1.1.0 through 1.2.4.
+#[near(serializers = [borsh])]
+pub struct WithGlobalContracts {
+    pub versions: IterableMap<String, VersionEntry>,
+    /// Initialised by every release that had it and never written to again.
+    pub global_contract_hashes: IterableSet<CryptoHash>,
+    pub registry: IterableMap<AccountId, RegistryEntry>,
+}
+
+impl StateVersion for WithGlobalContracts {
+    const VERSION: u32 = 0;
+
+    type NewArgs = ();
+
+    fn new((): ()) -> VersionedState<Self> {
+        VersionedState::new(Self {
+            versions: IterableMap::new(super::VERSIONS_PREFIX),
+            global_contract_hashes: IterableSet::new(GLOBAL_CONTRACT_HASHES_PREFIX),
+            registry: IterableMap::new(super::REGISTRY_PREFIX),
+        })
+    }
+}

--- a/contract/registry/src/state/migration.rs
+++ b/contract/registry/src/state/migration.rs
@@ -1,0 +1,326 @@
+//! Migrations from each pre-versioning layout into [`state::V1`].
+//!
+//! Both start at version 0 and end at 1, so each registry runs a single step rather than a chain.
+//! Which variant is correct depends on the release a registry is running, not on anything it
+//! reports: see [`state::legacy`].
+
+use near_sdk::{env, near, store::IterableMap};
+use templar_common::versioned_state::{Migrator, StateTransformer};
+
+use crate::{state, VersionEntry};
+
+/// Registry 0.1.0 / 1.0.0 → [`state::V1`].
+#[derive(Clone, Debug)]
+#[near(serializers = [json])]
+pub struct PreGlobalContracts;
+
+impl StateTransformer for PreGlobalContracts {
+    type Input = state::legacy::PreGlobalContracts;
+    type Output = state::V1;
+    type Error = ();
+
+    fn transform(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        let state::legacy::PreGlobalContracts {
+            mut versions,
+            registry,
+        } = input;
+
+        // Every value gains borsh's enum discriminant, so the map is rebuilt rather than moved.
+        // Draining and dropping the old one first is load-bearing: two live collections over one
+        // prefix both flush on drop, in an order neither of them agrees on.
+        let keys = versions.keys().cloned().collect::<Vec<_>>();
+        let drained = keys
+            .into_iter()
+            .map(|key| {
+                let entry = versions
+                    .remove(&key)
+                    .unwrap_or_else(|| env::panic_str("version key vanished mid-migration"));
+                let entry = VersionEntry::Code {
+                    hash: entry.hash,
+                    code: entry.code,
+                };
+                (key, entry)
+            })
+            .collect::<Vec<_>>();
+        drop(versions);
+
+        let mut versions = IterableMap::new(state::VERSIONS_PREFIX);
+        for (key, entry) in drained {
+            versions.insert(key, entry);
+        }
+
+        Ok(state::V1 { versions, registry })
+    }
+}
+
+/// Registry 1.1.0 / 1.2.x → [`state::V1`].
+#[derive(Clone, Debug)]
+#[near(serializers = [json])]
+pub struct WithGlobalContracts;
+
+impl StateTransformer for WithGlobalContracts {
+    type Input = state::legacy::WithGlobalContracts;
+    type Output = state::V1;
+    type Error = ();
+
+    fn transform(&self, input: Self::Input) -> Result<Self::Output, Self::Error> {
+        let state::legacy::WithGlobalContracts {
+            versions,
+            mut global_contract_hashes,
+            registry,
+        } = input;
+
+        // Dropping the field is the whole migration; both maps keep their prefixes and their
+        // encodings. Clearing is for the entries no release ever wrote — dropping a non-empty
+        // collection would strand them under a prefix nothing reads.
+        global_contract_hashes.clear();
+
+        Ok(state::V1 { versions, registry })
+    }
+}
+
+/// The migrations `upgrade` can be asked to run, JSON-tagged by the layout they read.
+#[derive(Clone, Debug)]
+#[near(serializers = [json])]
+#[serde(tag = "from_version", rename_all = "snake_case")]
+pub enum Migration {
+    PreGlobalContracts(PreGlobalContracts),
+    WithGlobalContracts(WithGlobalContracts),
+}
+
+impl From<PreGlobalContracts> for Migration {
+    fn from(value: PreGlobalContracts) -> Self {
+        Self::PreGlobalContracts(value)
+    }
+}
+
+impl From<WithGlobalContracts> for Migration {
+    fn from(value: WithGlobalContracts) -> Self {
+        Self::WithGlobalContracts(value)
+    }
+}
+
+impl Migrator for Migration {
+    fn input_version(&self) -> u32 {
+        match self {
+            Migration::PreGlobalContracts(m) => m.input_version(),
+            Migration::WithGlobalContracts(m) => m.input_version(),
+        }
+    }
+
+    fn output_version(&self) -> u32 {
+        match self {
+            Migration::PreGlobalContracts(m) => m.output_version(),
+            Migration::WithGlobalContracts(m) => m.output_version(),
+        }
+    }
+
+    fn run(self) {
+        let (result, label) = match self {
+            Migration::PreGlobalContracts(m) => (m.run().map(|_| ()), "PreGlobalContracts"),
+            Migration::WithGlobalContracts(m) => (m.run().map(|_| ()), "WithGlobalContracts"),
+        };
+
+        result.unwrap_or_else(|e| env::panic_str(&format!("Failed to migrate {label}: {e}")));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use near_sdk::{
+        env,
+        json_types::Base58CryptoHash,
+        serde_json::{self, json},
+        store::{IterableMap, IterableSet},
+        test_utils::VMContextBuilder,
+        testing_env,
+    };
+    use templar_common::{
+        registry::Deployment,
+        versioned_state::{read_state_version, run_migration_chain, MigrationChainError},
+    };
+
+    use crate::{state::legacy, RegistryEntry};
+
+    use super::*;
+
+    const MARKET: &str = "market@1.5.0";
+    const REMOVED: &str = "market@1.0.0";
+
+    fn context() {
+        testing_env!(VMContextBuilder::new().build());
+    }
+
+    fn reserved_id() -> near_sdk::AccountId {
+        "a.registry.near".parse().unwrap()
+    }
+
+    fn deployed_id() -> near_sdk::AccountId {
+        "b.registry.near".parse().unwrap()
+    }
+
+    fn deployment() -> Deployment {
+        Deployment {
+            version_key: MARKET.to_string(),
+            code_hash: Base58CryptoHash::from([9u8; 32]),
+            block_height: 100.into(),
+        }
+    }
+
+    fn write_pre_global_contracts() {
+        let mut state = legacy::PreGlobalContracts {
+            versions: IterableMap::new(state::VERSIONS_PREFIX),
+            registry: IterableMap::new(state::REGISTRY_PREFIX),
+        };
+        state.versions.insert(
+            MARKET.to_string(),
+            legacy::StoredVersionEntry {
+                hash: [1u8; 32],
+                code: Some(vec![0xde, 0xad, 0xbe, 0xef]),
+            },
+        );
+        // remove_version soft-deletes by clearing the blob; the entry stays.
+        state.versions.insert(
+            REMOVED.to_string(),
+            legacy::StoredVersionEntry {
+                hash: [2u8; 32],
+                code: None,
+            },
+        );
+        state
+            .registry
+            .insert(reserved_id(), RegistryEntry::Reserved);
+        state
+            .registry
+            .insert(deployed_id(), RegistryEntry::Deployed(deployment()));
+        env::state_write(&state);
+        drop(state);
+    }
+
+    fn write_with_global_contracts() {
+        let mut state = legacy::WithGlobalContracts {
+            versions: IterableMap::new(state::VERSIONS_PREFIX),
+            global_contract_hashes: IterableSet::new(b"g"),
+            registry: IterableMap::new(state::REGISTRY_PREFIX),
+        };
+        state.versions.insert(
+            MARKET.to_string(),
+            VersionEntry::Code {
+                hash: [1u8; 32],
+                code: Some(vec![0xde, 0xad, 0xbe, 0xef]),
+            },
+        );
+        state.versions.insert(
+            "oracle@0.4.1".to_string(),
+            VersionEntry::GlobalHash([3u8; 32]),
+        );
+        state
+            .registry
+            .insert(deployed_id(), RegistryEntry::Deployed(deployment()));
+        env::state_write(&state);
+        drop(state);
+    }
+
+    #[test]
+    fn pre_global_contracts_rewrites_entries_and_keeps_everything() {
+        context();
+        write_pre_global_contracts();
+
+        let new = PreGlobalContracts.run().unwrap();
+
+        assert_eq!(read_state_version().unwrap(), 1);
+        assert_eq!(new.versions.len(), 2);
+        assert!(matches!(
+            new.versions.get(MARKET),
+            Some(VersionEntry::Code { hash, code: Some(code) }) if *hash == [1u8; 32] && code == &[0xde, 0xad, 0xbe, 0xef],
+        ));
+        // The soft-delete has to survive as one, not become a deployable version.
+        assert!(matches!(
+            new.versions.get(REMOVED),
+            Some(VersionEntry::Code { code: None, .. }),
+        ));
+        assert_eq!(new.registry.len(), 2);
+        assert!(matches!(
+            new.registry.get(&reserved_id()),
+            Some(RegistryEntry::Reserved),
+        ));
+    }
+
+    #[test]
+    fn with_global_contracts_keeps_both_version_kinds() {
+        context();
+        write_with_global_contracts();
+
+        let new = WithGlobalContracts.run().unwrap();
+
+        assert_eq!(read_state_version().unwrap(), 1);
+        assert_eq!(new.versions.len(), 2);
+        assert!(matches!(
+            new.versions.get(MARKET),
+            Some(VersionEntry::Code { code: Some(_), .. }),
+        ));
+        assert!(matches!(
+            new.versions.get("oracle@0.4.1"),
+            Some(VersionEntry::GlobalHash(hash)) if *hash == [3u8; 32],
+        ));
+        assert_eq!(new.registry.len(), 1);
+    }
+
+    /// Both layouts report a stored version of 0, so nothing but the operator's choice selects
+    /// between them, and a wrong choice has to fail rather than misread. It does: the layouts
+    /// differ by a whole collection, so reading either as the other runs out of bytes or leaves
+    /// some over, and borsh rejects both. The abort takes the batched deploy down with it, which
+    /// is why no separate confirmation argument is needed to make the choice safe.
+    #[rstest::rstest]
+    #[case::three_field_read_as_two(write_with_global_contracts, || { PreGlobalContracts.run().ok(); })]
+    #[case::two_field_read_as_three(write_pre_global_contracts, || { WithGlobalContracts.run().ok(); })]
+    #[should_panic(expected = "Cannot deserialize the contract state.")]
+    fn wrong_variant_refuses_to_read_state(
+        #[case] write_state: fn(),
+        #[case] run_mismatched: fn(),
+    ) {
+        context();
+        write_state();
+
+        run_mismatched();
+    }
+
+    #[test]
+    fn both_migrations_span_zero_to_one() {
+        context();
+        for migration in [
+            Migration::from(PreGlobalContracts),
+            Migration::from(WithGlobalContracts),
+        ] {
+            assert_eq!(migration.input_version(), 0);
+            assert_eq!(migration.output_version(), 1);
+        }
+    }
+
+    /// The tag an operator types is a wire format; a rename would silently invalidate a runbook.
+    #[test]
+    fn migration_wire_format() {
+        assert_eq!(
+            serde_json::to_value(Migration::from(PreGlobalContracts)).unwrap(),
+            json!({ "from_version": "pre_global_contracts" }),
+        );
+        assert_eq!(
+            serde_json::to_value(Migration::from(WithGlobalContracts)).unwrap(),
+            json!({ "from_version": "with_global_contracts" }),
+        );
+    }
+
+    #[test]
+    fn chain_rejects_a_migration_that_does_not_reach_the_target() {
+        context();
+        write_pre_global_contracts();
+
+        assert!(matches!(
+            run_migration_chain(vec![Migration::from(PreGlobalContracts)], 2),
+            Err(MigrationChainError::EndMismatch {
+                output: 1,
+                target: 2
+            }),
+        ));
+    }
+}

--- a/contract/registry/src/state/mod.rs
+++ b/contract/registry/src/state/mod.rs
@@ -1,0 +1,40 @@
+//! Versioned contract state.
+//!
+//! Versioning was adopted after three registries were already live on 0.1.0, 1.0.0 and 1.1.0,
+//! none of which wrote the version key — so [`read_state_version`] reports 0 for all of them and
+//! every migration into [`V1`] starts from 0 regardless of which layout it is actually reading.
+//! See [`legacy`] for the two layouts that exist and how the right one is chosen.
+//!
+//! [`read_state_version`]: templar_common::versioned_state::read_state_version
+
+pub mod legacy;
+pub mod migration;
+
+pub use migration::Migration;
+
+use near_sdk::{near, store::IterableMap, AccountId};
+use templar_common::versioned_state::{StateVersion, VersionedState};
+
+use crate::{RegistryEntry, VersionEntry};
+
+pub(crate) const VERSIONS_PREFIX: &[u8] = b"v";
+pub(crate) const REGISTRY_PREFIX: &[u8] = b"r";
+
+#[near(serializers = [borsh])]
+pub struct V1 {
+    pub versions: IterableMap<String, VersionEntry>,
+    pub registry: IterableMap<AccountId, RegistryEntry>,
+}
+
+impl StateVersion for V1 {
+    const VERSION: u32 = 1;
+
+    type NewArgs = ();
+
+    fn new((): ()) -> VersionedState<Self> {
+        VersionedState::new(Self {
+            versions: IterableMap::new(VERSIONS_PREFIX),
+            registry: IterableMap::new(REGISTRY_PREFIX),
+        })
+    }
+}

--- a/contract/registry/tests/migration.rs
+++ b/contract/registry/tests/migration.rs
@@ -1,0 +1,581 @@
+//! Bring each live registry release onto the current one.
+//!
+//! `templar-alpha.near`, `v1.tmplr.near` and `user0.tmplr.near` run 0.1.0, 1.0.0 and 1.1.0
+//! respectively, spanning both pre-versioning state layouts, and none of them wrote a state
+//! version. Each case starts from that release's real binary, builds state through *its* API, and
+//! upgrades onto current source — so a migration that cannot carry one of them fails here rather
+//! than on the account.
+
+use anyhow::{Context, Result};
+use near_api::types::AccountId;
+use near_token::NearToken;
+use rstest::rstest;
+use templar_common::{
+    market::YieldWeights,
+    registry::{DeployMode, VersionAvailability},
+};
+use templar_gateway_testing::{harness, SandboxHarness};
+
+const MARKET_VERSION: &str = "market@0.0.0";
+const REMOVED_VERSION: &str = "market@0.0.0-removed";
+/// The registry's own code, republished as a global contract so `upgrade` can name it by hash.
+const SELF_VERSION: &str = "registry@self";
+
+/// Which layout a release stores, and therefore the migration it needs. Both report a stored
+/// version of 0, so this mapping is knowledge the operator supplies — nothing on-chain reveals it.
+fn migration_for(release: &str) -> serde_json::Value {
+    let from_version = match release {
+        "0.1.0" | "1.0.0" => "pre_global_contracts",
+        "1.1.0" => "with_global_contracts",
+        other => panic!("no migration mapped for registry {other}"),
+    };
+    serde_json::json!({ "from_version": from_version })
+}
+
+struct Populated {
+    market_id: AccountId,
+    code_hash: String,
+}
+
+/// Register a deployable version and a soft-deleted one, then deploy a market from the first, so
+/// the migration has a `versions` map holding both entry shapes and a `registry` map holding a
+/// real `Deployed`.
+async fn populate(harness: &SandboxHarness, registry_id: &AccountId) -> Result<Populated> {
+    let deployer = harness.registry_signer_account_id.clone();
+    let market_wasm = templar_gateway_testing::wasm::market().await.to_vec();
+
+    // Every version on every live registry is Normal-mode, which is also the only mode 0.1.0 and
+    // 1.0.0 have — and the mode whose stored blob the migration has to rewrite. Only the
+    // deployable one needs to be a real contract; the other exists to be soft-deleted, and
+    // `remove_version` discards its blob regardless.
+    for (key, code) in [
+        (MARKET_VERSION, market_wasm),
+        (REMOVED_VERSION, b"not a contract".to_vec()),
+    ] {
+        harness
+            .registry_add_version(
+                &deployer,
+                registry_id,
+                key,
+                DeployMode::Normal,
+                code,
+                NearToken::from_yoctonear(1),
+            )
+            .await?;
+    }
+    harness
+        .call_function_payable(
+            &deployer,
+            registry_id,
+            "remove_version",
+            serde_json::json!({ "version_key": REMOVED_VERSION }),
+            NearToken::from_yoctonear(1),
+        )
+        .await?;
+
+    let oracle = harness.create_user("oracle").await?;
+    let borrow = harness.create_user("borrow").await?;
+    let collateral = harness.create_user("collateral").await?;
+    let protocol = harness.create_user("protocol").await?;
+    let configuration = test_utils::market_configuration(
+        oracle.0,
+        borrow.0,
+        collateral.0,
+        protocol.0,
+        YieldWeights::new_with_supply_weight(1),
+    );
+    harness
+        .registry_deploy(
+            &deployer,
+            registry_id,
+            "market",
+            MARKET_VERSION,
+            serde_json::to_vec(&serde_json::json!({ "configuration": configuration }))?,
+            None,
+            NearToken::from_near(10),
+        )
+        .await?;
+
+    let code_hash = harness
+        .view_json::<Option<String>>(
+            registry_id,
+            "get_version_code_hash",
+            serde_json::json!({ "version_key": MARKET_VERSION }),
+        )
+        .await?
+        .context("the registered version has a code hash")?;
+
+    Ok(Populated {
+        market_id: format!("market.{registry_id}").parse()?,
+        code_hash,
+    })
+}
+
+#[rstest]
+#[case::alpha_near("0.1.0")]
+#[case::v1_tmplr_near("1.0.0")]
+#[case::user0_tmplr_near("1.1.0")]
+#[tokio::test]
+async fn live_release_migrates_onto_current(
+    #[future(awt)] harness: SandboxHarness,
+    #[case] release: &str,
+) -> Result<()> {
+    let registry_id = harness.deploy_registry_version(release).await?;
+    let before = populate(&harness, &registry_id).await?;
+
+    let versions_before = harness
+        .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+        .await?;
+    let deployments_before = harness
+        .view_json::<Vec<AccountId>>(&registry_id, "list_deployments", serde_json::json!({}))
+        .await?;
+    assert_eq!(deployments_before, vec![before.market_id.clone()]);
+
+    // None of these releases has `upgrade`, so the first migration has to be the batch an
+    // operator signs with a full-access key. `upgrade` only takes over afterwards — which is the
+    // order the rollout has to follow too.
+    harness
+        .redeploy_registry_with_migrate(
+            templar_gateway_testing::wasm::registry().await.to_vec(),
+            migration_for(release),
+            near_api::types::NearGas::from_tgas(100),
+        )
+        .await?;
+
+    assert!(
+        !harness
+            .view_json::<bool>(&registry_id, "needs_migration", serde_json::json!({}))
+            .await?,
+        "{release} still reports an outstanding migration",
+    );
+    assert_eq!(
+        harness
+            .view_json::<u32>(
+                &registry_id,
+                "get_stored_state_version",
+                serde_json::json!({})
+            )
+            .await?,
+        1,
+    );
+
+    // Nothing the registry was holding may have moved.
+    assert_eq!(
+        harness
+            .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+            .await?,
+        versions_before,
+    );
+    assert_eq!(
+        harness
+            .view_json::<Vec<AccountId>>(&registry_id, "list_deployments", serde_json::json!({}))
+            .await?,
+        deployments_before,
+    );
+    assert_eq!(
+        harness
+            .view_json::<Option<String>>(
+                &registry_id,
+                "get_version_code_hash",
+                serde_json::json!({ "version_key": MARKET_VERSION }),
+            )
+            .await?,
+        Some(before.code_hash.clone()),
+        "the rewritten entry must keep its hash",
+    );
+
+    // And the soft-delete must survive as one rather than becoming deployable again.
+    let removed = harness
+        .view_json::<Option<templar_common::registry::VersionInfo>>(
+            &registry_id,
+            "get_version",
+            serde_json::json!({ "version_key": REMOVED_VERSION }),
+        )
+        .await?
+        .context("the soft-deleted version is still registered")?;
+    assert_eq!(removed.availability, VersionAvailability::Removed);
+
+    Ok(())
+}
+
+/// Once a registry is on this release, `upgrade` replaces the full-access-key batch — which is
+/// what has to be true before the keys can be deleted.
+///
+/// Upgrades from a global contract rather than an inline blob. Passing the code by hash is the
+/// cheaper of the two on any network, and the only one that fits here: a 237 KB blob costs more
+/// gas to hand over and decode than is left after reserving [`GAS_FOR_MIGRATE`], under the 300
+/// Tgas the sandbox's protocol version allows a transaction.
+///
+/// [`GAS_FOR_MIGRATE`]: templar_registry_contract::Contract::GAS_FOR_MIGRATE
+#[rstest]
+#[tokio::test]
+async fn upgrade_replaces_the_key_signed_batch(
+    #[future(awt)] harness: SandboxHarness,
+) -> Result<()> {
+    let registry_id = harness.deploy_registry_version("1.1.0").await?;
+    let before = populate(&harness, &registry_id).await?;
+    let current = templar_gateway_testing::wasm::registry().await.to_vec();
+    harness
+        .redeploy_registry_with_migrate(
+            current.clone(),
+            migration_for("1.1.0"),
+            near_api::types::NearGas::from_tgas(100),
+        )
+        .await?;
+
+    // Publish the new code as a global contract, then upgrade onto it by hash.
+    let cost_per_byte = NearToken::from_near(1).saturating_div(10_000);
+    harness
+        .registry_add_version(
+            &harness.registry_signer_account_id.clone(),
+            &registry_id,
+            SELF_VERSION,
+            DeployMode::GlobalHash,
+            current.clone(),
+            cost_per_byte.saturating_mul(current.len() as u128),
+        )
+        .await?;
+    let global_hash = harness
+        .view_json::<Option<String>>(
+            &registry_id,
+            "get_version_code_hash",
+            serde_json::json!({ "version_key": SELF_VERSION }),
+        )
+        .await?
+        .context("the global version has a code hash")?;
+
+    // Already at the target version, so this upgrade carries no migration.
+    let result = harness
+        .call_function_payable(
+            &harness.registry_signer_account_id.clone(),
+            &registry_id,
+            "upgrade",
+            serde_json::json!({
+                "code": { "GlobalHash": global_hash },
+                "migrate_args": near_sdk::json_types::Base64VecU8(Vec::new()),
+            }),
+            NearToken::from_yoctonear(1),
+        )
+        .await?;
+
+    println!(
+        "registry upgrade burnt {} Tgas",
+        harness.operation_gas_burnt(&result) / 1_000_000_000_000,
+    );
+
+    assert_eq!(
+        harness
+            .view_json::<Vec<AccountId>>(&registry_id, "list_deployments", serde_json::json!({}))
+            .await?,
+        vec![before.market_id],
+    );
+
+    Ok(())
+}
+
+#[rstest]
+#[tokio::test]
+async fn upgrade_rejects_a_non_owner(#[future(awt)] harness: SandboxHarness) -> Result<()> {
+    let registry_id = harness.deploy_registry().await?;
+    let stranger = harness.create_user("stranger").await?;
+
+    let result = harness
+        .call_function_payable(
+            &stranger,
+            &registry_id,
+            "upgrade",
+            serde_json::json!({
+                "code": near_sdk::json_types::Base64VecU8(
+                    templar_gateway_testing::wasm::registry().await.to_vec(),
+                ),
+                "migrate_args": near_sdk::json_types::Base64VecU8(Vec::new()),
+            }),
+            NearToken::from_yoctonear(1),
+        )
+        .await;
+
+    // Named rather than merely failed: an `is_err` here also passes when the call never reached
+    // `assert_owner` — a bad deposit, a typo'd method — which would prove nothing about access.
+    let error = format!(
+        "{:#}",
+        result.expect_err("a non-owner upgraded the registry"),
+    );
+    assert!(
+        error.contains("Owner only"),
+        "expected the owner guard to reject this, got: {error}",
+    );
+
+    Ok(())
+}
+
+/// The largest state one `migrate` can carry — a proof-size ceiling, not a gas one.
+///
+/// A receipt may record at most 4 MB of trie storage proof
+/// (`per_receipt_storage_proof_size_limit`, the same on mainnet and in the sandbox), and the
+/// pre-1.1.0 transform reads and rewrites every stored blob. Measured either side of the line:
+/// 3.4 MB of blobs migrates, 3.9 MB does not, and both burn about 95 Tgas — so gas is never what
+/// runs out, and raising it does not help.
+///
+/// `v1.tmplr.near` and `templar-alpha.near` each hold roughly 5 MB, so both must be pruned with
+/// `remove_version` before they can be migrated at all. This pins the headroom that pruning aims
+/// at: if the transform grows costlier per entry, it fails here rather than on the account.
+#[rstest]
+#[tokio::test]
+async fn migrates_the_largest_state_a_receipt_can_carry(
+    #[future(awt)] harness: SandboxHarness,
+) -> Result<()> {
+    const VERSIONS: usize = 8;
+    const BLOB: usize = 440 * 1024;
+
+    let registry_id = harness.deploy_registry_version("1.0.0").await?;
+    let deployer = harness.registry_signer_account_id.clone();
+    for index in 0..VERSIONS {
+        harness
+            .registry_add_version(
+                &deployer,
+                &registry_id,
+                &format!("bulk@{index}"),
+                DeployMode::Normal,
+                vec![u8::try_from(index % 256)?; BLOB],
+                NearToken::from_yoctonear(1),
+            )
+            .await?;
+    }
+
+    let burnt = harness
+        .redeploy_registry_with_migrate(
+            templar_gateway_testing::wasm::registry().await.to_vec(),
+            migration_for("1.0.0"),
+            near_api::types::NearGas::from_tgas(280),
+        )
+        .await?;
+
+    println!(
+        "migrated {} MB of blobs for {} Tgas",
+        VERSIONS * BLOB / (1024 * 1024),
+        burnt.as_gas() / 1_000_000_000_000,
+    );
+
+    assert!(
+        !harness
+            .view_json::<bool>(&registry_id, "needs_migration", serde_json::json!({}))
+            .await?,
+        "the migration did not complete",
+    );
+    assert_eq!(
+        harness
+            .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+            .await?
+            .len(),
+        VERSIONS,
+        "every version must survive the rewrite",
+    );
+
+    Ok(())
+}
+
+/// The whole point of `upgrade`: a registry with no access keys left can still be replaced.
+///
+/// Ownership has to move off the registry first. `new` makes the registry its own owner, so
+/// revoking its keys without handing ownership to another account would strand `upgrade` behind a
+/// signer that no longer exists — the exact brick this method is meant to prevent. That ordering
+/// is the runbook: publish the code, hand over ownership, revoke, then upgrade.
+#[rstest]
+#[tokio::test]
+async fn a_keyless_registry_still_upgrades_through_its_owner(
+    #[future(awt)] harness: SandboxHarness,
+) -> Result<()> {
+    let registry_id = harness.deploy_registry_version("1.1.0").await?;
+    let before = populate(&harness, &registry_id).await?;
+    let current = templar_gateway_testing::wasm::registry().await.to_vec();
+    let registry_signer = harness.registry_signer_account_id.clone();
+    harness
+        .redeploy_registry_with_migrate(
+            current.clone(),
+            migration_for("1.1.0"),
+            near_api::types::NearGas::from_tgas(100),
+        )
+        .await?;
+
+    // Publish the replacement while the registry still owns itself.
+    let cost_per_byte = NearToken::from_near(1).saturating_div(10_000);
+    harness
+        .registry_add_version(
+            &registry_signer,
+            &registry_id,
+            SELF_VERSION,
+            DeployMode::GlobalHash,
+            current.clone(),
+            cost_per_byte.saturating_mul(current.len() as u128),
+        )
+        .await?;
+    let global_hash = harness
+        .view_json::<Option<String>>(
+            &registry_id,
+            "get_version_code_hash",
+            serde_json::json!({ "version_key": SELF_VERSION }),
+        )
+        .await?
+        .context("the global version has a code hash")?;
+
+    let new_owner = harness.create_user("registry-owner").await?;
+    harness
+        .transfer_ownership(&registry_id, &registry_signer, &new_owner)
+        .await?;
+
+    harness.revoke_all_access_keys(&registry_id).await?;
+    assert!(harness.view_access_keys(&registry_id).await?.is_empty());
+
+    harness
+        .call_function_payable(
+            &new_owner,
+            &registry_id,
+            "upgrade",
+            serde_json::json!({
+                "code": { "GlobalHash": global_hash },
+                "migrate_args": near_sdk::json_types::Base64VecU8(Vec::new()),
+            }),
+            NearToken::from_yoctonear(1),
+        )
+        .await?;
+
+    // The upgrade landed and took nothing with it.
+    assert_eq!(
+        harness
+            .view_json::<Vec<AccountId>>(&registry_id, "list_deployments", serde_json::json!({}))
+            .await?,
+        vec![before.market_id],
+    );
+    assert!(
+        !harness
+            .view_json::<bool>(&registry_id, "needs_migration", serde_json::json!({}))
+            .await?,
+    );
+
+    Ok(())
+}
+
+/// Naming the wrong migration must cost nothing. Both layouts report a stored version of 0, so
+/// the operator picks — and a wrong pick has to leave the registry exactly as it was, still on its
+/// old code, rather than half-converted or bricked.
+///
+/// The revert is what makes the choice safe, and it comes from the deploy and the `migrate`
+/// sharing one receipt: the failed migration takes the code with it.
+#[rstest]
+#[tokio::test]
+async fn a_mismatched_migration_leaves_the_registry_untouched(
+    #[future(awt)] harness: SandboxHarness,
+) -> Result<()> {
+    // 1.0.0 stores the two-field layout, so the three-field migration cannot read it.
+    let registry_id = harness.deploy_registry_version("1.0.0").await?;
+    let before = populate(&harness, &registry_id).await?;
+    let versions_before = harness
+        .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+        .await?;
+
+    let result = harness
+        .redeploy_registry_with_migrate(
+            templar_gateway_testing::wasm::registry().await.to_vec(),
+            migration_for("1.1.0"),
+            near_api::types::NearGas::from_tgas(100),
+        )
+        .await;
+    assert!(
+        result.is_err(),
+        "a mismatched migration was accepted: {result:?}",
+    );
+
+    // Still the old binary: these views only exist on the code that was never deployed.
+    assert!(
+        harness
+            .view_json::<u32>(
+                &registry_id,
+                "get_stored_state_version",
+                serde_json::json!({})
+            )
+            .await
+            .is_err(),
+        "the new code survived a failed migration",
+    );
+    // And still the old state, readable through the API the old binary does serve.
+    assert_eq!(
+        harness
+            .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+            .await?,
+        versions_before,
+    );
+    assert_eq!(
+        harness
+            .view_json::<Vec<AccountId>>(&registry_id, "list_deployments", serde_json::json!({}))
+            .await?,
+        vec![before.market_id],
+    );
+
+    Ok(())
+}
+
+/// A migration cannot be replayed once it has run.
+///
+/// The same-shape case borsh cannot catch: [`state::V1`] and the pre-1.1.0 layout are both two
+/// `IterableMap`s, and a map's borsh footprint is its prefix and length rather than its values, so
+/// reading one as the other succeeds at the struct level. What refuses the replay is the stored
+/// version — a transform only runs from the version it declares, and this one has moved past it.
+///
+/// [`state::V1`]: templar_registry_contract::Contract
+#[rstest]
+#[tokio::test]
+async fn a_replayed_migration_is_refused(#[future(awt)] harness: SandboxHarness) -> Result<()> {
+    let registry_id = harness.deploy_registry_version("1.0.0").await?;
+    let before = populate(&harness, &registry_id).await?;
+    let current = templar_gateway_testing::wasm::registry().await.to_vec();
+    harness
+        .redeploy_registry_with_migrate(
+            current.clone(),
+            migration_for("1.0.0"),
+            near_api::types::NearGas::from_tgas(100),
+        )
+        .await?;
+    let versions_after = harness
+        .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+        .await?;
+
+    let result = harness
+        .redeploy_registry_with_migrate(
+            current,
+            migration_for("1.0.0"),
+            near_api::types::NearGas::from_tgas(100),
+        )
+        .await;
+
+    let error = format!("{:#}", result.expect_err("a migration ran twice"));
+    assert!(
+        error.contains("no state migration is needed"),
+        "expected the stored version to refuse the replay, got: {error}",
+    );
+
+    // Still migrated, and still holding everything.
+    assert_eq!(
+        harness
+            .view_json::<u32>(
+                &registry_id,
+                "get_stored_state_version",
+                serde_json::json!({})
+            )
+            .await?,
+        1,
+    );
+    assert_eq!(
+        harness
+            .view_json::<Vec<String>>(&registry_id, "list_versions", serde_json::json!({}))
+            .await?,
+        versions_after,
+    );
+    assert_eq!(
+        harness
+            .view_json::<Vec<AccountId>>(&registry_id, "list_deployments", serde_json::json!({}))
+            .await?,
+        vec![before.market_id],
+    );
+
+    Ok(())
+}

--- a/gateway/testing/src/ops.rs
+++ b/gateway/testing/src/ops.rs
@@ -1286,6 +1286,77 @@ impl SandboxHarness {
             .map_err(|error| anyhow::anyhow!("get_configuration failed: {error}"))
     }
 
+    /// The generic read escape hatch: call a view by name and decode its JSON.
+    ///
+    /// Counterpart to [`call_function`](Self::call_function), for entrypoints with no gateway
+    /// method spec — a contract's own tests reach its views before the gateway learns about them.
+    pub async fn view_json<T: serde::de::DeserializeOwned + Send + Sync + 'static>(
+        &self,
+        contract_id: &AccountId,
+        method_name: &str,
+        args: impl serde::Serialize,
+    ) -> Result<T> {
+        near_api::Contract(contract_id.clone())
+            .call_function_raw(method_name, serde_json::to_vec(&args)?)
+            .read_only()
+            .at(TEST_FINALITY_POLICY.query_reference())
+            .fetch_from(&self.network)
+            .await
+            .map(|response| response.data)
+            .with_context(|| format!("view {contract_id}.{method_name} failed"))
+    }
+
+    /// Complete the `Owner` two-step handover: `current` proposes `next`, then `next` accepts.
+    pub async fn transfer_ownership(
+        &self,
+        contract_id: &AccountId,
+        current: &ManagedAccountId,
+        next: &ManagedAccountId,
+    ) -> Result<()> {
+        self.execute(
+            current,
+            templar_gateway_methods_spec::owner::ProposeOwner {
+                contract_id: contract_id.clone(),
+                account_id: Some(next.0.clone()),
+            },
+        )
+        .await?;
+        self.execute(
+            next,
+            templar_gateway_methods_spec::owner::AcceptOwner {
+                contract_id: contract_id.clone(),
+            },
+        )
+        .await?;
+        Ok(())
+    }
+
+    /// Delete every access key on `account_id`, signed by one of those keys — the last thing it
+    /// can do. Nothing off-chain can deploy over the account afterwards; only its own code can.
+    pub async fn revoke_all_access_keys(&self, account_id: &AccountId) -> Result<()> {
+        let keys = self
+            .view_access_keys(account_id)
+            .await?
+            .into_iter()
+            .map(|(public_key, _)| public_key.parse::<near_api::types::PublicKey>())
+            .collect::<Result<Vec<_>, _>>()?;
+        anyhow::ensure!(!keys.is_empty(), "{account_id} already has no access keys");
+
+        Account(account_id.clone())
+            .delete_keys(keys)
+            .with_signer(crate::sandbox::test_signer())
+            .wait_until(TEST_FINALITY_POLICY.transaction_status())
+            .send_to(&self.network)
+            .await?
+            .assert_success();
+
+        anyhow::ensure!(
+            self.view_access_keys(account_id).await?.is_empty(),
+            "{account_id} should have no access keys left",
+        );
+        Ok(())
+    }
+
     /// List `account_id`'s access keys at the sandbox's optimistic query
     /// reference as `(public_key, is_full_access)`.
     pub async fn view_access_keys(&self, account_id: &AccountId) -> Result<Vec<(String, bool)>> {
@@ -1937,6 +2008,26 @@ impl SandboxHarness {
         method_name: &str,
         args: impl serde::Serialize,
     ) -> Result<WriteOperationResult> {
+        self.try_deploy_and_init_with_gas(
+            account_id,
+            code,
+            method_name,
+            args,
+            NearGas::from_tgas(300),
+        )
+        .await
+    }
+
+    /// [`try_deploy_and_init`](Self::try_deploy_and_init) with the init call's gas named, for the
+    /// migrations whose cost is the thing under test.
+    pub async fn try_deploy_and_init_with_gas(
+        &self,
+        account_id: &AccountId,
+        code: Vec<u8>,
+        method_name: &str,
+        args: impl serde::Serialize,
+        gas: NearGas,
+    ) -> Result<WriteOperationResult> {
         self.try_execute(
             &ManagedAccountId(account_id.clone()),
             tx::DeployAndInit {
@@ -1944,7 +2035,7 @@ impl SandboxHarness {
                 code: Base64Bytes(code),
                 method_name: ContractMethodName(method_name.to_owned()),
                 args: ContractArgs::Json(serde_json::to_value(args)?),
-                gas: NearGas::from_tgas(300),
+                gas,
                 deposit: near_token::NearToken::from_yoctonear(0),
             },
         )

--- a/gateway/testing/src/sandbox.rs
+++ b/gateway/testing/src/sandbox.rs
@@ -351,17 +351,70 @@ impl SandboxHarness {
     }
 
     pub async fn deploy_registry(&self) -> Result<AccountId> {
+        self.deploy_registry_code(crate::wasm::registry().await.to_vec())
+            .await
+    }
+
+    /// Deploy a *released* registry, for migration tests that have to start from the binary a
+    /// live registry is actually running rather than from current source.
+    pub async fn deploy_registry_version(&self, version: &str) -> Result<AccountId> {
+        let code = crate::wasm::released(crate::ArtifactId::Registry, version).await;
+        self.deploy_registry_code(code).await
+    }
+
+    async fn deploy_registry_code(&self, code: Vec<u8>) -> Result<AccountId> {
         let account_id = self.registry_signer_account_id.0.clone();
         deploy_contract(
             &self.network,
             account_id.clone(),
             test_signer(),
-            crate::wasm::registry().await.to_vec(),
+            code,
             "new",
             serde_json::json!({}),
         )
         .await?;
         Ok(account_id)
+    }
+
+    /// Replace the registry's code and run `migrate` in the same transaction, signed by a
+    /// full-access key on the registry itself. Returns the gas the batch burnt.
+    ///
+    /// How a registry predating the `upgrade` method has to be upgraded — it has no such method,
+    /// so the batch an operator signs is the only route. `migrate` is reachable because it admits
+    /// its own account, which is what a full-access key on that account signs as.
+    ///
+    /// `gas` is on the `migrate` action, where the signer sets it directly rather than a contract
+    /// constant carving it out — the reason this path can afford a migration `upgrade` could not.
+    /// A sandbox caps a transaction well below mainnet, so a burn measured here is a lower bound
+    /// on what is affordable, not on what is needed.
+    pub async fn redeploy_registry_with_migrate(
+        &self,
+        code: Vec<u8>,
+        migrate_args: impl serde::Serialize,
+        gas: near_api::types::NearGas,
+    ) -> Result<near_api::types::NearGas> {
+        let result = self
+            .try_deploy_and_init_with_gas(
+                &self.registry_signer_account_id.0.clone(),
+                code,
+                templar_common::upgrade::MIGRATE_METHOD,
+                migrate_args,
+                gas,
+            )
+            .await?;
+        // Raised to an `Err` rather than returned: a migration that must fail — a mismatched one —
+        // is a case worth testing, and every caller here expects the batch to have landed.
+        anyhow::ensure!(
+            result.operation.status == templar_gateway_types::operation::OperationStatus::Succeeded,
+            "registry deploy+migrate failed: {}",
+            result
+                .operation
+                .failure_message()
+                .unwrap_or("<no failure message>"),
+        );
+        Ok(near_api::types::NearGas::from_gas(
+            self.operation_gas_burnt(&result),
+        ))
     }
 
     pub async fn deploy_market(&self) -> Result<(AccountId, MarketConfiguration)> {


### PR DESCRIPTION
Third of five stacked PRs clearing the **Registry Contract** project, and the one that carries all five issues' contract halves: ENG-571, ENG-572, ENG-559, ENG-560, ENG-464.

## The three live registries

`templar-alpha.near`, `v1.tmplr.near` and `user0.tmplr.near` run **0.1.0, 1.0.0 and 1.1.0** — three versions spanning two pre-versioning state layouts, none of which wrote a state version.

| | 0.1.0 / 1.0.0 | 1.1.0 / 1.2.x |
|---|---|---|
| struct | `{versions, registry}` | `{versions, global_contract_hashes, registry}` |
| `VersionEntry` | struct `{hash, code}` | enum `{Code{..}, GlobalHash(..)}` |

Borsh prefixes an enum with a discriminant, so those map *values* cannot be reinterpreted, only rewritten. Neither layout is detectable from its bytes: the legacy encoding opens with the first byte of a sha256, which aliases both enum tags.

## Why the migrations look the way they do

All three report stored version 0, since none wrote the key. So there is no `V0→V1→V2` chain — there are **two legacy state types both at `VERSION = 0`**, each converging on a single `V1`, and every registry runs one step. Picking the wrong one cannot corrupt anything: the layouts differ by a whole collection, borsh rejects both leftover and missing bytes, and the abort takes the batched deploy with it (`wrong_variant_refuses_to_read_state`).

`V1` drops `global_contract_hashes`, written once at init and never read again. Dropping it is the *cheaper* target: 1.1.0 then needs only a top-level rewrite, and 0.1.0/1.0.0 are already two-field.

## Two constraints found by testing, not reasoning

**The first migration cannot use `upgrade`.** None of these releases has the method, so it must be a `DeployContract` + `migrate` batch signed by a full-access key on the registry — reachable because `migrate` admits its own account. `upgrade` only takes over afterwards, which is also the order the rollout must follow.

**A migration is bounded by proof size, not gas.** A receipt records at most 4 MB of trie storage proof (`per_receipt_storage_proof_size_limit`, identical on mainnet and sandbox). Measured: **3.4 MB of blobs migrates, 3.9 MB does not**, and both burn ~95 Tgas — gas never runs out, and raising it does not help. Alpha and v1 hold ~5 MB each, so **both must be pruned with `remove_version` before they can be migrated at all**. `migrates_the_largest_state_a_receipt_can_carry` pins that headroom.

`GAS_FOR_MIGRATE` is therefore the same 250 Tgas the other contracts reserve: the expensive rewrite never runs through `upgrade`, where a contract constant carves the sub-call's budget, but through the key-signed batch, where gas sits on the transaction.

## The views

`get_version` and `get_registry_entry` replace checks that could only test membership — a soft-deleted version and a reserved name were both invisible. `get_version_code_chunk` is deliberately last-resort and borsh-serialized: a view returns to the caller as one JSON integer per byte, so a whole contract does not fit a response body, and `get_version`'s hash usually resolves it from the artifact cache instead.

## Testing

One sandbox case per live registry, each starting from that release's real binary and building state through its own API; plus keyless-upgrade, non-owner, proof-ceiling, and unit coverage of both transforms and all three views.

Closes ENG-571, ENG-572.

Relates to ENG-559, ENG-560 (their consumer wiring lands with #590/#591) and ENG-464, which carries the `get_version_code_chunk` view here but stays open pending ENG-463.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/589)
<!-- Reviewable:end -->