### PR TITLE
feat(manager): make target and version preflight checks sound

### DIFF
--- a/tools/manager/src/dispatch/plan.rs
+++ b/tools/manager/src/dispatch/plan.rs
@@ -9,6 +9,7 @@ use anyhow::Context as _;
 use near_account_id::AccountId;
 use near_api::types::NearToken;
 use templar_common::oracle::pyth::PriceIdentifier;
+use templar_common::registry::RegistryEntryView;
 use templar_common::Nanoseconds;
 use templar_gateway_client::{Client, Network};
 use templar_gateway_core::{
@@ -853,12 +854,11 @@ fn deploy_target(
 /// deployment map still holds, and `market remove` deletes the account without
 /// removing that entry, so a torn-down name is free and unusable at once.
 ///
-/// Best-effort in one direction: `get_deployment` reports a `Reserved` entry as
-/// absent, and no registry view distinguishes it, so a name another deploy has
-/// reserved but not yet created is invisible here. That window is a concurrent
-/// in-flight deploy of the same name — a failed one removes its entry — and the
-/// registry rejects it either way, so the unseen case costs a failed step
-/// rather than a bad deployment. Closing it needs an additive view.
+/// Against a registry too old to serve `get_registry_entry` this stays blind in
+/// one direction: `get_deployment` reports a reserved entry as absent, so a name
+/// another deploy has claimed but not yet finalized looks free. That costs a
+/// refused final step rather than a bad deployment, since the registry rejects
+/// it either way.
 async fn target_conflict(
     ctx: &CliContext,
     registry_id: &AccountId,
@@ -868,23 +868,50 @@ async fn target_conflict(
         return Ok(Some(format!("`{account_id}` already exists")));
     }
 
-    let claimed = ctx
-        .client
-        .read(registry::GetDeployment {
-            registry_id: registry_id.clone(),
-            account_id: account_id.clone(),
-        })
-        .await
-        .with_context(|| format!("read `{registry_id}`'s deployment record for `{account_id}`"))?
-        .deployment
-        .is_some();
+    let entry = if super::preflight::serves_entry_and_version_views(ctx, registry_id).await {
+        ctx.client
+            .read(registry::GetRegistryEntry {
+                registry_id: registry_id.clone(),
+                account_id: account_id.clone(),
+            })
+            .await
+            .with_context(|| format!("read `{registry_id}`'s entry for `{account_id}`"))?
+            .entry
+    } else {
+        // The older view reports a reserved name as absent, so the fallback is exactly this
+        // mapping with one state it can never produce.
+        ctx.client
+            .read(registry::GetDeployment {
+                registry_id: registry_id.clone(),
+                account_id: account_id.clone(),
+            })
+            .await
+            .with_context(|| {
+                format!("read `{registry_id}`'s deployment record for `{account_id}`")
+            })?
+            .deployment
+            .map(RegistryEntryView::Deployed)
+    };
 
-    Ok(claimed.then(|| {
-        format!(
+    Ok(claimed_reason(registry_id, account_id, entry.as_ref()))
+}
+
+/// Why an entry in the deployment map blocks `account_id`, if it does.
+fn claimed_reason(
+    registry_id: &AccountId,
+    account_id: &AccountId,
+    entry: Option<&RegistryEntryView>,
+) -> Option<String> {
+    match entry? {
+        RegistryEntryView::Deployed(_) => Some(format!(
             "`{registry_id}` still records a deployment for `{account_id}`, so it \
              would be refused as a collision even though the account is gone"
-        )
-    }))
+        )),
+        RegistryEntryView::Reserved => Some(format!(
+            "`{registry_id}` has `{account_id}` reserved by a deploy that never \
+             finalized, so it would be refused as a collision"
+        )),
+    }
 }
 
 /// The same question `targets_available` asks at plan time, re-asked at the
@@ -1386,5 +1413,61 @@ mod tests {
         let error = super::ensure_schema(&foreign, std::path::Path::new("plan.json"))
             .expect_err("wrong schema");
         assert!(error.to_string().contains("Regenerate it"), "{error:#}");
+    }
+
+    use near_account_id::AccountId;
+    use templar_common::registry::{Deployment, RegistryEntryView};
+
+    /// `Reserved` is the whole reason `get_registry_entry` exists: `deploy` refuses the name just
+    /// as firmly as a deployed one, while `get_deployment` reports it absent.
+    #[test]
+    fn claimed_reason_separates_reserved_from_deployed_and_free() {
+        let registry: AccountId = "v1.tmplr.near".parse().unwrap();
+        let account: AccountId = "market.v1.tmplr.near".parse().unwrap();
+        let deployment = Deployment {
+            version_key: "market@1.5.0".to_owned(),
+            code_hash: near_sdk::json_types::Base58CryptoHash::from([1u8; 32]),
+            block_height: 1.into(),
+        };
+
+        assert_eq!(super::claimed_reason(&registry, &account, None), None);
+
+        let deployed = RegistryEntryView::Deployed(deployment);
+        let reserved = RegistryEntryView::Reserved;
+        let deployed = super::claimed_reason(&registry, &account, Some(&deployed))
+            .expect("a deployed name is claimed");
+        let reserved = super::claimed_reason(&registry, &account, Some(&reserved))
+            .expect("a reserved name is claimed too");
+
+        assert!(
+            deployed.contains("still records a deployment"),
+            "{deployed}"
+        );
+        assert!(reserved.contains("never finalized"), "{reserved}");
+    }
+
+    /// The legacy fallback maps a deployment record onto the same answer, and structurally cannot
+    /// produce `Reserved` — which is the one state it is blind to.
+    #[test]
+    fn the_legacy_fallback_can_never_report_reserved() {
+        let registry: AccountId = "v1.tmplr.near".parse().unwrap();
+        let account: AccountId = "market.v1.tmplr.near".parse().unwrap();
+        let from_legacy =
+            |deployment: Option<Deployment>| deployment.map(RegistryEntryView::Deployed);
+
+        assert_eq!(
+            super::claimed_reason(&registry, &account, from_legacy(None).as_ref()),
+            None,
+            "an absent record reads as free, reserved or not",
+        );
+        let deployment = Deployment {
+            version_key: "market@1.5.0".to_owned(),
+            code_hash: near_sdk::json_types::Base58CryptoHash::from([1u8; 32]),
+            block_height: 1.into(),
+        };
+        assert!(matches!(
+            from_legacy(Some(deployment)),
+            Some(RegistryEntryView::Deployed(_)),
+        ));
     }
 }

--- a/tools/manager/src/dispatch/preflight.rs
+++ b/tools/manager/src/dispatch/preflight.rs
@@ -9,6 +9,7 @@ use near_account_id::AccountId;
 use templar_common::asset::{AssetClass, FungibleAsset};
 use templar_common::oracle::pyth::PriceIdentifier;
 use templar_common::price::PricePair;
+use templar_common::registry::VersionInfo;
 use templar_gateway_core::GatewayError;
 use templar_gateway_methods_spec::{account, contract, registry};
 use templar_gateway_types::common::{ContractArgs, Pagination};
@@ -369,11 +370,12 @@ async fn ft_decimals(ctx: &CliContext, account_id: &AccountId) -> anyhow::Result
         .and_then(|decimals| u8::try_from(decimals).ok()))
 }
 
-/// Every version key must already be registered, or the deploy fails partway.
+/// Every version key must already be registered *and still deployable*, or the deploy fails
+/// partway.
 ///
-/// Membership is all this can check: `remove_version` soft-deletes, and no
-/// registry view distinguishes that from a live version, so a soft-deleted one
-/// passes here and fails mid-deploy. Closing it needs an additive view.
+/// Against a registry too old to serve `get_version` this falls back to membership, which cannot
+/// see that `remove_version` cleared a version's code — such a key passes here and fails
+/// mid-deploy, after the governance and oracle steps have already run.
 async fn versions(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
     // A direct market deploys only itself, so the proxy versions it never uses
     // need not be registered.
@@ -383,48 +385,82 @@ async fn versions(ctx: &CliContext, spec: &MarketSpec) -> Vec<Check> {
         labeled.push(("governance", governance_version));
     }
 
-    let registered = match ctx
+    if serves_entry_and_version_views(ctx, &spec.registry).await {
+        let mut checks = Vec::with_capacity(labeled.len());
+        for (label, key) in labeled {
+            let found = ctx
+                .client
+                .read(registry::GetVersion {
+                    registry_id: spec.registry.clone(),
+                    version_key: key.clone(),
+                })
+                .await
+                .map(|result| result.version)
+                .map_err(|error| error.to_string());
+            checks.push(Check::new(
+                format!("registry.version.{label}"),
+                version_status(key, &spec.registry, found),
+            ));
+        }
+        return checks;
+    }
+
+    let registered = ctx
         .client
         .read(registry::ListVersions {
             registry_id: spec.registry.clone(),
             args: Pagination::default(),
         })
         .await
-    {
-        Ok(registered) => registered.values,
-        // One failed read must not swallow the rest of the report.
-        Err(error) => {
-            return labeled
-                .into_iter()
-                .map(|(label, _)| {
-                    Check::new(
-                        format!("registry.version.{label}"),
-                        Status::failed(format!(
-                            "could not list versions in {}: {error}",
-                            spec.registry
-                        )),
-                    )
-                })
-                .collect()
-        }
-    };
+        .map(|registered| registered.values)
+        .map_err(|error| error.to_string());
 
     labeled
         .into_iter()
         .map(|(label, key)| {
             Check::new(
                 format!("registry.version.{label}"),
-                if registered.iter().any(|known| known == key) {
-                    Status::passed(key.clone())
-                } else {
-                    Status::failed(format!(
-                        "`{key}` is not registered in {}; the deploy would fail partway",
-                        spec.registry
-                    ))
-                },
+                membership_status(key, &spec.registry, registered.as_deref()),
             )
         })
         .collect()
+}
+
+/// What `get_version` says about a key: deployable, present but stripped of its code, or absent.
+fn version_status(
+    key: &str,
+    registry: &AccountId,
+    found: Result<Option<VersionInfo>, String>,
+) -> Status {
+    match found {
+        Ok(Some(info)) if info.availability.is_deployable() => Status::passed(key.to_owned()),
+        Ok(Some(_)) => Status::failed(format!(
+            "`{key}`'s code was removed from {registry}; the deploy would fail partway"
+        )),
+        Ok(None) => Status::failed(format!(
+            "`{key}` is not registered in {registry}; the deploy would fail partway"
+        )),
+        Err(error) => Status::failed(format!("could not read `{key}` in {registry}: {error}")),
+    }
+}
+
+/// The same question against a registry that can only answer membership, which cannot tell a live
+/// version from one `remove_version` emptied.
+fn membership_status(
+    key: &str,
+    registry: &AccountId,
+    registered: Result<&[String], &String>,
+) -> Status {
+    match registered {
+        // One failed read must not swallow the rest of the report.
+        Err(error) => Status::failed(format!("could not list versions in {registry}: {error}")),
+        Ok(registered) if registered.iter().any(|known| known == key) => {
+            Status::passed(key.to_owned())
+        }
+        Ok(_) => Status::failed(format!(
+            "`{key}` is not registered in {registry}; the deploy would fail partway"
+        )),
+    }
 }
 
 /// A direct market skips the three checks a proxy gets, which left the oracle
@@ -622,10 +658,37 @@ pub(super) async fn exists(ctx: &CliContext, account_id: &AccountId) -> anyhow::
     }
 }
 
+/// Whether `registry_id` serves the views that make the target and version checks sound.
+///
+/// Unreadable or unparseable counts as "no". Every registry deployed so far predates these
+/// views, so the checks that want them have to degrade to what any registry can answer — failing
+/// closed would refuse to plan against all of them.
+pub(super) async fn serves_entry_and_version_views(
+    ctx: &CliContext,
+    registry_id: &AccountId,
+) -> bool {
+    ctx.client
+        .read(contract::GetVersion {
+            contract_id: registry_id.clone(),
+        })
+        .await
+        .ok()
+        .and_then(|result| result.parsed)
+        .is_some_and(|version| {
+            version
+                .cast::<templar_gateway_types::Registry>()
+                .supports_entry_and_version_views()
+        })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{prices_are_usable, underlying_ft, Leg, Price, Status};
+    use super::{
+        membership_status, prices_are_usable, underlying_ft, version_status, Leg, Price, Status,
+    };
+    use near_sdk::json_types::Base58CryptoHash;
     use templar_common::asset::{CollateralAsset, FungibleAsset};
+    use templar_common::registry::{VersionAvailability, VersionInfo};
 
     fn price(value: i64, conf: u64) -> Price {
         Price {
@@ -702,5 +765,78 @@ mod tests {
                 .parse()
                 .expect("valid asset");
         assert_eq!(underlying_ft(&opaque), None);
+    }
+
+    fn registry() -> super::AccountId {
+        "v1.tmplr.near".parse().unwrap()
+    }
+
+    fn info(availability: VersionAvailability) -> VersionInfo {
+        VersionInfo {
+            code_hash: Base58CryptoHash::from([1u8; 32]),
+            availability,
+        }
+    }
+
+    /// The state that motivated `get_version`: `remove_version` leaves the key in place, so
+    /// membership still finds it and only `availability` says it can no longer deploy.
+    #[rstest::rstest]
+    #[case::stored(Ok(Some(info(VersionAvailability::Stored { code_len: 10 }))), true)]
+    #[case::global(Ok(Some(info(VersionAvailability::Global))), true)]
+    #[case::code_removed(Ok(Some(info(VersionAvailability::Removed))), false)]
+    #[case::unregistered(Ok(None), false)]
+    #[case::read_failed(Err("rpc exploded".to_owned()), false)]
+    fn version_status_reports_every_state(
+        #[case] found: Result<Option<VersionInfo>, String>,
+        #[case] passes: bool,
+    ) {
+        let status = version_status("market@1.5.0", &registry(), found);
+        assert_eq!(
+            matches!(status, Status::Passed { .. }),
+            passes,
+            "{status:?}"
+        );
+    }
+
+    #[test]
+    fn version_status_distinguishes_removed_from_unregistered() {
+        let removed = version_status(
+            "market@1.5.0",
+            &registry(),
+            Ok(Some(info(VersionAvailability::Removed))),
+        );
+        let absent = version_status("market@1.5.0", &registry(), Ok(None));
+        assert_ne!(
+            format!("{removed:?}"),
+            format!("{absent:?}"),
+            "an operator needs to know which of the two they are looking at",
+        );
+    }
+
+    /// The legacy path cannot see a soft-delete at all: a removed version is still a member, so it
+    /// passes here and fails mid-deploy. Pinned so the blindness is deliberate rather than noticed
+    /// later.
+    #[rstest::rstest]
+    #[case::registered(&["market@1.5.0"], true)]
+    #[case::absent(&["market@1.0.0"], false)]
+    #[case::empty(&[], false)]
+    fn membership_status_can_only_answer_presence(
+        #[case] registered: &[&str],
+        #[case] passes: bool,
+    ) {
+        let registered: Vec<String> = registered.iter().map(|s| (*s).to_owned()).collect();
+        let status = membership_status("market@1.5.0", &registry(), Ok(registered.as_slice()));
+        assert_eq!(
+            matches!(status, Status::Passed { .. }),
+            passes,
+            "{status:?}"
+        );
+    }
+
+    #[test]
+    fn membership_status_reports_a_failed_listing() {
+        let error = "rpc exploded".to_owned();
+        let status = membership_status("market@1.5.0", &registry(), Err(&error));
+        assert!(matches!(status, Status::Failed { .. }), "{status:?}");
     }
 }


### PR DESCRIPTION
Last of five stacked PRs clearing the **Registry Contract** project.

Both checks carried a comment describing what they could not see. Neither does now, against a registry that serves the views.

`target_conflict` reports a name reserved by a deploy that never finalized, which `get_deployment` renders as absent even though the registry would refuse it. The version check reports a key whose code `remove_version` cleared, which membership cannot distinguish from a live one — and that failure lands on the market step, after governance and the oracle have already deployed.

Both degrade rather than fail closed when the registry is older, because every registry deployed so far is: the live ones run 0.1.0, 1.0.0 and 1.1.0. The capability probe treats an unreadable or unparseable version as unsupported for the same reason — refusing to plan is worse than planning with the weaker check that has been in use all along.

The version check now reads each key directly instead of listing every version and scanning, so it also stops pulling an unbounded list to answer three questions.

**Coverage note:** `templar-manager` is not in `sandbox_full_packages`, so its tests are all offline. The degrade path is covered by the version-predicate unit tests rather than end-to-end against a real pre-1.3.0 registry; the contract-side views are directly unit-tested, including the `Reserved` case `get_deployment` hides.

Closes ENG-559, ENG-560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Templar-Protocol/contracts/591)
<!-- Reviewable:end -->
